### PR TITLE
chore(azure): improve azure  disk performance to avoid c-s failures

### DIFF
--- a/test-cases/longevity/longevity-10gb-3h.yaml
+++ b/test-cases/longevity/longevity-10gb-3h.yaml
@@ -8,7 +8,7 @@ n_loaders: 2
 instance_type_db: 'i4i.2xlarge'
 gce_instance_type_db: 'n2-highmem-16'
 gce_instance_type_loader: 'e2-standard-4'
-azure_instance_type_db: 'Standard_L8s_v3'
+azure_instance_type_db: 'Standard_L8s_v4'
 run_fullscan: ['{"mode": "table_and_aggregate", "ks_cf": "keyspace1.standard1", "interval": 10}']
 nemesis_class_name: 'SisyphusMonkey'
 nemesis_seed: '111'


### PR DESCRIPTION
Increase the Azure instance size to avoid  disk bottleneck that
 caused test failures


The workload uses a relatively small dataset (~10M keys / ~10GB logical data, RF=3), so it should be treated as a mixed IO / resilience / tail-latency test rather than a large-capacity test. During the add/remove index operation, several Azure nodes show clear localized disk starvation: compaction, memtable, sl:default, and main I/O queues spike, with sl:default disk starvation reaching ~5.5s on one node and ~4.1s on another.

This change moves the affected test to a stronger Azure storage-optimized instance to reduce disk bottlenecks and improve test stability.

Disk performance comparison: Standard_L8s_v3 vs Standard_L8s_v4

Standard_L8s_v3: ~400k IOPS (only aggregated info)
Standard_L8s_v4: ~550k read IOPS

Increase: +150k IOPS
Percentage increase: +37.5%


Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-1729

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
