### PR TITLE
 fix(alternator-dns): fix DNS routing for YCSB alternator tests

### DIFF
--- a/defaults/docker_images/ycsb/values_ycsb.yaml
+++ b/defaults/docker_images/ycsb/values_ycsb.yaml
@@ -1,2 +1,2 @@
 ycsb:
-  image: docker.io/scylladb/ycsb:1.3.0
+  image: docker.io/scylladb/ycsb:1.3.2

--- a/docker/alternator-dns/dns_server.py
+++ b/docker/alternator-dns/dns_server.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python3
+import json
 import sys
 import dnslib.server
 import dnslib
@@ -30,7 +31,7 @@ def livenodes_update():
         print("updating livenodes from {}".format(url))
         try:
             nodes = urllib.request.urlopen(url, None, 1.0).read().decode("ascii")
-            a = [x.strip('"').rstrip('"') for x in nodes.strip("[").rstrip("]").split(",")]
+            a = json.loads(nodes)
             # If we're successful, replace livenodes by the new list
             livenodes = a
             print(livenodes)
@@ -58,7 +59,11 @@ class Resolver:
 
         if qname == "alternator":
             ip = random.choice(livenodes)
-            reply.add_answer(*dnslib.RR.fromZone("{} 4 A {}".format(qname, ip)))
+            try:
+                reply.add_answer(*dnslib.RR.fromZone("{} 4 A {}".format(qname, ip)))
+            except Exception:  # noqa: BLE001
+                print("Invalid IP in livenodes, skipping: {!r}".format(ip))
+                reply.header.rcode = getattr(RCODE, "SERVFAIL")
 
         # Otherwise proxy
         if not reply.rr:

--- a/sdcm/ycsb_thread.py
+++ b/sdcm/ycsb_thread.py
@@ -405,10 +405,23 @@ class YcsbStressThread(DockerBasedStressThread):
                     loader,
                     dns_image,
                     command_line=dns_cmd,
-                    extra_docker_opts=f"--label shell_marker={self.shell_marker}",
+                    extra_docker_opts=f"--cap-add=NET_BIND_SERVICE --label shell_marker={self.shell_marker}",
                     docker_network=self.params.get("docker_network"),
                 )
-                dns_options += f"--dns {dns.internal_ip_address} --dns-option use-vc"
+                dns_ip = dns.internal_ip_address
+                # Wait for the DNS server to be ready (port 53/tcp)
+                for attempt in range(30):
+                    result = loader.remoter.run(
+                        f"timeout 1 bash -c 'echo > /dev/tcp/{dns_ip}/53' 2>/dev/null",
+                        ignore_status=True,
+                    )
+                    if result.ok:
+                        break
+                    if attempt == 29:
+                        dns_logs = loader.remoter.run(f"docker logs {dns.docker_id} 2>&1", ignore_status=True).stdout
+                        raise RuntimeError(f"DNS container failed to bind port 53 after 30s. Logs:\n{dns_logs}")
+                    time.sleep(1)
+                dns_options += f"--dns {dns_ip} --dns-option use-vc"
             extra_docker_opts = (
                 f"{dns_options} {cpu_options} --entrypoint /bin/bash --label shell_marker={self.shell_marker}"
             )

--- a/sdcm/ycsb_thread.py
+++ b/sdcm/ycsb_thread.py
@@ -246,6 +246,8 @@ class YcsbStressThread(DockerBasedStressThread):
                     dynamodb.alternator.trustAllCertificates = {trustAllCerts}
                     dynamodb.awsAccessKey = {access_key}
                     dynamodb.awsSecretKey = {secret_key}
+                    aws.accessKeyId = {access_key}
+                    aws.secretKey = {secret_key}
                 """)
                 )
                 # Only write datacenter/rack when non-empty. Java's Properties.getProperty()


### PR DESCRIPTION
Fixes [SCT-279](https://scylladb.atlassian.net/browse/SCT-279).

### Fix

`docker/alternator-dns/dns_server.py`
- Replace the broken manual parser with `json.loads()`, which correctly handles the JSON array returned by `/localnodes`.
- Wrap `dnslib.RR.fromZone` in a try/except so a bad IP logs a clear message and returns explicit SERVFAIL instead of crashing the handler silently.

`sdcm/ycsb_thread.py`
- Add `--cap-add=NET_BIND_SERVICE` to the DNS container so it can unconditionally bind port 53.
- Add a 30-second readiness poll on port 53/tcp before passing the DNS container's IP to the YCSB container via `--dns`. If the container never comes up, its logs are captured and surfaced as a `RuntimeError` immediately rather than a cryptic `UnknownHostException` 10 minutes into the stress run.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- :yellow_circle:  https://argus.scylladb.com/tests/scylla-cluster-tests/02cf9738-356e-4d8f-b6c7-fda9268b3aa8

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)

P.S Backporting to perf-v17 requires a seperate PR to reintroduce v1.3.x version of YCSB and the fixes

[SCT-279]: https://scylladb.atlassian.net/browse/SCT-279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