### PR TITLE
fix(backtrace-decoding): use backtraces.scylladb.com to avoid monitor OOM [SCT-275]

### DIFF
--- a/docs/plans/mini-plans/2026-04-28-sct-275-external-backtrace-decoding.md
+++ b/docs/plans/mini-plans/2026-04-28-sct-275-external-backtrace-decoding.md
@@ -1,0 +1,81 @@
+# Mini-Plan: Use backtraces.scylladb.com for Backtrace Decoding (SCT-275)
+
+**Date:** 2026-04-28
+**Estimated LOC:** ~250
+**Related Issue:** SCT-275
+
+## Problem
+
+During longevity tests (e.g. `longevity-10gb-3h-azure-test`), the `addr2line` process on the
+monitor node consumes ~6.6 GB RSS when decoding Scylla backtraces from 1+ GB debug binaries.
+This OOM-kills the monitor node (8 GB VM), loses monitoring connectivity, and fails the test.
+
+The root cause is `decode_raw_backtrace()` in `sdcm/cluster.py` (line ~2066) which runs
+`addr2line -Cpife <debug_file> <addresses>` locally on the monitor node, loading full DWARF
+debug info into memory for every backtrace.
+
+## Approach
+
+**Strategy:** Try the external `backtraces.scylladb.com` service first, fall back to local
+`addr2line` only when the external service fails.
+
+### Step 1: Add external service helper method
+
+Add `_decode_via_external_service(self, build_id, raw_backtrace)` to the monitor node class
+in `sdcm/cluster.py`:
+- POST to `https://api.backtrace.scylladb.com/api/backtrace` with JSON body
+  `{"build_id": "<hex>", "input": "Backtrace:\n<addresses>"}`
+- Timeout: 120 seconds (decoding large binaries can take 30+ seconds on cache miss)
+- Return `output.stdout` on success (`response["success"] == True`)
+- Raise on failure (404 build not found, network error, `success == false`)
+
+### Step 2: Modify `decode_backtrace()` to try external first
+
+In the `decode_backtrace()` method (line ~1966), which already has `build_id` available from
+`obj["build_id"]`:
+1. If `build_id` is available, try `_decode_via_external_service(build_id, raw_backtrace)`
+2. On success → use the result, **skip** `copy_scylla_debug_info()` and local `addr2line` entirely
+3. On failure → log warning, fall back to existing flow (copy debug file + local `addr2line`)
+4. If `build_id` is `None` → go directly to local fallback
+
+This avoids copying the 1+ GB debug file to the monitor node when external decoding succeeds,
+which is the majority case for official Scylla builds.
+
+### Step 3: Refactor `decode_raw_backtrace()` as local-only fallback
+
+Rename or keep `decode_raw_backtrace()` as the local-only path. The external service path
+bypasses it entirely — no signature change needed for the local method.
+
+### Step 4: Add unit tests
+
+Test the new external service path with mocked HTTP responses:
+- External success → no local `addr2line` called
+- External failure (404) → falls back to local `addr2line`
+- External timeout → falls back to local `addr2line`
+- No `build_id` → goes directly to local `addr2line`
+
+### Design Notes
+
+- **Build ID source:** Already available in the decoding queue object (`obj["build_id"]`),
+  extracted from logs by `DbLogReader` (see `sdcm/db_log_reader.py` line ~157).
+- **Input format:** The API requires `"Backtrace:\n"` prefix before raw addresses.
+  Addresses can be raw hex (`0x12f34`) or path+offset format.
+- **Response format:** `{"success": true, "stdout": "<decoded lines>", "stderr": "", "duration": 5.2}`
+- **Existing API usage:** `sdcm/utils/version_utils.py` already calls the same service
+  (`/api/search/build_id`) — reuse similar HTTP patterns.
+- **No new config params needed initially.** The external service is always tried first;
+  local fallback is automatic. Can add a config toggle later if needed.
+
+## Files to Modify
+
+- `sdcm/cluster.py` — Add `_decode_via_external_service()`, modify `decode_backtrace()` to try external first
+- `unit_tests/unit/test_decode_backtrace.py` — Add tests for external service path and fallback logic
+
+## Verification
+
+- [ ] Unit tests pass: `uv run python -m pytest unit_tests/unit/test_decode_backtrace.py -v`
+- [ ] External service success path skips `copy_scylla_debug_info` and local `addr2line`
+- [ ] Fallback to local `addr2line` works when external service returns 404
+- [ ] Fallback to local `addr2line` works when external service times out
+- [ ] No `build_id` case goes directly to local path without attempting external call
+- [ ] `uv run sct.py pre-commit` passes

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2024,7 +2024,7 @@ class BaseNode(AutoSshContainerMixin):
 
                 if decoded is None:
                     scylla_debug_file = self.copy_scylla_debug_info(obj["node"], build_id)
