### PR TITLE
fix(xcloud): correct job path in weekly perf trigger

### DIFF
--- a/jenkins-pipelines/master-triggers/sct_triggers/xcloud-weekly-perf-trigger.xml
+++ b/jenkins-pipelines/master-triggers/sct_triggers/xcloud-weekly-perf-trigger.xml
@@ -34,7 +34,7 @@ requested_by_user=dimakr</properties>
               <textParamValueOnNewLine>false</textParamValueOnNewLine>
             </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
           </configs>
-          <projects>../scylla-master/perf-regression/scylla-cloud-perf-regression-predefined-throughput-steps-vnodes</projects>
+          <projects>../perf-regression/scylla-cloud-predefined-throughput-steps-sanity-vnodes</projects>
           <condition>SUCCESS</condition>
           <triggerWithNoParameters>false</triggerWithNoParameters>
           <triggerFromChildProjects>false</triggerFromChildProjects>


### PR DESCRIPTION
Remove an extra `../scylla-master/` prefix from scylla-cloud performance job in the trigger; and corect the job name itself.

Refs: QAINFRA-38

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
