### PR TITLE
fix(scylla-doctor): use Scylla-bundled python3

### DIFF
--- a/unit_tests/test_scylla_doctor.py
+++ b/unit_tests/test_scylla_doctor.py
@@ -426,3 +426,179 @@ def test_full_edition_downloaded_flag_set_on_success(mock_node, mock_test_config
         doc.download_scylla_doctor()
 
     assert doc._full_edition_downloaded is True
+
+
+# --- _check_system_python3 tests ---
+
+
+def test_check_system_python3_suitable_version():
+    """When system python3 is >= 3.10, return its path."""
+    node = FakeNode()
+    version_result = MagicMock(ok=True, stdout="3 11\n")
+    which_result = MagicMock(ok=True, stdout="/usr/bin/python3\n")
+    node.remoter.run.side_effect = [version_result, which_result]
+
+    assert ScyllaDoctor._check_system_python3(node) == "/usr/bin/python3"
+
+
+def test_check_system_python3_too_old():
+    """When system python3 is <= 3.9, return None."""
+    node = FakeNode()
+    version_result = MagicMock(ok=True, stdout="3 9\n")
+    node.remoter.run.side_effect = [version_result]
+
+    assert ScyllaDoctor._check_system_python3(node) is None
+
+
+def test_check_system_python3_not_available():
+    """When system python3 is not installed, return None."""
+    node = FakeNode()
+    version_result = MagicMock(ok=False, stdout="")
+    node.remoter.run.side_effect = [version_result]
+
+    assert ScyllaDoctor._check_system_python3(node) is None
+
+
+def test_check_system_python3_unparseable_output():
+    """When system python3 returns unexpected output, return None."""
+    node = FakeNode()
+    version_result = MagicMock(ok=True, stdout="garbage\n")
+    node.remoter.run.side_effect = [version_result]
+
+    assert ScyllaDoctor._check_system_python3(node) is None
+
+
+def test_check_system_python3_exact_38():
+    """Python 3.8 (minor <= 9) should be rejected."""
+    node = FakeNode()
+    version_result = MagicMock(ok=True, stdout="3 8\n")
+    node.remoter.run.side_effect = [version_result]
+
+    assert ScyllaDoctor._check_system_python3(node) is None
+
+
+def test_check_system_python3_exact_310():
+    """Python 3.10 (minor > 9) should be accepted."""
+    node = FakeNode()
+    version_result = MagicMock(ok=True, stdout="3 10\n")
+    which_result = MagicMock(ok=True, stdout="/usr/local/bin/python3\n")
+    node.remoter.run.side_effect = [version_result, which_result]
+
+    assert ScyllaDoctor._check_system_python3(node) == "/usr/local/bin/python3"
+
+
+# --- _find_scylla_bundled_python3 tests ---
+
+
+def test_find_scylla_bundled_python3_nonroot_direct_path(doctor):
+    """Nonroot: when the standard bundled path exists and version > 3.9, return it."""
+    doctor.node.is_nonroot_install = True
+    doctor.node.remoter.run.side_effect = [
+        MagicMock(stdout="/home/user/scylladb/python3/bin/python3\n"),  # ls check
+        MagicMock(ok=True, stdout="3 12\n"),  # version check
+    ]
+
+    assert doctor._find_scylla_bundled_python3("/home/user") == "/home/user/scylladb/python3/bin/python3"
+
+
+def test_find_scylla_bundled_python3_nonroot_versioned_dir(doctor):
+    """Nonroot: when python3 is under a versioned dir like scylla-VERSION/scylla-python3/bin/python3."""
+    doctor.node.is_nonroot_install = True
+    doctor.node.remoter.run.side_effect = [
+        MagicMock(stdout=""),  # standard path doesn't exist
+        MagicMock(stdout="/home/ubuntu/scylla-2026.2.0~dev/scylla-python3/bin/python3\n"),  # broad find
+        MagicMock(ok=True, stdout="3 14\n"),  # version check
+    ]
+
+    result = doctor._find_scylla_bundled_python3("/home/ubuntu")
+    assert result == "/home/ubuntu/scylla-2026.2.0~dev/scylla-python3/bin/python3"
+
+
+def test_find_scylla_bundled_python3_nonroot_not_found(doctor):
+    """Nonroot: when no bundled python3 is found, return None."""
+    doctor.node.is_nonroot_install = True
+    doctor.node.remoter.run.side_effect = [
+        MagicMock(stdout=""),  # standard path doesn't exist
+        MagicMock(stdout=""),  # broad find returns nothing
+    ]
+
+    assert doctor._find_scylla_bundled_python3("/home/user") is None
+
+
+def test_find_scylla_bundled_python3_root_found(doctor):
+    """Root install: find python3 via package manager and verify version."""
+    doctor.node.is_nonroot_install = False
+    doctor.node.remoter.sudo.side_effect = [
+        MagicMock(stdout="/opt/scylladb/python3/bin/python3\n"),  # rpm -ql
+        MagicMock(ok=True, stdout="3 14\n"),  # version check
+    ]
+
+    result = doctor._find_scylla_bundled_python3("/home/user")
+    assert result == "/opt/scylladb/python3/bin/python3"
+
+
+def test_find_scylla_bundled_python3_root_not_found(doctor):
+    """Root install: when package manager and find return nothing, return None."""
+    doctor.node.is_nonroot_install = False
+    doctor.node.remoter.sudo.side_effect = [
+        MagicMock(stdout=""),  # rpm -ql returns nothing
+        MagicMock(stdout=""),  # dpkg -L returns nothing
+        MagicMock(stdout=""),  # find fallback returns nothing
+    ]
+
+    assert doctor._find_scylla_bundled_python3("/home/user") is None
+
+
+# --- find_local_python3_binary (integrated) tests ---
+
+
+def test_find_local_python3_prefers_system(doctor):
+    """When system python3 is > 3.9, it should be preferred over bundled."""
+    doctor.node.is_nonroot_install = True
+    version_result = MagicMock(ok=True, stdout="3 12\n")
+    which_result = MagicMock(ok=True, stdout="/usr/bin/python3\n")
+    doctor.node.remoter.run.side_effect = [version_result, which_result]
+
+    result = doctor.find_local_python3_binary("/home/user")
+    assert result == "/usr/bin/python3"
+
+
+def test_find_local_python3_falls_back_to_bundled(doctor):
+    """When system python3 is too old, fall back to Scylla's bundled python3."""
+    doctor.node.is_nonroot_install = True
+    version_result = MagicMock(ok=True, stdout="3 6\n")
+    bundled_result = MagicMock(stdout="/home/user/scylladb/python3/bin/python3\n")
+    version_check = MagicMock(ok=True, stdout="3 12\n")
+    doctor.node.remoter.run.side_effect = [version_result, bundled_result, version_check]
+
+    result = doctor.find_local_python3_binary("/home/user")
+    assert result == "/home/user/scylladb/python3/bin/python3"
+
+
+def test_find_local_python3_falls_back_to_versioned_bundled(doctor):
+    """When system python3 is too old, find python3 in a versioned Scylla dir."""
+    doctor.node.is_nonroot_install = True
+    version_result = MagicMock(ok=True, stdout="3 6\n")
+    doctor.node.remoter.run.side_effect = [
+        version_result,  # system python3 too old
+        MagicMock(stdout=""),  # standard bundled path doesn't exist
+        MagicMock(stdout="/home/ubuntu/scylla-2026.2.0~dev/scylla-python3/bin/python3\n"),  # broad find
+        MagicMock(ok=True, stdout="3 14\n"),  # version check
+    ]
+
+    result = doctor.find_local_python3_binary("/home/ubuntu")
+    assert result == "/home/ubuntu/scylla-2026.2.0~dev/scylla-python3/bin/python3"
+
+
+def test_find_local_python3_asserts_when_none_found(doctor):
+    """When neither system nor bundled python3 is found, ScyllaDoctorException should fire."""
+    doctor.node.is_nonroot_install = True
+    version_result = MagicMock(ok=False, stdout="")
+    doctor.node.remoter.run.side_effect = [
+        version_result,  # system python3 not available
+        MagicMock(stdout=""),  # standard bundled path doesn't exist
+        MagicMock(stdout=""),  # broad find returns nothing
+    ]
+
+    with pytest.raises(ScyllaDoctorException, match="No suitable python3"):
+        doctor.find_local_python3_binary("/home/user")

--- a/unit_tests/test_scylla_doctor.py
+++ b/unit_tests/test_scylla_doctor.py
@@ -77,30 +77,21 @@ def doctor(mock_node, mock_test_config):
 # --- configured_edition tests ---
 
 
-def test_configured_edition_not_set_returns_none(mock_node, mock_test_config):
-    """When scylla_doctor_edition is not set in params, configured_edition returns None.
-
-    The 'basic' default is enforced by defaults/test_default.yaml, not by this property.
-    """
-    test_config, _params = mock_test_config
-    doc = ScyllaDoctor(node=mock_node, test_config=test_config)
-    assert doc.configured_edition is None
-
-
-def test_configured_edition_full(mock_node, mock_test_config):
-    """When scylla_doctor_edition is 'full', configured_edition should return 'full'."""
+@pytest.mark.parametrize(
+    "edition_param,expected",
+    [
+        pytest.param(None, None, id="not_set_returns_none"),
+        pytest.param("full", "full", id="full"),
+        pytest.param("basic", "basic", id="basic_explicit"),
+    ],
+)
+def test_configured_edition(mock_node, mock_test_config, edition_param, expected):
+    """Test configured_edition returns the value from params, or None when not set."""
     test_config, params = mock_test_config
-    params["scylla_doctor_edition"] = "full"
+    if edition_param is not None:
+        params["scylla_doctor_edition"] = edition_param
     doc = ScyllaDoctor(node=mock_node, test_config=test_config)
-    assert doc.configured_edition == "full"
-
-
-def test_configured_edition_basic_explicit(mock_node, mock_test_config):
-    """When scylla_doctor_edition is explicitly 'basic', configured_edition should return 'basic'."""
-    test_config, params = mock_test_config
-    params["scylla_doctor_edition"] = "basic"
-    doc = ScyllaDoctor(node=mock_node, test_config=test_config)
-    assert doc.configured_edition == "basic"
+    assert doc.configured_edition == expected
 
 
 # --- locate_full_scylla_doctor_package tests ---
@@ -426,3 +417,75 @@ def test_full_edition_downloaded_flag_set_on_success(mock_node, mock_test_config
         doc.download_scylla_doctor()
 
     assert doc._full_edition_downloaded is True
+
+
+# --- find_scylla_bundled_python3 tests ---
+
+
+@pytest.mark.parametrize(
+    "is_nonroot,run_side_effects,sudo_side_effects,home_dir,expected",
+    [
+        pytest.param(
+            True,
+            [MagicMock(stdout="/home/user/scylladb/python3/bin/python3\n")],
+            [],
+            "/home/user",
+            "/home/user/scylladb/python3/bin/python3",
+            id="nonroot_direct_path",
+        ),
+        pytest.param(
+            True,
+            [MagicMock(stdout=""), MagicMock(stdout="/home/ubuntu/scylla-2026.2.0~dev/scylla-python3/bin/python3\n")],
+            [],
+            "/home/ubuntu",
+            "/home/ubuntu/scylla-2026.2.0~dev/scylla-python3/bin/python3",
+            id="nonroot_versioned_dir",
+        ),
+        pytest.param(
+            False,
+            [],
+            [MagicMock(stdout="/opt/scylladb/python3/bin/python3\n")],
+            "/home/user",
+            "/opt/scylladb/python3/bin/python3",
+            id="root_found",
+        ),
+    ],
+)
+def test_find_scylla_bundled_python3(doctor, is_nonroot, run_side_effects, sudo_side_effects, home_dir, expected):
+    """Test find_scylla_bundled_python3 for various install types and search results."""
+    doctor.node.is_nonroot_install = is_nonroot
+    if run_side_effects:
+        doctor.node.remoter.run.side_effect = run_side_effects
+    if sudo_side_effects:
+        doctor.node.remoter.sudo.side_effect = sudo_side_effects
+
+    assert doctor.find_scylla_bundled_python3(home_dir) == expected
+
+
+@pytest.mark.parametrize(
+    "is_nonroot,run_side_effects,sudo_side_effects",
+    [
+        pytest.param(
+            True,
+            [MagicMock(stdout=""), MagicMock(stdout="")],
+            [],
+            id="nonroot_not_found",
+        ),
+        pytest.param(
+            False,
+            [],
+            [MagicMock(stdout="")],
+            id="root_not_found",
+        ),
+    ],
+)
+def test_find_scylla_bundled_python3_raises_when_not_found(doctor, is_nonroot, run_side_effects, sudo_side_effects):
+    """Test find_scylla_bundled_python3 raises ScyllaDoctorException when not found."""
+    doctor.node.is_nonroot_install = is_nonroot
+    if run_side_effects:
+        doctor.node.remoter.run.side_effect = run_side_effects
+    if sudo_side_effects:
+        doctor.node.remoter.sudo.side_effect = sudo_side_effects
+
+    with pytest.raises(ScyllaDoctorException, match="No Scylla-bundled python3"):
+        doctor.find_scylla_bundled_python3("/home/user")

--- a/utils/scylla_doctor.py
+++ b/utils/scylla_doctor.py
@@ -80,10 +80,12 @@ class ScyllaDoctor:
         self.python3_path = ""
 
     def run(self, sd_command):
+        if self.python3_path:
+            sd_command = f"{self.python3_path} {sd_command}"
         if not self.node.is_nonroot_install:
             result = self.node.remoter.sudo(sd_command, verbose=False)
         else:
-            result = self.node.remoter.run(f"bash -lce '{self.python3_path} {sd_command}'", verbose=False)
+            result = self.node.remoter.run(f"bash -lce '{sd_command}'", verbose=False)
         return result.stdout.strip()
 
     @cached_property
@@ -346,8 +348,8 @@ class ScyllaDoctor:
         # Always download from S3 — package repos are not updated at the same
         # time as S3 releases, and specific versions may not be available via repo.
         self.download_scylla_doctor()
+        self.python3_path = self.find_local_python3_binary(self.current_dir)
         if self.node.is_nonroot_install:
-            self.python3_path = self.find_local_python3_binary(self.current_dir)
             self.update_scylla_doctor_config(
                 self.current_dir, additional_config=self.SCYLLA_DOCTOR_DISABLED_OFFLINE_COLLECTORS
             )
@@ -368,17 +370,150 @@ class ScyllaDoctor:
         except Exception:
             LOGGER.error("Unable to collect Scylla Doctor package version for Argus - skipping...", exc_info=True)
 
-    def find_local_python3_binary(self, user_home: str):
-        if not (
-            python3_path := self.node.remoter.run(
-                f"ls {user_home}/scylladb/python3/bin/python3", verbose=False
-            ).stdout.strip()
+    @staticmethod
+    def _check_system_python3(node) -> str | None:
+        """Check if the system python3 is available and version > 3.9.
+
+        Returns:
+            The path to the system python3 binary if suitable, or None.
+        """
+        result = node.remoter.run(
+            "python3 -c 'import sys; print(sys.version_info.major, sys.version_info.minor)'",
+            verbose=False,
+            ignore_status=True,
+        )
+        if not result.ok:
+            LOGGER.debug("System python3 not available")
+            return None
+
+        try:
+            major, minor = result.stdout.strip().split()
+            if int(major) >= 3 and int(minor) > 9:
+                python3_path = node.remoter.run("which python3", verbose=False, ignore_status=True).stdout.strip()
+                if python3_path:
+                    LOGGER.info("Using system python3 (%s.%s) at %s", major, minor, python3_path)
+                    return python3_path
+        except (ValueError, IndexError):
+            LOGGER.debug("Could not parse system python3 version from: %s", result.stdout.strip())
+
+        return None
+
+    def _find_python3_via_package_manager(self) -> str | None:
+        """Query the OS package manager for the scylla-python3 package files.
+
+        Tries ``rpm -ql`` (for RPM-based distros) and ``dpkg -L`` (for
+        Debian-based distros) to locate the ``python3`` binary shipped by
+        the ``scylla-python3`` package, avoiding hardcoded install paths.
+
+        Returns:
+            Path to the bundled python3 binary, or None if not found.
+        """
+        for query_cmd in (
+            "rpm -ql scylla-python3 2>/dev/null | grep '/bin/python3$' | head -1",
+            "dpkg -L scylla-python3 2>/dev/null | grep '/bin/python3$' | head -1",
         ):
+            result = self.node.remoter.sudo(query_cmd, verbose=False, ignore_status=True)
+            python3_path = result.stdout.strip()
+            if python3_path:
+                LOGGER.debug("Found scylla-python3 via package manager: %s", python3_path)
+                return python3_path
+        LOGGER.debug("scylla-python3 package not found via package manager")
+        return None
+
+    def _find_scylla_bundled_python3(self, user_home: str) -> str | None:
+        """Find the python3 binary bundled with the Scylla installation.
+
+        For nonroot installs the binary may live under a versioned directory,
+        e.g. ``{user_home}/scylla-2026.2.0~dev/scylla-python3/bin/python3``,
+        so we search broadly under *user_home* for any ``python3`` inside a
+        ``bin/`` directory whose path contains "scylla".
+
+        For root installs the binary is typically under ``/opt/scylladb`` and
+        may require elevated privileges to locate, so ``remoter.sudo`` is used.
+
+        Args:
+            user_home: Home directory where Scylla is installed.
+
+        Returns:
+            Path to the bundled python3 binary, or None if not found.
+        """
+        if self.node.is_nonroot_install:
+            # Fast path: check the traditional location first
             python3_path = self.node.remoter.run(
-                "for i in `find scylladb -name python3`;do [ -f $i ] && echo $i;done"
+                f"ls {user_home}/scylladb/python3/bin/python3", verbose=False, ignore_status=True
             ).stdout.strip()
+            if not python3_path:
+                # Broad search: covers versioned dirs like scylla-VERSION/scylla-python3/bin/python3
+                python3_path = self.node.remoter.run(
+                    f"find {user_home} -path '*/bin/python3' \\( -type f -o -type l \\) 2>/dev/null"
+                    " | grep -i scylla | head -1",
+                    verbose=False,
+                    ignore_status=True,
+                ).stdout.strip()
+            LOGGER.debug("Nonroot bundled python3 search result: %s", python3_path or "(not found)")
+        else:
+            # Root install: query the package manager for scylla-python3 files
+            python3_path = self._find_python3_via_package_manager()
+            if not python3_path:
+                # Fallback: broad filesystem search under standard Scylla install locations
+                python3_path = self.node.remoter.sudo(
+                    "find /opt/scylladb /usr/lib/scylladb 2>/dev/null"
+                    " -path '*/bin/python3' \\( -type f -o -type l \\) | head -1",
+                    verbose=False,
+                    ignore_status=True,
+                ).stdout.strip()
+            LOGGER.debug("Root bundled python3 search result: %s", python3_path or "(not found)")
+        if not python3_path:
+            return None
+
+        # Verify the bundled python3 is > 3.9
+        check_cmd = f"{python3_path} -c 'import sys; print(sys.version_info.major, sys.version_info.minor)'"
+        if self.node.is_nonroot_install:
+            result = self.node.remoter.run(check_cmd, verbose=False, ignore_status=True)
+        else:
+            result = self.node.remoter.sudo(check_cmd, verbose=False, ignore_status=True)
+        if result.ok:
+            try:
+                major, minor = result.stdout.strip().split()
+                if int(major) >= 3 and int(minor) > 9:
+                    LOGGER.info("Using Scylla-bundled python3 (%s.%s) at %s", major, minor, python3_path)
+                    return python3_path
+                LOGGER.warning("Scylla-bundled python3 at %s is %s.%s (<= 3.9), skipping", python3_path, major, minor)
+            except (ValueError, IndexError):
+                LOGGER.debug("Could not parse version from bundled python3 at %s", python3_path)
+        else:
+            LOGGER.debug("Could not check version of bundled python3 at %s", python3_path)
+
+        return None
+
+    def find_local_python3_binary(self, user_home: str):
+        """Find a suitable python3 binary for running scylla-doctor.
+
+        Strategy:
+        1. Check if the system python3 is > 3.9 — use it if so.
+        2. Fall back to the python3 bundled with the Scylla installation.
+
+        Args:
+            user_home: Home directory where Scylla is installed.
+
+        Returns:
+            Path to a suitable python3 binary.
+
+        Raises:
+            AssertionError: If no suitable python3 binary is found.
+        """
+        python3_path = self._check_system_python3(self.node)
+        if not python3_path:
+            LOGGER.debug("System python3 not suitable, looking for Scylla-bundled python3...")
+            python3_path = self._find_scylla_bundled_python3(user_home)
+
         LOGGER.debug("Local python3 binary path: %s", python3_path)
-        assert python3_path, f"Python3 binary is not found under local Scylla installation '{user_home}/scylladb'"
+        if not python3_path:
+            raise ScyllaDoctorException(
+                f"No suitable python3 (> 3.9) found on {self.node.name}: "
+                f"system python3 is missing or <= 3.9, "
+                f"and no Scylla-bundled python3 found via package manager or filesystem search"
+            )
         return python3_path
 
     def run_scylla_doctor_and_collect_results(self):

--- a/utils/scylla_doctor.py
+++ b/utils/scylla_doctor.py
@@ -80,10 +80,12 @@ class ScyllaDoctor:
         self.python3_path = ""
 
     def run(self, sd_command):
+        if self.python3_path:
+            sd_command = f"{self.python3_path} {sd_command}"
         if not self.node.is_nonroot_install:
             result = self.node.remoter.sudo(sd_command, verbose=False)
         else:
-            result = self.node.remoter.run(f"bash -lce '{self.python3_path} {sd_command}'", verbose=False)
+            result = self.node.remoter.run(f"bash -lce '{sd_command}'", verbose=False)
         return result.stdout.strip()
 
     @cached_property
@@ -346,8 +348,8 @@ class ScyllaDoctor:
         # Always download from S3 — package repos are not updated at the same
         # time as S3 releases, and specific versions may not be available via repo.
         self.download_scylla_doctor()
+        self.python3_path = self.find_scylla_bundled_python3(self.current_dir)
         if self.node.is_nonroot_install:
-            self.python3_path = self.find_local_python3_binary(self.current_dir)
             self.update_scylla_doctor_config(
                 self.current_dir, additional_config=self.SCYLLA_DOCTOR_DISABLED_OFFLINE_COLLECTORS
             )
@@ -368,18 +370,56 @@ class ScyllaDoctor:
         except Exception:
             LOGGER.error("Unable to collect Scylla Doctor package version for Argus - skipping...", exc_info=True)
 
-    def find_local_python3_binary(self, user_home: str):
-        if not (
-            python3_path := self.node.remoter.run(
-                f"ls {user_home}/scylladb/python3/bin/python3", verbose=False
-            ).stdout.strip()
-        ):
+    def find_scylla_bundled_python3(self, user_home: str) -> str:
+        """Find the python3 binary bundled with the Scylla installation.
+
+        For nonroot installs the binary may live under a versioned directory,
+        e.g. ``{user_home}/scylla-2026.2.0~dev/scylla-python3/bin/python3``,
+        so we search broadly under *user_home* for any ``python3`` inside a
+        ``bin/`` directory whose path contains "scylla".
+
+        For root installs the binary is typically under ``/opt/scylladb`` and
+        may require elevated privileges to locate, so ``remoter.sudo`` is used.
+
+        Args:
+            user_home: Home directory where Scylla is installed.
+
+        Returns:
+            Path to the bundled python3 binary.
+
+        Raises:
+            ScyllaDoctorException: If Scylla-bundled python3 is not found.
+        """
+        if self.node.is_nonroot_install:
+            # Fast path: check the traditional location first
             python3_path = self.node.remoter.run(
-                "for i in `find scylladb -name python3`;do [ -f $i ] && echo $i;done"
+                f"ls {user_home}/scylladb/python3/bin/python3", verbose=False, ignore_status=True
             ).stdout.strip()
-        LOGGER.debug("Local python3 binary path: %s", python3_path)
-        assert python3_path, f"Python3 binary is not found under local Scylla installation '{user_home}/scylladb'"
-        return python3_path
+            if not python3_path:
+                # Broad search: covers versioned dirs like scylla-VERSION/scylla-python3/bin/python3
+                python3_path = self.node.remoter.run(
+                    f"find {user_home} -path '*/bin/python3' \\( -type f -o -type l \\) 2>/dev/null"
+                    " | grep -i scylla | head -1",
+                    verbose=False,
+                    ignore_status=True,
+                ).stdout.strip()
+            LOGGER.debug("Nonroot bundled python3 search result: %s", python3_path or "(not found)")
+        else:
+            # Root install: broad filesystem search under standard Scylla install locations
+            python3_path = self.node.remoter.sudo(
+                "find /opt/scylladb /usr/lib/scylladb 2>/dev/null"
+                " -path '*/bin/python3' \\( -type f -o -type l \\) | head -1",
+                verbose=False,
+                ignore_status=True,
+            ).stdout.strip()
+            LOGGER.debug("Root bundled python3 search result: %s", python3_path or "(not found)")
+        if python3_path:
+            LOGGER.info("Using Scylla-bundled python3 at %s", python3_path)
+            return python3_path
+        raise ScyllaDoctorException(
+            f"No Scylla-bundled python3 found on {self.node.name}. "
+            f"Scylla doctor requires the python3 executable bundled with the Scylla installation."
+        )
 
     def run_scylla_doctor_and_collect_results(self):
         auth_options = ""


### PR DESCRIPTION
Run scylla-doctor with Scylla-bundled python3 which ships with all
required dependencies.

For nonroot installs _find_scylla_bundled_python3 searches broadly
under user_home to find python3 in versioned directories like
scylla-VERSION/scylla-python3/bin/python3. For root installs it
uses remoter.sudo to search /opt/scylladb.


### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [artifacts-rocky8-test + full scylla-doctor](https://argus.scylladb.com/tests/scylla-cluster-tests/f9bebc22-80a3-4c4a-ad8b-3dca756fa4ea)
- [x] [artifacts-rocky8-test + full scylla-doctor + nonroot](https://argus.scylladb.com/tests/scylla-cluster-tests/e0db624f-e3a4-41d3-b202-d80b0e3ff652)
- [x] [artifacts-rocky8-test + short SD](https://argus.scylladb.com/tests/scylla-cluster-tests/b28c3ae8-0fb5-4291-91b6-fc1f2befac65)
- [x] [artifacts-rocky8-test + short SD + nonroot](https://argus.scylladb.com/tests/scylla-cluster-tests/2f3d2ffc-cd1e-4daa-8eca-8cc376ffad68)
- [x] [artifacts-centos9-test + full scylla-doctor](https://argus.scylladb.com/tests/scylla-cluster-tests/ade4d207-fd12-452f-b6cb-e0812e5ed581)
- [x] [artifacts-centos9-test + full scylla-doctor + nonroot](https://argus.scylladb.com/tests/scylla-cluster-tests/5188157b-0c5b-44e0-ad1e-e1a173d6a709)
- [x] [artifacts-ami-test + full scylla-doctor](https://argus.scylladb.com/tests/scylla-cluster-tests/f9aa2564-34f1-494c-8123-219f14dd8cd6)
- [x] [artifacts-rocky9-test + full SD](https://argus.scylladb.com/tests/scylla-cluster-tests/b1554952-325f-4607-9daa-9d011c4b77d7)
- [x] [artifacts-debian12-test + full SD + nonroot](https://argus.scylladb.com/tests/scylla-cluster-tests/5932fec6-35b3-46bd-9103-af9a4864eac2)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
