### PR TITLE
fix(unit-tests): replace tempfile.mkdtemp() with pytest tmp_path fixtures

### DIFF
--- a/unit_tests/integration/conftest.py
+++ b/unit_tests/integration/conftest.py
@@ -92,8 +92,9 @@ def mock_remote_scylla_yaml(scylla_node):
 
 
 @contextmanager
-def create_ssl_dir(test_id: str):
-    ssl_dir = (_REPO_ROOT / "data_dir" / f"ssl_conf_{test_id}").absolute()
+def create_ssl_dir(test_id: str, base_dir: Path | None = None):
+    parent = base_dir if base_dir is not None else (_REPO_ROOT / "data_dir")
+    ssl_dir = (parent / f"ssl_conf_{test_id}").absolute()
     ssl_dir.mkdir(parents=True, exist_ok=True)
 
     localhost = LocalHost(user_prefix="unit_test_fake_user", test_id="unit_test_fake_test_id")
@@ -196,11 +197,15 @@ def configure_scylla_node(docker_scylla_args: dict, params, ssl_dir: Path | None
 
 
 @pytest.fixture(name="docker_scylla", scope="function")
-def fixture_docker_scylla(request: pytest.FixtureRequest, params):  # noqa: PLR0914
+def fixture_docker_scylla(request: pytest.FixtureRequest, params, tmp_path):  # noqa: PLR0914
     docker_scylla_args = {}
     if test_marker := request.node.get_closest_marker("docker_scylla_args"):
         docker_scylla_args = test_marker.kwargs
-    ctx = create_ssl_dir(test_id=str(uuid.uuid4())[:8]) if docker_scylla_args.get("ssl") else nullcontext()
+    ctx = (
+        create_ssl_dir(test_id=str(uuid.uuid4())[:8], base_dir=tmp_path)
+        if docker_scylla_args.get("ssl")
+        else nullcontext()
+    )
     with ctx as ssl_dir:
         scylla = configure_scylla_node(docker_scylla_args, params, ssl_dir=ssl_dir)
         yield scylla
@@ -208,12 +213,16 @@ def fixture_docker_scylla(request: pytest.FixtureRequest, params):  # noqa: PLR0
 
 
 @pytest.fixture(name="docker_scylla_2", scope="function")
-def fixture_docker_2_scylla(request: pytest.FixtureRequest, docker_scylla, params):  # noqa: PLR0914
+def fixture_docker_2_scylla(request: pytest.FixtureRequest, docker_scylla, params, tmp_path):  # noqa: PLR0914
     docker_scylla_args = {}
     if test_marker := request.node.get_closest_marker("docker_scylla_args"):
         docker_scylla_args = test_marker.kwargs
     docker_scylla_args["seeds"] = docker_scylla.ip_address
-    ctx = create_ssl_dir(test_id=str(uuid.uuid4())[:8]) if docker_scylla_args.get("ssl") else nullcontext()
+    ctx = (
+        create_ssl_dir(test_id=str(uuid.uuid4())[:8], base_dir=tmp_path)
+        if docker_scylla_args.get("ssl")
+        else nullcontext()
+    )
     with ctx as ssl_dir:
         scylla = configure_scylla_node(docker_scylla_args, params, ssl_dir=ssl_dir)
         yield scylla

--- a/unit_tests/lib/dummy_remote.py
+++ b/unit_tests/lib/dummy_remote.py
@@ -12,9 +12,9 @@
 # Copyright (c) 2020 ScyllaDB
 
 
-import os
 import shutil
 import logging
+import tempfile
 from pathlib import Path
 
 from sdcm.remote import LocalCmdRunner
@@ -46,12 +46,20 @@ class DummyRemote:
 
 class LocalNode(BaseNode):
     def __init__(
-        self, name, parent_cluster, ssh_login_info=None, base_logdir=None, node_prefix=None, dc_idx=0, node_index=1
+        self,
+        name,
+        parent_cluster,
+        ssh_login_info=None,
+        base_logdir=None,
+        node_prefix=None,
+        dc_idx=0,
+        node_index=1,
+        logdir=None,
     ):
         super().__init__(name, parent_cluster)
         self.node_index = node_index
         self.remoter = LocalCmdRunner()
-        self.logdir = os.path.dirname(__file__)
+        self.logdir = logdir or tempfile.mkdtemp(prefix="sct-localnode-")
 
     @property
     def ip_address(self):
@@ -116,12 +124,12 @@ class LocalNode(BaseNode):
 
 
 class LocalLoaderSetDummy(BaseCluster):
-    def __init__(self, nodes=None, params=None):
+    def __init__(self, nodes=None, params=None, logdir=None):
         self.name = "LocalLoaderSetDummy"
         self.params = params or {}
         self.added_password_suffix = False
         self.nodes = nodes if nodes is not None else [LocalNode("loader_node", parent_cluster=self)]
-        self.logdir = os.path.dirname(__file__)
+        self.logdir = logdir or tempfile.mkdtemp(prefix="sct-loader-")
 
     def add_nodes(self, *args, **kwargs):
         raise NotImplementedError

--- a/unit_tests/unit/test_cluster.py
+++ b/unit_tests/unit/test_cluster.py
@@ -12,7 +12,6 @@
 # Copyright (c) 2020 ScyllaDB
 
 import logging
-import shutil
 import tempfile
 import time
 import unittest.mock
@@ -260,13 +259,9 @@ class VersionDummyRemote:
 
 
 class TestBaseNodeGetScyllaVersion:
-    @classmethod
-    def setup_class(cls):
-        cls.temp_dir = tempfile.mkdtemp()
-
-    @classmethod
-    def teardown_class(cls):
-        shutil.rmtree(cls.temp_dir)
+    @pytest.fixture(autouse=True, scope="class")
+    def _class_tmp_dir(self, tmp_path_factory):
+        TestBaseNodeGetScyllaVersion.temp_dir = str(tmp_path_factory.mktemp("scylla_version"))
 
     def setup_method(self):
         self.node = DummyNode(
@@ -428,13 +423,9 @@ class TestBaseNodeGetScyllaVersion:
 
 
 class TestBaseMonitorSet:
-    @classmethod
-    def setup_class(cls):
-        cls.temp_dir = tempfile.mkdtemp()
-
-    @classmethod
-    def teardown_class(cls):
-        shutil.rmtree(cls.temp_dir)
+    @pytest.fixture(autouse=True, scope="class")
+    def _class_tmp_dir(self, tmp_path_factory):
+        TestBaseMonitorSet.temp_dir = str(tmp_path_factory.mktemp("monitor_set"))
 
     def setup_method(self):
         self.node = DummyNode(
@@ -782,11 +773,11 @@ class TestNodetoolStatus:
         ("1-7,9,17-23,25", 16),
     ),
 )
-def test_base_node_cpuset(cat_results, expected_core_number):
+def test_base_node_cpuset(cat_results, expected_core_number, tmp_path):
     dummy_node = DummyNode(
         name="dummy_node",
         parent_cluster=None,
-        base_logdir=tempfile.mkdtemp(),
+        base_logdir=str(tmp_path),
         ssh_login_info=dict(key_file="~/.ssh/scylla-test"),
     )
     dummy_node.parent_cluster = DummyDbCluster([dummy_node])
@@ -816,11 +807,11 @@ def test_base_node_cpuset(cat_results, expected_core_number):
         '# CPUSET="--cpuset 1-7,9-15,17-23,31\' "',
     ),
 )
