### PR TITLE
Revert "[Backport perf-v17] feature(ycsb): enable native YCSB loadbalancer"

### DIFF
--- a/configurations/rolling-upgrade-alternator.yaml
+++ b/configurations/rolling-upgrade-alternator.yaml
@@ -24,5 +24,5 @@ authenticator_password: cassandra
 authorizer: 'CassandraAuthorizer'
 
 alternator_port: 8080
-alternator_use_dns_routing: false
+alternator_use_dns_routing: true
 docker_network: 'ycsb_net'

--- a/configurations/rolling-upgrade-alternator.yaml
+++ b/configurations/rolling-upgrade-alternator.yaml
@@ -24,5 +24,5 @@ authenticator_password: cassandra
 authorizer: 'CassandraAuthorizer'
 
 alternator_port: 8080
-
+alternator_use_dns_routing: false
 docker_network: 'ycsb_net'

--- a/defaults/docker_images/ycsb/values_ycsb.yaml
+++ b/defaults/docker_images/ycsb/values_ycsb.yaml
@@ -1,2 +1,8 @@
 ycsb:
+<<<<<<< HEAD
+  image: docker.io/scylladb/ycsb:0.2.0
+||||||| parent of 55e74319b (feature(ycsb): enable native YCSB loadbalancer)
+  image: docker.io/scylladb/ycsb:1.0.0
+=======
   image: docker.io/scylladb/ycsb:1.2.0
+>>>>>>> 55e74319b (feature(ycsb): enable native YCSB loadbalancer)

--- a/defaults/docker_images/ycsb/values_ycsb.yaml
+++ b/defaults/docker_images/ycsb/values_ycsb.yaml
@@ -1,8 +1,2 @@
 ycsb:
-<<<<<<< HEAD
   image: docker.io/scylladb/ycsb:0.2.0
-||||||| parent of 55e74319b (feature(ycsb): enable native YCSB loadbalancer)
-  image: docker.io/scylladb/ycsb:1.0.0
-=======
-  image: docker.io/scylladb/ycsb:1.2.0
->>>>>>> 55e74319b (feature(ycsb): enable native YCSB loadbalancer)

--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -90,8 +90,6 @@ compaction_strategy: 'SizeTieredCompactionStrategy'
 use_preinstalled_scylla: false
 
 alternator_enforce_authorization: false
-alternator_use_dns_routing: false
-alternator_loadbalancing: true
 alternator_access_key_id: ''
 alternator_secret_access_key: ''
 dynamodb_primarykey_type: 'HASH'

--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -92,7 +92,6 @@ use_preinstalled_scylla: false
 alternator_enforce_authorization: false
 alternator_use_dns_routing: false
 alternator_loadbalancing: true
-alternator_trust_all_certificates: true
 alternator_access_key_id: ''
 alternator_secret_access_key: ''
 dynamodb_primarykey_type: 'HASH'

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -933,37 +933,6 @@ If true, spawn a docker with a dns server for the ycsb loader to point to
 **type:** boolean
 
 
-<<<<<<< HEAD
-||||||| parent of 55e74319b (feature(ycsb): enable native YCSB loadbalancer)
-## **alternator_test_table** / SCT_ALTERNATOR_TEST_TABLE
-
-Dictionary of a test alternator table features:<br>name: str - the name of the table<br>lsi_name: str - the name of the local secondary index to create with a table<br>gsi_name: str - the name of the global secondary index to create with a table<br>tags: dict - the tags to apply to the created table<br>items: int - expected number of items in the table after prepare
-
-**default:** N/A
-
-**type:** dict
-
-
-=======
-## **alternator_loadbalancing** / SCT_ALTERNATOR_LOADBALANCING
-
-If true, enable native load balancing for alternator
-
-**default:** N/A
-
-**type:** boolean
-
-
-## **alternator_test_table** / SCT_ALTERNATOR_TEST_TABLE
-
-Dictionary of a test alternator table features:<br>name: str - the name of the table<br>lsi_name: str - the name of the local secondary index to create with a table<br>gsi_name: str - the name of the global secondary index to create with a table<br>tags: dict - the tags to apply to the created table<br>items: int - expected number of items in the table after prepare
-
-**default:** N/A
-
-**type:** dict
-
-
->>>>>>> 55e74319b (feature(ycsb): enable native YCSB loadbalancer)
 ## **alternator_enforce_authorization** / SCT_ALTERNATOR_ENFORCE_AUTHORIZATION
 
 If true, enable the authorization check in dynamodb api (alternator)

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -933,6 +933,18 @@ If true, spawn a docker with a dns server for the ycsb loader to point to
 **type:** boolean
 
 
+<<<<<<< HEAD
+||||||| parent of 55e74319b (feature(ycsb): enable native YCSB loadbalancer)
+## **alternator_test_table** / SCT_ALTERNATOR_TEST_TABLE
+
+Dictionary of a test alternator table features:<br>name: str - the name of the table<br>lsi_name: str - the name of the local secondary index to create with a table<br>gsi_name: str - the name of the global secondary index to create with a table<br>tags: dict - the tags to apply to the created table<br>items: int - expected number of items in the table after prepare
+
+**default:** N/A
+
+**type:** dict
+
+
+=======
 ## **alternator_loadbalancing** / SCT_ALTERNATOR_LOADBALANCING
 
 If true, enable native load balancing for alternator
