### PR TITLE
feat(pre-commit): add lint-pipelines hook for pipeline and config changes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -98,6 +98,13 @@ repos:
         pass_filenames: false
         files: ^pyproject.toml$
 
+    -   id: lint-pipelines
+        name: lint-pipelines
+        entry: ./sct.py lint-pipelines
+        language: system
+        pass_filenames: false
+        files: (?x)(^jenkins-pipelines/.*\.jenkinsfile$|^test-cases/.*\.yaml$|^configurations/.*\.yaml$|^defaults/.*\.yaml$)
+
 - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
   rev: v9.22.0
   hooks:


### PR DESCRIPTION
Runs lint-pipelines automatically when jenkinsfiles, test-cases, configurations, or defaults YAML files are modified. We run it on CI, we should run it locally

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] local

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