-def test_base_node_cpuset_not_configured(cat_results):
+def test_base_node_cpuset_not_configured(cat_results, tmp_path):
     dummy_node = DummyNode(
         name="dummy_node",
         parent_cluster=None,
-        base_logdir=tempfile.mkdtemp(),
+        base_logdir=str(tmp_path),
         ssh_login_info=dict(key_file="~/.ssh/scylla-test"),
     )
     dummy_node.parent_cluster = DummyDbCluster([dummy_node])

--- a/unit_tests/unit/test_coredump.py
+++ b/unit_tests/unit/test_coredump.py
@@ -1,5 +1,4 @@
 import time
-import tempfile
 from abc import abstractmethod
 from pathlib import Path
 
@@ -93,6 +92,10 @@ class CoredumpExportTestBase:
     def inject_test_data_dir(self, test_data_dir):
         self.test_data_dir = test_data_dir
 
+    @pytest.fixture(autouse=True)
+    def inject_tmp_path(self, tmp_path):
+        self._tmp_path = tmp_path
+
     @abstractmethod
     def _init_target_coredump_class(self, test_name: str) -> CoredumpThreadBase:
         pass
@@ -130,7 +133,7 @@ class CoredumpExportExceptionTest(CoredumpExportTestBase):
                         self.test_data_dir / "test_coredump" / self.test_data_folder / (test_name + "_remoter.json")
                     )
                 ),
-                tempfile.mkdtemp(),
+                str(self._tmp_path / "logdir"),
             ),
             5,
         )
