### PR TITLE
test(gemini): switch instance types from i4i to i7i due to low availability

### DIFF
--- a/test-cases/gemini/gemini-1tb-10h.yaml
+++ b/test-cases/gemini/gemini-1tb-10h.yaml
@@ -2,8 +2,8 @@ test_duration: 780
 n_db_nodes: 6
 n_test_oracle_db_nodes: 1
 n_loaders: 1
-instance_type_db: 'i4i.2xlarge'
-instance_type_loader: 'm6i.xlarge'
+instance_type_db: 'i7i.2xlarge'
+instance_type_loader: 'c7i.xlarge'
 
 user_prefix: 'gemini-1tb-10h'
 

--- a/test-cases/gemini/gemini-3h-cdc-postimage-write.yaml
+++ b/test-cases/gemini/gemini-3h-cdc-postimage-write.yaml
@@ -1,7 +1,8 @@
 test_duration: 300
 n_db_nodes: 3
 n_loaders: 1
-instance_type_db: 'i4i.4xlarge'
+instance_type_db: 'i7i.2xlarge'
+instance_type_loader: 'c7i.large'
 
 user_prefix: 'gemini-cdc-postimage-write'
 

--- a/test-cases/gemini/gemini-3h-cdc-preimage-write.yaml
+++ b/test-cases/gemini/gemini-3h-cdc-preimage-write.yaml
@@ -1,8 +1,8 @@
 test_duration: 300
 n_db_nodes: 3
 n_loaders: 1
-instance_type_db: 'i4i.4xlarge'
-
+instance_type_db: 'i7i.4xlarge'
+instance_type_loader: 'c7i.xlarge'
 user_prefix: 'gemini-cdc-preimage-write'
 
 gemini_cmd: |

--- a/test-cases/gemini/gemini-3h-cdc-write.yaml
+++ b/test-cases/gemini/gemini-3h-cdc-write.yaml
@@ -1,7 +1,8 @@
 test_duration: 300
 n_db_nodes: 3
 n_loaders: 1
-instance_type_db: 'i4i.4xlarge'
+instance_type_db: 'i7i.4xlarge'
+instance_type_loader: 'c7i.xlarge'
 
 user_prefix: 'gemini-cdc-write'
 

--- a/test-cases/gemini/gemini-3h-ics-cdc-with-nemesis.yaml
+++ b/test-cases/gemini/gemini-3h-ics-cdc-with-nemesis.yaml
@@ -2,7 +2,8 @@ test_duration: 500
 n_db_nodes: 6
 n_test_oracle_db_nodes: 1
 n_loaders: 1
-instance_type_db: 'i4i.large'
+instance_type_db: 'i7i.large'
+instance_type_loader: 'c7i.large'
 
 user_prefix: 'ics-cdc-gemini-basic-3h'
 ami_db_scylla_user: 'centos'

--- a/test-cases/gemini/gemini-3h-ics-with-nondisruptive-nemesis.yaml
+++ b/test-cases/gemini/gemini-3h-ics-with-nondisruptive-nemesis.yaml
@@ -2,7 +2,8 @@ test_duration: 500
 n_db_nodes: 6
 n_test_oracle_db_nodes: 1
 n_loaders: 1
-instance_type_db: 'i4i.large'
+instance_type_db: 'i7i.large'
+instance_type_loader: 'c7i.large'
 
 user_prefix: 'ics-gemini-nemesis-3h'
 ami_db_scylla_user: 'centos'

--- a/test-cases/gemini/gemini-3h-with-nemesis.yaml
+++ b/test-cases/gemini/gemini-3h-with-nemesis.yaml
@@ -2,7 +2,8 @@ test_duration: 300
 n_db_nodes: 6
 n_test_oracle_db_nodes: 1
 n_loaders: 1
-instance_type_db: 'i4i.large'
+instance_type_db: 'i7i.large'
+instance_type_loader: 'c7i.large'
 
 user_prefix: 'gemini-with-nemesis-3h-normal'
 

--- a/test-cases/gemini/gemini-3h-with-nondisruptive-nemesis.yaml
+++ b/test-cases/gemini/gemini-3h-with-nondisruptive-nemesis.yaml
@@ -2,7 +2,8 @@ test_duration: 500
 n_db_nodes: 3
 n_test_oracle_db_nodes: 1
 n_loaders: 1
-instance_type_db: 'i4i.xlarge'
+instance_type_db: 'i7i.xlarge'
+instance_type_loader: 'c7i.xlarge'
 
 user_prefix: 'gemini-basic-3h'
 

--- a/test-cases/gemini/gemini-basic-3h-ics.yaml
+++ b/test-cases/gemini/gemini-basic-3h-ics.yaml
@@ -2,7 +2,8 @@ test_duration: 500
 n_db_nodes: 3
 n_test_oracle_db_nodes: 1
 n_loaders: 1
-instance_type_db: 'i4i.large'
+instance_type_db: 'i7i.large'
+instance_type_loader: 'c7i.large'
 
 user_prefix: 'ics-gemini-basic-3h'
 ami_db_scylla_user: 'centos'

--- a/test-cases/gemini/gemini-basic-3h.yaml
+++ b/test-cases/gemini/gemini-basic-3h.yaml
@@ -2,7 +2,8 @@ test_duration: 500
 n_db_nodes: 3
 n_test_oracle_db_nodes: 1
 n_loaders: 1
-instance_type_db: 'i4i.large'
+instance_type_db: 'i7i.large'
+instance_type_loader: 'c7i.large'
 
 user_prefix: 'gemini-basic-3h'
 


### PR DESCRIPTION
i4i instances have been experiencing availability issues causing gemini tests to fail to start (see Argus runs over the past week). Replace all i4i DB instances with equivalent i7i generations and m6i/c7i loaders with c7i across all 10 gemini test configurations.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
