### PR TITLE
fix(rolling-upgrade): increase OS upgrade timeout

### DIFF
--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -36,7 +36,7 @@ from sdcm.utils.issues import SkipPerIssues
 from sdcm.fill_db_data import FillDatabaseData
 from sdcm.sct_events import Severity
 from sdcm.stress_thread import CassandraStressThread
-from sdcm.utils.parallel_object import ParallelObject
+from sdcm.utils.parallel_object import ParallelObject, ParallelObjectException
 from sdcm.utils.decorators import retrying
 from sdcm.utils.sstable.sstable_utils import get_sstable_data_dump_command
 from sdcm.utils.user_profile import get_profile_content
@@ -181,7 +181,7 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
     # would be recalculated after all the cluster finish upgrade
     expected_sstable_format_version = "mc"
 
-    system_upgrade_timeout = 10 * 60
+    system_upgrade_timeout = 30 * 60
 
     def should_do_complex_profile(self) -> bool:
         """
@@ -383,10 +383,31 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
         def upgrade(node):
             node.upgrade_system()
 
-        if self.params.get("upgrade_node_system"):
-            with self.actions_log.action_scope("upgrade OS on nodes"):
-                parallel_obj = ParallelObject(objects=nodes, timeout=self.system_upgrade_timeout)
-                parallel_obj.run(upgrade)
+        def wait_for_package_manager(node):
+            if node.distro.is_rhel_like:
+                lock_file = "/var/run/yum.pid"
+            elif node.distro.is_sles:
+                lock_file = "/run/zypp.pid"
+            else:
+                lock_file = "/var/lib/dpkg/lock-frontend"
+            self.log.warning("OS upgrade timed out on %s, waiting for package manager to finish...", node.name)
+            node.remoter.run(f"while fuser {lock_file} >/dev/null 2>&1; do sleep 10; done", timeout=10 * 60)
+            self.log.info("OS upgrade on %s completed after initial timeout", node.name)
+
+        if not self.params.get("upgrade_node_system"):
+            return
+
+        with self.actions_log.action_scope("upgrade OS on nodes"):
+            try:
+                ParallelObject(objects=nodes, timeout=self.system_upgrade_timeout).run(upgrade)
+            except ParallelObjectException as exc:
+                timed_out = [r for r in exc.results if isinstance(r.exc, TimeoutError)]
+                other_failures = [r for r in exc.results if r.exc and not isinstance(r.exc, TimeoutError)]
+                if other_failures:
+                    raise
+                # package manager may still be running on remote node, wait for it to finish
+                for result in timed_out:
+                    wait_for_package_manager(result.obj)
 
     @truncate_entries
     # https://github.com/scylladb/scylla/issues/10447#issuecomment-1194155163


### PR DESCRIPTION
Cloud APT mirrors (azure.archive.ubuntu.com, gce.archive.ubuntu.com) intermittently throttle downloads to 50-95 kB/s on some of nodes of the cluster being upgraded. This causes exception after the 10-minute ParallelObject timeout is finished, while the underlying apt-get command completes later successfully. This ocassionally produces false-positive failures during Azure and GCE rolling upgrade tests.

The fix addresses the problem with:
- Increase of system_upgrade timeout
- If timeout still happens, check if package manager is still running on a node and wait up to 10 minutes for it to release the lock file

Fixes: SCT-192

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :green_circle: executed 2 runs of rolling-upgrade-azure-image test - [run 1](https://jenkins.scylladb.com/job/scylla-staging/job/dimakr/job/upgrades/job/rolling-upgrade-azure-image-test/4/) and [run 2](https://jenkins.scylladb.com/job/scylla-staging/job/dimakr/job/upgrades/job/rolling-upgrade-azure-image-test/5/).

During run 2 no slow upgrade happened on any of cluster nodes.
During run 1:
- on `2026.1.0 > 2026.1.1` upgrade: one of nodes experienced slow system upgrade - 19m. This would cause failure previously, but was within the increased timeout value
- on `2025.1.11 > 2026.1.1` upgrade: two of nodes experienced slow system upgrade, and for one of them it took even 32m. This was past the increased timeout, but the added recovery path was triggered (additional waiting for packager manager to finish its work), so upgrade eventually finished and the test passed.


### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