@@ -156,7 +159,7 @@ class CoredumpExportSystemdTest(CoredumpExportTestBase):
                         self.test_data_dir / "test_coredump" / self.test_data_folder / (test_name + "_remoter.json")
                     )
                 ),
-                tempfile.mkdtemp(),
+                str(self._tmp_path / "logdir"),
             ),
             5,
         )
@@ -186,7 +189,7 @@ class CoredumpExportFileTest(CoredumpExportTestBase):
                         self.test_data_dir / "test_coredump" / self.test_data_folder / (test_name + "_remoter.json")
                     )
                 ),
-                tempfile.mkdtemp(),
+                str(self._tmp_path / "logdir"),
             ),
             5,
             coredump_directories=["/var/lib/scylla/coredumps"],

--- a/unit_tests/unit/test_hydra_sh.py
+++ b/unit_tests/unit/test_hydra_sh.py
@@ -2,6 +2,7 @@ import contextlib
 import dataclasses
 import os
 import re
+import shutil
 import tempfile
 from functools import cached_property
 from typing import Dict, Union, Tuple, Iterable, Sequence, List
@@ -43,7 +44,7 @@ class HydraTestCaseTmpDir:
 
     def teardown(self):
         with contextlib.suppress(Exception):
-            os.unlink(self.home_dir)
+            shutil.rmtree(self.home_dir)
 
     def __enter__(self):
         self.setup()

--- a/unit_tests/unit/test_scylla_yaml_builders.py
+++ b/unit_tests/unit/test_scylla_yaml_builders.py
@@ -14,7 +14,6 @@
 import contextlib
 import json
 import os
-import tempfile
 from typing import List
 from unittest.mock import patch
 
@@ -608,11 +607,12 @@ class IntegrationTests:
 
     @property
     def temp_dir(self):
-        return tempfile.mkdtemp()
+        return str(self._tmp_path)
 
     @pytest.fixture(autouse=True)
-    def fixture_env(self, monkeypatch):
+    def fixture_env(self, monkeypatch, tmp_path):
         self.monkeypatch = monkeypatch
