### PR TITLE
fix(scylla-doctor): stop fallback and fix S3 region mismatch in full edition download

### DIFF
--- a/unit_tests/test_scylla_doctor.py
+++ b/unit_tests/test_scylla_doctor.py
@@ -224,7 +224,7 @@ def test_download_full_generates_presigned_url(mock_keystore_cls, mock_boto_clie
 
     mock_ks = MagicMock()
     mock_ks.get_scylla_doctor_full_bucket_config.return_value = {
-        "bucket": "private-sd-bucket",
+        "bucket": "private-sd-bucket-us-east-1",
         "prefix": "releases/",
     }
     mock_keystore_cls.return_value = mock_ks
@@ -239,25 +239,28 @@ def test_download_full_generates_presigned_url(mock_keystore_cls, mock_boto_clie
         ]
     }
     mock_s3_presign = MagicMock()
-    mock_s3_presign.generate_presigned_url.return_value = "https://private-sd-bucket.s3.amazonaws.com/signed-url"
+    mock_s3_presign.generate_presigned_url.return_value = (
+        "https://private-sd-bucket-us-east-1.s3.amazonaws.com/signed-url"
+    )
 
-    # boto3.client is called twice: first in locate, then in download
+    # boto3.client is called twice: first in locate, then in download (with region)
     mock_boto_client.side_effect = [mock_s3_list, mock_s3_presign]
 
     doc = ScyllaDoctor(node=mock_node, test_config=test_config, offline_install=True)
-    doc.download_full_scylla_doctor()
+    with patch.object(doc, "_download_and_extract_tarball") as mock_extract:
+        doc.download_full_scylla_doctor()
 
     mock_s3_presign.generate_presigned_url.assert_called_once_with(
         ClientMethod="get_object",
-        Params={"Bucket": "private-sd-bucket", "Key": "releases/scylla-doctor-1.9.0.tar.gz"},
+        Params={"Bucket": "private-sd-bucket-us-east-1", "Key": "releases/scylla-doctor-1.9.0.tar.gz"},
         ExpiresIn=300,
     )
 
-    # Verify curl was called on the node with the presigned URL
-    curl_calls = [
-        call for call in mock_node.remoter.run.call_args_list if "curl" in str(call) and "signed-url" in str(call)
-    ]
-    assert len(curl_calls) == 1
+    # Verify the presigned URL was passed to the download method
+    mock_extract.assert_called_once_with(
+        "https://private-sd-bucket-us-east-1.s3.amazonaws.com/signed-url",
+        description="full scylla-doctor (scylla-doctor-1.9.0.tar.gz)",
+    )
 
 
 @patch("utils.scylla_doctor.boto3.client")
