### PR TITLE
docs(plans): add config type normalization plan

### DIFF
--- a/docs/plans/MASTER.md
+++ b/docs/plans/MASTER.md
@@ -62,6 +62,7 @@ For plan writing guidelines, see [INSTRUCTIONS.md](INSTRUCTIONS.md).
 | Typed Config Access Migration | `pending_pr` | [#13878](https://github.com/scylladb/scylla-cluster-tests/pull/13878) |
 | SCT Config Validation and Lazy Images | `draft` | [sct-config-validation-and-lazy-images.md](sct-config-validation-and-lazy-images.md) |
 | SCT Config Follow-up Refactoring | `pending_pr` | [#13845](https://github.com/scylladb/scylla-cluster-tests/pull/13845) |
+| Config Type Normalization | `draft` | [config-type-normalization.md](config/config-type-normalization.md) |
 
 ### K8s — Kubernetes operator, K8s backends
 

--- a/docs/plans/assets/progress-roadmap.svg
+++ b/docs/plans/assets/progress-roadmap.svg
@@ -1,10 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="840" height="884" viewBox="0 0 840 884">
-<rect width="840" height="884" fill="#0D1B2A" rx="8"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="840" height="892" viewBox="0 0 840 892">
+<rect width="840" height="892" fill="#0D1B2A" rx="8"/>
 <text x="420" y="60" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="22" font-weight="bold" fill="#00BCD4">SCT Implementation Plans</text>
-<text x="420" y="84" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="13" fill="#8899AA">26 plans across 8 domains</text>
+<text x="420" y="84" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="13" fill="#8899AA">27 plans across 8 domains</text>
 <rect x="30" y="120" width="780" height="50" rx="6" fill="#1B2A4A" stroke="#2A3F5F" stroke-width="1"/>
 <circle cx="50" cy="148" r="5" fill="#607D8B"/>
-<text x="60" y="152" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#E0E6ED">Draft: 15</text>
+<text x="60" y="152" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#E0E6ED">Draft: 16</text>
 <circle cx="180" cy="148" r="5" fill="#FFC107"/>
 <text x="190" y="152" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#E0E6ED">In Progress: 3</text>
 <circle cx="310" cy="148" r="5" fill="#2196F3"/>
@@ -16,12 +16,12 @@
 <circle cx="700" cy="148" r="5" fill="#9E9E9E"/>
 <text x="710" y="152" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#E0E6ED">Pending PR: 8</text>
 <rect x="40" y="175" width="760" height="20" rx="10" fill="#1B2A4A" stroke="#2A3F5F" stroke-width="1"/>
-<rect x="40" y="175" width="87.6923076923077" height="20" rx="10" fill="#FFC107"/>
-<text x="83.84615384615384" y="189" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="bold" fill="#0D1B2A">3</text>
-<rect x="127.6923076923077" y="175" width="438.4615384615384" height="20" rx="0" fill="#607D8B"/>
-<text x="346.9230769230769" y="189" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="bold" fill="#0D1B2A">15</text>
-<rect x="566.1538461538461" y="175" width="233.84615384615387" height="20" rx="0" fill="#9E9E9E"/>
-<text x="683.076923076923" y="189" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="bold" fill="#0D1B2A">8</text>
+<rect x="40" y="175" width="84.44444444444444" height="20" rx="10" fill="#FFC107"/>
+<text x="82.22222222222223" y="189" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="bold" fill="#0D1B2A">3</text>
+<rect x="124.44444444444444" y="175" width="450.3703703703703" height="20" rx="0" fill="#607D8B"/>
+<text x="349.6296296296296" y="189" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="bold" fill="#0D1B2A">16</text>
+<rect x="574.8148148148148" y="175" width="225.18518518518516" height="20" rx="0" fill="#9E9E9E"/>
+<text x="687.4074074074074" y="189" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="bold" fill="#0D1B2A">8</text>
 <rect x="30" y="220" width="380" height="32" rx="4" fill="#1B2A4A" stroke="#00BCD4" stroke-width="1"/>
 <text x="42" y="241" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="bold" fill="#00BCD4">cluster</text>
 <text x="398" y="241" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#8899AA">6 plans</text>
@@ -45,7 +45,7 @@
 <text x="398" y="410" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#607D8B">Draft</text>
 <rect x="30" y="436" width="380" height="32" rx="4" fill="#1B2A4A" stroke="#00BCD4" stroke-width="1"/>
 <text x="42" y="457" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="bold" fill="#00BCD4">config</text>
-<text x="398" y="457" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#8899AA">4 plans</text>
+<text x="398" y="457" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#8899AA">5 plans</text>
 <circle cx="44" cy="482" r="4" fill="#9E9E9E"/>
 <text x="56" y="486" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">Resilient Test Config Dependencies</text>
 <text x="398" y="486" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#9E9E9E">Pending PR</text>
@@ -55,21 +55,30 @@
 <circle cx="44" cy="538" r="4" fill="#607D8B"/>
 <text x="56" y="542" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">SCT Config Validation and Lazy Images</text>
 <text x="398" y="542" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#607D8B">Draft</text>
-<circle cx="44" cy="566" r="4" fill="#9E9E9E"/>
-<text x="56" y="570" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">SCT Config Follow-up Refactoring</text>
-<text x="398" y="570" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#9E9E9E">Pending PR</text>
-<rect x="30" y="596" width="380" height="32" rx="4" fill="#1B2A4A" stroke="#00BCD4" stroke-width="1"/>
-<text x="42" y="617" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="bold" fill="#00BCD4">framework</text>
-<text x="398" y="617" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#8899AA">3 plans</text>
-<circle cx="44" cy="642" r="4" fill="#607D8B"/>
-<text x="56" y="646" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">Full Version Tag Lookup</text>
-<text x="398" y="646" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#607D8B">Draft</text>
+<circle cx="44" cy="566" r="4" fill="#607D8B"/>
+<text x="56" y="570" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">Config Type Normalization</text>
+<text x="398" y="570" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#607D8B">Draft</text>
+<circle cx="44" cy="594" r="4" fill="#9E9E9E"/>
+<text x="56" y="598" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">SCT Config Follow-up Refactoring</text>
+<text x="398" y="598" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#9E9E9E">Pending PR</text>
+<rect x="30" y="624" width="380" height="32" rx="4" fill="#1B2A4A" stroke="#00BCD4" stroke-width="1"/>
+<text x="42" y="645" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="bold" fill="#00BCD4">ai-tooling</text>
+<text x="398" y="645" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#8899AA">2 plans</text>
 <circle cx="44" cy="670" r="4" fill="#607D8B"/>
-<text x="56" y="674" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">Health Check Optimization</text>
+<text x="56" y="674" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">AI Skills Framework</text>
 <text x="398" y="674" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#607D8B">Draft</text>
-<circle cx="44" cy="698" r="4" fill="#9E9E9E"/>
-<text x="56" y="702" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">Keystore Improvements</text>
-<text x="398" y="702" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#9E9E9E">Pending PR</text>
+<circle cx="44" cy="698" r="4" fill="#FFC107"/>
+<text x="56" y="702" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">PR Review Taxonomy Analysis</text>
+<text x="398" y="702" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#FFC107">In Progress</text>
+<rect x="30" y="728" width="380" height="32" rx="4" fill="#1B2A4A" stroke="#00BCD4" stroke-width="1"/>
+<text x="42" y="749" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="bold" fill="#00BCD4">testing</text>
+<text x="398" y="749" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#8899AA">2 plans</text>
+<circle cx="44" cy="774" r="4" fill="#9E9E9E"/>
+<text x="56" y="778" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">MiniCloud Local Testing</text>
+<text x="398" y="778" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#9E9E9E">Pending PR</text>
+<circle cx="44" cy="802" r="4" fill="#607D8B"/>
+<text x="56" y="806" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">Unit/Integration Test Separation</text>
+<text x="398" y="806" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#607D8B">Draft</text>
 <rect x="430" y="220" width="380" height="32" rx="4" fill="#1B2A4A" stroke="#00BCD4" stroke-width="1"/>
 <text x="442" y="241" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="bold" fill="#00BCD4">nemesis</text>
 <text x="798" y="241" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#8899AA">2 plans</text>
@@ -107,22 +116,16 @@
 <text x="456" y="590" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">K8s Multitenancy Dict Config</text>
 <text x="798" y="590" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#607D8B">Draft</text>
 <rect x="430" y="616" width="380" height="32" rx="4" fill="#1B2A4A" stroke="#00BCD4" stroke-width="1"/>
-<text x="442" y="637" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="bold" fill="#00BCD4">ai-tooling</text>
-<text x="798" y="637" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#8899AA">2 plans</text>
+<text x="442" y="637" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="bold" fill="#00BCD4">framework</text>
+<text x="798" y="637" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#8899AA">3 plans</text>
 <circle cx="444" cy="662" r="4" fill="#607D8B"/>
-<text x="456" y="666" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">AI Skills Framework</text>
+<text x="456" y="666" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">Full Version Tag Lookup</text>
 <text x="798" y="666" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#607D8B">Draft</text>
-<circle cx="444" cy="690" r="4" fill="#FFC107"/>
-<text x="456" y="694" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">PR Review Taxonomy Analysis</text>
-<text x="798" y="694" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#FFC107">In Progress</text>
-<rect x="430" y="720" width="380" height="32" rx="4" fill="#1B2A4A" stroke="#00BCD4" stroke-width="1"/>
-<text x="442" y="741" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="bold" fill="#00BCD4">testing</text>
-<text x="798" y="741" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#8899AA">2 plans</text>
-<circle cx="444" cy="766" r="4" fill="#9E9E9E"/>
-<text x="456" y="770" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">MiniCloud Local Testing</text>
-<text x="798" y="770" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#9E9E9E">Pending PR</text>
-<circle cx="444" cy="794" r="4" fill="#607D8B"/>
-<text x="456" y="798" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">Unit/Integration Test Separation</text>
-<text x="798" y="798" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#607D8B">Draft</text>
-<text x="420" y="849" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#8899AA">Generated from docs/plans/progress.json</text>
+<circle cx="444" cy="690" r="4" fill="#607D8B"/>
+<text x="456" y="694" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">Health Check Optimization</text>
+<text x="798" y="694" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#607D8B">Draft</text>
+<circle cx="444" cy="718" r="4" fill="#9E9E9E"/>
+<text x="456" y="722" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">Keystore Improvements</text>
+<text x="798" y="722" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#9E9E9E">Pending PR</text>
+<text x="420" y="857" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#8899AA">Generated from docs/plans/progress.json</text>
 </svg>

--- a/docs/plans/config/config-type-normalization.md
+++ b/docs/plans/config/config-type-normalization.md
@@ -86,6 +86,126 @@ The SCT configuration system defines four union-type aliases — `StringOrList`,
 
 **DictOrStr consumers** (all assume dict, ~20 sites): Every consumer calls `.get()`, `.items()`, or subscript access. None handle a raw string. No isinstance guards exist — a non-dict return would crash at all sites.
 
+## Affected Config Options
+
+**85 parameters total** across 4 type aliases.
+
+### `IntOrList` — 6 bare + 6 via `MultitenantValue` = 12 params
+
+Bare `IntOrList`:
+- `n_db_nodes` (line 521)
+- `n_test_oracle_db_nodes` (line 524)
+- `n_loaders` (line 527)
+- `n_monitor_nodes` (line 530)
+- `cluster_target_size` (line 918)
+- `n_db_zero_token_nodes` (line 1206)
+
+`MultitenantValue(IntOrList)`:
+- `nemesis_interval` (line 900)
+- `nemesis_sequence_sleep_between_ops` (line 903)
+- `nemesis_seed` (line 909)
+- `nemesis_add_node_cnt` (line 912)
+- `space_node_threshold` (line 921)
+- `nemesis_multiply_factor` (line 2016)
+
+### `StringOrList` — 46 bare + 9 via `MultitenantValue` = 55 params
+
+Bare `StringOrList`:
+- `config_files` (line 477)
+- `scylla_apt_keys` (line 579)
+- `assert_linux_distro_features` (line 624)
+- `email_recipients` (line 785)
+- `experimental_features` (line 797)
+- `region_name` (line 978)
+- `backup_bucket_location` (line 1049)
+- `scylla_d_overrides_files` (line 1058)
+- `gce_datacenter` (line 1065)
+- `aws_dedicated_host_ids` (line 1125)
+- `azure_region_name` (line 1259)
+- `oci_region_name` (line 1289)
+- `eks_admin_arn` (line 1342)
+- `db_nodes_private_ip` (line 1491)
+- `db_nodes_public_ip` (line 1494)
+- `loaders_private_ip` (line 1497)
+- `loaders_public_ip` (line 1500)
+- `monitor_nodes_private_ip` (line 1503)
+- `monitor_nodes_public_ip` (line 1506)
+- `pre_create_keyspace` (line 1556)
+- `post_prepare_cql_cmds` (line 1559)
+- `stress_read_cmd` (line 1582)
+- `prepare_verify_cmd` (line 1588)
+- `stress_cmd_no_mv` (line 1660)
+- `stress_cmd_no_mv_profile` (line 1663)
+- `cs_user_profiles` (line 1666)
+- `prepare_cs_user_profiles` (line 1669)
+- `stress_cmd_mv` (line 1678)
+- `prepare_stress_cmd` (line 1681)
+- `stress_cmd_lwt_i` (line 1698)
+- `stress_cmd_lwt_d` (line 1701)
+- `stress_cmd_lwt_u` (line 1704)
+- `stress_cmd_lwt_ine` (line 1707)
+- `stress_cmd_lwt_uc` (line 1710)
+- `stress_cmd_lwt_ue` (line 1713)
+- `stress_cmd_lwt_de` (line 1717)
+- `stress_cmd_lwt_dc` (line 1720)
+- `stress_cmd_lwt_mixed` (line 1723)
+- `stress_cmd_lwt_mixed_baseline` (line 1726)
+- `stress_cmd_1` (line 1761)
+- `stress_cmd_complex_prepare` (line 1764)
+- `prepare_write_stress` (line 1767)
+- `stress_cmd_read_10m` (line 1770)
+- `stress_cmd_read_cl_one` (line 1773)
+- `stress_cmd_read_60m` (line 1776)
+- `stress_cmd_complex_verify_read` (line 1779)
+- `stress_cmd_complex_verify_more` (line 1782)
+- `write_stress_during_entire_test` (line 1785)
+- `verify_data_after_entire_test` (line 1788)
+- `stress_cmd_read_cl_quorum` (line 1791)
+- `verify_stress_after_cluster_upgrade` (line 1794)
+- `stress_cmd_complex_verify_delete` (line 1800)
+- `stress_before_upgrade` (line 1937)
+- `large_partition_stress_during_upgrade` (line 1941)
+- `stress_during_entire_upgrade` (line 1945)
+- `stress_after_cluster_upgrade` (line 1948)
+- `jepsen_test_cmd` (line 1956)
+- `max_events_severities` (line 1969)
+
+`MultitenantValue(StringOrList)`:
+- `nemesis_class_name` (line 885)
+- `stress_cmd` (line 934)
+- `stress_cmd_w` (line 1630)
+- `stress_cmd_r` (line 1633)
+- `stress_cmd_m` (line 1636)
+- `stress_cmd_read_disk` (line 1639)
+- `stress_cmd_cache_warmup` (line 1645)
+- `prepare_write_cmd` (line 1651)
+- `nemesis_selector` (line 2010)
+
+### `BooleanOrList` — 0 bare + 3 via `MultitenantValue` = 3 params
+
+`MultitenantValue(BooleanOrList)`:
+- `nemesis_during_prepare` (line 906)
+- `nemesis_filter_seeds` (line 929)
+- `round_robin` (line 1547)
+
+### `DictOrStr` / `DictOrStrOrPydantic` — 12 params
+
+`DictOrStr`:
+- `agent` (line 667)
+- `alternator_test_table` (line 850)
+- `teardown_validators` (line 1116)
+- `skip_test_stages` (line 1200)
+- `latency_decorator_error_thresholds` (line 1216)
+- `mgmt_snapshots_preparer_params` (line 1625)
+- `perf_gradual_threads` (line 1684)
+- `perf_gradual_throttle_steps` (line 1688)
+- `perf_gradual_step_duration` (line 1692)
+- `stress_image` (line 2025)
+- `latte_schema_parameters` (line 2032)
+
+`DictOrStrOrPydantic`:
+- `append_scylla_yaml` (line 877)
+
 ## Goals
 
 1. **Canonical output types**: Each `BeforeValidator` returns exactly one type — `list[T]` for `*OrList` types, `dict` for `DictOrStr` — with no scalar/collection ambiguity.

--- a/docs/plans/config/config-type-normalization.md
+++ b/docs/plans/config/config-type-normalization.md
@@ -1,0 +1,341 @@
+---
+status: draft
+domain: config
+created: 2026-04-17
+last_updated: 2026-04-17
+owner: null
+---
+
+# Config Type Normalization Plan
+
+## Problem Statement
+
+The SCT configuration system defines four union-type aliases — `StringOrList`, `IntOrList`, `BooleanOrList`, and `DictOrStr` — whose `BeforeValidator` functions do not guarantee a single canonical output type. Consumers must defensively check `isinstance(value, list)` vs scalar everywhere, leading to:
+
+- **~37 scattered `isinstance` guards** across `tester.py`, `sct_config.py`, `mgmt/operations.py`, `cluster_tools.py`, `longevity_test.py`, `loader_utils.py`, `operations_thread.py`, `performance_regression_test.py`, and others that manually wrap scalars in lists or branch on type before use.
+- **Silent type-unsafety**: `ast.literal_eval()` in all four validators can return any Python literal (int, tuple, dict, str), not the declared type. For example, `str_or_list_or_eval("3")` returns `3` (an `int`), not `["3"]` or `[3]`.
+- **Runtime `TypeError` risk**: ~25 call sites in K8s backends, capacity reservation, performance tests, and `grow_cluster_test.py` assume scalar `int` for `IntOrList` params like `n_db_nodes`, while other sites assume `list`. Both can't be right — the type system should enforce one.
+
+## Current State
+
+### Validator Functions (`sdcm/sct_config.py`)
+
+**`str_or_list_or_eval`** (line 124):
+- String input: `ast.literal_eval(value)` returns the eval result **unchecked** — can be `int`, `dict`, `tuple`, not just `list[str]`. Falls back to `[str(value)]` only if eval raises.
+- List input: Runs `ast.literal_eval()` per item, can produce mixed-type lists.
+- Type annotation claims `-> List[str] | None` but the implementation does not enforce this.
+
+**`int_or_space_separated_ints`** (line 159):
+- Returns bare `int` for single-value input (line 163-164).
+- Returns `list[int]` for space-separated strings or list input.
+- Consumers face `int | list[int]` ambiguity.
+
+**`boolean_or_space_separated_booleans`** (line 188):
+- Returns bare `bool` for single-value input (lines 201-202, 207-210, 227-228).
+- Returns `list[bool]` for multi-value input.
+- Single-item lists are unwrapped to scalar (lines 205-210).
+
+**`dict_or_str`** (line 289):
+- `ast.literal_eval(value)` returns any literal unchecked (line 294).
+- `yaml.safe_load(value)` can return `str`, `int`, `list`, not just `dict` (line 301).
+- Neither path verifies the result is actually a `dict`.
+
+### Type Aliases
+
+| Alias | Declared Type | Actual Output |
+|-------|--------------|---------------|
+| `StringOrList` (line 154) | `str \| list[str]` | `Any` (via `ast.literal_eval`) or `list[str]` |
+| `IntOrList` (line 185) | `int \| list[int]` | `int` or `list[int]` |
+| `BooleanOrList` (line 236) | `bool \| list[bool]` | `bool` or `list[bool]` |
+| `DictOrStr` (line 311) | `dict \| str` | `Any` (via `ast.literal_eval`/`yaml.safe_load`) or `dict` |
+
+### Consumer Patterns — Full isinstance Guard Inventory
+
+**`n_db_nodes`** (IntOrList) — 17 guards:
+- `sdcm/tester.py`: lines 910, 1626, 1628, 1736, 1738, 1815, 1817, 2536, 2538
+- `sdcm/sct_config.py`: lines 2910, 3474, 3485, 3530, 4209
+- `sdcm/utils/cluster_tools.py`: line 45
+- `sdcm/mgmt/operations.py`: lines 549, 605
+- `platform_migration_test.py`: line 282
+- `sdcm/nemesis/__init__.py`: line 4449
+
+**`n_loaders`** (IntOrList) — 5 guards:
+- `sdcm/sct_config.py`: line 4151
+- `sdcm/mgmt/operations.py`: lines 259, 261, 596, 598
+
+**`nemesis_seed`** (IntOrList via MultitenantValue) — 3 guards:
+- `sdcm/utils/operations_thread.py`: line 129 — `if isinstance(nemesis_seed, list): nemesis_seed = nemesis_seed[0]`
+- `sdcm/tester.py`: lines 1546, 1548 — `if isinstance(nemesis_seeds, int):` wraps in list / `elif isinstance(nemesis_seeds, str):` splits
+
+**`stress_cmd`** (StringOrList via MultitenantValue) — 6 guards:
+- `sdcm/sct_config.py`: lines 3267, 3283, 4118
+- `sdcm/utils/loader_utils.py`: line 356
+- `longevity_test.py`: line 421
+- `unit_tests/unit/test_gradual_grow_throughput.py`: line 35
+
+**`prepare_write_cmd`** (StringOrList via MultitenantValue) — 4 guards:
+- `performance_regression_test.py`: lines 225, 228
+- `longevity_test.py`: line 460
+- `performance_regression_alternator_test.py`: line 140
+
+**`cluster_target_size`** (IntOrList) — 1 guard:
+- `longevity_test.py`: line 173
+
+**Assumes scalar for IntOrList** (~25 sites, no isinstance guard):
+- `sdcm/cluster_k8s/eks.py` (lines 133, 741, 750), `sdcm/cluster_k8s/gke.py` (lines 109, 133, 498), `sdcm/cluster_k8s/mini_k8s.py` (line 551), `sdcm/cluster_cloud.py` (line 1227), `sdcm/provision/aws/capacity_reservation.py` (lines 42, 49, 54, 116), `sdcm/tester.py` (lines 1992, 2068, 2159, 2192, 2219, 2281, 2317, 2353, 2434, 4184), `sdcm/nemesis/__init__.py` (lines 2960-2962), `grow_cluster_test.py` (lines 33, 97, 156), `performance_regression_gradual_grow_throughput.py` (line 59), `performance_regression_alternator_test.py` (line 236), `performance_regression_row_level_repair_test.py` (lines 279-286).
+
+**DictOrStr consumers** (all assume dict, ~20 sites): Every consumer calls `.get()`, `.items()`, or subscript access. None handle a raw string. No isinstance guards exist — a non-dict return would crash at all sites.
+
+## Goals
+
+1. **Canonical output types**: Each `BeforeValidator` returns exactly one type — `list[T]` for `*OrList` types, `dict` for `DictOrStr` — with no scalar/collection ambiguity.
+2. **Zero per-parameter boilerplate**: Fix only the 4 validator functions and 4 type alias declarations; no per-field validators needed.
+3. **Eliminate all ~37 `isinstance` guards** in consumer code that currently check and wrap scalars.
+4. **Fix ~25 scalar-assuming call sites** for `IntOrList` params to work with `list[int]`.
+5. **All existing unit tests pass** after the changes, plus new tests covering edge cases.
+
+## Implementation Phases
+
+Each phase covers one type end-to-end: validator fix, type alias update, all consumer fixes, and all isinstance guard removals. One PR per phase.
+
+### Phase 1: Normalize `IntOrList` → always `list[int]`
+
+**Importance**: Critical
+**Description**: Fix `int_or_space_separated_ints` to always return `list[int]`. Update `IntOrList` type alias. Fix all ~25 scalar-assuming consumer sites. Remove all ~26 isinstance guards for `IntOrList` params.
+
+**Deliverables**:
+
+**Validator fix** (`sdcm/sct_config.py`):
+- `int_or_space_separated_ints` (line 159): Change lines 163-164 from `return value` to `return [int(value)]`.
+- `IntOrList` type alias (line 185): Change `int | list[int]` → `list[int]`.
+
+**Scalar consumer fixes** (~25 sites — use `sum()` for totals, `[0]` for single-region):
+- `sdcm/cluster_k8s/eks.py`: lines 133, 741, 750
+- `sdcm/cluster_k8s/gke.py`: lines 109, 133, 498
+- `sdcm/cluster_k8s/mini_k8s.py`: line 551
+- `sdcm/cluster_cloud.py`: line 1227
+- `sdcm/provision/aws/capacity_reservation.py`: lines 42, 49, 54, 116
+- `sdcm/tester.py`: lines 1992, 2068, 2159, 2192, 2219, 2281, 2317, 2353, 2434, 4184
+- `sdcm/nemesis/__init__.py`: lines 2960-2962
+- `grow_cluster_test.py`: lines 33, 97, 156
+- `performance_regression_gradual_grow_throughput.py`: line 59
+- `performance_regression_alternator_test.py`: line 236
+- `performance_regression_row_level_repair_test.py`: lines 279-286
+
+**isinstance guard removals** (~26 guards — replace branching with direct list usage):
+
+`n_db_nodes` — 17 guards:
+- `sdcm/tester.py`: lines 910, 1626, 1628, 1736, 1738, 1815, 1817, 2536, 2538
+- `sdcm/sct_config.py`: lines 2910, 3474, 3485, 3530, 4209
+- `sdcm/utils/cluster_tools.py`: line 45
+- `sdcm/mgmt/operations.py`: lines 549, 605
+- `platform_migration_test.py`: line 282
+- `sdcm/nemesis/__init__.py`: line 4449
+
+`n_loaders` — 5 guards:
+- `sdcm/sct_config.py`: line 4151
+- `sdcm/mgmt/operations.py`: lines 259, 261, 596, 598
+
+`nemesis_seed` — 3 guards:
+- `sdcm/utils/operations_thread.py`: line 129
+- `sdcm/tester.py`: lines 1546, 1548
+
+`cluster_target_size` — 1 guard:
+- `longevity_test.py`: line 173
+
+**Unit tests for `int_or_space_separated_ints`**:
+- `3` → `[3]`; `"5"` → `[5]`; `"1 2 3"` → `[1, 2, 3]`
+- `[1, 2]` → `[1, 2]`; `None` → `None`
+- `"abc"` → raises `ValueError`
+
+**Definition of Done**:
+- [ ] `int_or_space_separated_ints` always returns `list[int] | None`
+- [ ] `IntOrList` declared as `list[int]`
+- [ ] No consumer performs scalar arithmetic/comparison on IntOrList params
+- [ ] No `isinstance` guards remain for `n_db_nodes`, `n_loaders`, `nemesis_seed`, `n_monitor_nodes`, `n_test_oracle_db_nodes`, `cluster_target_size`, `n_db_zero_token_nodes`
+- [ ] Unit tests for `int_or_space_separated_ints` edge cases added and passing
+- [ ] `uv run sct.py unit-tests` passes
+- [ ] `uv run sct.py pre-commit` passes
+
+---
+
+### Phase 2: Normalize `StringOrList` → always `list[str]`
+
+**Importance**: Critical
+**Description**: Fix `str_or_list_or_eval` to always return `list[str]`. Update `StringOrList` type alias. Remove all ~10 isinstance guards for `StringOrList` params.
+
+**Dependencies**: None (independent of Phase 1)
+
+**Deliverables**:
+
+**Validator fix** (`sdcm/sct_config.py`):
+- `str_or_list_or_eval` (line 124): After `ast.literal_eval(value)` at line 131, check result is a `list`; if not, wrap in `[result]`.
+- `StringOrList` type alias (line 154): Change `str | list[str]` → `list[str]`.
+
+**isinstance guard removals** (~10 guards):
+
+`stress_cmd` — 6 guards:
+- `sdcm/sct_config.py`: lines 3267, 3283, 4118
+- `sdcm/utils/loader_utils.py`: line 356
+- `longevity_test.py`: line 421
+- `unit_tests/unit/test_gradual_grow_throughput.py`: line 35
+
+`prepare_write_cmd` — 4 guards:
+- `performance_regression_test.py`: lines 225, 228
+- `longevity_test.py`: line 460
+- `performance_regression_alternator_test.py`: line 140
+
+**Unit tests for `str_or_list_or_eval`**:
+- `"3"` → `["3"]` (not `3`); `"{'a': 1}"` → `[{'a': 1}]` (not `{'a': 1}`)
+- `"[1,2]"` → `[1, 2]`; `"['cmd1', 'cmd2']"` → `['cmd1', 'cmd2']`
+- `"hello"` → `["hello"]`; `""` → `[]`; `None` → `None`
+- `["a", "b"]` → `["a", "b"]`
+
+**Definition of Done**:
+- [ ] `str_or_list_or_eval` always returns `list[str] | None`; `ast.literal_eval` result is wrapped if not a list
+- [ ] `StringOrList` declared as `list[str]`
+- [ ] No `isinstance` guards remain for `stress_cmd`, `prepare_write_cmd`, or other `StringOrList` params
+- [ ] Unit tests for `str_or_list_or_eval` edge cases added and passing
+- [ ] `uv run sct.py unit-tests` passes
+- [ ] `uv run sct.py pre-commit` passes
+
+---
+
+### Phase 3: Normalize `BooleanOrList` → always `list[bool]`
+
+**Importance**: Important
+**Description**: Fix `boolean_or_space_separated_booleans` to always return `list[bool]`. Update `BooleanOrList` type alias. All `BooleanOrList` params are accessed via `MultitenantValue` which resolves to a scalar per-tenant, so no downstream consumer fixes are expected.
+
+**Dependencies**: None (independent of Phases 1-2)
+
+**Deliverables**:
+
+**Validator fix** (`sdcm/sct_config.py`):
+- `boolean_or_space_separated_booleans` (line 188):
+  - Lines 201-202: `return value` → `return [value]`
+  - Lines 205-210: Remove single-item list unwrap; return `[bool_val]`
+  - Lines 227-228: Return `[bool(strtobool(values[0]))]` instead of bare bool
+- `BooleanOrList` type alias (line 236): Change `bool | list[bool]` → `list[bool]`.
+
+**Consumer verification**: All `BooleanOrList` params (`nemesis_during_prepare`, `nemesis_filter_seeds`, `round_robin`) are wrapped in `MultitenantValue`, which resolves per-tenant before access. Verify `MultitenantValue(list[bool])` = `list[bool] | dict[str, list[bool]]` works correctly.
+
+**Unit tests for `boolean_or_space_separated_booleans`**:
+- `True` → `[True]`; `False` → `[False]`
+- `"true"` → `[True]`; `"false"` → `[False]`
+- `"true false"` → `[True, False]`
+- `[True]` → `[True]` (not unwrapped to bare `True`)
+- `[True, False]` → `[True, False]`
+- `None` → `None`
+
+**Definition of Done**:
+- [ ] `boolean_or_space_separated_booleans` always returns `list[bool] | None`
+- [ ] `BooleanOrList` declared as `list[bool]`
+- [ ] MultitenantValue-wrapped BooleanOrList params still resolve correctly per-tenant
+- [ ] Unit tests for `boolean_or_space_separated_booleans` edge cases added and passing
+- [ ] `uv run sct.py unit-tests` passes
+- [ ] `uv run sct.py pre-commit` passes
+
+---
+
+### Phase 4: Normalize `DictOrStr` → always `dict`
+
+**Importance**: Important
+**Description**: Fix `dict_or_str` to reject non-dict results from `ast.literal_eval` and `yaml.safe_load`. Update `DictOrStr` type alias. No consumer changes needed — all ~20 sites already assume dict.
+
+**Dependencies**: None (independent of Phases 1-3)
+
+**Deliverables**:
+
+**Validator fix** (`sdcm/sct_config.py`):
+- `dict_or_str` (line 289):
+  - Line 294: After `ast.literal_eval(value)`, check `isinstance(result, dict)`; if not, fall through to `yaml.safe_load` instead of returning.
+  - Line 301: After `yaml.safe_load(value)`, check `isinstance(result, dict)`; if not, raise `ValueError`.
+- `DictOrStr` type alias (line 311): Change `dict | str` → `dict`.
+
+**Unit tests for `dict_or_str`**:
+- `"{'a': 1}"` → `{'a': 1}`
+- `"[1, 2]"` → raises `ValueError` (not a dict)
+- `"3"` → raises `ValueError` (not a dict)
+- `"plain string"` → raises `ValueError`
+- `{"key": "val"}` → `{"key": "val"}` (passthrough)
+- `None` → `None`
+
+**Definition of Done**:
+- [ ] `dict_or_str` always returns `dict | None`; non-dict eval/yaml results are rejected
+- [ ] `DictOrStr` declared as `dict`
+- [ ] Unit tests for `dict_or_str` edge cases added and passing
+- [ ] `uv run sct.py unit-tests` passes
+- [ ] `uv run sct.py pre-commit` passes
+
+---
+
+### Phase 5: Documentation Update
+
+**Importance**: Nice-to-have
+**Description**: Update `docs/sct-configuration.md` (if applicable) to document that `*OrList` params always produce lists and `DictOrStr` always produces dicts. Add inline docstrings to the type aliases.
+
+**Dependencies**: Phases 1-4
+
+**Definition of Done**:
+- [ ] Type alias docstrings explain canonical output type
+- [ ] Configuration docs updated if they reference these types
+
+## Testing Requirements
+
+### Unit Tests
+- Each phase includes its own validator edge-case tests (see per-phase deliverables).
+- Existing `test_config.py` must continue passing after each phase.
+- Full unit test suite must pass after each phase: `uv run sct.py unit-tests`.
+
+### Integration Tests
+- Run a Docker backend test to verify config loading end-to-end:
+  `uv run sct.py run-test longevity_test.LongevityTest.test_custom_time --backend docker --config test-cases/PR-provision-test.yaml`
+
+### Manual Testing
+- Verify multi-region config (where `n_db_nodes` is legitimately a multi-element list like `"3 3 3"`) still parses correctly.
+
+## Success Criteria
+
+All Definition of Done items across phases are met. Additionally:
+
+1. Every `*OrList` validator provably returns `list[T] | None` — no code path returns a scalar.
+2. `dict_or_str` provably returns `dict | None` — no code path returns a non-dict.
+3. All ~37 isinstance guards removed across the codebase.
+4. No regressions in the full unit test suite.
+
+## Risk Mitigation
+
+### Risk: Downstream Code Assumes Scalar IntOrList Values
+**Likelihood**: High (confirmed ~25 sites)
+**Impact**: `TypeError` at runtime for any missed consumer site.
+**Mitigation**: Phase 1 covers all IntOrList changes in one PR — validator, consumers, and guards together — so nothing breaks mid-migration. Use `grep -rn` to find all accesses to each param name. Run full unit test suite to catch regressions.
+
+### Risk: MultitenantValue Wrapping Interaction
+**Likelihood**: Low
+**Impact**: `MultitenantValue(IntOrList)` or `MultitenantValue(BooleanOrList)` might double-wrap or break tenant resolution.
+**Mitigation**: `MultitenantValue` wraps the inner type with `T | dict[str, T]`. After this change, `T` becomes `list[int]` instead of `int | list[int]`, so `MultitenantValue(list[int])` = `list[int] | dict[str, list[int]]`. This is correct — the dict branch is for per-tenant overrides. Verify with existing multitenancy tests.
+
+### Risk: Config File Backward Compatibility
+**Likelihood**: Low
+**Impact**: Existing YAML config files that specify scalar values (e.g., `n_db_nodes: 3`) might not load.
+**Mitigation**: The `BeforeValidator` still accepts scalar input — it just wraps the output. `int_or_space_separated_ints(3)` will return `[3]`. No config file changes needed.
+
+### Risk: StringOrList ast.literal_eval Behavior Change
+**Likelihood**: Medium
+**Impact**: `str_or_list_or_eval("['cmd1', 'cmd2']")` currently returns `['cmd1', 'cmd2']` (a list). After the fix, it still returns `['cmd1', 'cmd2']` because the result of `ast.literal_eval` is already a list. But `str_or_list_or_eval("3")` changes from `3` to `["3"]`.
+**Mitigation**: Phase 2 removes all isinstance guards that handled this ambiguity. Unit tests in Phase 2 explicitly verify these edge cases.
+
+## Related Plans
+
+- [sct-config-validation-and-lazy-images.md](../sct-config-validation-and-lazy-images.md) — Broader config validation work; this plan is a focused subset.
+- [Typed Config Access Migration](https://github.com/scylladb/scylla-cluster-tests/pull/13878) — Type safety improvements; this plan makes types more predictable for typed access.
+
+## PR History
+
+| Phase | PR | Status |
+|-------|-----|--------|
+| Phase 1: IntOrList | — | Not started |
+| Phase 2: StringOrList | — | Not started |
+| Phase 3: BooleanOrList | — | Not started |
+| Phase 4: DictOrStr | — | Not started |
+| Phase 5: Docs | — | Not started |

--- a/docs/plans/progress.json
+++ b/docs/plans/progress.json
@@ -216,6 +216,16 @@
       "phases_done": 0
     },
     {
+      "id": "config-type-normalization",
+      "title": "Config Type Normalization",
+      "file": "config/config-type-normalization.md",
+      "domain": "config",
+      "status": "draft",
+      "created": "2026-04-17",
+      "phases_total": 5,
+      "phases_done": 0
+    },
+    {
       "id": "sct-config-followup-refactoring",
       "title": "SCT Config Follow-up Refactoring",
       "domain": "config",


### PR DESCRIPTION
Currently, the composite config types (`StringOrList`, `IntOrList`, `BooleanOrList`, and `DictOrStr`) can return multiple types and they have to be unified in EVERY consumer by an `if isinstance()` guard. This creates a lot of duplicate code, make it easy to miss some consumers when changing types (happened during pydantic migration and we had to do multiple followup fixes) or when adding a new consumer. It is error prone.

Plan to fix BeforeValidator functions for composite config types  to always return canonical types. Phases organized per-type, each including validator fix, consumer fixes, isinstance guard removal, and unit tests.

Example https://github.com/scylladb/scylla-cluster-tests/blob/f92d0f851503130531c41e6e3fc1538b3aedfd09/sdcm/tester.py#L1546