### PR TITLE
fix(pipelines): update object_storage.yaml references to object_storage_s3.yaml

### DIFF
--- a/jenkins-pipelines/manager/restore_benchmark/ubuntu22-manager-1tb-1t-3nodes.jenkinsfile
+++ b/jenkins-pipelines/manager/restore_benchmark/ubuntu22-manager-1tb-1t-3nodes.jenkinsfile
@@ -8,7 +8,7 @@ managerPipeline(
     region: 'us-east-1',
     provision_type: 'on_demand',
     test_name: 'mgmt_cli_test.ManagerRestoreBenchmarkTests.test_restore_benchmark',
-    test_config: '''["test-cases/manager/manager-backup-restore-set-dataset.yaml", "configurations/manager/1TB_dataset.yaml", "configurations/object_storage.yaml", "configurations/object_storage_native_method.yaml"]''',
+    test_config: '''["test-cases/manager/manager-backup-restore-set-dataset.yaml", "configurations/manager/1TB_dataset.yaml", "configurations/object_storage_s3.yaml", "configurations/object_storage_native_method.yaml"]''',
     mgmt_reuse_backup_snapshot_name: '1tb_1t_ics',
 
     post_behavior_db_nodes: 'destroy',

--- a/jenkins-pipelines/manager/restore_benchmark/ubuntu22-manager-1tb-2t-9nodes-rclone.jenkinsfile
+++ b/jenkins-pipelines/manager/restore_benchmark/ubuntu22-manager-1tb-2t-9nodes-rclone.jenkinsfile
@@ -8,7 +8,7 @@ managerPipeline(
     region: 'us-east-1',
     provision_type: 'on_demand',
     test_name: 'mgmt_cli_test.ManagerRestoreBenchmarkTests.test_restore_benchmark',
-    test_config: '''["test-cases/manager/manager-backup-restore-set-dataset.yaml", "configurations/manager/1TB_dataset.yaml", "configurations/object_storage.yaml", "configurations/object_storage_rclone_method.yaml"]''',
+    test_config: '''["test-cases/manager/manager-backup-restore-set-dataset.yaml", "configurations/manager/1TB_dataset.yaml", "configurations/object_storage_s3.yaml", "configurations/object_storage_rclone_method.yaml"]''',
     mgmt_reuse_backup_snapshot_name: '1tb_2t_twcs',
 
     post_behavior_db_nodes: 'destroy',

--- a/jenkins-pipelines/manager/restore_benchmark/ubuntu22-manager-1tb-2t-9nodes.jenkinsfile
+++ b/jenkins-pipelines/manager/restore_benchmark/ubuntu22-manager-1tb-2t-9nodes.jenkinsfile
@@ -8,7 +8,7 @@ managerPipeline(
     region: 'us-east-1',
     provision_type: 'on_demand',
     test_name: 'mgmt_cli_test.ManagerRestoreBenchmarkTests.test_restore_benchmark',
-    test_config: '''["test-cases/manager/manager-backup-restore-set-dataset.yaml", "configurations/manager/1TB_dataset.yaml", "configurations/object_storage.yaml", "configurations/object_storage_native_method.yaml"]''',
+    test_config: '''["test-cases/manager/manager-backup-restore-set-dataset.yaml", "configurations/manager/1TB_dataset.yaml", "configurations/object_storage_s3.yaml", "configurations/object_storage_native_method.yaml"]''',
     mgmt_reuse_backup_snapshot_name: '1tb_2t_twcs',
 
     post_behavior_db_nodes: 'destroy',

--- a/jenkins-pipelines/manager/ubuntu22-manager-sanity.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu22-manager-sanity.jenkinsfile
@@ -7,7 +7,7 @@ managerPipeline(
     backend: 'aws',
     region: 'us-east-1',
     test_name: 'mgmt_cli_test.ManagerSanityTests.test_manager_sanity',
-    test_config: '''["test-cases/manager/manager-regression-singleDC-set-distro.yaml", "configurations/disable_kms_key_rotation.yaml", "configurations/object_storage.yaml", "configurations/object_storage_native_method.yaml"]''',
+    test_config: '''["test-cases/manager/manager-regression-singleDC-set-distro.yaml", "configurations/disable_kms_key_rotation.yaml", "configurations/object_storage_s3.yaml", "configurations/object_storage_native_method.yaml"]''',
 
     scylla_version: '2025.3',
 

--- a/jenkins-pipelines/manager/ubuntu22-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu22-manager-upgrade.jenkinsfile
@@ -14,5 +14,5 @@ managerPipeline(
     target_manager_version: 'master_latest',
 
     test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',
-    test_config: '''["test-cases/upgrades/manager-upgrade.yaml", "configurations/object_storage.yaml", "configurations/object_storage_native_method.yaml"]'''
+    test_config: '''["test-cases/upgrades/manager-upgrade.yaml", "configurations/object_storage_s3.yaml", "configurations/object_storage_native_method.yaml"]'''
 )

--- a/jenkins-pipelines/manager/ubuntu24-manager-backup-restore-custom-dataset.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu24-manager-backup-restore-custom-dataset.jenkinsfile
@@ -7,7 +7,7 @@ managerPipeline(
     backend: 'aws',
     region: 'us-east-1',
     test_name: 'mgmt_cli_test.ManagerRestoreBenchmarkTests.test_restore_benchmark',
-    test_config: """["test-cases/manager/manager-backup-restore-set-dataset.yaml", "configurations/object_storage.yaml", "configurations/manager/ubuntu24.yaml", "configurations/object_storage_native_method.yaml"]""",
+    test_config: """["test-cases/manager/manager-backup-restore-set-dataset.yaml", "configurations/object_storage_s3.yaml", "configurations/manager/ubuntu24.yaml", "configurations/object_storage_native_method.yaml"]""",
 
     mgmt_restore_extra_params: "--batch-size 2 --parallel 1",
     mgmt_agent_backup_config: "{'checkers': 100, 'transfers': 2, 'low_level_retries': 20}"

--- a/jenkins-pipelines/manager/ubuntu24-manager-backup.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu24-manager-backup.jenkinsfile
@@ -7,5 +7,5 @@ managerPipeline(
     backend: 'aws',
     region: 'us-east-1',
     test_name: 'mgmt_cli_test.ManagerBackupTests.test_backup_feature',
-    test_config: '''["test-cases/manager/manager-regression-singleDC-set-distro.yaml", "configurations/manager/ubuntu24.yaml", "configurations/object_storage.yaml", "configurations/object_storage_native_method.yaml"]'''
+    test_config: '''["test-cases/manager/manager-regression-singleDC-set-distro.yaml", "configurations/manager/ubuntu24.yaml", "configurations/object_storage_s3.yaml", "configurations/object_storage_native_method.yaml"]'''
 )

--- a/jenkins-pipelines/manager/ubuntu24-manager-sanity-ipv6.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu24-manager-sanity-ipv6.jenkinsfile
@@ -7,5 +7,5 @@ managerPipeline(
     backend: 'aws',
     region: 'us-east-1',
     test_name: 'mgmt_cli_test.ManagerSanityTests.test_manager_sanity',
-    test_config: '''["test-cases/manager/manager-regression-ipv6.yaml", "configurations/network_config/all_addresses_ipv6_public.yaml", "configurations/manager/ubuntu24.yaml", "configurations/disable_kms_key_rotation.yaml", "configurations/object_storage.yaml", "configurations/object_storage_native_method.yaml"]'''
+    test_config: '''["test-cases/manager/manager-regression-ipv6.yaml", "configurations/network_config/all_addresses_ipv6_public.yaml", "configurations/manager/ubuntu24.yaml", "configurations/disable_kms_key_rotation.yaml", "configurations/object_storage_s3.yaml", "configurations/object_storage_native_method.yaml"]'''
 )

--- a/jenkins-pipelines/manager/ubuntu24-manager-sanity.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu24-manager-sanity.jenkinsfile
@@ -7,7 +7,7 @@ managerPipeline(
     backend: 'aws',
     region: '''["us-east-1", "us-west-2"]''',
     test_name: 'mgmt_cli_test.ManagerSanityTests.test_manager_sanity',
-    test_config: '''["test-cases/manager/manager-regression-multiDC-set-distro.yaml", "configurations/manager/ubuntu24.yaml", "configurations/disable_kms_key_rotation.yaml", "configurations/object_storage.yaml", "configurations/object_storage_native_method.yaml"]''',
+    test_config: '''["test-cases/manager/manager-regression-multiDC-set-distro.yaml", "configurations/manager/ubuntu24.yaml", "configurations/disable_kms_key_rotation.yaml", "configurations/object_storage_s3.yaml", "configurations/object_storage_native_method.yaml"]''',
 
     downstream_jobs_to_run: 'ubuntu24-upgrade-test'
 )

--- a/jenkins-pipelines/manager/ubuntu24-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu24-manager-upgrade.jenkinsfile
@@ -12,5 +12,5 @@ managerPipeline(
     target_manager_version: 'master_latest',
 
     test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',
-    test_config: '''["test-cases/upgrades/manager-upgrade.yaml", "configurations/manager/ubuntu24.yaml", "configurations/object_storage.yaml", "configurations/object_storage_native_method.yaml"]'''
+    test_config: '''["test-cases/upgrades/manager-upgrade.yaml", "configurations/manager/ubuntu24.yaml", "configurations/object_storage_s3.yaml", "configurations/object_storage_native_method.yaml"]'''
 )

--- a/jenkins-pipelines/manager/ubuntu24-manager-vnodes-tablets-enterprise.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu24-manager-vnodes-tablets-enterprise.jenkinsfile
@@ -7,5 +7,5 @@ managerPipeline(
     backend: 'aws',
     region: 'us-east-1',
     test_name: 'mgmt_cli_test.ManagerSanityTests.test_manager_sanity_vnodes_tablets_cluster',
-    test_config: '''["test-cases/manager/manager-regression-singleDC-set-distro.yaml", "configurations/manager/ubuntu24.yaml", "configurations/object_storage.yaml", "configurations/object_storage_native_method.yaml"]'''
+    test_config: '''["test-cases/manager/manager-regression-singleDC-set-distro.yaml", "configurations/manager/ubuntu24.yaml", "configurations/object_storage_s3.yaml", "configurations/object_storage_native_method.yaml"]'''
 )

--- a/jenkins-pipelines/oss/vnodes/backup/ubuntu22-manager-1tb-2t-9nodes-vnodes.jenkinsfile
+++ b/jenkins-pipelines/oss/vnodes/backup/ubuntu22-manager-1tb-2t-9nodes-vnodes.jenkinsfile
@@ -8,7 +8,7 @@ managerPipeline(
     region: 'us-east-1',
     provision_type: 'on_demand',
     test_name: 'mgmt_cli_test.ManagerRestoreBenchmarkTests.test_restore_benchmark',
-    test_config: '''["test-cases/manager/manager-backup-restore-set-dataset.yaml", "configurations/manager/1TB_dataset.yaml", "configurations/tablets_disabled.yaml", "configurations/object_storage.yaml", "configurations/object_storage_native_method.yaml"]''',
+    test_config: '''["test-cases/manager/manager-backup-restore-set-dataset.yaml", "configurations/manager/1TB_dataset.yaml", "configurations/tablets_disabled.yaml", "configurations/object_storage_s3.yaml", "configurations/object_storage_native_method.yaml"]''',
     mgmt_reuse_backup_snapshot_name: '1tb_2t_twcs',
 
     post_behavior_db_nodes: 'destroy',


### PR DESCRIPTION
## Summary

- Fixes 12 pipeline files that still reference the deleted `configurations/object_storage.yaml` (renamed to `object_storage_s3.yaml` in #13491)
- This resolves `lint-pipelines` failures caused by `FileNotFoundError`

Fixes breakage introduced by #13491.