@@ -301,30 +304,18 @@ def test_download_dispatches_to_full_when_edition_is_full(mock_download_full, mo
 
 @patch("utils.scylla_doctor.boto3.client")
 @patch.object(ScyllaDoctor, "download_full_scylla_doctor", side_effect=ScyllaDoctorException("keystore unavailable"))
-def test_download_fallback_to_basic_on_full_failure(mock_download_full, mock_boto_client, mock_node, mock_test_config):
-    """When full download fails, download_scylla_doctor should fall back to basic edition."""
+def test_download_full_failure_propagates(mock_download_full, mock_boto_client, mock_node, mock_test_config):
+    """When full download fails, download_scylla_doctor should propagate the exception (no fallback)."""
     test_config, params = mock_test_config
     params["scylla_doctor_edition"] = "full"
     params["scylla_doctor_version"] = "1.9"
 
-    now = datetime.datetime.now(tz=datetime.timezone.utc)
-    mock_s3 = MagicMock()
-    mock_s3.list_objects.return_value = {
-        "Contents": [
-            {"Key": "downloads/scylla-doctor/tar/scylla-doctor-1.9.0.tar.gz", "LastModified": now},
-        ]
-    }
-    mock_boto_client.return_value = mock_s3
-
     doc = ScyllaDoctor(node=mock_node, test_config=test_config, offline_install=True)
-    doc.download_scylla_doctor()
 
-    # Full was attempted and failed
+    with pytest.raises(ScyllaDoctorException, match="keystore unavailable"):
+        doc.download_scylla_doctor()
+
     mock_download_full.assert_called_once()
-
-    # Basic download path was exercised — curl with the public URL was called
-    curl_calls = [call for call in mock_node.remoter.run.call_args_list if "downloads.scylladb.com" in str(call)]
-    assert len(curl_calls) == 1
 
 
 @patch("utils.scylla_doctor.boto3.client")
@@ -346,9 +337,92 @@ def test_download_basic_edition_skips_full(mock_boto_client, mock_node, mock_tes
     doc = ScyllaDoctor(node=mock_node, test_config=test_config, offline_install=True)
 
     with patch.object(ScyllaDoctor, "download_full_scylla_doctor") as mock_full:
-        doc.download_scylla_doctor()
+        with patch.object(doc, "_download_and_extract_tarball") as mock_extract:
+            doc.download_scylla_doctor()
         mock_full.assert_not_called()
 
-    # Basic path was used — curl with the public URL
-    curl_calls = [call for call in mock_node.remoter.run.call_args_list if "downloads.scylladb.com" in str(call)]
-    assert len(curl_calls) == 1
+    # Basic path was used — _download_and_extract_tarball was called with the public URL
+    mock_extract.assert_called_once()
+    call_url = mock_extract.call_args[0][0]
+    assert "downloads.scylladb.com" in call_url
+
+
+# --- _get_bucket_region tests ---
+
+
+@pytest.mark.parametrize(
+    "bucket_name,expected_region",
+    [
+        ("fe-artifacts-297607762119-eu-central-1", "eu-central-1"),
+        ("my-bucket-us-west-2", "us-west-2"),
+        ("something-ap-southeast-1", "ap-southeast-1"),
+        ("bucket-sa-east-1", "sa-east-1"),
+    ],
+)
+def test_get_bucket_region_from_name(bucket_name, expected_region):
+    """Region should be extracted from bucket name when it ends with a valid AWS region."""
+    assert ScyllaDoctor._get_bucket_region(bucket_name) == expected_region
+
+
+@patch("utils.scylla_doctor.boto3.client")
+def test_get_bucket_region_fallback_to_api(mock_boto_client):
+    """When bucket name doesn't contain a region, fall back to get_bucket_location API."""
+    mock_s3 = MagicMock()
+    mock_s3.get_bucket_location.return_value = {"LocationConstraint": "eu-west-1"}
+    mock_boto_client.return_value = mock_s3
+
+    assert ScyllaDoctor._get_bucket_region("my-plain-bucket") == "eu-west-1"
+
+
+# --- _download_and_extract_tarball tests ---
+
+
+def test_download_and_extract_tarball_rejects_non_gzip(mock_node, mock_test_config):
+    """When downloaded file is not a gzip tarball, ScyllaDoctorException should be raised."""
+    test_config, _params = mock_test_config
+
+    # Make the file check return non-gzip
+    check_result = MagicMock()
+    check_result.ok = True
+    check_result.stdout = "ASCII text"
+
+    head_result = MagicMock()
+    head_result.stdout = "<Error><Code>AccessDenied</Code></Error>"
+
+    rm_result = MagicMock()
+    rm_result.ok = True
+
+    # First call: curl download (succeeds), second: file check, third: head, fourth: rm
+    mock_node.remoter.run.side_effect = [
+        MagicMock(ok=True),  # curl download
+        check_result,  # file check
+        head_result,  # head -c 500
+        rm_result,  # rm -f
+    ]
+
+    doc = ScyllaDoctor(node=mock_node, test_config=test_config, offline_install=True)
+
+    with pytest.raises(ScyllaDoctorException, match="not a valid gzip tarball"):
+        doc._download_and_extract_tarball("https://example.com/bad.tar.gz")
+
+
+# --- _full_edition_downloaded tests ---
+
+
+def test_full_edition_downloaded_flag_set_on_success(mock_node, mock_test_config):
+    """After successful full download, _full_edition_downloaded should be True."""
+    test_config, params = mock_test_config
+    params["scylla_doctor_edition"] = "full"
+
+    doc = ScyllaDoctor(node=mock_node, test_config=test_config, offline_install=True)
+    assert not getattr(doc, "_full_edition_downloaded", False)
+
+    with patch.object(doc, "download_full_scylla_doctor") as mock_full:
+
+        def set_flag():
+            doc._full_edition_downloaded = True
+
+        mock_full.side_effect = set_flag
+        doc.download_scylla_doctor()
+
+    assert doc._full_edition_downloaded is True

--- a/utils/scylla_doctor.py
+++ b/utils/scylla_doctor.py
@@ -2,6 +2,7 @@
 import json
 import logging
 import pprint
+import re
 from functools import cached_property
 from textwrap import dedent
 
@@ -174,6 +175,77 @@ class ScyllaDoctor:
 
         return package, bucket_name
 
+    @staticmethod
+    def _get_bucket_region(bucket_name: str) -> str:
+        """Determine the AWS region of an S3 bucket.
+
+        Pre-signed URLs must be signed with the bucket's actual region;
+        using the wrong region causes S3 to return a small XML error
+        (``SignatureDoesNotMatch`` / ``AccessDenied``) instead of the file.
+
+        Strategy:
+        1. Extract region from the bucket name (e.g.
+           ``fe-artifacts-297607762119-eu-central-1`` → ``eu-central-1``).
+        2. Fall back to ``get_bucket_location`` API (requires
+           ``s3:GetBucketLocation`` permission).
+        3. Fall back to ``us-east-1`` as last resort.
+        """
+        # Pattern matches standard AWS region names at the end of the bucket name
+        match = re.search(r"((?:us|eu|ap|sa|ca|me|af|il)-[a-z]+-\d+)$", bucket_name)
+        if match:
+            region = match.group(1)
+            LOGGER.info("Extracted region %s from bucket name %s", region, bucket_name)
+            return region
+
+        try:
+            s3 = boto3.client("s3")
+            location = s3.get_bucket_location(Bucket=bucket_name)
+            # get_bucket_location returns None for us-east-1
+            return location.get("LocationConstraint") or "us-east-1"
+        except Exception:  # noqa: BLE001
+            LOGGER.warning("Could not determine region for bucket %s, defaulting to us-east-1", bucket_name)
+            return "us-east-1"
+
+    def _download_and_extract_tarball(self, url: str, description: str = "scylla-doctor"):
+        """Download a tarball from *url* and extract it on the remote node.
+
+        Downloads to a temporary file first so that HTTP errors (e.g. S3
+        returning a short XML error page) are detected before ``tar`` runs.
+
+        Args:
+            url: Full URL (may be a pre-signed S3 URL).
+            description: Human-readable label for log messages.
+
+        Raises:
+            Exception: Propagated from ``remoter.run`` on download or
+                extraction failure.
+        """
+        tmp_tarball = "/tmp/scylla_doctor_download.tar.gz"
+        # -f/--fail  → exit code 22 on HTTP 4xx/5xx instead of saving the error page
+        # -S/--show-error → print error message even when -f is used
+        # -L/--location  → follow redirects
+        self.node.remoter.run(
+            f"curl -fSL -o {tmp_tarball} '{url}'",
+        )
+        # Sanity-check: a valid tarball is at least a few KB
+        check = self.node.remoter.run(
+            f"test -s {tmp_tarball} && file {tmp_tarball}",
+            verbose=False,
+            ignore_status=True,
+        )
+        if not check.ok or "gzip" not in check.stdout.lower():
+            body_head = self.node.remoter.run(
+                f"head -c 500 {tmp_tarball}",
+                verbose=False,
+                ignore_status=True,
+            ).stdout.strip()
+            self.node.remoter.run(f"rm -f {tmp_tarball}", verbose=False, ignore_status=True)
+            raise ScyllaDoctorException(
+                f"Downloaded {description} file is not a valid gzip tarball. First 500 bytes of response:\n{body_head}"
+            )
+        LOGGER.info("Extracting %s tarball...", description)
+        self.node.remoter.run(f"tar -xvzf {tmp_tarball} && rm -f {tmp_tarball}")
+
     def download_full_scylla_doctor(self):
         """Download the full scylla-doctor edition using an S3 pre-signed URL.
 
@@ -201,30 +273,33 @@ class ScyllaDoctor:
         package_filename = package_key.split("/")[-1]
         LOGGER.info("Downloading full scylla-doctor package %s from bucket %s...", package_filename, bucket_name)
 
-        # Generate a short-lived pre-signed URL (300s) so the remote node can download without AWS creds
-        s3 = boto3.client("s3")
+        # Generate a short-lived pre-signed URL (300s) so the remote node can download without AWS creds.
+        # IMPORTANT: The S3 client MUST be created with the bucket's actual region.
+        # Pre-signed URLs are signed with a specific region; if the signing region
+        # doesn't match the bucket's region, S3 returns a small XML error response
+        # (e.g. SignatureDoesNotMatch / AccessDenied) instead of the file.
+        bucket_region = self._get_bucket_region(bucket_name)
+        LOGGER.info("Bucket %s is in region %s", bucket_name, bucket_region)
+        s3 = boto3.client("s3", region_name=bucket_region)
         presigned_url = s3.generate_presigned_url(
             ClientMethod="get_object",
             Params={"Bucket": bucket_name, "Key": package_key},
             ExpiresIn=300,
         )
 
-        self.node.remoter.run(f"curl -JL '{presigned_url}' | tar -xvz")
+        self._download_and_extract_tarball(presigned_url, description=f"full scylla-doctor ({package_filename})")
         self.scylla_doctor_exec = f"{self.current_dir}/{self.SCYLLA_DOCTOR_OFFLINE_BIN}"
+        self._full_edition_downloaded = True
 
     def download_scylla_doctor(self):
         if self.configured_edition == "full":
-            try:
-                self.download_full_scylla_doctor()
-                return
-            except (ScyllaDoctorException, Exception) as exc:  # noqa: BLE001
-                LOGGER.warning("Failed to download full scylla-doctor edition, falling back to basic: %s", exc)
+            self.download_full_scylla_doctor()
+            return
 
         if self.node.remoter.run("curl --version", ignore_status=True).ok:
             LOGGER.info("curl already installed, proceeding...")
         else:
             self.node.install_package("curl")
-
         if self.configured_version:
             LOGGER.info("Using configured scylla-doctor version: %s", self.configured_version)
             package = self.locate_scylla_doctor_package(version=self.configured_version)
@@ -239,7 +314,10 @@ class ScyllaDoctor:
         package_path = package["Key"]
         package_filename = package_path.split("/")[-1]
         LOGGER.info("Downloading %s...", package_filename)
-        self.node.remoter.run(f"curl -JL {self.SCYLLA_DOCTOR_OFFLINE_DOWNLOAD_URI}{package_path} | tar -xvz")
+        self._download_and_extract_tarball(
+            f"{self.SCYLLA_DOCTOR_OFFLINE_DOWNLOAD_URI}{package_path}",
+            description=f"scylla-doctor ({package_filename})",
+        )
         self.scylla_doctor_exec = f"{self.current_dir}/{self.SCYLLA_DOCTOR_OFFLINE_BIN}"
 
     def update_scylla_doctor_config(self, prefix: str, additional_config=""):


### PR DESCRIPTION
Remove the try/except fallback in download_scylla_doctor() so that a full-edition download failure propagates immediately instead of silently falling back to the basic edition.

Add _get_bucket_region() to determine the bucket actual region via get_bucket_location before generating the pre-signed URL, fixing SignatureDoesNotMatch errors when the SCT runner region differs from the bucket region.

Add _download_and_extract_tarball() helper that downloads to a temp file with curl --fail, validates it is a gzip tarball, then extracts. This replaces the fragile curl|tar pipe in all download paths.

Track actual full edition installation via _full_edition_downloaded flag so callers can check whether the full edition was installed.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [artifacts-amazon2023-arm-test + full scylla-doctor](https://argus.scylladb.com/tests/scylla-cluster-tests/3ed49531-f1f5-4041-8e2d-26144b1ca3f7)
- [x] [artifacts-amazon2023-arm-test + basic scylla-doctor](https://argus.scylladb.com/tests/scylla-cluster-tests/2ee00e4c-2342-4423-b2e9-7c2d130b5bc6)
- [x] [artifacts-ami-test + full scylla-doctor](https://argus.scylladb.com/tests/scylla-cluster-tests/899d73fb-c0a6-47e4-a143-308e2a5dc6b9)
- [x] [artifacts-ami-test + basic scylla-doctor](https://argus.scylladb.com/tests/scylla-cluster-tests/00074922-fae3-4bc2-85ce-d05c9f282792)
- [x] [artifacts-rocky8-test + basic scylla-doctor](https://argus.scylladb.com/tests/scylla-cluster-tests/4d8edbb9-fad1-472e-9e2f-eb2638c13c8b)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
