### PR TITLE
feature(oci): support OCI multi-dc setups

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -128,6 +128,7 @@ from sdcm.utils.gce_builder import GceBuilder
 from sdcm.utils.oci_region import OciRegion
 from sdcm.utils.oci_builder import OciBuilder
 from sdcm.utils.aws_peering import AwsVpcPeering
+from sdcm.utils.oci_peering import OciVcnPeering
 from sdcm.utils.get_username import get_username
 from sdcm.utils.sct_cmd_helpers import add_file_logger, CloudRegion, get_test_config, get_all_regions
 from sdcm.utils.aws_utils import AwsArchType
@@ -2126,6 +2127,14 @@ def prepare_regions(cloud_provider, regions):
 def configure_aws_peering(regions):
     add_file_logger()
     peering = AwsVpcPeering(regions)
+    peering.configure()
+
+
+@cli.command("configure-oci-peering", help="Configure OCI cross-region VCN peering for multi-dc SCT runs")
+@click.option("-r", "--regions", type=CloudRegion(cloud_provider="oci"), default=[], help="OCI regions", multiple=True)
+def configure_oci_peering(regions):
+    add_file_logger()
+    peering = OciVcnPeering(regions or None)
     peering.configure()
 
 

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4023,8 +4023,12 @@ class BaseCluster:
 
         # NOTE: following is needed in case of K8S where we init multiple DB clusters first
         #       and only then we add nodes to it calling code in parallel.
-        # round-robin racks when backend is aws and multiple az's are specified
-        azs = len(self.params.get("availability_zone").split(",")) if self.params.get("cluster_backend") == "aws" else 1
+        # round-robin racks when backend supports multiple az's
+        azs = (
+            len(self.params.get("availability_zone").split(","))
+            if self.params.get("cluster_backend") in ("aws", "oci")
+            else 1
+        )
         if add_nodes:
             if isinstance(n_nodes, list):
                 for dc_idx, num in enumerate(n_nodes):

