### PR TITLE
fix(vector): use --nobest on Rocky 8 to work around GLIBC >= 2.29 dependency

### DIFF
--- a/sdcm/provision/common/utils.py
+++ b/sdcm/provision/common/utils.py
@@ -281,7 +281,7 @@ def install_vector_service():
             # https://github.com/vectordotdev/vector/issues/25253). Use --nobest so yum picks the latest
             # version that actually resolves on this OS.
             _yum_vector_flags=""
-            if grep -q 'ID=rocky' /etc/os-release 2>/dev/null && grep -q 'VERSION_ID="8' /etc/os-release 2>/dev/null; then
+            if [ -f /etc/os-release ] && . /etc/os-release 2>/dev/null && [ "$ID" = "rocky" ] && echo "$VERSION_ID" | grep -q "^8"; then
                 _yum_vector_flags="--nobest"
             fi
             for n in 2 4 6 8 10 10 10 10; do # cloud-init is running it with set +o braceexpand

--- a/sdcm/provision/common/utils.py
+++ b/sdcm/provision/common/utils.py
@@ -277,8 +277,15 @@ def install_vector_service():
 
         # install vector
         if yum --help 2>/dev/null 1>&2 ; then
+            # Rocky Linux 8 / EL8: vector >= 0.55.0 requires GLIBC_2.29/2.30 not available on EL8 (SCT-261,
+            # https://github.com/vectordotdev/vector/issues/25253). Use --nobest so yum picks the latest
+            # version that actually resolves on this OS.
+            _yum_vector_flags=""
+            if grep -q 'ID=rocky' /etc/os-release 2>/dev/null && grep -q 'VERSION_ID="8' /etc/os-release 2>/dev/null; then
+                _yum_vector_flags="--nobest"
+            fi
             for n in 2 4 6 8 10 10 10 10; do # cloud-init is running it with set +o braceexpand
-                if yum install -y vector; then
+                if yum install -y $_yum_vector_flags vector; then
                     break
                 fi
                 sleep $(backoff $n)


### PR DESCRIPTION
## Summary

- Vector v0.55.0 RPM requires `GLIBC_2.29` and `GLIBC_2.30`, which are not available on Rocky Linux 8 (ships with glibc 2.28)
- This broke `artifacts-rocky8-test` on 2026-04-22 immediately after v0.55.0 was published to yum.vector.dev
- On Rocky Linux 8 only, pass `--nobest` to `yum install` so it picks the latest version that actually resolves dependencies instead of hard-failing

## Root cause

```
Problem: cannot install the best candidate for the job
  - nothing provides libc.so.6(GLIBC_2.30)(64bit) needed by vector-0.55.0-1.x86_64
  - nothing provides libm.so.6(GLIBC_2.29)(64bit) needed by vector-0.55.0-1.x86_64
```

Upstream bug report: https://github.com/vectordotdev/vector/issues/25253

## Test plan

- [x] Run `artifacts-rocky8-test` with this change — vector should install (picking 0.54.x) and the test should pass
- [x] Confirm other distro artifact tests are unaffected (no `--nobest` applied elsewhere)

Fixes SCT-261

### Testing

- [x] 🟢 [artifacts-rocky8-test #26](https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-rocky8-test/26/)
