### PR TITLE
refactor(aws-regions): add eu-west-3 and consolidate default AWS region lists

### DIFF
--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -441,6 +441,7 @@ available_backends: list[str] = [
 AWS_SUPPORTED_REGIONS: list[str] = [
     "eu-west-1",
     "eu-west-2",
+    "eu-west-3",
     "us-west-2",
     "us-east-1",
     "eu-north-1",

--- a/sdcm/utils/aws_builder.py
+++ b/sdcm/utils/aws_builder.py
@@ -20,9 +20,10 @@ import boto3
 import botocore
 import requests
 
-from sdcm.utils.aws_region import AwsRegion
-from sdcm.sct_runner import AwsSctRunner, AwsFipsSctRunner
 from sdcm.keystore import KeyStore
+from sdcm.sct_config import AWS_SUPPORTED_REGIONS
+from sdcm.sct_runner import AwsSctRunner, AwsFipsSctRunner
+from sdcm.utils.aws_region import AwsRegion
 from sdcm.utils.common import wait_ami_available
 
 LOGGER = logging.getLogger(__name__)
@@ -286,7 +287,7 @@ class AwsBuilder:
 
     @classmethod
     def configure_in_all_region(cls, regions=None):
-        regions = regions or ["eu-west-1", "eu-west-2", "eu-north-1", "eu-central-1", "us-east-1", "us-west-2"]
+        regions = regions or AWS_SUPPORTED_REGIONS
         for region_name in regions:
             region = cls(AwsRegion(region_name))
             region.configure_auto_scaling_group()

--- a/utils/create_aws_region_data.py
+++ b/utils/create_aws_region_data.py
@@ -2,6 +2,8 @@ from textwrap import dedent
 
 import boto3
 
+from sdcm.sct_config import AWS_SUPPORTED_REGIONS
+
 region_names = {
     "us-east-1": "US East (N. Virginia)",
     "us-east-2": "US East (Ohio)",
@@ -28,7 +30,7 @@ region_names = {
 
 
 def main():
-    for region in ["us-east-1", "us-west-2", "eu-west-1", "eu-west-2", "eu-north-1", "eu-central-1"]:
+    for region in AWS_SUPPORTED_REGIONS:
         # Create an EC2 client
         ec2 = boto3.client("ec2", region_name=region)
 


### PR DESCRIPTION
## Summary

- Add `eu-west-3` (Paris) to `AWS_SUPPORTED_REGIONS` in `sct_config.py`
- Consolidate duplicated region lists: `aws_builder.py` and `create_aws_region_data.py` now import `AWS_SUPPORTED_REGIONS` instead of maintaining separate hardcoded lists
- Prevents future drift between region lists across the codebase

## Changes

| File | Change |
|------|--------|
| `sdcm/sct_config.py` | Added `eu-west-3` to `AWS_SUPPORTED_REGIONS` |
| `sdcm/utils/aws_builder.py` | Import and use `AWS_SUPPORTED_REGIONS` instead of hardcoded list |
| `utils/create_aws_region_data.py` | Import and use `AWS_SUPPORTED_REGIONS` instead of hardcoded list |

## Notes

- `sct.py` Jenkins throttle region list (`configure_jenkins_throttle`) intentionally kept separate — it's a performance-test-specific subset, not a general default
- `sdcm/utils/pricing.py` region dict also kept as-is — serves a different purpose (region name mapping)