--- a/sdcm/cluster_oci.py
+++ b/sdcm/cluster_oci.py
@@ -355,7 +355,11 @@ class OciCluster(cluster.BaseCluster):
         for node_index in range(self._node_index + 1, self._node_index + count + 1):
             definitions.append(
                 self._definition_builder.build_instance_definition(
-                    region=region, node_type=self.node_type, index=node_index, instance_type=instance_type
+                    region=region,
+                    node_type=self.node_type,
+                    index=node_index,
+                    dc_idx=dc_idx,
+                    instance_type=instance_type,
                 )
             )
         return provision_instances_with_fallback(

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -3596,8 +3596,8 @@ class SCTConfiguration(BaseModel):
                 case "oci":
                     if oci_region_names := self.get("oci_region_name"):
                         if not isinstance(oci_region_names, list):
-                            oci_region_names = [self.get("oci_region_name")]
-                        for region in self.get("oci_region_name"):
+                            oci_region_names = [oci_region_names]
+                        for region in oci_region_names:
                             assert oci_utils.is_shape_available(instance_type, region), (
                                 f"Instance type [{instance_type}] not supported in region [{region}]"
                             )
@@ -3726,9 +3726,11 @@ class SCTConfiguration(BaseModel):
 
         if backend == "oci":
             oci_image_db = self.get("oci_image_db").split()
-            oci_region_name = self.get("oci_region_name")[0] if self.get("oci_region_name") else ""
-            for image in oci_image_db:
-                tags = oci_utils.get_image_tags(oci_region_name, image, "scylla")
+            oci_region_names = self.get("oci_region_name") or []
+            if not isinstance(oci_region_names, list):
+                oci_region_names = [oci_region_names]
+            for image, region in zip(oci_image_db, oci_region_names):
+                tags = oci_utils.get_image_tags(region, image, "scylla")
                 if "user_data_format_version" not in tags.keys():
                     logging.warning("'user_data_format_version' tag missing from [%s]: existing tags: %s", image, tags)
                 self["user_data_format_version"] = tags.get("user_data_format_version", "3")
@@ -3820,8 +3822,10 @@ class SCTConfiguration(BaseModel):
             _is_enterprise = is_enterprise(scylla_version)
         elif backend == "oci":
             images = self.get("oci_image_db").split()
-            oci_region_name = self.get("oci_region_name")[0] if self.get("oci_region_name") else ""
-            tags = oci_utils.get_image_tags(oci_region_name, images[0], "scylla")
+            oci_region_names = self.get("oci_region_name") or []
+            if not isinstance(oci_region_names, list):
+                oci_region_names = [oci_region_names]
+            tags = oci_utils.get_image_tags(oci_region_names[0], images[0], "scylla")
             scylla_version = self._require_scylla_version_tag(
                 tags=tags,
                 resource_label="Oracle image",

--- a/sdcm/sct_provision/oci/oci_region_definition_builder.py
+++ b/sdcm/sct_provision/oci/oci_region_definition_builder.py
@@ -62,7 +62,17 @@ class OciDefinitionBuilder(DefinitionBuilder):
     def build_instance_definition(
         self, region: str, node_type: NodeTypeType, index: int, dc_idx: int = 0, instance_type: str = None
     ):
-        definition = super().build_instance_definition(region, node_type, index, instance_type)
+        definition = super().build_instance_definition(region, node_type, index, dc_idx, instance_type)
+
+        # Select the correct region-specific image from the space-separated list
+        if definition.image_id and " " in definition.image_id:
+            images = [img.strip() for img in definition.image_id.split()]
+            definition.image_id = images[dc_idx] if dc_idx < len(images) else images[0]
+
+        # Select the correct region-specific instance type from the space-separated list
+        if definition.type and " " in definition.type:
+            types = [t.strip() for t in definition.type.split()]
+            definition.type = types[dc_idx] if dc_idx < len(types) else types[0]
 
         # NOTE: set latest ubuntu image for loader and monitor nodes if not defined
         if not definition.image_id and "db" not in node_type:

--- a/sdcm/utils/oci_peering.py
+++ b/sdcm/utils/oci_peering.py
@@ -1,0 +1,128 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2026 ScyllaDB
+
+import itertools
+import logging
+
+import oci
+from oci.core.models import ConnectRemotePeeringConnectionsDetails
+
+from sdcm.utils.oci_region import OciRegion
+from sdcm.utils.oci_utils import SUPPORTED_REGIONS
+
+LOG = logging.getLogger(__name__)
+
+
+class OciVcnPeering:
+    """Configure cross-region VCN peering for OCI using DRG + Remote Peering Connections."""
+
+    def __init__(self, regions=None):
+        regions = regions or SUPPORTED_REGIONS
+        self.regions = [OciRegion(r) for r in regions]
+
+    @staticmethod
+    def peering_connection(origin_region: OciRegion, target_region: OciRegion):
+        """Establish a Remote Peering Connection between two OCI regions.
+
+        Creates DRG + DRG-VCN attachment in each region if they don't exist,
+        then creates RPCs and connects them.
+
+        Returns (origin_rpc, target_rpc).
+        """
+        # Ensure DRG infrastructure exists in both regions
+        origin_region.get_or_create_drg_attachment()
+        target_region.get_or_create_drg_attachment()
+
+        origin_rpc = origin_region.get_or_create_rpc(target_region.region_name)
+        target_rpc = target_region.get_or_create_rpc(origin_region.region_name)
+
+        if origin_rpc.peering_status == "PEERED":
+            LOG.info(
+                "RPC between %s and %s is already PEERED",
+                origin_region.region_name,
+                target_region.region_name,
+            )
+            return origin_rpc, target_rpc
+
+        LOG.info(
+            "Connecting RPC %s (%s) -> %s (%s)",
+            origin_rpc.id,
+            origin_region.region_name,
+            target_rpc.id,
+            target_region.region_name,
+        )
+        try:
+            origin_region.network_client.connect_remote_peering_connections(
+                remote_peering_connection_id=origin_rpc.id,
+                connect_remote_peering_connections_details=ConnectRemotePeeringConnectionsDetails(
+                    peer_id=target_rpc.id,
+                    peer_region_name=target_region.region_name,
+                ),
+            )
+        except oci.exceptions.ServiceError as exc:
+            if "InvalidState" in str(exc) or "already peered" in str(exc).lower():
+                LOG.info(
+                    "Peering already established between %s and %s",
+                    origin_region.region_name,
+                    target_region.region_name,
+                )
+            else:
+                raise
+
+        # Wait for PEERED status
+        oci.wait_until(
+            origin_region.network_client,
+            origin_region.network_client.get_remote_peering_connection(origin_rpc.id),
+            evaluate_response=lambda r: r.data.peering_status == "PEERED",
+            max_wait_seconds=300,
+            max_interval_seconds=10,
+        )
+
+        return origin_rpc, target_rpc
+
+    @staticmethod
+    def configure_route_tables(origin_region: OciRegion, target_region: OciRegion):
+        """Add routes in origin_region pointing to target_region's VCN CIDR via DRG."""
+        origin_region.add_drg_route_to_tables(peer_vcn_cidr=str(target_region.vcn_ipv4_cidr))
+
+    @staticmethod
+    def open_security_list(origin_region: OciRegion, target_region: OciRegion):
+        """Allow all traffic from target_region's VCN CIDR in origin_region's security list."""
+        origin_region.allow_cross_vcn_traffic(peer_vcn_cidr=str(target_region.vcn_ipv4_cidr))
+
+    def configure(self):
+        """Configure full cross-region peering for all region pairs."""
+        if len(self.regions) < 2:
+            LOG.info("Only %d region(s) configured, skipping peering setup", len(self.regions))
+            return
+
+        regions_pairs: list[tuple[OciRegion, OciRegion]] = list(itertools.combinations(self.regions, 2))
+        for origin_region, target_region in regions_pairs:
+            LOG.info(
+                "Configure peering for: %s %s <-> %s %s",
+                origin_region.region_name,
+                origin_region.vcn_ipv4_cidr,
+                target_region.region_name,
+                target_region.vcn_ipv4_cidr,
+            )
+            self.peering_connection(origin_region, target_region)
+
+            LOG.info("Configuring route tables")
+            self.configure_route_tables(origin_region, target_region)
+            self.configure_route_tables(target_region, origin_region)
+
+            LOG.info("Configuring security lists")
+            self.open_security_list(origin_region, target_region)
+            self.open_security_list(target_region, origin_region)
+
+        LOG.info("OCI VCN peering configured for all region pairs")

--- a/sdcm/utils/oci_region.py
+++ b/sdcm/utils/oci_region.py
@@ -25,7 +25,10 @@ import hashlib
 import logging
 import time
 from ipaddress import ip_network
-from functools import cached_property
+from functools import (
+    cache,
+    cached_property,
+)
 
 import oci
 from oci.core.models import (
@@ -33,7 +36,10 @@ from oci.core.models import (
     AddSecurityRuleDetails,
     CreateInternetGatewayDetails,
     CreateNatGatewayDetails,
+    CreateDrgAttachmentDetails,
+    CreateDrgDetails,
     CreateNetworkSecurityGroupDetails,
+    CreateRemotePeeringConnectionDetails,
     CreateRouteTableDetails,
     CreateSecurityListDetails,
     CreateSubnetDetails,
@@ -43,6 +49,9 @@ from oci.core.models import (
     PortRange,
     RouteRule,
     TcpOptions,
+    UpdateRouteTableDetails,
+    UpdateSecurityListDetails,
+    VcnDrgAttachmentNetworkCreateDetails,
 )
 from oci.identity.models import (
     CreateTagDetails,
@@ -356,7 +365,8 @@ class OciRegion:
             return self._create_nsg(nsg_name, suffix)
 
     def _find_nsg(self, display_name, _cache={}):  # noqa: B006
-        if existing := _cache.get(display_name):
+        cache_key = (self.region_name, display_name)
+        if existing := _cache.get(cache_key):
             return existing
         nsgs = oci.pagination.list_call_get_all_results_generator(
             self.network_client.list_network_security_groups,
@@ -367,7 +377,7 @@ class OciRegion:
         )
         while current_nsg := next(nsgs, None):
             if current_nsg.lifecycle_state == "AVAILABLE":
-                _cache[display_name] = current_nsg
+                _cache[cache_key] = current_nsg
                 return current_nsg
         return None
 
@@ -539,9 +549,10 @@ class OciRegion:
         return self.SCT_SUBNET_NAME_TMPL.format(suffix=suffix)
 
     def subnet(self, public: bool = False, _cache: dict = {}):  # noqa: B006
-        if existing := _cache.get(public):
+        cache_key = (self.region_name, public)
+        if existing := _cache.get(cache_key):
             return existing
-        with KEY_BASED_LOCKS.get_lock(f"oci-subnet--public-{public}"):
+        with KEY_BASED_LOCKS.get_lock(f"oci-subnet-{self.region_name}-public-{public}"):
             name = self.subnet_name(public=public)
             subnets = oci.pagination.list_call_get_all_results_generator(
                 self.network_client.list_subnets,
@@ -552,7 +563,7 @@ class OciRegion:
             )
             while current_subnet := next(subnets, None):
                 if current_subnet.lifecycle_state == "AVAILABLE":
-                    _cache[public] = current_subnet
+                    _cache[cache_key] = current_subnet
                     return current_subnet
         return None
 
@@ -719,6 +730,167 @@ class OciRegion:
             LOGGER.error("Failed to determine home region: %s", exc)
             raise
 
+    # ── DRG (Dynamic Routing Gateway) for cross-region peering ───────────
+
+    SCT_DRG_NAME = "SCT-2-drg"
+    SCT_RPC_NAME_TMPL = "SCT-2-rpc-{peer}"
+
+    @cached_property
+    def drg(self):
+        with KEY_BASED_LOCKS.get_lock(f"oci-drg--{self.region_name}"):
+            existing = self._find_drg()
+            if existing:
+                return existing
+            return self._create_drg()
+
+    def _find_drg(self):
+        drgs = oci.pagination.list_call_get_all_results_generator(
+            self.network_client.list_drgs,
+            yield_mode="record",
+            compartment_id=self.compartment_id,
+        )
+        while current_drg := next(drgs, None):
+            if current_drg.display_name == self.SCT_DRG_NAME and current_drg.lifecycle_state == "AVAILABLE":
+                return current_drg
+        return None
+
+    def _create_drg(self):
+        LOGGER.info("Creating DRG '%s' in %s", self.SCT_DRG_NAME, self.region_name)
+        details = CreateDrgDetails(
+            compartment_id=self.compartment_id,
+            display_name=self.SCT_DRG_NAME,
+            freeform_tags=self._base_tags(self.SCT_DRG_NAME),
+        )
+        response = self.network_client.create_drg(details)
+        return self._wait_for_state(
+            self.network_client,
+            self.network_client.get_drg,
+            response.data.id,
+            "AVAILABLE",
+        )
+
+    @cache
+    def get_or_create_drg_attachment(self):
+        with KEY_BASED_LOCKS.get_lock(f"oci-drg-att--{self.region_name}"):
+            existing = self._find_drg_attachment()
+            if existing:
+                return existing
+            return self._create_drg_attachment()
+
+    def _find_drg_attachment(self):
+        attachments = oci.pagination.list_call_get_all_results_generator(
+            self.network_client.list_drg_attachments,
+            yield_mode="record",
+            compartment_id=self.compartment_id,
+            drg_id=self.drg.id,
+        )
+        while att := next(attachments, None):
+            if att.lifecycle_state == "ATTACHED":
+                net = att.network_details
+                if net and getattr(net, "id", None) == self.vcn.id:
+                    return att
+        return None
+
+    def _create_drg_attachment(self):
+        display_name = f"{self.SCT_DRG_NAME}-att-vcn"
+        LOGGER.info("Attaching DRG to VCN in %s", self.region_name)
+        details = CreateDrgAttachmentDetails(
+            drg_id=self.drg.id,
+            display_name=display_name,
+            network_details=VcnDrgAttachmentNetworkCreateDetails(
+                type="VCN",
+                id=self.vcn.id,
+            ),
+            freeform_tags=self._base_tags(display_name),
+        )
+        response = self.network_client.create_drg_attachment(details)
+        return self._wait_for_state(
+            self.network_client,
+            self.network_client.get_drg_attachment,
+            response.data.id,
+            "ATTACHED",
+        )
+
+    def get_or_create_rpc(self, peer_region_name: str):
+        """Get or create a Remote Peering Connection for a given peer region."""
+        rpc_name = self.SCT_RPC_NAME_TMPL.format(peer=peer_region_name)
+        with KEY_BASED_LOCKS.get_lock(f"oci-rpc--{self.region_name}--{peer_region_name}"):
+            existing = self._find_rpc(rpc_name)
+            if existing:
+                return existing
+            return self._create_rpc(rpc_name)
+
+    def _find_rpc(self, display_name: str):
+        rpcs = oci.pagination.list_call_get_all_results_generator(
+            self.network_client.list_remote_peering_connections,
+            yield_mode="record",
+            compartment_id=self.compartment_id,
+            drg_id=self.drg.id,
+        )
+        while rpc := next(rpcs, None):
+            if rpc.display_name == display_name and rpc.lifecycle_state == "AVAILABLE":
+                return rpc
+        return None
+
+    def _create_rpc(self, display_name: str):
+        LOGGER.info("Creating RPC '%s' on DRG in %s", display_name, self.region_name)
+        details = CreateRemotePeeringConnectionDetails(
+            compartment_id=self.compartment_id,
+            drg_id=self.drg.id,
+            display_name=display_name,
+        )
+        response = self.network_client.create_remote_peering_connection(details)
+        return self._wait_for_state(
+            self.network_client,
+            self.network_client.get_remote_peering_connection,
+            response.data.id,
+            "AVAILABLE",
+        )
+
+    def add_drg_route_to_tables(self, peer_vcn_cidr: str):
+        """Add a route rule for the peer VCN CIDR via DRG to all VCN route tables."""
+        drg_id = self.drg.id
+        for rt_name_suffix, rt in [("public", self.public_route_table), ("private", self.private_route_table)]:
+            existing_rules = rt.route_rules or []
+            already_routed = any(
+                r.destination == str(peer_vcn_cidr) and r.network_entity_id == drg_id for r in existing_rules
+            )
+            if already_routed:
+                LOGGER.info("Route to %s via DRG already exists in %s route table", peer_vcn_cidr, rt_name_suffix)
+                continue
+            new_rule = RouteRule(
+                destination=str(peer_vcn_cidr),
+                destination_type="CIDR_BLOCK",
+                network_entity_id=drg_id,
+                description=f"Route to peer VCN {peer_vcn_cidr} via DRG",
+            )
+            updated_rules = [*existing_rules, new_rule]
+            LOGGER.info("Adding route to %s via DRG in %s route table", peer_vcn_cidr, rt_name_suffix)
+            self.network_client.update_route_table(
+                rt.id,
+                UpdateRouteTableDetails(route_rules=updated_rules),
+            )
+
+    def allow_cross_vcn_traffic(self, peer_vcn_cidr: str):
+        """Add ingress rules to the security list to allow all traffic from a peer VCN CIDR."""
+        sl = self.security_list
+        existing_ingress = sl.ingress_security_rules or []
+        already_allowed = any(r.source == str(peer_vcn_cidr) and r.protocol == "all" for r in existing_ingress)
+        if already_allowed:
+            LOGGER.info("Cross-VCN ingress from %s already allowed", peer_vcn_cidr)
+            return
+        new_rule = IngressSecurityRule(
+            protocol="all",
+            source=str(peer_vcn_cidr),
+            description=f"Allow all traffic from peer VCN {peer_vcn_cidr}",
+        )
+        updated_ingress = list(existing_ingress) + [new_rule]
+        LOGGER.info("Adding cross-VCN ingress rule for %s in %s", peer_vcn_cidr, self.region_name)
+        self.network_client.update_security_list(
+            sl.id,
+            UpdateSecurityListDetails(ingress_security_rules=updated_ingress),
+        )
+
     def configure_network(self):
         _ = self.vcn
         _ = self.security_list
@@ -767,7 +939,7 @@ class OciRegion:
         label_source = f"{self.region_name}-{visibility}"
         checksum = hashlib.sha1(label_source.encode("utf-8")).hexdigest()[:7]
         base = self._dns_label_from_name(visibility)
-        return f"{base[:7]}-{checksum}"
+        return f"{base[:7]}{checksum}"
 
     @staticmethod
     def _dns_label_from_name(name: str) -> str:

--- a/unit_tests/unit/test_oci_peering.py
+++ b/unit_tests/unit/test_oci_peering.py
@@ -1,0 +1,430 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2026 ScyllaDB
+
+"""Unit tests for OCI VCN peering (sdcm.utils.oci_peering) and OciRegion DRG methods."""
+
+from ipaddress import ip_network
+from unittest.mock import MagicMock, PropertyMock, patch
+
+from sdcm.utils.oci_peering import OciVcnPeering
+from sdcm.utils.oci_region import OciRegion
+from sdcm.utils.oci_utils import SUPPORTED_REGIONS
+
+
+# ---------------------------------------------------------------------------
+# OciVcnPeering.__init__
+# ---------------------------------------------------------------------------
+
+
+@patch("sdcm.utils.oci_peering.OciRegion", side_effect=lambda r: MagicMock(region_name=r))
+def test_peering_init_default_regions(mock_region_cls):
+    """Default constructor creates region objects (one per SUPPORTED_REGIONS entry)."""
+    peering = OciVcnPeering()
+
+    assert len(peering.regions) == len(SUPPORTED_REGIONS)
+    assert mock_region_cls.call_count == len(SUPPORTED_REGIONS)
+    for region_name in SUPPORTED_REGIONS:
+        mock_region_cls.assert_any_call(region_name)
+
+
+@patch("sdcm.utils.oci_peering.OciRegion", side_effect=lambda r: MagicMock(region_name=r))
+def test_peering_init_custom_regions(mock_region_cls):
+    """Custom region list creates only requested regions."""
+    peering = OciVcnPeering(regions=["us-ashburn-1"])
+
+    assert len(peering.regions) == 1
+    mock_region_cls.assert_called_once_with("us-ashburn-1")
+    assert peering.regions[0].region_name == "us-ashburn-1"
+
+
+# ---------------------------------------------------------------------------
+# OciVcnPeering.peering_connection
+# ---------------------------------------------------------------------------
+
+
+@patch(
+    "sdcm.utils.oci_region.OciRegion.get_or_create_drg_attachment",
+    return_value=MagicMock(id="ocid1.drgattachment.oc1..fake"),
+)
+@patch(
+    "sdcm.utils.oci_region.OciRegion.drg",
+    new_callable=PropertyMock,
+    return_value=MagicMock(id="ocid1.drg.oc1..fake"),
+)
+@patch("sdcm.utils.oci_utils.OciService.get_network_client", return_value=MagicMock())
+def test_peering_connection_already_peered_skips_connect(
+    mock_network,
+    mock_drg,
+    mock_drg_att,
+):
+    """When RPCs are already PEERED, no connect call is made."""
+    origin = OciRegion("us-ashburn-1")
+    target = OciRegion("us-phoenix-1")
+    origin_rpc = MagicMock(id="ocid1.rpc.origin", peering_status="PEERED")
+    target_rpc = MagicMock(id="ocid1.rpc.target", peering_status="PEERED")
+    origin.get_or_create_rpc = MagicMock(return_value=origin_rpc)
+    target.get_or_create_rpc = MagicMock(return_value=target_rpc)
+
+    result_origin, result_target = OciVcnPeering.peering_connection(origin, target)
+
+    assert result_origin is origin_rpc
+    assert result_target is target_rpc
+    origin.get_or_create_rpc.assert_called_once_with("us-phoenix-1")
+    target.get_or_create_rpc.assert_called_once_with("us-ashburn-1")
+    origin.network_client.connect_remote_peering_connections.assert_not_called()
+    target.network_client.connect_remote_peering_connections.assert_not_called()
+    assert mock_drg_att.call_count == 2
+
+
+@patch("sdcm.utils.oci_peering.oci.wait_until")
+@patch(
+    "sdcm.utils.oci_region.OciRegion.get_or_create_drg_attachment",
+    return_value=MagicMock(id="ocid1.drgattachment.oc1..fake"),
+)
+@patch(
+    "sdcm.utils.oci_region.OciRegion.drg",
+    new_callable=PropertyMock,
+    return_value=MagicMock(id="ocid1.drg.oc1..fake"),
+)
+@patch("sdcm.utils.oci_utils.OciService.get_network_client", return_value=MagicMock())
+def test_peering_connection_connects_rpcs_when_not_peered(
+    mock_network,
+    mock_drg,
+    mock_drg_att,
+    mock_wait,
+):
+    """When RPCs have status NEW, a connect call is issued."""
+    origin = OciRegion("us-ashburn-1")
+    target = OciRegion("us-phoenix-1")
+    origin_rpc = MagicMock(id="ocid1.rpc.origin", peering_status="NEW")
+    target_rpc = MagicMock(id="ocid1.rpc.target", peering_status="NEW")
+    origin.get_or_create_rpc = MagicMock(return_value=origin_rpc)
+    target.get_or_create_rpc = MagicMock(return_value=target_rpc)
+
+    OciVcnPeering.peering_connection(origin, target)
+
+    origin.get_or_create_rpc.assert_called_once_with("us-phoenix-1")
+    target.get_or_create_rpc.assert_called_once_with("us-ashburn-1")
+    origin.network_client.connect_remote_peering_connections.assert_called_once()
+    call_kwargs = origin.network_client.connect_remote_peering_connections.call_args
+    assert call_kwargs.kwargs["remote_peering_connection_id"] == "ocid1.rpc.origin"
+    connect_details = call_kwargs.kwargs["connect_remote_peering_connections_details"]
+    assert connect_details.peer_id == "ocid1.rpc.target"
+    assert connect_details.peer_region_name == "us-phoenix-1"
+    mock_wait.assert_called_once()
+    assert mock_drg_att.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# OciVcnPeering.configure_route_tables / open_security_list
+# ---------------------------------------------------------------------------
+
+
+@patch("sdcm.utils.oci_utils.OciService.get_network_client", return_value=MagicMock())
+def test_configure_route_tables_delegates_to_region(mock_network):
+    """configure_route_tables calls add_drg_route_to_tables on origin with target CIDR."""
+    origin = OciRegion("us-ashburn-1")
+    target = OciRegion("us-phoenix-1")
+    origin.add_drg_route_to_tables = MagicMock()
+    target.add_drg_route_to_tables = MagicMock()
+
+    OciVcnPeering.configure_route_tables(origin, target)
+
+    origin.add_drg_route_to_tables.assert_called_once_with(peer_vcn_cidr=str(target.vcn_ipv4_cidr))
+    target.add_drg_route_to_tables.assert_not_called()
+
+
+@patch("sdcm.utils.oci_utils.OciService.get_network_client", return_value=MagicMock())
+def test_open_security_list_delegates_to_region(mock_network):
+    """open_security_list calls allow_cross_vcn_traffic on origin with target CIDR."""
+    origin = OciRegion("us-ashburn-1")
+    target = OciRegion("us-phoenix-1")
+    origin.allow_cross_vcn_traffic = MagicMock()
+    target.allow_cross_vcn_traffic = MagicMock()
+
+    OciVcnPeering.open_security_list(origin, target)
+
+    origin.allow_cross_vcn_traffic.assert_called_once_with(peer_vcn_cidr=str(target.vcn_ipv4_cidr))
+    target.allow_cross_vcn_traffic.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# OciVcnPeering.configure
+# ---------------------------------------------------------------------------
+
+
+@patch("sdcm.utils.oci_peering.OciVcnPeering.peering_connection")
+@patch("sdcm.utils.oci_peering.OciVcnPeering.configure_route_tables")
+@patch("sdcm.utils.oci_peering.OciVcnPeering.open_security_list")
+@patch("sdcm.utils.oci_peering.OciRegion", return_value=MagicMock(region_name="us-ashburn-1"))
+def test_configure_single_region_skips_peering(mock_region_cls, mock_security, mock_routes, mock_peer):
+    """With only one region, configure() does nothing."""
+    peering = OciVcnPeering(regions=["us-ashburn-1"])
+
+    peering.configure()
+
+    mock_region_cls.assert_called_once_with("us-ashburn-1")
+    mock_peer.assert_not_called()
+    mock_routes.assert_not_called()
+    mock_security.assert_not_called()
+
+
+@patch("sdcm.utils.oci_peering.OciVcnPeering.open_security_list")
+@patch("sdcm.utils.oci_peering.OciVcnPeering.configure_route_tables")
+@patch("sdcm.utils.oci_peering.OciVcnPeering.peering_connection")
+@patch(
+    "sdcm.utils.oci_peering.OciRegion",
+    side_effect=[
+        MagicMock(region_name="us-ashburn-1", vcn_ipv4_cidr=ip_network("10.0.0.0/16")),
+        MagicMock(region_name="us-phoenix-1", vcn_ipv4_cidr=ip_network("10.1.0.0/16")),
+    ],
+)
+def test_configure_two_regions_configures_peering(mock_region_cls, mock_peer, mock_routes, mock_security):
+    """With two regions, configure() establishes peering and updates routes+security in both directions."""
+    peering = OciVcnPeering(regions=["us-ashburn-1", "us-phoenix-1"])
+
+    peering.configure()
+
+    assert mock_region_cls.call_count == 2
+    mock_region_cls.assert_any_call("us-ashburn-1")
+    mock_region_cls.assert_any_call("us-phoenix-1")
+    r1, r2 = peering.regions
+    mock_peer.assert_called_once_with(r1, r2)
+    assert mock_routes.call_count == 2
+    mock_routes.assert_any_call(r1, r2)
+    mock_routes.assert_any_call(r2, r1)
+    assert mock_security.call_count == 2
+    mock_security.assert_any_call(r1, r2)
+    mock_security.assert_any_call(r2, r1)
+
+
+# ---------------------------------------------------------------------------
+# OciRegion — DRG creation
+# ---------------------------------------------------------------------------
+
+
+@patch("sdcm.utils.oci_region.get_username", return_value="tester")
+@patch("sdcm.utils.oci_region.oci.wait_until", side_effect=lambda client, resp, **kwargs: resp)
+@patch("sdcm.utils.oci_region.oci.pagination.list_call_get_all_results_generator", return_value=iter([]))
+@patch(
+    "sdcm.utils.oci_region.OciRegion.compartment_id",
+    new_callable=PropertyMock,
+    return_value="ocid1.compartment.oc1..test",
+)
+@patch(
+    "sdcm.utils.oci_utils.OciService.get_network_client",
+    return_value=MagicMock(
+        create_drg=MagicMock(
+            return_value=MagicMock(data=MagicMock(id="ocid1.drg.oc1..new", lifecycle_state="AVAILABLE")),
+        ),
+        get_drg=MagicMock(
+            return_value=MagicMock(data=MagicMock(id="ocid1.drg.oc1..new", lifecycle_state="AVAILABLE")),
+        ),
+    ),
+)
+def test_drg_create_when_none_exists(mock_network, mock_comp, mock_paginator, mock_wait, mock_user):
+    """When no DRG exists, accessing .drg creates one via the network client."""
+    region = OciRegion("us-ashburn-1")
+
+    drg = region.drg
+
+    assert drg.id == "ocid1.drg.oc1..new"
+    assert drg.lifecycle_state == "AVAILABLE"
+    region.network_client.create_drg.assert_called_once()
+    region.network_client.get_drg.assert_called_once()
+    mock_paginator.assert_called_once()
+    mock_wait.assert_called_once()
+
+
+@patch("sdcm.utils.oci_region.get_username", return_value="tester")
+@patch(
+    "sdcm.utils.oci_region.oci.pagination.list_call_get_all_results_generator",
+    return_value=iter([MagicMock(display_name="SCT-2-drg", lifecycle_state="AVAILABLE", id="ocid1.drg.oc1..existing")]),
+)
+@patch(
+    "sdcm.utils.oci_region.OciRegion.compartment_id",
+    new_callable=PropertyMock,
+    return_value="ocid1.compartment.oc1..test",
+)
+@patch("sdcm.utils.oci_utils.OciService.get_network_client", return_value=MagicMock())
+def test_drg_find_existing(mock_network, mock_comp, mock_paginator, mock_user):
+    """When a matching DRG already exists, .drg returns it without creating."""
+    region = OciRegion("us-ashburn-1")
+
+    drg = region.drg
+
+    assert drg.id == "ocid1.drg.oc1..existing"
+    assert drg.display_name == "SCT-2-drg"
+    region.network_client.create_drg.assert_not_called()
+    mock_paginator.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# OciRegion — RPC creation
+# ---------------------------------------------------------------------------
+
+
+@patch("sdcm.utils.oci_region.get_username", return_value="tester")
+@patch("sdcm.utils.oci_region.oci.wait_until", side_effect=lambda client, resp, **kwargs: resp)
+@patch("sdcm.utils.oci_region.oci.pagination.list_call_get_all_results_generator", return_value=iter([]))
+@patch(
+    "sdcm.utils.oci_region.OciRegion.compartment_id",
+    new_callable=PropertyMock,
+    return_value="ocid1.compartment.oc1..test",
+)
+@patch(
+    "sdcm.utils.oci_region.OciRegion.drg",
+    new_callable=PropertyMock,
+    return_value=MagicMock(id="ocid1.drg.oc1..existing"),
+)
+@patch(
+    "sdcm.utils.oci_utils.OciService.get_network_client",
+    return_value=MagicMock(
+        create_remote_peering_connection=MagicMock(
+            return_value=MagicMock(data=MagicMock(id="ocid1.rpc.oc1..new", lifecycle_state="AVAILABLE")),
+        ),
+        get_remote_peering_connection=MagicMock(
+            return_value=MagicMock(data=MagicMock(id="ocid1.rpc.oc1..new", lifecycle_state="AVAILABLE")),
+        ),
+    ),
+)
+def test_rpc_create_when_none_exists(mock_network, mock_drg, mock_comp, mock_paginator, mock_wait, mock_user):
+    """When no RPC exists for the peer, get_or_create_rpc creates one."""
+    region = OciRegion("us-ashburn-1")
+
+    rpc = region.get_or_create_rpc("us-phoenix-1")
+
+    assert rpc.id == "ocid1.rpc.oc1..new"
+    assert rpc.lifecycle_state == "AVAILABLE"
+    region.network_client.create_remote_peering_connection.assert_called_once()
+    create_details = region.network_client.create_remote_peering_connection.call_args.args[0]
+    assert create_details.display_name == "SCT-2-rpc-us-phoenix-1"
+    assert create_details.drg_id == "ocid1.drg.oc1..existing"
+    assert create_details.compartment_id == "ocid1.compartment.oc1..test"
+    mock_paginator.assert_called_once()
+    mock_wait.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# OciRegion — route table management
+# ---------------------------------------------------------------------------
+
+
+@patch(
+    "sdcm.utils.oci_region.OciRegion.private_route_table",
+    new_callable=PropertyMock,
+    return_value=MagicMock(
+        id="ocid1.rt.oc1..private",
+        route_rules=[MagicMock(destination="10.1.0.0/16", network_entity_id="ocid1.drg.oc1..123")],
+    ),
+)
+@patch(
+    "sdcm.utils.oci_region.OciRegion.public_route_table",
+    new_callable=PropertyMock,
+    return_value=MagicMock(
+        id="ocid1.rt.oc1..public",
+        route_rules=[MagicMock(destination="10.1.0.0/16", network_entity_id="ocid1.drg.oc1..123")],
+    ),
+)
+@patch(
+    "sdcm.utils.oci_region.OciRegion.drg",
+    new_callable=PropertyMock,
+    return_value=MagicMock(id="ocid1.drg.oc1..123"),
+)
+@patch("sdcm.utils.oci_utils.OciService.get_network_client", return_value=MagicMock())
+def test_add_drg_route_to_tables_skips_if_exists(mock_network, mock_drg, mock_pub_rt, mock_priv_rt):
+    """When a route for the peer CIDR already exists, no update call is made."""
+    region = OciRegion("us-ashburn-1")
+
+    region.add_drg_route_to_tables("10.1.0.0/16")
+
+    region.network_client.update_route_table.assert_not_called()
+
+
+@patch(
+    "sdcm.utils.oci_region.OciRegion.private_route_table",
+    new_callable=PropertyMock,
+    return_value=MagicMock(id="ocid1.rt.oc1..private", route_rules=[]),
+)
+@patch(
+    "sdcm.utils.oci_region.OciRegion.public_route_table",
+    new_callable=PropertyMock,
+    return_value=MagicMock(id="ocid1.rt.oc1..public", route_rules=[]),
+)
+@patch(
+    "sdcm.utils.oci_region.OciRegion.drg",
+    new_callable=PropertyMock,
+    return_value=MagicMock(id="ocid1.drg.oc1..123"),
+)
+@patch("sdcm.utils.oci_utils.OciService.get_network_client", return_value=MagicMock())
+def test_add_drg_route_to_tables_adds_new_rule(mock_network, mock_drg, mock_pub_rt, mock_priv_rt):
+    """When no matching route exists, a new route rule is added to both tables."""
+    region = OciRegion("us-ashburn-1")
+
+    region.add_drg_route_to_tables("10.1.0.0/16")
+
+    assert region.network_client.update_route_table.call_count == 2
+    for call_args in region.network_client.update_route_table.call_args_list:
+        rt_id, update_details = call_args.args
+        assert rt_id in ("ocid1.rt.oc1..public", "ocid1.rt.oc1..private")
+        assert len(update_details.route_rules) == 1
+        rule = update_details.route_rules[0]
+        assert rule.destination == "10.1.0.0/16"
+        assert rule.destination_type == "CIDR_BLOCK"
+        assert rule.network_entity_id == "ocid1.drg.oc1..123"
+
+
+# ---------------------------------------------------------------------------
+# OciRegion — security list management
+# ---------------------------------------------------------------------------
+
+
+@patch(
+    "sdcm.utils.oci_region.OciRegion.security_list",
+    new_callable=PropertyMock,
+    return_value=MagicMock(
+        id="ocid1.sl.oc1..fake",
+        ingress_security_rules=[MagicMock(source="10.1.0.0/16", protocol="all")],
+    ),
+)
+@patch("sdcm.utils.oci_utils.OciService.get_network_client", return_value=MagicMock())
+def test_allow_cross_vcn_traffic_skips_if_exists(mock_network, mock_sl):
+    """When an ingress rule for the peer CIDR already exists, no update call is made."""
+    region = OciRegion("us-ashburn-1")
+
+    region.allow_cross_vcn_traffic("10.1.0.0/16")
+
+    region.network_client.update_security_list.assert_not_called()
+
+
+@patch(
+    "sdcm.utils.oci_region.OciRegion.security_list",
+    new_callable=PropertyMock,
+    return_value=MagicMock(id="ocid1.sl.oc1..fake", ingress_security_rules=[]),
+)
+@patch("sdcm.utils.oci_utils.OciService.get_network_client", return_value=MagicMock())
+def test_allow_cross_vcn_traffic_adds_rule(mock_network, mock_sl):
+    """When no matching rule exists, a new ingress rule is added."""
+    region = OciRegion("us-ashburn-1")
+
+    region.allow_cross_vcn_traffic("10.1.0.0/16")
+
+    region.network_client.update_security_list.assert_called_once()
+    update_args = region.network_client.update_security_list.call_args
+    assert update_args.args[0] == "ocid1.sl.oc1..fake"
+    updated_details = update_args.args[1]
+    assert len(updated_details.ingress_security_rules) == 1
+    rule = updated_details.ingress_security_rules[0]
+    assert rule.source == "10.1.0.0/16"
+    assert rule.protocol == "all"
+    assert rule.description == "Allow all traffic from peer VCN 10.1.0.0/16"

--- a/vars/createSctRunner.groovy
+++ b/vars/createSctRunner.groovy
@@ -27,8 +27,6 @@ def call(Map params, Integer test_duration, String region) {
 
     if ( params.backend.equals("azure") ) {
         region_zone_arg = "--region " + params.azure_region_name
-    } else if ( params.backend.equals("oci") )  {
-        region_zone_arg = "--region " + params.oci_region_name
     } else {
         region_zone_arg = "--region " + region
     }

--- a/vars/getJenkinsLabels.groovy
+++ b/vars/getJenkinsLabels.groovy
@@ -27,6 +27,12 @@ def call(String backend, String region=null, String datacenter=null, String loca
     } catch(Exception) {
 
     }
+    try {
+        ociRegionList = new JsonSlurperClassic().parseText(oci_region)
+        oci_region = ociRegionList[0]
+    } catch(Exception) {
+
+    }
 
     def gcp_project = params.gce_project?.trim() ?: 'gcp-sct-project-1'
     gcp_project = gcp_project == 'gcp' ? 'gcp-skilled-adapter-452' : gcp_project

--- a/vars/getJobTimeouts.groovy
+++ b/vars/getJobTimeouts.groovy
@@ -3,6 +3,10 @@
 List<Integer> call(Map params, String region){
     // handle params which can be a json list
     def current_region = initAwsRegionParam(params.region, region)
+    def current_oci_region = ""
+    if (params.oci_region_name) {
+        current_oci_region = initAwsRegionParam(params.oci_region_name, region)
+    }
     def test_config = groovy.json.JsonOutput.toJson(params.test_config)
     def cmd = """#!/bin/bash
     export SCT_CLUSTER_BACKEND="${params.backend}"
@@ -17,6 +21,10 @@ List<Integer> call(Map params, String region){
 
     if [[ -n "${params.azure_region_name ? params.azure_region_name : ''}" ]] ; then
         export SCT_AZURE_REGION_NAME=${groovy.json.JsonOutput.toJson(params.azure_region_name)}
+    fi
+
+    if [[ -n "${params.oci_region_name ? params.oci_region_name : ''}" ]] ; then
+        export SCT_OCI_REGION_NAME=${current_oci_region}
     fi
 
     if [[ "${params.backend}" == "xcloud" ]] ; then

--- a/vars/managerPipeline.groovy
+++ b/vars/managerPipeline.groovy
@@ -320,6 +320,10 @@ def call(Map pipelineParams) {
                                         // handle params which can be a json list
                                         def region = initAwsRegionParam(params.region, builder.region)
                                         def datacenter = groovy.json.JsonOutput.toJson(params.gce_datacenter)
+                                        def oci_region = ""
+                                        if (params.oci_region_name) {
+                                            oci_region = initAwsRegionParam(params.oci_region_name, builder.region)
+                                        }
                                         def test_config = groovy.json.JsonOutput.toJson(params.test_config)
                                         def cloud_provider = params.backend.trim().toLowerCase()
 
@@ -335,7 +339,7 @@ def call(Map pipelineParams) {
                                             export SCT_AZURE_REGION_NAME=${params.azure_region_name}
                                         fi
                                         if [[ -n "${params.oci_region_name ? params.oci_region_name : ''}" ]] ; then
-                                            export SCT_OCI_REGION_NAME=${params.oci_region_name}
+                                            export SCT_OCI_REGION_NAME=${oci_region}
                                         fi
                                         export SCT_CONFIG_FILES=${test_config}
                                         export SCT_COLLECT_LOGS=false

--- a/vars/provisionResources.groovy
+++ b/vars/provisionResources.groovy
@@ -7,6 +7,10 @@ def call(Map params, String region){
     }
 
     def current_region = initAwsRegionParam(params.region, region)
+    def current_oci_region = ""
+    if (params.oci_region_name) {
+        current_oci_region = initAwsRegionParam(params.oci_region_name, region)
+    }
     def test_config = groovy.json.JsonOutput.toJson(params.test_config)
     def cloud_provider = getCloudProviderFromBackend(params.backend)
 
@@ -45,7 +49,7 @@ def call(Map params, String region){
     fi
 
     if [[ -n "${params.oci_region_name ? params.oci_region_name : ''}" ]] ; then
-        export SCT_OCI_REGION_NAME=${params.oci_region_name}
+        export SCT_OCI_REGION_NAME=${current_oci_region}
     fi
 
     if [[ -n "${params.new_version ? params.new_version : ''}" ]] ; then

--- a/vars/runCleanupResource.groovy
+++ b/vars/runCleanupResource.groovy
@@ -6,6 +6,10 @@ def call(Map params, String region){
     if (params.gce_datacenter) {
         current_gce_datacenter = groovy.json.JsonOutput.toJson(params.gce_datacenter)
     }
+    def current_oci_region = ""
+    if (params.oci_region_name) {
+        current_oci_region = initAwsRegionParam(params.oci_region_name, region)
+    }
     def test_config = groovy.json.JsonOutput.toJson(params.test_config)
     def cloud_provider = getCloudProviderFromBackend(params.backend)
 
@@ -38,6 +42,9 @@ def call(Map params, String region){
     fi
     if [[ -n "${params.azure_region_name ? params.azure_region_name : ''}" ]] ; then
         export SCT_AZURE_REGION_NAME=${params.azure_region_name}
+    fi
+    if [[ -n "${params.oci_region_name ? params.oci_region_name : ''}" ]] ; then
+        export SCT_OCI_REGION_NAME=${current_oci_region}
     fi
     if [[ -n "${params.post_behavior_db_nodes ? params.post_behavior_db_nodes : ''}" ]] ; then
         export SCT_POST_BEHAVIOR_DB_NODES="${params.post_behavior_db_nodes}"

--- a/vars/runCollectLogs.groovy
+++ b/vars/runCollectLogs.groovy
@@ -7,6 +7,10 @@ def call(Map params, String region){
     if (params.gce_datacenter) {
         current_gce_datacenter = groovy.json.JsonOutput.toJson(params.gce_datacenter)
     }
+    def current_oci_region = ""
+    if (params.oci_region_name) {
+        current_oci_region = initAwsRegionParam(params.oci_region_name, region)
+    }
     def test_config = groovy.json.JsonOutput.toJson(params.test_config)
     def cloud_provider = getCloudProviderFromBackend(params.backend)
     sh """#!/bin/bash
@@ -22,6 +26,9 @@ def call(Map params, String region){
     fi
     if [[ -n "${params.azure_region_name ? params.azure_region_name : ''}" ]] ; then
         export SCT_AZURE_REGION_NAME=${params.azure_region_name}
+    fi
+    if [[ -n "${params.oci_region_name ? params.oci_region_name : ''}" ]] ; then
+        export SCT_OCI_REGION_NAME=${current_oci_region}
     fi
     if [[ "${params.backend}" == "xcloud" ]] ; then
         export SCT_XCLOUD_PROVIDER="${params.xcloud_provider}"

--- a/vars/runSctTest.groovy
+++ b/vars/runSctTest.groovy
@@ -7,6 +7,10 @@ def call(Map params, String region, functional_test = false, Map pipelineParams 
     if (params.gce_datacenter) {
         current_gce_datacenter = groovy.json.JsonOutput.toJson(params.gce_datacenter)
     }
+    def current_oci_region = ""
+    if (params.oci_region_name) {
+        current_oci_region = initAwsRegionParam(params.oci_region_name, region)
+    }
     def test_config = groovy.json.JsonOutput.toJson(params.test_config)
     def cloud_provider = getCloudProviderFromBackend(params.backend)
     def email_recipients = params.email_recipients ? groovy.json.JsonOutput.toJson(params.email_recipients) : ""
@@ -69,7 +73,7 @@ def call(Map params, String region, functional_test = false, Map pipelineParams 
     fi
 
     if [[ -n "${params.oci_region_name ? params.oci_region_name : ''}" ]] ; then
-        export SCT_OCI_REGION_NAME=${params.oci_region_name}
+        export SCT_OCI_REGION_NAME=${current_oci_region}
     fi
 
     if [[ -n "${params.new_version ? params.new_version : ''}" ]] ; then


### PR DESCRIPTION
Code changes consist of the following parts:
- Add `OciVcnPeering` class.
  It creates Dynamic Routing Gateways (DRG), DRG-VCN attachments, RPCs, route rule and security list ingress between all region pairs.
- Add Hydra command "configure-oci-peering".
- Extend OciRegion with DRG/RPC lifecycle methods.
- Fix bunch of multi-region bugs
- Update groovy files to properly handle the OCI multi-dc setups

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [scylla-staging/valerii/vp-oci-multidc#15](https://argus.scylladb.com/tests/scylla-cluster-tests/2b1df1b9-0e8d-4f66-a432-1129521c1ab1)
- [scylla-staging/valerii/vp-oci-multidc#16](https://argus.scylladb.com/tests/scylla-cluster-tests/1f9fb87d-766a-45ae-9525-bdea53e4a690)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