-                    decoded = self.decode_raw_backtrace(scylla_debug_file, raw_backtrace_oneline).stdout
+                    decoded = self.decode_backtrace_local(scylla_debug_file, raw_backtrace_oneline).stdout
 
                 event.backtrace = decoded
                 the_map = FindIssuePerBacktrace()
@@ -2116,7 +2116,7 @@ class BaseNode(AutoSshContainerMixin):
         raise Exception("Couldn't find scylla debug information")
 
     @lru_cache(maxsize=None)
-    def decode_raw_backtrace(self, scylla_debug_file, raw_backtrace):
+    def decode_backtrace_local(self, scylla_debug_file, raw_backtrace):
         """run decode backtrace on monitor node
 
         Decode backtrace on monitor node

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1974,6 +1974,33 @@ class BaseNode(AutoSshContainerMixin):
         self._decoding_backtraces_thread.daemon = True
         self._decoding_backtraces_thread.start()
 
+    def _decode_via_external_service(self, build_id: str, raw_backtrace: str) -> str:
+        """Decode backtrace using the external backtraces.scylladb.com service.
+
+        Avoids loading 1+ GB DWARF debug info on the monitor node (prevents OOM).
+
+        Args:
+            build_id: hex build ID of the scylla binary
+            raw_backtrace: raw backtrace string (newline-separated addresses)
+
+        Returns:
+            decoded backtrace string (stdout from the service)
+
+        Raises:
+            requests.RequestException: on network/HTTP error
+            ValueError: if the service returns success=false
+        """
+        response = requests.post(
+            "https://api.backtrace.scylladb.com/api/backtrace",
+            json={"build_id": build_id, "input": "Backtrace:\n" + raw_backtrace},
+            timeout=120,
+        )
+        response.raise_for_status()
+        result = response.json()
+        if not result.get("success"):
+            raise ValueError(f"External backtrace service failed: {result.get('stderr', 'unknown error')}")
+        return result["stdout"]
+
     def decode_backtrace(self):
         while True:
             event = None
@@ -1983,9 +2010,22 @@ class BaseNode(AutoSshContainerMixin):
                     break
                 event = obj["event"]
                 self.log.debug("Event origin severity: %s", event.severity)
-                scylla_debug_file = self.copy_scylla_debug_info(obj["node"], obj["build_id"])
-                output = self.decode_raw_backtrace(scylla_debug_file, " ".join(event.raw_backtrace.split("\n")))
-                event.backtrace = output.stdout
+                build_id = obj["build_id"]
+                raw_backtrace_oneline = " ".join(event.raw_backtrace.split("\n"))
+
+                decoded = None
+                if build_id:
+                    try:
+                        decoded = self._decode_via_external_service(build_id, event.raw_backtrace)
+                        self.log.debug("Decoded backtrace via external service for build_id=%s", build_id)
+                    except Exception as exc:  # noqa: BLE001
+                        self.log.warning("External backtrace service failed (%s), falling back to local addr2line", exc)
+
+                if decoded is None:
+                    scylla_debug_file = self.copy_scylla_debug_info(obj["node"], build_id)
+                    decoded = self.decode_raw_backtrace(scylla_debug_file, raw_backtrace_oneline).stdout
+
+                event.backtrace = decoded
                 the_map = FindIssuePerBacktrace()
                 if issue_url := the_map.find_issue(backtrace_type=event.type, decoded_backtrace=event.backtrace):
                     event.known_issue = issue_url

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1974,6 +1974,7 @@ class BaseNode(AutoSshContainerMixin):
         self._decoding_backtraces_thread.daemon = True
         self._decoding_backtraces_thread.start()
 
+    @lru_cache(maxsize=None)
     def _decode_via_external_service(self, build_id: str, raw_backtrace: str) -> str:
         """Decode backtrace using the external backtraces.scylladb.com service.
 
