### PR TITLE
fix(platform-migration): escape '%' in trigger job description

### DIFF
--- a/jenkins-pipelines/master-triggers/sct_triggers/platform-migration-weekly-trigger.xml
+++ b/jenkins-pipelines/master-triggers/sct_triggers/platform-migration-weekly-trigger.xml
@@ -2,7 +2,7 @@
   <actions/>
   <description>Triggers platform migration test weekly every Saturday at 02:00 UTC
 
-  Runs x86 to ARM batched per-rack migration with 50% disk utilization and tablets enabled.
+  Runs x86 to ARM batched per-rack migration with 50%% disk utilization and tablets enabled.
   </description>
   <scm class="hudson.scm.NullSCM"/>
   <disabled>false</disabled>


### PR DESCRIPTION
Escape '%' in the platform-migration weekly trigger description, otherwise Python '%' string formatter interprets '50% d' as a %d format specifier, crashing create-test-release-jobs pipeline.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] tested with the following simple python script locally
```
content = open('jenkins-pipelines/master-triggers/sct_triggers/platform-migration-weekly-trigger.xml').read()
context = {}
result = content % context

print('OK:', result[:80])
```
on master the issue is reproduced as:
```
Error: Exit code 1
Traceback (most recent call last):
  File "<string>", line 4, in <module>
    result = content % {}
             ~~~~~~~~^~~~~~~~~
TypeError: %d format: a real number is required, not dict
```
on fix feature branch this is passing
```
OK: <?xml version="1.1" encoding="UTF-8" standalone="no"?><project>
  <actions/>
```

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
