### PR TITLE
fix(config): handle list type in zero_token_nodes validation

### DIFF
--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -3055,12 +3055,16 @@ class SCTConfiguration(BaseModel):
             # if number of zero nodes is set for cluster setup, check correctness of settings
             if zero_nodes_num:
                 zero_nodes_num = (
-                    [zero_nodes_num]
+                    zero_nodes_num
+                    if isinstance(zero_nodes_num, list)
+                    else [zero_nodes_num]
                     if isinstance(zero_nodes_num, int)
                     else [int(i) for i in str(zero_nodes_num).split()]
                 )
                 data_nodes_num = (
-                    [data_nodes_num]
+                    data_nodes_num
+                    if isinstance(data_nodes_num, list)
+                    else [data_nodes_num]
                     if isinstance(data_nodes_num, int)
                     else [int(i) for i in str(data_nodes_num).split()]
                 )


### PR DESCRIPTION
## Summary
- Fix `ValueError: invalid literal for int() with base 10: '[0,'` when `n_db_zero_token_nodes` is parsed as a list by pydantic's `IntOrList` validator
- Add `isinstance(list)` check for both `zero_nodes_num` and `data_nodes_num` in `SCTConfiguration.__init__`, matching the pattern already used in the `total_db_nodes` property

## Root Cause
When config YAML has `n_db_zero_token_nodes: '0 1 1'`, pydantic converts it to `[0, 1, 1]`. The validation code then fell through to `str(zero_nodes_num).split()` which produced `["[0,", "1,", "1]"]`, failing on `int("[0,")`.

## Failing Pipelines
- `jenkins-pipelines/oss/longevity/longevity-multi-dc-rack-aware-with-znode-dc.jenkinsfile`
- `jenkins-pipelines/oss/vnodes/zero_nodes/longevity-multi-dc-rack-aware-with-znode-dc-vnodes.jenkinsfile`