### PR TITLE
feature(perf): add cql-stress variant of i8g-tablets predefined throughput steps

### DIFF
--- a/configurations/performance/rust-predefined-throughput-steps-cql-stress.yaml
+++ b/configurations/performance/rust-predefined-throughput-steps-cql-stress.yaml
@@ -42,4 +42,12 @@ stress_cmd_m: [
   "cql-stress-cassandra-stress mixed  cl=QUORUM duration=$duration -mode cql3 native -rate 'threads=$threads $throttle' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=15000001..20000000"
 ]
 
+# Read the entire data set to ensure disk only reads
+stress_cmd_read_disk: [
+  "cql-stress-cassandra-stress read  cl=QUORUM duration=$duration -mode cql3 native -rate 'threads=$threads $throttle' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..162500001",
+  "cql-stress-cassandra-stress read  cl=QUORUM duration=$duration -mode cql3 native -rate 'threads=$threads $throttle' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=162500002..325000002",
+  "cql-stress-cassandra-stress read  cl=QUORUM duration=$duration -mode cql3 native -rate 'threads=$threads $throttle' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=325000003..487500003",
+  "cql-stress-cassandra-stress read  cl=QUORUM duration=$duration -mode cql3 native -rate 'threads=$threads $throttle' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=487500004..650000004"
+]
+
 instance_type_loader: 'c7i.2xlarge'

--- a/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-i8g-tablets-cql-stress.jenkinsfile
+++ b/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-i8g-tablets-cql-stress.jenkinsfile
@@ -1,0 +1,13 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+perfRegressionParallelPipeline(
+    backend: "aws",
+    region: "us-east-1",
+    provision_type: 'on_demand',
+    test_name: "performance_regression_gradual_grow_throughput.PerformanceRegressionPredefinedStepsTest",
+    test_config: '''["test-cases/performance/perf-regression-predefined-throughput-steps.yaml", "configurations/performance/cassandra_stress_gradual_load_steps_i8g.yaml", "configurations/performance/rust-predefined-throughput-steps-cql-stress.yaml", "configurations/disable_kms.yaml", "configurations/disable_speculative_retry.yaml", "configurations/performance/latency-decorator-error-thresholds-steps-ent-tablets.yaml", "configurations/arm_instance_types/i8g_4xlarge.yaml"]''',
+    sub_tests: ["test_read_gradual_increase_load", "test_mixed_gradual_increase_load", "test_read_disk_only_gradual_increase_load", "test_write_gradual_increase_load"],
+)


### PR DESCRIPTION
## Summary
- New Jenkins pipeline that runs the i8g-tablets predefined-throughput-steps performance test using `cql-stress-cassandra-stress` in place of `cassandra-stress`.
- Reuses `configurations/performance/rust-predefined-throughput-steps-cql-stress.yaml` for the cql-stress command overrides; keeps the i8g gradual-load shape, tablets latency thresholds, and `i8g.4xlarge` DB instance from the existing pipeline.
- Drops `configurations/c-s-driver-version-4.yaml` (Java driver pin, not applicable to cql-stress).
- Extends `rust-predefined-throughput-steps-cql-stress.yaml` with a `stress_cmd_read_disk` definition so `test_read_disk_only_gradual_increase_load` can be driven by `cql-stress-cassandra-stress` too (backward-compatible: existing pipelines that use this yaml do not enable the disk-only sub-test).

## Test plan
- [ ] Trigger the new Jenkins job end-to-end and confirm all four sub-tests run to completion.
- [ ] Compare throughput/latency results against the cassandra-stress i8g-tablets baseline.
- [ ] Re-tune `perf_gradual_throttle_steps` / `perf_gradual_threads` in the gradual-load config if cql-stress saturates the cluster at different targets than cassandra-stress on i8g.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Testing

- [ ] :clock1: [scylla-enterprise-perf-regression-predefined-throughput-steps-i8g-tablets-cql-stress-test #2](https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/performance/job/branch-perf-v17/job/scylla-enterprise/job/perf-regression/job/scylla-enterprise-perf-regression-predefined-throughput-steps-i8g-tablets-cql-stress-test/2/)
