### PR TITLE
fix(unit-tests): add missing after_config param to OCI test mock

### DIFF
--- a/unit_tests/unit/test_cluster_oci.py
+++ b/unit_tests/unit/test_cluster_oci.py
@@ -21,7 +21,15 @@ def _mock_cloud_instance(private_ip_address="10.0.4.4"):
 
 
 def _base_node_init(
-    self, name, parent_cluster, ssh_login_info=None, base_logdir=None, node_prefix=None, dc_idx=0, rack=0
+    self,
+    name,
+    parent_cluster,
+    ssh_login_info=None,
+    base_logdir=None,
+    node_prefix=None,
+    dc_idx=0,
+    rack=0,
+    after_config=None,
 ):
     self.name = name
     self.test_config = Mock(IP_SSH_CONNECTIONS="private", INTRA_NODE_COMM_PUBLIC=False)


### PR DESCRIPTION
## Summary

- Fix 6 failing OCI unit tests caused by a signature mismatch between `_base_node_init` mock and the updated `BaseNode.__init__`

## Root Cause

PR #13381 added an `after_config` parameter to `BaseNode.__init__()`. The OCI unit tests (`test_cluster_oci.py`) were introduced before that PR merged and patch `BaseNode.__init__` with a hardcoded `_base_node_init` mock that didn't include the new parameter. When `OciNode.__init__` calls `super().__init__(after_config=after_config)`, the mock rejects it:

```
TypeError: _base_node_init() got an unexpected keyword argument 'after_config'
```

## Fix

Add `after_config=None` to the `_base_node_init` mock signature to match the current `BaseNode.__init__` contract.

## Tests

All 6 previously failing tests now pass:
```
unit_tests/unit/test_cluster_oci.py ......  [100%]
6 passed in 1.18s
```