@@ -951,6 +963,7 @@ Dictionary of a test alternator table features:<br>name: str - the name of the t
 **type:** dict
 
 
+>>>>>>> 55e74319b (feature(ycsb): enable native YCSB loadbalancer)
 ## **alternator_enforce_authorization** / SCT_ALTERNATOR_ENFORCE_AUTHORIZATION
 
 If true, enable the authorization check in dynamodb api (alternator)
@@ -976,15 +989,6 @@ the aws_secret_access_key that would be used for alternator
 **default:** N/A
 
 **type:** str (appendable)
-
-
-## **alternator_trust_all_certificates** / SCT_ALTERNATOR_TRUST_ALL_CERTIFICATES
-
-If true, trust all TLS certificates for alternator connections (for testing with self-signed certs)
-
-**default:** True
-
-**type:** boolean
 
 
 ## **region_aware_loader** / SCT_REGION_AWARE_LOADER

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -949,7 +949,7 @@ Dictionary of a test alternator table features:<br>name: str - the name of the t
 
 If true, enable native load balancing for alternator
 
-**default:** True
+**default:** N/A
 
 **type:** boolean
 

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -909,38 +909,6 @@ class SCTConfiguration(dict):
             help="If true, spawn a docker with a dns server for the ycsb loader to point to",
         ),
         dict(
-<<<<<<< HEAD
-||||||| parent of 55e74319b (feature(ycsb): enable native YCSB loadbalancer)
-            name="alternator_test_table",
-            env="SCT_ALTERNATOR_TEST_TABLE",
-            type=dict,
-            help="""Dictionary of a test alternator table features:
-                    name: str - the name of the table
-                    lsi_name: str - the name of the local secondary index to create with a table
-                    gsi_name: str - the name of the global secondary index to create with a table
-                    tags: dict - the tags to apply to the created table
-                    items: int - expected number of items in the table after prepare""",
-        ),
-        dict(
-=======
-            name="alternator_loadbalancing",
-            env="SCT_ALTERNATOR_LOADBALANCING",
-            type=boolean,
-            help="If true, enable native load balancing for alternator",
-        ),
-        dict(
-            name="alternator_test_table",
-            env="SCT_ALTERNATOR_TEST_TABLE",
-            type=dict,
-            help="""Dictionary of a test alternator table features:
-                    name: str - the name of the table
-                    lsi_name: str - the name of the local secondary index to create with a table
-                    gsi_name: str - the name of the global secondary index to create with a table
-                    tags: dict - the tags to apply to the created table
-                    items: int - expected number of items in the table after prepare""",
-        ),
-        dict(
->>>>>>> 55e74319b (feature(ycsb): enable native YCSB loadbalancer)
             name="alternator_enforce_authorization",
             env="SCT_ALTERNATOR_ENFORCE_AUTHORIZATION",
             type=boolean,

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -909,6 +909,20 @@ class SCTConfiguration(dict):
             help="If true, spawn a docker with a dns server for the ycsb loader to point to",
         ),
         dict(
+<<<<<<< HEAD
+||||||| parent of 55e74319b (feature(ycsb): enable native YCSB loadbalancer)
+            name="alternator_test_table",
+            env="SCT_ALTERNATOR_TEST_TABLE",
+            type=dict,
+            help="""Dictionary of a test alternator table features:
+                    name: str - the name of the table
+                    lsi_name: str - the name of the local secondary index to create with a table
+                    gsi_name: str - the name of the global secondary index to create with a table
+                    tags: dict - the tags to apply to the created table
+                    items: int - expected number of items in the table after prepare""",
+        ),
+        dict(
+=======
             name="alternator_loadbalancing",
             env="SCT_ALTERNATOR_LOADBALANCING",
             type=boolean,
@@ -926,6 +940,7 @@ class SCTConfiguration(dict):
                     items: int - expected number of items in the table after prepare""",
         ),
         dict(
+>>>>>>> 55e74319b (feature(ycsb): enable native YCSB loadbalancer)
             name="alternator_enforce_authorization",
             env="SCT_ALTERNATOR_ENFORCE_AUTHORIZATION",
             type=boolean,
@@ -942,12 +957,6 @@ class SCTConfiguration(dict):
             env="SCT_ALTERNATOR_SECRET_ACCESS_KEY",
             type=str,
             help="the aws_secret_access_key that would be used for alternator",
-        ),
-        dict(
-            name="alternator_trust_all_certificates",
-            env="SCT_ALTERNATOR_TRUST_ALL_CERTIFICATES",
-            type=boolean,
-            help="If true, trust all TLS certificates for alternator connections (for testing with self-signed certs)",
         ),
         dict(
             name="region_aware_loader",

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -1243,8 +1243,6 @@ class FileFollowerThread:
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.stop()
-        if self.future:
-            self.future.result(timeout=30)
 
     def run(self):
         raise NotImplementedError()

--- a/sdcm/ycsb_thread.py
+++ b/sdcm/ycsb_thread.py
@@ -144,8 +144,7 @@ class YcsbStressThread(DockerBasedStressThread):
     def _hdr_files_directory_on_loaders_node(self, loader_idx, cpu_idx):
         return f"{self._hdr_main_dir_on_loaders_node()}/{loader_idx}/{cpu_idx}"
 
-    def copy_template(self, cmd_runner, loader, memo={}):  # noqa: B006
-        loader_name = loader.name
+    def copy_template(self, cmd_runner, loader_name, memo={}):  # noqa: B006
         if loader_name in memo:
             return None
         web_protocol = "http"
@@ -165,6 +164,7 @@ class YcsbStressThread(DockerBasedStressThread):
             dynamodb_teample = dedent(
                 """
                 measurementtype=hdrhistogram
+                dynamodb.awsCredentialsFile = /tmp/aws_dummy_credentials_file
                 dynamodb.endpoint = {0}://{1}:{2}
                 dynamodb.connectMax = 2500
                 requestdistribution = uniform
@@ -187,50 +187,26 @@ class YcsbStressThread(DockerBasedStressThread):
                     dynamodb.primaryKey = {alternator.consts.HASH_KEY_NAME}
                     dynamodb.primaryKeyType = {alternator.enums.YCSBSchemaTypes.HASH_SCHEMA.value}
                 """)
-            access_key = self.params.get("alternator_access_key_id")
             if self.params.get("alternator_enforce_authorization"):
-                secret_key = alternator.api.Alternator.get_salted_hash(node=self.node_list[0], username=access_key)
+                aws_credentials_content = dedent(f"""
+                    accessKey = {self.params.get("alternator_access_key_id")}
+                    secretKey = {alternator.api.Alternator.get_salted_hash(node=self.node_list[0], username=self.params.get("alternator_access_key_id"))}
+                """)
             else:
-                secret_key = self.params.get("alternator_secret_access_key")
-
-            dns_loadbalancing = self.params.get("alternator_use_dns_routing")
-            native_loading = self.params.get("alternator_loadbalancing")
-            if dns_loadbalancing:
-                native_loading = False
-
-            alternator_port = self.params.get("alternator_port")
-            trustAllCerts = self.params.get("alternator_trust_all_certificates")
-
-            if not alternator_port:
-                alternator_port = -1
-            if not trustAllCerts:
-                trustAllCerts = True
-
-            # This is a workaround to make AWS SDK v2 Happy
-            # as it will fail if the credentials are not provided,
-            # even if the alternator is running in a mode that does not require authentication.
-            if access_key is None or access_key == "":
-                access_key = "test"
-            if secret_key is None or secret_key == "":
-                secret_key = "test"
+                aws_credentials_content = dedent(f"""
+                    accessKey = {self.params.get("alternator_access_key_id")}
+                    secretKey = {self.params.get("alternator_secret_access_key")}
+                """)
 
             with tempfile.NamedTemporaryFile(mode="w+", encoding="utf-8") as tmp_file:
                 tmp_file.write(dynamodb_teample)
-                tmp_file.write(
-                    dedent(f"""
-                    dynamodb.alternator.datacenter = {getattr(loader, "datacenter", "")}
-                    dynamodb.alternator.rack = {getattr(loader, "rack", "")}
-                    dynamodb.debug = false
-                    dynamodb.alternator.port = {alternator_port}
-                    dynamodb.alternator.loadbalancing = {native_loading}
-                    dynamodb.virtualThreads = true
-                    dynamodb.alternator.trustAllCertificates = {trustAllCerts}
-                    dynamodb.awsAccessKey = {access_key}
-                    dynamodb.awsSecretKey = {secret_key}
-                """)
-                )
                 tmp_file.flush()
                 cmd_runner.send_files(tmp_file.name, os.path.join("/tmp", "dynamodb.properties"))
+
+            with tempfile.NamedTemporaryFile(mode="w+", encoding="utf-8") as tmp_file:
+                tmp_file.write(aws_credentials_content)
+                tmp_file.flush()
+                cmd_runner.send_files(tmp_file.name, os.path.join("/tmp", "aws_dummy_credentials_file"))
             if is_kubernetes:
                 if web_protocol == "https":
                     if ca_bundle_path := getattr(self.node_list[0], "alternator_ca_bundle_path", None):
@@ -392,7 +368,7 @@ class YcsbStressThread(DockerBasedStressThread):
             )
             cmd_runner_name = str(loader)
 
-        self.copy_template(cmd_runner, loader)
+        self.copy_template(cmd_runner, loader.name)
         stress_cmd = self.build_stress_cmd(loader_idx, cpu_idx)
 
         if not os.path.exists(loader.logdir):

--- a/sdcm/ycsb_thread.py
+++ b/sdcm/ycsb_thread.py
@@ -63,10 +63,7 @@ class YcsbStatsPublisher(FileFollowerThread):
     def handle_verify_metric(self, line):
         verify_status_regex = re.compile(r"Return\((?P<status>.*?)\)=(?P<value>\d*)")
         verify_regex = re.compile(r"\[VERIFY:(.*?)\]")
-        found = verify_regex.findall(line)
-        if not found:
-            return
-        verify_content = found[0]
+        verify_content = verify_regex.findall(line)[0]
 
         for status_match in verify_status_regex.finditer(verify_content):
             stat = status_match.groupdict()
@@ -111,13 +108,6 @@ class YcsbStatsPublisher(FileFollowerThread):
                                     except ValueError:
                                         value = float(0)  # noqa: PLW2901
                                 self.set_metric(operation, key, float(value))
-
-                    # [VERIFY: Return(OK/UNEXPECTED_STATE/ERROR)=N] lines are final summary lines
-                    # that do NOT match the stats regex (no Count/Max/Min/Avg fields), so
-                    # handle_verify_metric would never be called for them from inside the
-                    # stats regex loop above. Handle them separately here.
-                    if "[VERIFY:" in line and "Return(" in line:
-                        self.handle_verify_metric(line)
 
                 except Exception:
                     LOGGER.exception("fail to send metric")
@@ -238,6 +228,8 @@ class YcsbStressThread(DockerBasedStressThread):
                 tmp_file.write(dynamodb_teample)
                 tmp_file.write(
                     dedent(f"""
+                    dynamodb.alternator.datacenter = {getattr(loader, "datacenter", "")}
+                    dynamodb.alternator.rack = {getattr(loader, "rack", "")}
                     dynamodb.debug = false
                     dynamodb.alternator.port = {alternator_port}
                     dynamodb.alternator.loadbalancing = {native_loading}
@@ -247,16 +239,6 @@ class YcsbStressThread(DockerBasedStressThread):
                     dynamodb.awsSecretKey = {secret_key}
                 """)
                 )
-                # Only write datacenter/rack when non-empty. Java's Properties.getProperty()
-                # returns "" for empty values (not null), so `datacenter != null` would be
-                # true for "", creating DatacenterScope.of("") which routes to a non-existent
-                # datacenter and causes all operations to fail.
-                loader_datacenter = getattr(loader, "datacenter", "")
-                loader_rack = getattr(loader, "rack", "")
-                if loader_datacenter:
-                    tmp_file.write(f"dynamodb.alternator.datacenter = {loader_datacenter}\n")
-                if loader_rack:
-                    tmp_file.write(f"dynamodb.alternator.rack = {loader_rack}\n")
                 tmp_file.flush()
                 cmd_runner.send_files(tmp_file.name, os.path.join("/tmp", "dynamodb.properties"))
             if is_kubernetes:

--- a/sdcm/ycsb_thread.py
+++ b/sdcm/ycsb_thread.py
@@ -198,16 +198,6 @@ class YcsbStressThread(DockerBasedStressThread):
             if dns_loadbalancing:
                 native_loading = False
 
-            if dns_loadbalancing == False and native_loading == False:
-                LOGGER.error(
-                    "Both 'alternator_use_dns_routing' and 'alternator_loadbalancing' options are set to False, "
-                    "alternator must use some form of load balancing to distribute the load between the nodes in the cluster "
-                    ", or alternator will not be able to start as it will look for DEFAULT AWS address"
-                )
-                raise ValueError(
-                    "One of the 'alternator_use_dns_routing' or 'alternator_loadbalancing' options must be set to True"
-                )
-
             alternator_port = self.params.get("alternator_port")
             trustAllCerts = self.params.get("alternator_trust_all_certificates")
 

--- a/test-cases/features/alternator-ttl/longevity-alternator-1h-scan-12h-ttl-no-lwt-2h-grace-4loaders-sisyphus.yaml
+++ b/test-cases/features/alternator-ttl/longevity-alternator-1h-scan-12h-ttl-no-lwt-2h-grace-4loaders-sisyphus.yaml
@@ -48,7 +48,7 @@ nemesis_interval: 10
 user_prefix: 'alternator-ttl-4-loaders-no-lwt-sisyphus'
 
 alternator_port: 8080
-alternator_use_dns_routing: false
+alternator_use_dns_routing: true
 docker_network: 'ycsb_net'
 
 alternator_enforce_authorization: true

--- a/test-cases/features/alternator-ttl/longevity-alternator-1h-scan-12h-ttl-no-lwt-2h-grace-4loaders-sisyphus.yaml
+++ b/test-cases/features/alternator-ttl/longevity-alternator-1h-scan-12h-ttl-no-lwt-2h-grace-4loaders-sisyphus.yaml
@@ -48,7 +48,7 @@ nemesis_interval: 10
 user_prefix: 'alternator-ttl-4-loaders-no-lwt-sisyphus'
 
 alternator_port: 8080
-
+alternator_use_dns_routing: false
 docker_network: 'ycsb_net'
 
 alternator_enforce_authorization: true

--- a/test-cases/features/alternator-ttl/longevity-alternator-4m-scan-36m-ttl-8m-grace-sisyphus-rewrite-expired-data.yaml
+++ b/test-cases/features/alternator-ttl/longevity-alternator-4m-scan-36m-ttl-8m-grace-sisyphus-rewrite-expired-data.yaml
@@ -38,7 +38,7 @@ nemesis_seed: '033'
 user_prefix: '4m-scan-36m-ttl-8m-grace-sisyphus-rewrite-expired'
 
 alternator_port: 8080
-alternator_use_dns_routing: false
+alternator_use_dns_routing: true
 docker_network: 'ycsb_net'
 
 alternator_enforce_authorization: true

--- a/test-cases/features/alternator-ttl/longevity-alternator-4m-scan-36m-ttl-8m-grace-sisyphus-rewrite-expired-data.yaml
+++ b/test-cases/features/alternator-ttl/longevity-alternator-4m-scan-36m-ttl-8m-grace-sisyphus-rewrite-expired-data.yaml
@@ -38,7 +38,7 @@ nemesis_seed: '033'
 user_prefix: '4m-scan-36m-ttl-8m-grace-sisyphus-rewrite-expired'
 
 alternator_port: 8080
-
+alternator_use_dns_routing: false
 docker_network: 'ycsb_net'
 
 alternator_enforce_authorization: true

--- a/test-cases/features/alternator-ttl/longevity-alternator-4m-scan-36m-ttl-no-lwt-8m-grace-sisyphus.yaml
+++ b/test-cases/features/alternator-ttl/longevity-alternator-4m-scan-36m-ttl-no-lwt-8m-grace-sisyphus.yaml
@@ -31,7 +31,7 @@ nemesis_seed: '033'
 user_prefix: '4m-scan-36m-ttl-8m-grace-sisyphus'
 
 alternator_port: 8080
-alternator_use_dns_routing: false
+alternator_use_dns_routing: true
 docker_network: 'ycsb_net'
 
 alternator_enforce_authorization: true

--- a/test-cases/features/alternator-ttl/longevity-alternator-4m-scan-36m-ttl-no-lwt-8m-grace-sisyphus.yaml
+++ b/test-cases/features/alternator-ttl/longevity-alternator-4m-scan-36m-ttl-no-lwt-8m-grace-sisyphus.yaml
@@ -31,7 +31,7 @@ nemesis_seed: '033'
 user_prefix: '4m-scan-36m-ttl-8m-grace-sisyphus'
 
 alternator_port: 8080
-
+alternator_use_dns_routing: false
 docker_network: 'ycsb_net'
 
 alternator_enforce_authorization: true

--- a/test-cases/features/alternator-ttl/longevity-alternator-4m-scan-multiple-ttl-8m-grace.yaml
+++ b/test-cases/features/alternator-ttl/longevity-alternator-4m-scan-multiple-ttl-8m-grace.yaml
@@ -86,7 +86,7 @@ nemesis_seed: '033'
 user_prefix: 'longevity-alternator-multiple-ttl'
 
 alternator_port: 8080
-
+alternator_use_dns_routing: false
 docker_network: 'ycsb_net'
 
 alternator_enforce_authorization: true

--- a/test-cases/features/alternator-ttl/longevity-alternator-4m-scan-multiple-ttl-8m-grace.yaml
+++ b/test-cases/features/alternator-ttl/longevity-alternator-4m-scan-multiple-ttl-8m-grace.yaml
@@ -86,7 +86,7 @@ nemesis_seed: '033'
 user_prefix: 'longevity-alternator-multiple-ttl'
 
 alternator_port: 8080
-alternator_use_dns_routing: false
+alternator_use_dns_routing: true
 docker_network: 'ycsb_net'
 
 alternator_enforce_authorization: true

--- a/test-cases/features/alternator-ttl/longevity-alternator-disable-enable-ttl.yaml
+++ b/test-cases/features/alternator-ttl/longevity-alternator-disable-enable-ttl.yaml
@@ -38,7 +38,7 @@ nemesis_interval: 30
 user_prefix: 'alternator-disable-enable-ttl'
 
 alternator_port: 8080
-
+alternator_use_dns_routing: false
 docker_network: 'ycsb_net'
 
 alternator_enforce_authorization: true

--- a/test-cases/features/alternator-ttl/longevity-alternator-disable-enable-ttl.yaml
+++ b/test-cases/features/alternator-ttl/longevity-alternator-disable-enable-ttl.yaml
@@ -38,7 +38,7 @@ nemesis_interval: 30
 user_prefix: 'alternator-disable-enable-ttl'
 
 alternator_port: 8080
-alternator_use_dns_routing: false
+alternator_use_dns_routing: true
 docker_network: 'ycsb_net'
 
 alternator_enforce_authorization: true

--- a/test-cases/features/alternator-ttl/longevity-alternator-ttl-big-dataset.yaml
+++ b/test-cases/features/alternator-ttl/longevity-alternator-ttl-big-dataset.yaml
@@ -45,7 +45,7 @@ nemesis_during_prepare: false
 user_prefix: 'alternator-ttl-big-data-set'
 
 alternator_port: 8080
-alternator_use_dns_routing: false
+alternator_use_dns_routing: true
 docker_network: 'ycsb_net'
 
 alternator_enforce_authorization: true

--- a/test-cases/features/alternator-ttl/longevity-alternator-ttl-big-dataset.yaml
+++ b/test-cases/features/alternator-ttl/longevity-alternator-ttl-big-dataset.yaml
@@ -45,7 +45,7 @@ nemesis_during_prepare: false
 user_prefix: 'alternator-ttl-big-data-set'
 
 alternator_port: 8080
-
+alternator_use_dns_routing: false
 docker_network: 'ycsb_net'
 
 alternator_enforce_authorization: true

--- a/test-cases/features/alternator-ttl/longevity-alternator-ttl-large-writes.yaml
+++ b/test-cases/features/alternator-ttl/longevity-alternator-ttl-large-writes.yaml
@@ -44,7 +44,7 @@ nemesis_during_prepare: false
 user_prefix: 'alternator-ttl-large-writes'
 
 alternator_port: 8080
-alternator_use_dns_routing: false
+alternator_use_dns_routing: true
 docker_network: 'ycsb_net'
 
 alternator_enforce_authorization: true

--- a/test-cases/features/alternator-ttl/longevity-alternator-ttl-large-writes.yaml
+++ b/test-cases/features/alternator-ttl/longevity-alternator-ttl-large-writes.yaml
@@ -44,7 +44,7 @@ nemesis_during_prepare: false
 user_prefix: 'alternator-ttl-large-writes'
 
 alternator_port: 8080
-
+alternator_use_dns_routing: false
 docker_network: 'ycsb_net'
 
 alternator_enforce_authorization: true

--- a/test-cases/features/alternator-ttl/longevity-alternator-ttl-lwt.yaml
+++ b/test-cases/features/alternator-ttl/longevity-alternator-ttl-lwt.yaml
@@ -27,7 +27,7 @@ nemesis_during_prepare: false
 user_prefix: 'alternator-lwt-ttl'
 
 alternator_port: 8080
-
+alternator_use_dns_routing: false
 docker_network: 'ycsb_net'
 
 alternator_enforce_authorization: true

--- a/test-cases/features/alternator-ttl/longevity-alternator-ttl-lwt.yaml
+++ b/test-cases/features/alternator-ttl/longevity-alternator-ttl-lwt.yaml
@@ -27,7 +27,7 @@ nemesis_during_prepare: false
 user_prefix: 'alternator-lwt-ttl'
 
 alternator_port: 8080
-alternator_use_dns_routing: false
+alternator_use_dns_routing: true
 docker_network: 'ycsb_net'
 
 alternator_enforce_authorization: true

--- a/test-cases/longevity/longevity-alternator-200GB-48h.yaml
+++ b/test-cases/longevity/longevity-alternator-200GB-48h.yaml
@@ -48,7 +48,7 @@ nemesis_during_prepare: false
 user_prefix: 'alternator-48h'
 
 alternator_port: 8080
-alternator_use_dns_routing: false
+alternator_use_dns_routing: true
 docker_network: 'ycsb_net'
 
 alternator_enforce_authorization: true

--- a/test-cases/longevity/longevity-alternator-200GB-48h.yaml
+++ b/test-cases/longevity/longevity-alternator-200GB-48h.yaml
@@ -48,7 +48,7 @@ nemesis_during_prepare: false
 user_prefix: 'alternator-48h'
 
 alternator_port: 8080
-
+alternator_use_dns_routing: false
 docker_network: 'ycsb_net'
 
 alternator_enforce_authorization: true

--- a/test-cases/longevity/longevity-alternator-3h-multidc.yaml
+++ b/test-cases/longevity/longevity-alternator-3h-multidc.yaml
@@ -45,5 +45,5 @@ space_node_threshold: 64424
 
 alternator_port: 8080
 dynamodb_primarykey_type: HASH_AND_RANGE
-
+alternator_use_dns_routing: false
 docker_network: 'ycsb_net'

--- a/test-cases/longevity/longevity-alternator-3h-multidc.yaml
+++ b/test-cases/longevity/longevity-alternator-3h-multidc.yaml
@@ -45,5 +45,5 @@ space_node_threshold: 64424
 
 alternator_port: 8080
 dynamodb_primarykey_type: HASH_AND_RANGE
-alternator_use_dns_routing: false
+alternator_use_dns_routing: true
 docker_network: 'ycsb_net'

--- a/test-cases/longevity/longevity-alternator-3h.yaml
+++ b/test-cases/longevity/longevity-alternator-3h.yaml
@@ -46,5 +46,5 @@ space_node_threshold: 64424
 
 alternator_port: 8080
 dynamodb_primarykey_type: HASH_AND_RANGE
-
+alternator_use_dns_routing: false
 docker_network: 'ycsb_net'

--- a/test-cases/longevity/longevity-alternator-3h.yaml
+++ b/test-cases/longevity/longevity-alternator-3h.yaml
@@ -46,5 +46,5 @@ space_node_threshold: 64424
 
 alternator_port: 8080
 dynamodb_primarykey_type: HASH_AND_RANGE
-alternator_use_dns_routing: false
+alternator_use_dns_routing: true
 docker_network: 'ycsb_net'

--- a/test-cases/longevity/longevity-alternator-streams-100gb-12h.yaml
+++ b/test-cases/longevity/longevity-alternator-streams-100gb-12h.yaml
@@ -49,7 +49,7 @@ experimental_features:
 
 alternator_port: 8080
 dynamodb_primarykey_type: HASH
-alternator_use_dns_routing: false
+alternator_use_dns_routing: true
 docker_network: 'ycsb_net'
 
 use_mgmt: false # just to make setup quicker for now

--- a/test-cases/longevity/longevity-alternator-streams-100gb-12h.yaml
+++ b/test-cases/longevity/longevity-alternator-streams-100gb-12h.yaml
@@ -49,7 +49,7 @@ experimental_features:
 
 alternator_port: 8080
 dynamodb_primarykey_type: HASH
-
+alternator_use_dns_routing: false
 docker_network: 'ycsb_net'
 
 use_mgmt: false # just to make setup quicker for now

--- a/test-cases/performance/perf-regression-alternator-basic.yaml
+++ b/test-cases/performance/perf-regression-alternator-basic.yaml
@@ -67,8 +67,6 @@ prepare_stress_duration: 20
 alternator_write_isolation: 'forbid'
 alternator_port: 8080
 dynamodb_primarykey_type: HASH_AND_RANGE
-alternator_use_dns_routing: true
-alternator_loadbalancing: false
 
 user_prefix: 'perf-alternator-latency'
 space_node_threshold: 644245094

--- a/test-cases/performance/perf-regression-alternator-full.yaml
+++ b/test-cases/performance/perf-regression-alternator-full.yaml
@@ -37,37 +37,38 @@ prepare_write_cmd:
     bin/ycsb load dynamodb -P workloads/workloada -threads 100 -p recordcount=18000000 -p fieldcount=10 -p fieldlength=512
     -p insertorder=hashed -p insertstart=16000000 -p insertcount=2000000 -p operationcount=2000000
 
-stress_cmd_w: >2-
+stress_cmd_w: >-2
   bin/ycsb run dynamodb -P workloads/workloada -threads 100 -p recordcount=18000000
   -p readproportion=0 -p updateproportion=1 -p scanproportion=0 -p insertproportion=0 -p requestdistribution=uniform -p operationcount=0
   -p fieldcount=10 -p fieldlength=512
 
-stress_cmd_r: >2-
+stress_cmd_r: >-2
   bin/ycsb run dynamodb -P workloads/workloada -threads 100 -p recordcount=18000000
   -p readproportion=1 -p updateproportion=0 -p scanproportion=0 -p insertproportion=0 -p requestdistribution=uniform -p operationcount=0
   -p fieldcount=10 -p fieldlength=512
 
-stress_cmd_m: >2-
+stress_cmd_m: >-2
   bin/ycsb run dynamodb -P workloads/workloada -threads 100 -p recordcount=18000000
   -p readproportion=0.5 -p updateproportion=0.5 -p scanproportion=0 -p insertproportion=0 -p requestdistribution=uniform -p operationcount=0
   -p fieldcount=10 -p fieldlength=512
+
 
 n_db_nodes: 3
 n_loaders: 9
 n_monitor_nodes: 1
 
-instance_type_loader: "c7i.2xlarge"
-instance_type_monitor: "t3.small"
-instance_type_db: "i3.4xlarge"
+instance_type_loader: 'c7i.2xlarge'
+instance_type_monitor: 't3.small'
+instance_type_db: 'i3.4xlarge'
 
 stress_multiplier: 1
 stress_duration: 360
 prepare_stress_duration: 20
-alternator_write_isolation: "forbid"
+alternator_write_isolation: 'forbid'
 alternator_port: 8080
 dynamodb_primarykey_type: HASH_AND_RANGE
 
-user_prefix: "perf-alternator-latency"
+user_prefix: 'perf-alternator-latency'
 space_node_threshold: 644245094
 
 use_hdrhistogram: true
@@ -75,15 +76,12 @@ alternator_stress_rate: 60000
 alternator_write_always_lwt_stress_rate: 10000
 
 round_robin: true
-append_scylla_args: "--blocked-reactor-notify-ms 5 --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc --abort-on-internal-error 1 --abort-on-ebadf 1"
+append_scylla_args: '--blocked-reactor-notify-ms 5 --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc --abort-on-internal-error 1 --abort-on-ebadf 1'
 backtrace_decoding: true
 backtrace_stall_decoding: false
 
-email_recipients: [] # TODO: Re-enable email notifications by setting to ['alternator-perf-results@scylladb.com'] once the email template issue is resolved.
+email_recipients: []  # TODO: Re-enable email notifications by setting to ['alternator-perf-results@scylladb.com'] once the email template issue is resolved.
 argus_email_report_template: email_report_performance.yaml
-
-alternator_use_dns_routing: true
-alternator_loadbalancing: false
 
 latency_decorator_error_thresholds:
   write:
@@ -122,8 +120,8 @@ latency_decorator_error_thresholds:
       P90 write:
         fixed_limit: 5
       P90 read:
-        fixed_limit: 5
+          fixed_limit: 5
       P99 write:
-        fixed_limit: 8
+          fixed_limit: 8
       P99 read:
-        fixed_limit: 8
+          fixed_limit: 8

--- a/test-cases/performance/perf-regression-alternator.100threads.30M-keys.yaml
+++ b/test-cases/performance/perf-regression-alternator.100threads.30M-keys.yaml
@@ -47,8 +47,6 @@ instance_type_monitor: 't3.small'
 
 alternator_port: 8080
 dynamodb_primarykey_type: HASH_AND_RANGE
-alternator_use_dns_routing: true
-alternator_loadbalancing: false
 
 user_prefix: 'perf-alternator'
 space_node_threshold: 644245094

--- a/test-cases/scylla-operator/longevity-scylla-operator-alternator-http-3h.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-alternator-http-3h.yaml
@@ -68,3 +68,4 @@ authorizer: 'CassandraAuthorizer'
 
 dynamodb_primarykey_type: HASH_AND_RANGE
 # NOTE: 'alternator_use_dns_routing' is not applicable in K8S case and will be ignored.
+alternator_use_dns_routing: false

--- a/test-cases/scylla-operator/longevity-scylla-operator-alternator-https-3h.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-alternator-https-3h.yaml
@@ -68,3 +68,4 @@ authorizer: 'CassandraAuthorizer'
 
 dynamodb_primarykey_type: HASH_AND_RANGE
 # NOTE: 'alternator_use_dns_routing' is not applicable in K8S case and will be ignored.
+alternator_use_dns_routing: false

--- a/unit_tests/test_alternator_streams_kcl.py
+++ b/unit_tests/test_alternator_streams_kcl.py
@@ -32,8 +32,6 @@ def test_01_kcl_with_ycsb(request, docker_scylla, events, params):
         dict(
             dynamodb_primarykey_type="HASH_AND_RANGE",
             alternator_port=ALTERNATOR_PORT,
-            alternator_loadbalancing=True,
-            alternator_use_dns_routing=False,
             alternator_enforce_authorization=True,
             alternator_access_key_id="alternator",
             alternator_secret_access_key="password",

--- a/unit_tests/test_alternator_streams_kcl.py
+++ b/unit_tests/test_alternator_streams_kcl.py
@@ -31,6 +31,7 @@ def test_01_kcl_with_ycsb(request, docker_scylla, events, params):
     params.update(
         dict(
             dynamodb_primarykey_type="HASH_AND_RANGE",
+            alternator_use_dns_routing=True,
             alternator_port=ALTERNATOR_PORT,
             alternator_enforce_authorization=True,
             alternator_access_key_id="alternator",

--- a/unit_tests/test_ycsb_thread.py
+++ b/unit_tests/test_ycsb_thread.py
@@ -36,6 +36,7 @@ def fixture_alternator_api(params):
     params.update(
         dict(
             dynamodb_primarykey_type="HASH_AND_RANGE",
+            alternator_use_dns_routing=True,
             alternator_port=ALTERNATOR_PORT,
             alternator_enforce_authorization=True,
             alternator_access_key_id="alternator",

--- a/unit_tests/test_ycsb_thread.py
+++ b/unit_tests/test_ycsb_thread.py
@@ -12,7 +12,6 @@
 # Copyright (c) 2021 ScyllaDB
 
 import re
-from unittest.mock import MagicMock
 
 import pytest
 import requests
@@ -116,7 +115,7 @@ def test_01_dynamodb_api(request, docker_scylla, prom_address, params):
 
     cmd = (
         "bin/ycsb run dynamodb -P workloads/workloada -threads 5 -p recordcount=1000000 "
-        "-p fieldcount=10 -p fieldlength=1024 -p operationcount=200200300 -p status.interval=2 -s"
+        "-p fieldcount=10 -p fieldlength=1024 -p operationcount=200200300 -s"
     )
     ycsb_thread = YcsbStressThread(loader_set, cmd, node_list=[docker_scylla], timeout=5, params=params)
 
@@ -135,7 +134,7 @@ def test_01_dynamodb_api(request, docker_scylla, prom_address, params):
         assert "sct_ycsb_update_gauge" in output
 
         matches = regex.findall(output)
-        assert any(float(i) > 0 for i in matches), output
+        assert all(float(i) > 0 for i in matches), output
 
     check_metrics()
 
@@ -211,15 +210,7 @@ def test_03_cql(request, docker_scylla, prom_address, params):
 
     cmd = (
         "bin/ycsb load scylla -P workloads/workloada -threads 5 -p recordcount=1000000 "
-        "-p fieldcount=10 -p fieldlength=1024 -p operationcount=200200300 -p status.interval=2 -s"
-    )
-    ycsb_thread = YcsbStressThread(
-        loader_set,
-        cmd,
-        node_list=[docker_scylla],
-        timeout=30,
-        params=params,
-        cluster_tester=MagicMock(),
+        f"-p fieldcount=10 -p fieldlength=1024 -p operationcount=200200300 -p scylla.hosts={docker_scylla.ip_address} -s"
     )
     ycsb_thread = YcsbStressThread(loader_set, cmd, node_list=[docker_scylla], timeout=5, params=params)
 
@@ -233,11 +224,12 @@ def test_03_cql(request, docker_scylla, prom_address, params):
     @timeout(timeout=60)
     def check_metrics():
         output = requests.get("http://{}/metrics".format(prom_address)).text
-        regex = re.compile(r"^sct_ycsb_insert_gauge.*?([0-9\.]*?)$", re.MULTILINE)
-        assert "sct_ycsb_insert_gauge" in output
+        regex = re.compile(r"^sct_ycsb_read_gauge.*?([0-9\.]*?)$", re.MULTILINE)
+        assert "sct_ycsb_read_gauge" in output
+        assert "sct_ycsb_update_gauge" in output
 
         matches = regex.findall(output)
-        assert any(float(i) > 0 for i in matches), output
+        assert all(float(i) > 0 for i in matches), output
 
     check_metrics()
     ycsb_thread.get_results()

--- a/unit_tests/test_ycsb_thread.py
+++ b/unit_tests/test_ycsb_thread.py
@@ -37,8 +37,6 @@ def fixture_alternator_api(params):
         dict(
             dynamodb_primarykey_type="HASH_AND_RANGE",
             alternator_port=ALTERNATOR_PORT,
-            alternator_loadbalancing=True,
-            alternator_use_dns_routing=False,
             alternator_enforce_authorization=True,
             alternator_access_key_id="alternator",
             alternator_secret_access_key="password",


### PR DESCRIPTION
This reverts commit b7d1a3f.Reverts scylladb/scylla-cluster-tests#13839

Since this version merged alternator perf tests are crashing

See: [SCT-259](https://scylladb.atlassian.net/browse/SCT-259)

[SCT-259]: https://scylladb.atlassian.net/browse/SCT-259?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