### PR TITLE
fix(gce-provision): exclude us-east1-d from zone selection to avoid resource exhaustion

### DIFF
--- a/sdcm/utils/gce_utils.py
+++ b/sdcm/utils/gce_utils.py
@@ -88,8 +88,9 @@ def vmarch_to_gcp(arch: "VmArch") -> str:
 # The keys are the region name, the value is the available zones, which will be used for random.choice()
 SUPPORTED_REGIONS = {
     # us-east1 zones: b, c, and d. Details: https://cloud.google.com/compute/docs/regions-zones#locations
-    # Currently choose only zones c and d as zone b frequently fails allocating resources.
-    "us-east1": "cd",
+    # Zone b frequently fails allocating resources, zone d hits ZONE_RESOURCE_POOL_EXHAUSTED
+    # for z3-highmem-32-highlssd instances. Only zone c is reliable.
+    "us-east1": "c",
     "us-east4": "abc",
     "us-west1": "abc",
     "us-central1": "a",


### PR DESCRIPTION
GCE zone us-east1-d consistently hits ZONE_RESOURCE_POOL_EXHAUSTED for z3-highmem-32-highlssd instances, causing SCT tests to abort during provisioning without actually running. This wastes CI capacity as Jenkins marks the jobs as ABORTED. Restrict us-east1 to zone c only, which is the last remaining reliable zone (zone b was already excluded for similar allocation failures).

Fixes: https://scylladb.atlassian.net/browse/SCT-248

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
