### PR TITLE
Fix log collection on provision failure

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -1811,6 +1811,11 @@ def collect_logs(test_id=None, logdir=None, backend=None, config_file=None):
 
     config = SCTConfiguration()
 
+    if not test_id:
+        test_id = config.get("test_id")
+        if test_id:
+            LOGGER.info("Using test_id from SCT configuration: %s", test_id)
+
     collector = Collector(test_id=test_id, params=config, test_dir=logdir)
 
     collected_logs, collection_error = collector.run()

--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -1000,6 +1000,8 @@ class LoaderLogCollector(LogCollector):
             name="test.crt",
             command="test -f /etc/scylla/ssl_conf/{0} && cat /etc/scylla/ssl_conf/{0}".format("test.crt"),
         ),
+        CommandLog(name="cloud-init-output.log", command="cat /var/log/cloud-init-output.log"),
+        CommandLog(name="cloud-init.log", command="cat /var/log/cloud-init.log"),
     ]
 
     def collect_logs(self, local_search_path=None) -> list[str]:
@@ -1036,6 +1038,8 @@ class MonitorLogCollector(LogCollector):
         PrometheusSnapshots(name="prometheus_data"),
         MonitoringStack(name="monitoring-stack"),
         GrafanaScreenShot(name="grafana-screenshot"),
+        CommandLog(name="cloud-init-output.log", command="cat /var/log/cloud-init-output.log"),
+        CommandLog(name="cloud-init.log", command="cat /var/log/cloud-init.log"),
     ]
     cluster_log_type = "monitor-set"
     cluster_dir_prefix = "monitor-set"


### PR DESCRIPTION
When provisioning pipeline step fails and run-test step never executes, the test_id  file is not written to disk, causing collect-logs to fail with "test_id not found".
The change adds fallback to reading test_id from SCT config (reads SCT_TEST_ID env var), during logs collection after provision failure.

Additionally, cloud-init logs collection was added to LoaderLogCollector and MonitorLogCollector collectors.
Otherwise it was hard to diagnose failures on these node types, if something happens during cloud-init.

Fixes: SCT-224

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :yellow_circle: [pr-provision-test on azure (as in initial issue) with deliberately raising RuntimeError during provisioning resources](https://argus.scylladb.com/tests/scylla-cluster-tests/48edeb80-80ff-483f-85ec-58aa98680726/logs)
Logs are collected (including cloud-init logs from monitor and loader), even though the SCT test is not started:
```
❯ ll ../sct-logs/48edeb80/loader-set-48edeb80/pr-provision-test-log-coll-loader-node-48edeb80-eastus-1
total 772K
drwxr-xr-x 2 dmitriy 4,0K kwi 15 11:52 .
drwxr-xr-x 3 dmitriy 4,0K kwi 15 11:52 ..
-rw-rw-r-- 1 dmitriy 165K kwi 15 11:52 cloud-init.log
-rw-rw-r-- 1 dmitriy  76K kwi 15 11:52 cloud-init-output.log
-rw-rw-r-- 1 dmitriy 520K kwi 15 11:52 system.log
❯ ll ../sct-logs/48edeb80/monitor-set-48edeb80/pr-provision-test-log-coll-monitor-node-48edeb80-eastus-1
total 616K
drwxr-xr-x 2 dmitriy 4,0K kwi 15 11:54 .
drwxr-xr-x 3 dmitriy 4,0K kwi 15 11:52 ..
-rw-rw-r-- 1 dmitriy   40 kwi 15 11:52 aalert.log
-rw-rw-r-- 1 dmitriy   40 kwi 15 11:52 agraf.log
-rw-rw-r-- 1 dmitriy   40 kwi 15 11:52 aprom.log
-rw-rw-r-- 1 dmitriy 134K kwi 15 11:54 cloud-init.log
-rw-rw-r-- 1 dmitriy  26K kwi 15 11:54 cloud-init-output.log
-rw-rw-r-- 1 dmitriy   17 kwi 15 11:52 manager_scylla_backend.log
-rw-rw-r-- 1 dmitriy   17 kwi 15 11:52 scylla_manager.log
-rw-rw-r-- 1 dmitriy   72 kwi 15 11:52 scylla-manager.yaml
-rw-rw-r-- 1 dmitriy 419K kwi 15 11:52 system.log
❯ ll ../sct-logs/48edeb80/db-cluster-48edeb80/pr-provision-test-log-coll-db-node-48edeb80-eastus-*
../sct-logs/48edeb80/db-cluster-48edeb80/pr-provision-test-log-coll-db-node-48edeb80-eastus-1:
total 644K
drwxr-xr-x 2 dmitriy 4,0K kwi 15 11:52 .
drwxr-xr-x 5 dmitriy 4,0K kwi 15 11:52 ..
-rw-r----- 1 dmitriy  366 kwi 15 11:52 cassandra-rackdc.properties
-rw-r----- 1 dmitriy 254K kwi 15 11:52 cloud-init.log
-rw-r----- 1 dmitriy  26K kwi 15 11:52 cloud-init-output.log
-rw-r----- 1 dmitriy 1,6K kwi 15 11:52 coredumps.info
-rw-r----- 1 dmitriy  12K kwi 15 11:52 cpu_info
-rw-r----- 1 dmitriy  49K kwi 15 11:52 dmesg.log
-rw-r----- 1 dmitriy 5,5K kwi 15 11:52 interrupts
-rw-r----- 1 dmitriy  135 kwi 15 11:52 io-properties.yaml
-rw-r----- 1 dmitriy 1,6K kwi 15 11:52 mem_info
-rw-r----- 1 dmitriy   48 kwi 15 11:52 scylla_doctor.vitals.json
-rw-r----- 1 dmitriy   84 kwi 15 11:52 scylla-manager-agent.yaml
-rw-r----- 1 dmitriy 1,4K kwi 15 11:52 scylla.yaml
-rw-r----- 1 dmitriy   80 kwi 15 11:52 setup_scripts_errors.log
-rw-r----- 1 dmitriy 230K kwi 15 11:52 systemctl.status
-rw-r----- 1 dmitriy 9,3K kwi 15 11:52 system.log
-rw-r----- 1 dmitriy 3,9K kwi 15 11:52 vmstat
...
```
- [x] :green_circle: [pr-provision-test on azure, normal run](https://jenkins.scylladb.com/job/scylla-staging/job/dimakr/job/pr-provision-test/261/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