+        self._tmp_path = tmp_path
 
     def _run_test(self, config_path: str, expected_node_config: str, region_names: str):
         with (

--- a/unit_tests/unit/test_seed_selector.py
+++ b/unit_tests/unit/test_seed_selector.py
@@ -1,6 +1,4 @@
-import tempfile
 import logging
-import shutil
 
 import pytest
 import sdcm.cluster
@@ -52,18 +50,10 @@ logging.basicConfig(format="%(asctime)s - %(levelname)-8s - %(name)-10s: %(messa
 
 
 class TestSeedSelector:
-    temp_dir = None
-    cluster = None
-
-    @classmethod
-    def setup_class(cls):
-        cls.temp_dir = tempfile.mkdtemp()
-        cls.cluster = None
-
-    @classmethod
-    def teardown_class(cls):
-        # stop_events_device()
-        shutil.rmtree(cls.temp_dir)
+    @pytest.fixture(autouse=True, scope="class")
+    def inject_temp_dir(self, tmp_path_factory):
+        TestSeedSelector.temp_dir = str(tmp_path_factory.mktemp("seed_selector"))
+        TestSeedSelector.cluster = None
 
     @pytest.fixture(autouse=True)
     def inject_test_data_dir(self, test_data_dir):

--- a/unit_tests/unit/test_utils_common.py
+++ b/unit_tests/unit/test_utils_common.py
@@ -13,9 +13,8 @@
 
 import os
 import time
-import hashlib
-import shutil
 import logging
+import shutil
 import unittest.mock
 from pathlib import Path
 
@@ -24,8 +23,6 @@ import pytest
 from sdcm.utils.common import convert_metric_to_ms, download_dir_from_cloud, get_testrun_dir
 from sdcm.utils.sstable import load_inventory
 from sdcm.utils.sstable.load_utils import SstableLoadUtils
-
-from unit_tests.lib.fake_cluster import DummyDbCluster, DummyNode, FakeSstableRemoter
 
 from unit_tests.lib.fake_cluster import DummyDbCluster, DummyNode, FakeSstableRemoter
 
@@ -51,17 +48,10 @@ class TestUtils:
 
 
 class TestDownloadDir:
-    @staticmethod
-    def clear_cloud_downloaded_path(url):
-        md5 = hashlib.md5()
-        md5.update(url.encode("utf-8"))
-        tmp_dir = os.path.join("/tmp/download_from_cloud", md5.hexdigest())
-        shutil.rmtree(tmp_dir, ignore_errors=True)
-
-    def test_update_db_packages_s3(self):
+    def test_update_db_packages_s3(self, tmp_path):
         sct_update_db_packages = "s3://downloads.scylladb.com/rpm/centos/scylladb-nightly/scylla/7/x86_64/repodata/"
 
-        self.clear_cloud_downloaded_path(sct_update_db_packages)
+        dst_dir = str(tmp_path / "s3_download")
 
         def touch_file(client, bucket, key, local_file_path):
             Path(local_file_path).touch()
@@ -73,11 +63,11 @@ class TestDownloadDir:
             mock_s3_client.return_value.list_objects_v2.return_value = {
                 "Contents": [{"Key": "rpm/centos/scylladb-nightly/scylla/7/x86_64/repodata/repomd.xml"}]
             }
-            update_db_packages = download_dir_from_cloud(sct_update_db_packages)
+            update_db_packages = download_dir_from_cloud(sct_update_db_packages, dst_dir=dst_dir)
 
         assert os.path.exists(os.path.join(update_db_packages, "repomd.xml"))
 
-    def test_update_db_packages_gce(self):
+    def test_update_db_packages_gce(self, tmp_path):
         sct_update_db_packages = "gs://scratch.scylladb.com/sct_test/"
 
         class FakeObject:
@@ -88,7 +78,7 @@ class TestDownloadDir:
             def download_to_filename(filename, *_, **__):
                 Path(filename).touch(exist_ok=True)
 
-        self.clear_cloud_downloaded_path(sct_update_db_packages)
+        dst_dir = str(tmp_path / "gce_download")
         test_file_names = ["sct_test/", "sct_test/bentsi.txt", "sct_test/charybdis.fs"]
         fake_client = unittest.mock.MagicMock()
         fake_client.list_blobs.return_value = [FakeObject(name=fname) for fname in test_file_names]
@@ -96,7 +86,7 @@ class TestDownloadDir:
             "sdcm.utils.common.get_gce_storage_client",
             return_value=(fake_client, {}),
         ):
-            update_db_packages = download_dir_from_cloud(sct_update_db_packages)
+            update_db_packages = download_dir_from_cloud(sct_update_db_packages, dst_dir=dst_dir)
         for fname in test_file_names:
             assert (Path(update_db_packages) / os.path.basename(fname)).exists()
 


### PR DESCRIPTION
Some unittest use test root for their logs/temporary files and it results in uncleaned pollution after forceful exist or sometimes failure.

## Summary

- Replace manual `tempfile.mkdtemp()` / `shutil.rmtree` pairs with pytest `tmp_path` and `tmp_path_factory` fixtures so cleanup is automatic
- Fix `dummy_remote.py` `LocalNode` and `LocalLoaderSetDummy` which set `logdir = os.path.dirname(__file__)`, causing tests to write artifacts into the source tree
- Fix `TestDownloadDir` which used hardcoded `/tmp/download_from_cloud` with manual `hashlib.md5` cleanup — now passes `tmp_path` as `dst_dir`
- Fix `test_hydra_sh.py` using `os.unlink` on a directory (should be `shutil.rmtree`)
- Add `base_dir` parameter to `create_ssl_dir` in integration conftest so SSL fixtures write to `tmp_path` instead of `data_dir/`

## Files changed

| File | Change |
|------|--------|
| `unit_tests/unit/test_cluster.py` | `setup_class`/`teardown_class` → `tmp_path_factory` fixture |
| `unit_tests/unit/test_coredump.py` | Added `inject_tmp_path` fixture alongside existing `inject_test_data_dir` |
| `unit_tests/unit/test_hydra_sh.py` | `os.unlink` → `shutil.rmtree` for directory cleanup |
| `unit_tests/unit/test_scylla_yaml_builders.py` | `setup_class`/`teardown_class` → `tmp_path_factory` fixture |
| `unit_tests/unit/test_seed_selector.py` | `setup_class`/`teardown_class` → `tmp_path_factory` fixture |
| `unit_tests/unit/test_utils_common.py` | `TestDownloadDir` uses `tmp_path` via `dst_dir` param; removed duplicate import |
| `unit_tests/lib/dummy_remote.py` | `logdir` defaults to `tempfile.mkdtemp()` instead of `os.path.dirname(__file__)` |
| `unit_tests/integration/conftest.py` | `create_ssl_dir` accepts `base_dir`; docker fixtures pass `tmp_path` |