### PR TITLE
chore(gemini): upgrade oracle cluster to 2026.1

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -123,7 +123,7 @@ authenticator_password: ''
 
 # gemini defaults
 n_test_oracle_db_nodes: 1
-oracle_scylla_version: '2025.4'
+oracle_scylla_version: '2026.1'
 append_scylla_args_oracle: '--enable-cache false'
 instance_type_db_oracle: 'i8g.2xlarge'
 run_gemini_in_rolling_upgrade: false

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -317,7 +317,7 @@ Format version of the user-data to use for scylla images,<br>default to what tag
 
 Version of scylla to use as oracle cluster with gemini tests, ex. '3.0.11'<br>Automatically lookup AMIs for formal versions.<br>WARNING: can't be used together with 'ami_id_db_oracle'
 
-**default:** 2025.4
+**default:** 2026.1
 
 **type:** str
 

--- a/test-cases/gemini/gemini-1tb-10h.yaml
+++ b/test-cases/gemini/gemini-1tb-10h.yaml
@@ -3,7 +3,7 @@ n_db_nodes: 6
 n_test_oracle_db_nodes: 1
 n_loaders: 1
 instance_type_db: 'i7i.2xlarge'
-instance_type_loader: 'c7i.xlarge'
+instance_type_loader: 'm7i.xlarge'
 
 user_prefix: 'gemini-1tb-10h'
 

--- a/test-cases/gemini/gemini-3h-cdc-postimage-write.yaml
+++ b/test-cases/gemini/gemini-3h-cdc-postimage-write.yaml
@@ -2,7 +2,7 @@ test_duration: 300
 n_db_nodes: 3
 n_loaders: 1
 instance_type_db: 'i7i.2xlarge'
-instance_type_loader: 'c7i.large'
+instance_type_loader: 'm7i.large'
 
 user_prefix: 'gemini-cdc-postimage-write'
 

--- a/test-cases/gemini/gemini-3h-cdc-preimage-write.yaml
+++ b/test-cases/gemini/gemini-3h-cdc-preimage-write.yaml
@@ -2,7 +2,7 @@ test_duration: 300
 n_db_nodes: 3
 n_loaders: 1
 instance_type_db: 'i7i.4xlarge'
-instance_type_loader: 'c7i.xlarge'
+instance_type_loader: 'm7i.xlarge'
 user_prefix: 'gemini-cdc-preimage-write'
 
 gemini_cmd: |

--- a/test-cases/gemini/gemini-3h-cdc-write.yaml
+++ b/test-cases/gemini/gemini-3h-cdc-write.yaml
@@ -2,7 +2,7 @@ test_duration: 300
 n_db_nodes: 3
 n_loaders: 1
 instance_type_db: 'i7i.4xlarge'
-instance_type_loader: 'c7i.xlarge'
+instance_type_loader: 'm7i.xlarge'
 
 user_prefix: 'gemini-cdc-write'
 

--- a/test-cases/gemini/gemini-3h-ics-cdc-with-nemesis.yaml
+++ b/test-cases/gemini/gemini-3h-ics-cdc-with-nemesis.yaml
@@ -3,7 +3,7 @@ n_db_nodes: 6
 n_test_oracle_db_nodes: 1
 n_loaders: 1
 instance_type_db: 'i7i.large'
-instance_type_loader: 'c7i.large'
+instance_type_loader: 'm7i.large'
 
 user_prefix: 'ics-cdc-gemini-basic-3h'
 ami_db_scylla_user: 'centos'

--- a/test-cases/gemini/gemini-3h-ics-with-nondisruptive-nemesis.yaml
+++ b/test-cases/gemini/gemini-3h-ics-with-nondisruptive-nemesis.yaml
@@ -3,7 +3,7 @@ n_db_nodes: 6
 n_test_oracle_db_nodes: 1
 n_loaders: 1
 instance_type_db: 'i7i.large'
-instance_type_loader: 'c7i.large'
+instance_type_loader: 'm7i.large'
 
 user_prefix: 'ics-gemini-nemesis-3h'
 ami_db_scylla_user: 'centos'

--- a/test-cases/gemini/gemini-3h-with-nemesis.yaml
+++ b/test-cases/gemini/gemini-3h-with-nemesis.yaml
@@ -3,7 +3,7 @@ n_db_nodes: 6
 n_test_oracle_db_nodes: 1
 n_loaders: 1
 instance_type_db: 'i7i.large'
-instance_type_loader: 'c7i.large'
+instance_type_loader: 'm7i.large'
 
 user_prefix: 'gemini-with-nemesis-3h-normal'
 

--- a/test-cases/gemini/gemini-3h-with-nondisruptive-nemesis.yaml
+++ b/test-cases/gemini/gemini-3h-with-nondisruptive-nemesis.yaml
@@ -3,7 +3,7 @@ n_db_nodes: 3
 n_test_oracle_db_nodes: 1
 n_loaders: 1
 instance_type_db: 'i7i.xlarge'
-instance_type_loader: 'c7i.xlarge'
+instance_type_loader: 'm7i.xlarge'
 
 user_prefix: 'gemini-basic-3h'
 

--- a/test-cases/gemini/gemini-basic-3h-ics.yaml
+++ b/test-cases/gemini/gemini-basic-3h-ics.yaml
@@ -3,7 +3,7 @@ n_db_nodes: 3
 n_test_oracle_db_nodes: 1
 n_loaders: 1
 instance_type_db: 'i7i.large'
-instance_type_loader: 'c7i.large'
+instance_type_loader: 'm7i.large'
 
 user_prefix: 'ics-gemini-basic-3h'
 ami_db_scylla_user: 'centos'

--- a/test-cases/gemini/gemini-basic-3h.yaml
+++ b/test-cases/gemini/gemini-basic-3h.yaml
@@ -3,7 +3,7 @@ n_db_nodes: 3
 n_test_oracle_db_nodes: 1
 n_loaders: 1
 instance_type_db: 'i7i.large'
-instance_type_loader: 'c7i.large'
+instance_type_loader: 'm7i.large'
 
 user_prefix: 'gemini-basic-3h'
 


### PR DESCRIPTION
We had to upgrade oracle cluster to 2025.4 to be able to use i8g instances. 2026.1 was not there yet at that time. Because 2025.4 is not LTS and some bugfixes won't be backported there (and soon this version will be EOL), upgrading Gemini's oracle to 2026.1

also increase memory for loaders
In https://github.com/scylladb/scylla-cluster-tests/pull/14449 we
changed loader machines for gemini based tests. But Gemini requires more
memory than typical stress tool.
Switching c7i->m7i (double memory) for gemini tests.
### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- https://argus.scylladb.com/tests/scylla-cluster-tests/d1aa0d3b-c726-4e1c-b628-964297915040

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
