### PR TITLE
improvement(pipelines) : allow performance pipelines to run with custom gce scylla image or manager

### DIFF
--- a/vars/perfRegressionParallelPipeline.groovy
+++ b/vars/perfRegressionParallelPipeline.groovy
@@ -46,6 +46,7 @@ def call(Map pipelineParams) {
             // ScyllaDB Configuration
             separator(name: 'SCYLLA_DB', sectionHeader: 'ScyllaDB Configuration Selection (Choose only one from below 6 options)')
             string(defaultValue: '', description: 'AMI ID for ScyllaDB', name: 'scylla_ami_id')
+            string(defaultValue: '', description: 'GCE image for ScyllaDB ', name: 'gce_image_db')
             string(defaultValue: '',
                    description: 'Version of ScyllaDB to run against. Can be a released version (2025.4) or a master (master:latest)',
                    name: 'scylla_version')
@@ -64,6 +65,22 @@ def call(Map pipelineParams) {
             string(defaultValue: '',
                    description: 'cloud path for RPMs, s3:// or gs://',
                    name: 'update_db_packages')
+
+            // Manager Configuration
+            separator(name: 'MANAGER_CONFIG', sectionHeader: 'Manager Configuration')
+            string(defaultValue: "${pipelineParams.get('manager_version', '')}",
+                   description: 'master_latest|3.8|3.7',
+                   name: 'manager_version')
+
+            string(defaultValue: '',
+                   description: 'If empty - the default manager version will be taken',
+                   name: 'scylla_mgmt_address')
+
+            string(defaultValue: '', description: 'Version of Management Agent', name: 'scylla_mgmt_agent_version')
+
+            string(defaultValue: "${pipelineParams.get('scylla_mgmt_agent_address', '')}",
+                   description: 'If empty - the default scylla manager agent repo will be taken',
+                   name: 'scylla_mgmt_agent_address')
 
             // Provisioning Configuration
             separator(name: 'PROVISIONING', sectionHeader: 'Provisioning Configuration')


### PR DESCRIPTION
During development, backup and restore performance test may need to run with a custom scylla on google cloud, or they may need a custom manager version.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://argus.scylladb.com/tests/scylla-cluster-tests/0e958023-dd48-46ea-af66-cba0d6522cc4
  This is ran on a different branch that also contains this commit

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
