### PR TITLE
fix(upgrade-test): exclude .tmp files from sstabledump verification

### DIFF
--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -847,7 +847,7 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
         dump_cmd = get_sstable_data_dump_command(first_node, keyspace, table)
         first_node.remoter.run(
             f"for i in `sudo find /var/lib/scylla/data/{keyspace}/ -type f |grep -v manifest.json |"
-            "grep -v snapshots |head -n 1`; do echo $i; "
+            "grep -v snapshots |grep -v '\\.tmp$' |head -n 1`; do echo $i; "
             f"sudo {dump_cmd} $i 1>/tmp/sstabledump.output || "
             "exit 1; done",
             verbose=True,


### PR DESCRIPTION
## Summary
- Exclude `.tmp` files from the `find` command in `test_rolling_upgrade` Step 7 (sstabledump verification), preventing failures when `upgradesstables` compaction is still active

Fixes: SCT-264

### Testing

- [x] 🟢 [rolling-upgrade-ami-test #43](https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/rolling-upgrade-ami-test/43/)