@@ -2114,6 +2115,7 @@ class BaseNode(AutoSshContainerMixin):
 
         raise Exception("Couldn't find scylla debug information")
 
+    @lru_cache(maxsize=None)
     def decode_raw_backtrace(self, scylla_debug_file, raw_backtrace):
         """run decode backtrace on monitor node
 

--- a/unit_tests/integration/test_external_backtrace_service.py
+++ b/unit_tests/integration/test_external_backtrace_service.py
@@ -1,0 +1,72 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2025 ScyllaDB
+
+"""Integration tests for the external backtrace decoding service (api.backtrace.scylladb.com).
+
+External services: HTTPS to api.backtrace.scylladb.com
+"""
+
+import pytest
+import requests
+
+pytestmark = [
+    pytest.mark.integration,
+]
+
+# Known-good build from Scylla 2026.1.0~dev (SCYLLADB-403)
+KNOWN_BUILD_ID = "527bc25417c81c8106b33400a4372616c7c90894"
+SAMPLE_BACKTRACE_ADDRESSES = "0x4a3c9b7\n0x11ddd33\n0x11ddcec"
+API_URL = "https://api.backtrace.scylladb.com/api/backtrace"
+
+
+def test_external_backtrace_service_decodes_known_build():
+    """Verify that api.backtrace.scylladb.com returns decoded backtrace for a known build.
+
+    This test validates that the external service used by
+    BaseNode._decode_via_external_service() is reachable and returns
+    decoded output for a known Scylla build ID.
+    """
+    response = requests.post(
+        API_URL,
+        json={"build_id": KNOWN_BUILD_ID, "input": "Backtrace:\n" + SAMPLE_BACKTRACE_ADDRESSES},
+        timeout=120,
+    )
+    response.raise_for_status()
+    result = response.json()
+
+    assert result["success"] is True, f"Service returned success=false: {result.get('stderr')}"
+    assert result["stdout"], "Service returned empty stdout"
+    assert "Backtrace" in result["stdout"], "Decoded output should contain 'Backtrace' header"
+    assert any(indicator in result["stdout"] for indicator in ["at ", "()", "::", "FRAME"]), (
+        f"Decoded output doesn't look like resolved symbols: {result['stdout'][:200]}"
+    )
+
+
+def test_external_backtrace_service_returns_error_for_unknown_build():
+    """Verify that the service handles unknown build IDs gracefully.
+
+    The service should either return success=false or raise an HTTP error
+    for a build ID that doesn't exist.
+    """
+    fake_build_id = "0" * 40
+    response = requests.post(
+        API_URL,
+        json={"build_id": fake_build_id, "input": "Backtrace:\n0x1234"},
+        timeout=120,
+    )
+    if response.status_code == 200:
+        response.json()
+    else:
+        assert response.status_code in (400, 404, 422, 500), (
+            f"Unexpected status code {response.status_code} for unknown build ID"
+        )

--- a/unit_tests/integration/test_external_backtrace_service.py
+++ b/unit_tests/integration/test_external_backtrace_service.py
@@ -11,13 +11,15 @@
 #
 # Copyright (c) 2025 ScyllaDB
 
-"""Integration tests for the external backtrace decoding service (api.backtrace.scylladb.com).
+"""Integration tests for BaseNode._decode_via_external_service().
 
 External services: HTTPS to api.backtrace.scylladb.com
 """
 
 import pytest
