### PR TITLE
fix(cluster-tools): increase major compaction timeout to prevent timeouts for longer load duration and larger dataset

### DIFF
--- a/sdcm/utils/cluster_tools.py
+++ b/sdcm/utils/cluster_tools.py
@@ -99,7 +99,7 @@ def major_compaction_nodes(cluster, keyspace: str, table: str):
         )
         for node in cluster.data_nodes
     ]
-    ParallelObject(objects=triggers, timeout=3000).call_objects()
+    ParallelObject(objects=triggers, timeout=10000).call_objects()
 
 
 def clear_snapshot_nodes(cluster):


### PR DESCRIPTION

The major_compaction_nodes timeout of 3000 seconds (40 minutes) was insufficient for large datasets (2TB) and a longer `prepare` stress duration, causing TimeoutError on all nodes during the align_cluster_data_state phase of performance regression manager backup tests. Increased the timeout to 10000 seconds to allow major compaction to complete on larger clusters.
Retesting with the fix, the nodes major compaction took about 1.5 hours (for 1TB per node). So increasing it ~ x3 might be good for larger datasets.

The origianl test failed in:
https://argus.scylladb.com/tests/scylla-cluster-tests/96a981c8-ce73-4842-81a6-97e88e461bf5
with:
```
2026-04-15 12:32:07.165: (TestFrameworkEvent Severity.ERROR) period_type=one-time event_id=aad1418e-5dd4-4b9a-9daa-9c591eed0834, source=PerformanceRegressionManagerBackupTest.test_manager_backup()
exception=self = <performance_regression_manager_backup_test.PerformanceRegressionManagerBackupTest testMethod=test_manager_backup>
    def test_manager_backup(self):
        keyspace = "keyspace1"
        table = "standard1"
        stress_cmd = self.params.get("stress_cmd_m")
        self.run_fstrim_on_all_db_nodes()
        self.preload_data()
>       self.align_cluster_data_state(keyspace, table)
performance_regression_manager_backup_test.py:45:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
sdcm/mgmt/operations.py:100: in align_cluster_data_state
    self._cluster_flush_and_major_compaction(keyspace, table)
sdcm/mgmt/operations.py:94: in _cluster_flush_and_major_compaction
    major_compaction_nodes(cluster=self.db_cluster, keyspace=keyspace, table=table)
sdcm/utils/cluster_tools.py:101: in major_compaction_nodes
    ParallelObject(objects=triggers, timeout=3000).call_objects()
sdcm/utils/parallel_object.py:134: in call_objects
    return self.run(lambda x: x(), ignore_exceptions=ignore_exceptions)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
self = <sdcm.utils.parallel_object.ParallelObject object at 0x71c9035c0e20>
func = <function ParallelObject.call_objects.<locals>.<lambda> at 0x71c8cacf8400>
ignore_exceptions = False, unpack_objects = False
    def run(self, func: Callable, ignore_exceptions=False, unpack_objects: bool = False) -> List[ParallelObjectResult]:
        """Run callable object "disrupt_func" in parallel
        Allow to run callable object in parallel.
        if ignore_exceptions is true,  return
        list of FutureResult object instances which contains
        two attributes:
            - result - result of callable object execution
            - exc - exception object, if happened during run
        if ignore_exceptions is False, then running will
        terminated on future where happened exception or by timeout
        what has stepped first.
        :param func: Callable object to run in parallel
        :param ignore_exceptions: ignore exception and return result, defaults to False
        :param unpack_objects: set to True when unpacking of objects to the disrupt_func as args or kwargs needed
        :returns: list of FutureResult object
        :rtype: {List[FutureResult]}
        """
        def func_wrap(fun):
            @wraps(fun)
            def inner(*args, **kwargs):
                thread_name = threading.current_thread().name
                fun_args = args
                fun_kwargs = kwargs
                fun_name = fun.__name__
                LOGGER.debug(
                    "[{thread_name}] {fun_name}({fun_args}, {fun_kwargs})".format(
                        thread_name=thread_name, fun_name=fun_name, fun_args=fun_args, fun_kwargs=fun_kwargs
                    )
                )
                return_val = fun(*args, **kwargs)
                LOGGER.debug("[{thread_name}] Done.".format(thread_name=thread_name))
                return return_val
            return inner
        results = []
        if not self.disable_logging:
            LOGGER.debug("Executing in parallel: '{}' on {}".format(func.__name__, self.objects))
            func = func_wrap(func)
        futures = []
        for obj in self.objects:
            if unpack_objects and isinstance(obj, (list, tuple)):
                futures.append((self._thread_pool.submit(func, *obj), obj))
            elif unpack_objects and isinstance(obj, dict):
                futures.append((self._thread_pool.submit(func, **obj), obj))
            else:
                futures.append((self._thread_pool.submit(func, obj), obj))
        time_out = self.timeout
        for future, target_obj in futures:
            try:
                result = future.result(time_out)
            except FuturesTimeoutError as exception:
                results.append(ParallelObjectResult(obj=target_obj, exc=exception, result=None))
                time_out = 0.001  # if there was a timeout on one of the futures there is no need to wait for all
            except Exception as exception:  # noqa: BLE001
                results.append(ParallelObjectResult(obj=target_obj, exc=exception, result=None))
            else:
                results.append(ParallelObjectResult(obj=target_obj, exc=None, result=result))
        self.clean_up(futures)
        if ignore_exceptions:
            return results
        runs_that_finished_with_exception = [res for res in results if res.exc]
        if runs_that_finished_with_exception:
>           raise ParallelObjectException(results=results)
E           sdcm.utils.parallel_object.ParallelObjectException: functools.partial(<bound method BaseNode.run_nodetool of <sdcm.cluster_aws.AWSNode object at 0x71c8ca970ad0>>, sub_cmd='compact', args='keyspace1 standard1'):
E            Traceback (most recent call last):
E             File "/home/ubuntu/scylla-cluster-tests/sdcm/utils/parallel_object.py", line 97, in run
E               result = future.result(time_out)
E             File "/usr/local/lib/python3.13/concurrent/futures/_base.py", line 458, in result
E               raise TimeoutError()
E           TimeoutError
E           functools.partial(<bound method BaseNode.run_nodetool of <sdcm.cluster_aws.AWSNode object at 0x71c8e2bc6710>>, sub_cmd='compact', args='keyspace1 standard1'):
E            Traceback (most recent call last):
E             File "/home/ubuntu/scylla-cluster-tests/sdcm/utils/parallel_object.py", line 97, in run
E               result = future.result(time_out)
E             File "/usr/local/lib/python3.13/concurrent/futures/_base.py", line 458, in result
E               raise TimeoutError()
E           TimeoutError
E           functools.partial(<bound method BaseNode.run_nodetool of <sdcm.cluster_aws.AWSNode object at 0x71c9035374d0>>, sub_cmd='compact', args='keyspace1 standard1'):
E            Traceback (most recent call last):
E             File "/home/ubuntu/scylla-cluster-tests/sdcm/utils/parallel_object.py", line 97, in run
E               result = future.result(time_out)
E             File "/usr/local/lib/python3.13/concurrent/futures/_base.py", line 458, in result
E               raise TimeoutError()
E           TimeoutError
E           functools.partial(<bound method BaseNode.run_nodetool of <sdcm.cluster_aws.AWSNode object at 0x71c903a542d0>>, sub_cmd='compact', args='keyspace1 standard1'):
E            Traceback (most recent call last):
E             File "/home/ubuntu/scylla-cluster-tests/sdcm/utils/parallel_object.py", line 97, in run
E               result = future.result(time_out)
E             File "/usr/local/lib/python3.13/concurrent/futures/_base.py", line 458, in result
E               raise TimeoutError()
E           TimeoutError
E           functools.partial(<bound method BaseNode.run_nodetool of <sdcm.cluster_aws.AWSNode object at 0x71c903a54690>>, sub_cmd='compact', args='keyspace1 standard1'):
E            Traceback (most recent call last):
E             File "/home/ubuntu/scylla-cluster-tests/sdcm/utils/parallel_object.py", line 97, in run
E               result = future.result(time_out)
E             File "/usr/local/lib/python3.13/concurrent/futures/_base.py", line 458, in result
E               raise TimeoutError()
E           TimeoutError
E           functools.partial(<bound method BaseNode.run_nodetool of <sdcm.cluster_aws.AWSNode object at 0x71c903a547d0>>, sub_cmd='compact', args='keyspace1 standard1'):
E            Traceback (most recent call last):
E             File "/home/ubuntu/scylla-cluster-tests/sdcm/utils/parallel_object.py", line 97, in run
E               result = future.result(time_out)
E             File "/usr/local/lib/python3.13/concurrent/futures/_base.py", line 458, in result
E               raise TimeoutError()
E           TimeoutError
sdcm/utils/parallel_object.py:113: ParallelObjectException
```

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [test_manager_backup](https://argus.scylladb.com/tests/scylla-cluster-tests/8adff233-b21e-4833-9a0c-36fc1a278e16)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
