### PR TITLE
fix(nemesis): don't abort test on teardown-killed stress

### DIFF
--- a/sdcm/stress/base.py
+++ b/sdcm/stress/base.py
@@ -27,6 +27,8 @@ from sdcm.remote.libssh2_client.exceptions import Failure
 
 LOGGER = logging.getLogger(__name__)
 
+ParseResults = tuple[list[dict], dict[str, list[tuple[Severity, str]]]]
+
 
 class DockerBasedStressThread:
     DOCKER_IMAGE_PARAM_NAME = ""  # test yaml param that stores image
@@ -111,14 +113,15 @@ class DockerBasedStressThread:
 
         return results
 
-    def parse_results(self) -> tuple[list, dict]:
+    def parse_results(self) -> ParseResults:
         """
         Parses the raw results from the finished stress threads
 
-        :returns: tuple of (results, errors) lists, where:
+        :returns: tuple of (results, errors), where:
             - results: list of results from the stress threads that finished successfully
-            - errors: dict of errors, where the key is the loader name and the value is a list of errors
-                occurred on that loader
+            - errors: dict keyed by loader name with list of (severity, message) tuples so callers
+                can distinguish real errors from WARNING-severity failures (e.g. stress killed by
+                test teardown via SIGKILL)
         """
         results = []
         errors = {}
@@ -134,7 +137,7 @@ class DockerBasedStressThread:
                     results.append(result)
 
             if event and getattr(event, "errors", None):
-                errors.setdefault(loader.name, []).extend(event.errors)
+                errors.setdefault(loader.name, []).extend((event.severity, msg) for msg in event.errors)
 
         return results, errors
 

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -3162,28 +3162,40 @@ class ClusterTester(unittest.TestCase):
         :return: bool, indication whether all stress threads have completed successfully
         """
         results, errors = thread_pool.parse_results()
-        if results:
-            pass
-        else:
+        if not results:
             self.log.warning("There is no stress results, probably stress thread has failed.")
 
+        # split errors by severity so WARNING-severity errors do not trigger test failure
+        real_errors, warnings = {}, {}
+        if isinstance(errors, dict):
+            for loader_name, errs in errors.items():
+                for severity, msg in errs:
+                    target = warnings if severity == Severity.WARNING else real_errors
+                    target.setdefault(loader_name, []).append(msg)
+        else:
+            real_errors = errors
+
+        if warnings:
+            warnings_msg = "\n".join(f"{node}:\n  " + "\n  ".join(msgs[-5:]) for node, msgs in warnings.items() if msgs)
+            self.log.warning("stress warnings on nodes:\n%s", warnings_msg)
+
         if error_handler:
-            error_handler(thread_pool, errors)
-        if errors:
+            error_handler(thread_pool, real_errors)
+        if real_errors:
             # Sometimes, we might have an epic error messages list
             # that will make small machines driving the test
             # to run out of memory when writing the XML report. Since
             # the error message is merely informational, let's simply
             # use the last 5 lines for the final error message.
-            if isinstance(errors, dict):
-                filtered_errors = {k: v[-5:] for k, v in errors.items() if v}
+            if isinstance(real_errors, dict):
+                filtered_errors = {k: v[-5:] for k, v in real_errors.items() if v}
                 errors_msg = "\n".join(
                     f"{node}:\n  " + "\n  ".join(err_list) for node, err_list in filtered_errors.items()
                 )
-            elif isinstance(errors, list):
-                errors_msg = "\n  ".join(errors[-5:])  # Use last 5 entries from the list
+            elif isinstance(real_errors, list):
+                errors_msg = "\n  ".join(real_errors[-5:])  # Use last 5 entries from the list
             self.log.warning("stress errors on nodes:\n%s", errors_msg)
-        return results and not errors
+        return results and not real_errors
 
     def get_stress_results(self, queue, store_results=True) -> list[dict | None]:
         results = queue.parse_results()[0]


### PR DESCRIPTION
Stress failures with exist status 137 (SIGKILL from test teardown) are flagged as Severity.WARNING, but their messages end up in the errors dict passed to
`sdcm.nemesis.NemesisRunner._nemesis_stress_failure_handler`, causing a false-negative NemesisStressFailure.

The change refactors base stress thread `parse_results` method to return errors with their severities. Additionally, the `verify_stress_thread` in tester.py is updated to
only log the warning severity stress thread entries, thus avoding false-negative stress failures.

Fixes: SCT-183

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :green_circle: [test from original issue - longevity-scylla-cloud-5gb-1h](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/pr-provision-test/262/)
- [x] :green_circle:  [longevity-10gb-3h test on aws](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/pr-provision-test/263/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
