### PR TITLE
fix(nemesis): fix log follow pattern

### DIFF
--- a/sdcm/nemesis/monkey/abort_decommission.py
+++ b/sdcm/nemesis/monkey/abort_decommission.py
@@ -53,7 +53,7 @@ class AbortDecommissionMonkey(NemesisBaseClass):
         # indicating that SSTable streaming has finished for at least one sstable.
         # Once the `log_follower` yields a line, we know streaming has started.
         log_follower = self.runner.target_node.follow_system_log(
-            patterns=[r"stream_blob - stream_sstables\[[0-9a-f-]+\] Finished sending sstable_nr"]
+            patterns=[r"stream_blob - stream_sstables\[[0-9a-f-]+\] Finished sending files_nr"]
         )
 
         _streaming_started = lambda: len(list(log_follower)) > 0


### PR DESCRIPTION
The log was changed in scylladb/scylladb@22949bae520b1fc482235193f98715de6285bfa2

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