-import requests
+
+from unit_tests.lib.dummy_remote import DummyRemote
+from unit_tests.lib.fake_cluster import DummyNode
 
 pytestmark = [
     pytest.mark.integration,
@@ -26,47 +28,28 @@ pytestmark = [
 # Known-good build from Scylla 2026.1.0~dev (SCYLLADB-403)
 KNOWN_BUILD_ID = "527bc25417c81c8106b33400a4372616c7c90894"
 SAMPLE_BACKTRACE_ADDRESSES = "0x4a3c9b7\n0x11ddd33\n0x11ddcec"
-API_URL = "https://api.backtrace.scylladb.com/api/backtrace"
 
 
-def test_external_backtrace_service_decodes_known_build():
-    """Verify that api.backtrace.scylladb.com returns decoded backtrace for a known build.
+@pytest.fixture(name="node")
+def node_fixture(tmp_path):
+    node = DummyNode(name="test_node", parent_cluster=None, base_logdir=tmp_path)
+    node.remoter = DummyRemote()
+    return node
 
-    This test validates that the external service used by
-    BaseNode._decode_via_external_service() is reachable and returns
-    decoded output for a known Scylla build ID.
-    """
-    response = requests.post(
-        API_URL,
-        json={"build_id": KNOWN_BUILD_ID, "input": "Backtrace:\n" + SAMPLE_BACKTRACE_ADDRESSES},
-        timeout=120,
-    )
-    response.raise_for_status()
-    result = response.json()
 
-    assert result["success"] is True, f"Service returned success=false: {result.get('stderr')}"
-    assert result["stdout"], "Service returned empty stdout"
-    assert "Backtrace" in result["stdout"], "Decoded output should contain 'Backtrace' header"
-    assert any(indicator in result["stdout"] for indicator in ["at ", "()", "::", "FRAME"]), (
-        f"Decoded output doesn't look like resolved symbols: {result['stdout'][:200]}"
+def test_decode_via_external_service_returns_symbols(node):
+    """Verify _decode_via_external_service returns decoded symbols for a known build."""
+    result = node._decode_via_external_service(KNOWN_BUILD_ID, SAMPLE_BACKTRACE_ADDRESSES)
+
+    assert result, "Decoded output should not be empty"
+    assert "Backtrace" in result
+    assert any(indicator in result for indicator in ["at ", "()", "::", "FRAME"]), (
+        f"Decoded output doesn't look like resolved symbols: {result[:200]}"
     )
 
 
-def test_external_backtrace_service_returns_error_for_unknown_build():
-    """Verify that the service handles unknown build IDs gracefully.
-
-    The service should either return success=false or raise an HTTP error
-    for a build ID that doesn't exist.
-    """
+def test_decode_via_external_service_raises_for_unknown_build(node):
+    """Verify _decode_via_external_service raises for an unknown build ID."""
     fake_build_id = "0" * 40
-    response = requests.post(
-        API_URL,
-        json={"build_id": fake_build_id, "input": "Backtrace:\n0x1234"},
-        timeout=120,
-    )
-    if response.status_code == 200:
-        response.json()
-    else:
-        assert response.status_code in (400, 404, 422, 500), (
-            f"Unexpected status code {response.status_code} for unknown build ID"
-        )
+    with pytest.raises(Exception):
+        node._decode_via_external_service(fake_build_id, "0x1234")

--- a/unit_tests/unit/test_decode_backtrace.py
+++ b/unit_tests/unit/test_decode_backtrace.py
@@ -12,7 +12,7 @@
 # Copyright (c) 2020 ScyllaDB
 
 import queue
-import threading
+
 from multiprocessing import Queue
 from unittest.mock import MagicMock, patch
 
@@ -243,9 +243,7 @@ def _run_decode_with_queue_item(monitor_node, build_id, raw_backtrace):
 
     monitor_node.test_config = config
 
-    t = threading.Thread(target=monitor_node.decode_backtrace)
-    t.start()
-    t.join(timeout=10)
+    monitor_node.decode_backtrace()
     return event
 
 
@@ -266,23 +264,36 @@ def test_external_service_success_skips_local_addr2line(monitor_node):
     mock_post.assert_called_once()
 
 
-def test_external_service_404_falls_back_to_local(monitor_node):
-    """When external service returns 404, fall back to local addr2line."""
-    http_error = requests.HTTPError(response=MagicMock(status_code=404))
+def test_external_service_post_request_payload(monitor_node):
+    """Verify the POST request sends correct URL, build_id and input format."""
+    mock_response = MagicMock()
+    mock_response.json.return_value = {"success": True, "stdout": "decoded", "stderr": ""}
+    mock_response.raise_for_status.return_value = None
 
-    with patch("sdcm.cluster.requests.post", side_effect=http_error):
+    with patch("sdcm.cluster.requests.post", return_value=mock_response) as mock_post:
+        _run_decode_with_queue_item(monitor_node, "abc123def", "0x1234\n0x5678")
+
+    mock_post.assert_called_once_with(
+        "https://api.backtrace.scylladb.com/api/backtrace",
+        json={"build_id": "abc123def", "input": "Backtrace:\n0x1234\n0x5678"},
+        timeout=120,
+    )
+
+
+@pytest.mark.parametrize(
+    "side_effect,description",
+    [
+        (requests.HTTPError(response=MagicMock(status_code=404)), "HTTP 404"),
+        (requests.Timeout("timed out"), "timeout"),
+        (requests.ConnectionError("connection refused"), "connection error"),
+    ],
+)
+def test_external_service_failure_falls_back_to_local(monitor_node, side_effect, description):
+    """When external service fails (%s), fall back to local addr2line."""
+    with patch("sdcm.cluster.requests.post", side_effect=side_effect):
         event = _run_decode_with_queue_item(monitor_node, "abc123", "0x1234\n0x5678")
 
-    assert event.backtrace is not None
-    assert "addr2line" in event.backtrace
-
-
-def test_external_service_timeout_falls_back_to_local(monitor_node):
-    """When external service times out, fall back to local addr2line."""
-    with patch("sdcm.cluster.requests.post", side_effect=requests.Timeout("timed out")):
-        event = _run_decode_with_queue_item(monitor_node, "abc123", "0x1234\n0x5678")
-
-    assert event.backtrace is not None
+    assert event.backtrace is not None, f"Should fall back to local for {description}"
     assert "addr2line" in event.backtrace
 
 

--- a/unit_tests/unit/test_decode_backtrace.py
+++ b/unit_tests/unit/test_decode_backtrace.py
@@ -11,9 +11,13 @@
 #
 # Copyright (c) 2020 ScyllaDB
 
+import queue
+import threading
 from multiprocessing import Queue
+from unittest.mock import MagicMock, patch
 
 import pytest
+import requests
 
 from sdcm.cluster import TestConfig
 from sdcm.db_log_reader import DbLogReader
@@ -219,3 +223,74 @@ def test_backtrace_decoding_configuration(
             assert event.get("backtrace") is None, (
                 f"Event of type {event.get('type')} should not have decoded backtrace"
             )
+
+
+def _run_decode_with_queue_item(monitor_node, build_id, raw_backtrace):
+    """Helper: enqueue one fake event, run decode_backtrace(), return the event mock."""
+    config = TestConfig()
+    config.DECODING_QUEUE = queue.Queue()
+
+    event = MagicMock()
+    event.raw_backtrace = raw_backtrace
+    event.backtrace = None
+    event.severity = MagicMock()
+    event.severity.value = 0
+    event.type = "REACTOR_STALLED"
+    event.event_id = "test-event-id"
+
+    config.DECODING_QUEUE.put({"event": event, "node": "test_node", "build_id": build_id})
+    config.DECODING_QUEUE.put(None)
+
+    monitor_node.test_config = config
+
+    t = threading.Thread(target=monitor_node.decode_backtrace)
+    t.start()
+    t.join(timeout=10)
+    return event
+
+
+def test_external_service_success_skips_local_addr2line(monitor_node):
+    """When external service succeeds, copy_scylla_debug_info and local addr2line are NOT called."""
+    mock_response = MagicMock()
+    mock_response.json.return_value = {"success": True, "stdout": "decoded-by-external", "stderr": ""}
+    mock_response.raise_for_status.return_value = None
+
+    with (
+        patch("sdcm.cluster.requests.post", return_value=mock_response) as mock_post,
+        patch.object(monitor_node, "copy_scylla_debug_info") as mock_copy,
+    ):
+        event = _run_decode_with_queue_item(monitor_node, "abc123", "0x1234\n0x5678")
+
+    assert event.backtrace == "decoded-by-external"
+    mock_copy.assert_not_called()
+    mock_post.assert_called_once()
+
+
+def test_external_service_404_falls_back_to_local(monitor_node):
+    """When external service returns 404, fall back to local addr2line."""
+    http_error = requests.HTTPError(response=MagicMock(status_code=404))
+
+    with patch("sdcm.cluster.requests.post", side_effect=http_error):
+        event = _run_decode_with_queue_item(monitor_node, "abc123", "0x1234\n0x5678")
+
+    assert event.backtrace is not None
+    assert "addr2line" in event.backtrace
+
+
+def test_external_service_timeout_falls_back_to_local(monitor_node):
+    """When external service times out, fall back to local addr2line."""
+    with patch("sdcm.cluster.requests.post", side_effect=requests.Timeout("timed out")):
+        event = _run_decode_with_queue_item(monitor_node, "abc123", "0x1234\n0x5678")
+
+    assert event.backtrace is not None
+    assert "addr2line" in event.backtrace
+
+
+def test_no_build_id_skips_external_service(monitor_node):
+    """When build_id is None, external service is never called."""
+    with patch("sdcm.cluster.requests.post") as mock_post:
+        event = _run_decode_with_queue_item(monitor_node, None, "0x1234\n0x5678")
+
+    mock_post.assert_not_called()
+    assert event.backtrace is not None
+    assert "addr2line" in event.backtrace


### PR DESCRIPTION
## Summary
- Add mini-plan for using `backtraces.scylladb.com` external API to decode backtraces instead of running `addr2line` locally on the monitor node
- Addresses SCT-275: `addr2line` OOM-kills the 8 GB monitor VM during longevity tests (6.6 GB RSS on large debug binaries)
- **Approach:** Try external service first → automatic fallback to local `addr2line` when service unavailable

## Plan Details
See `docs/plans/mini-plans/2026-04-28-sct-275-external-backtrace-decoding.md`

### Key Changes (Planned)
1. New `_decode_via_external_service()` method — POST to `api.backtrace.scylladb.com/api/backtrace` with `build_id` + raw addresses
2. Modify `decode_backtrace()` — try external first, skip debug file copy + local `addr2line` on success
3. Fallback to existing local path on external service failure
4. Unit tests for success/fallback/timeout scenarios

### Files to Modify
- `sdcm/cluster.py` — external service integration + fallback logic
- `unit_tests/unit/test_decode_backtrace.py` — new test cases

**This is a draft PR with the plan only. Implementation to follow.**