### PR TITLE
fix(gemini-test): exclude node isolation nemesis from gemini test cases

### DIFF
--- a/test-cases/gemini/gemini-1tb-10h.yaml
+++ b/test-cases/gemini/gemini-1tb-10h.yaml
@@ -8,7 +8,7 @@ instance_type_loader: 'm6i.xlarge'
 user_prefix: 'gemini-1tb-10h'
 
 nemesis_class_name: 'SisyphusMonkey'
-nemesis_selector: 'not enospc'
+nemesis_selector: 'not enospc and not IsolateNodeWithIptableRuleNemesis and not IsolateNodeWithProcessSignalNemesis'
 nemesis_seed: '041'
 
 gemini_cmd: |

--- a/test-cases/gemini/gemini-3h-ics-cdc-with-nemesis.yaml
+++ b/test-cases/gemini/gemini-3h-ics-cdc-with-nemesis.yaml
@@ -8,7 +8,7 @@ user_prefix: 'ics-cdc-gemini-basic-3h'
 ami_db_scylla_user: 'centos'
 
 nemesis_class_name: 'SisyphusMonkey'
-nemesis_selector: "not enospc"
+nemesis_selector: "not enospc and not IsolateNodeWithIptableRuleNemesis and not IsolateNodeWithProcessSignalNemesis"
 
 gemini_cmd: |
   --duration 3h

--- a/test-cases/gemini/gemini-3h-with-nemesis.yaml
+++ b/test-cases/gemini/gemini-3h-with-nemesis.yaml
@@ -7,7 +7,7 @@ instance_type_db: 'i4i.large'
 user_prefix: 'gemini-with-nemesis-3h-normal'
 
 nemesis_class_name: 'SisyphusMonkey'
-nemesis_selector: 'not enospc'
+nemesis_selector: 'not enospc and not IsolateNodeWithIptableRuleNemesis and not IsolateNodeWithProcessSignalNemesis'
 nemesis_seed: '032'
 
 gemini_cmd: |

--- a/test-cases/gemini/gemini-8h-large-num-columns.yaml
+++ b/test-cases/gemini/gemini-8h-large-num-columns.yaml
@@ -8,7 +8,7 @@ instance_type_loader: 'c6i.4xlarge'
 user_prefix: 'gemini-8h-large-num-columns'
 
 nemesis_class_name: 'SisyphusMonkey'
-nemesis_selector: 'not enospc'
+nemesis_selector: 'not enospc and not IsolateNodeWithIptableRuleNemesis and not IsolateNodeWithProcessSignalNemesis'
 nemesis_seed: '023'
 
 gemini_cmd: |


### PR DESCRIPTION
When gemini is running and node isolation nemesis (IsolateNodeWithIptableRuleNemesis or IsolateNodeWithProcessSignalNemesis) triggers, the isolated node cannot receive changes from other nodes, causing gemini validation to fail.

Exclude both IsolateNodeWithIptableRuleNemesis and IsolateNodeWithProcessSignalNemesis from the nemesis_selector in 4 gemini test-case YAML files that use negative selection filters.

Ref: https://scylladb.atlassian.net/browse/SCT-195

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
