### PR TITLE
feat: add P95 latency percentile to Argus result tabs

### DIFF
--- a/sdcm/argus_results.py
+++ b/sdcm/argus_results.py
@@ -40,8 +40,8 @@ if TYPE_CHECKING:
 LOGGER = logging.getLogger(__name__)
 
 LATENCY_ERROR_THRESHOLDS = {
-    "replace_node": {"percentile_90": 5, "percentile_99": 10},
-    "default": {"percentile_90": 5, "percentile_99": 10},
+    "replace_node": {"percentile_90": 5, "percentile_95": 7, "percentile_99": 10},
+    "default": {"percentile_90": 5, "percentile_95": 7, "percentile_99": 10},
 }
 
 
@@ -52,6 +52,8 @@ class LatencyCalculatorMixedResult(StaticGenericResultTable):
         Columns = [
             ColumnMetadata(name="P90 write", unit="ms", type=ResultType.FLOAT, higher_is_better=False),
             ColumnMetadata(name="P90 read", unit="ms", type=ResultType.FLOAT, higher_is_better=False),
+            ColumnMetadata(name="P95 write", unit="ms", type=ResultType.FLOAT, higher_is_better=False),
+            ColumnMetadata(name="P95 read", unit="ms", type=ResultType.FLOAT, higher_is_better=False),
             ColumnMetadata(name="P99 write", unit="ms", type=ResultType.FLOAT, higher_is_better=False),
             ColumnMetadata(name="P99 read", unit="ms", type=ResultType.FLOAT, higher_is_better=False),
             ColumnMetadata(name="Throughput write", unit="op/s", type=ResultType.INTEGER, higher_is_better=True),
@@ -70,6 +72,7 @@ class LatencyCalculatorWriteResult(StaticGenericResultTable):
         description = ""
         Columns = [
             ColumnMetadata(name="P90 write", unit="ms", type=ResultType.FLOAT, higher_is_better=False),
+            ColumnMetadata(name="P95 write", unit="ms", type=ResultType.FLOAT, higher_is_better=False),
             ColumnMetadata(name="P99 write", unit="ms", type=ResultType.FLOAT, higher_is_better=False),
             ColumnMetadata(name="Throughput write", unit="op/s", type=ResultType.INTEGER, higher_is_better=True),
             ColumnMetadata(name="duration", unit="HH:MM:SS", type=ResultType.DURATION, higher_is_better=False),
@@ -86,6 +89,7 @@ class LatencyCalculatorReadResult(StaticGenericResultTable):
         description = ""
         Columns = [
             ColumnMetadata(name="P90 read", unit="ms", type=ResultType.FLOAT, higher_is_better=False),
+            ColumnMetadata(name="P95 read", unit="ms", type=ResultType.FLOAT, higher_is_better=False),
             ColumnMetadata(name="P99 read", unit="ms", type=ResultType.FLOAT, higher_is_better=False),
             ColumnMetadata(name="Throughput read", unit="op/s", type=ResultType.INTEGER, higher_is_better=True),
             ColumnMetadata(name="duration", unit="HH:MM:SS", type=ResultType.DURATION, higher_is_better=False),
@@ -102,6 +106,7 @@ class LatencyCalculatorReadDiskOnlyResult(StaticGenericResultTable):
         description = ""
         Columns = [
             ColumnMetadata(name="P90 read", unit="ms", type=ResultType.FLOAT, higher_is_better=False),
+            ColumnMetadata(name="P95 read", unit="ms", type=ResultType.FLOAT, higher_is_better=False),
             ColumnMetadata(name="P99 read", unit="ms", type=ResultType.FLOAT, higher_is_better=False),
             ColumnMetadata(name="Throughput read", unit="op/s", type=ResultType.INTEGER, higher_is_better=True),
             ColumnMetadata(name="duration", unit="HH:MM:SS", type=ResultType.DURATION, higher_is_better=False),
@@ -325,7 +330,7 @@ def send_result_to_argus(  # noqa: PLR0914
       when "result['hdr_summary']" has more than 2 rows with unique HDR tags.
       It is useful for cases when we run multiple stress commands of different types in parallel
       like customer-scenarios covered by latte stress commands.
-      It stores the worst P90 and P99 latencies among all of the rows/results
+      It stores the worst P90, P95, and P99 latencies among all of the rows/results
       and summary throughput for all of them even if workload types are different.
     - Reactor stalls table is registered
       when relevant SCT events occured (result['reactor_stalls_stats'])
@@ -357,7 +362,7 @@ def send_result_to_argus(  # noqa: PLR0914
     for i, (workload_type_and_hdr_tag, hdr_data) in enumerate(hdr_summary.items()):
         (workload_type, hdr_tag) = workload_type_and_hdr_tag.split("--", maxsplit=1)
         row_name = f"{cycle}" + "" if skip_hdr_tag else f" (HDR tag: {hdr_tag})"
-        for percentile in ("90", "99"):
+        for percentile in ("90", "95", "99"):
             if (workload_type, percentile) not in summary_worst_lat:
                 summary_worst_lat[(workload_type, percentile)] = 0.0
             column_name = f"P{percentile} {workload_type.lower()}"

--- a/sdcm/utils/latency.py
+++ b/sdcm/utils/latency.py
@@ -149,6 +149,10 @@ def analyze_hdr_percentiles(result_stats: dict[str, Any]) -> dict[str, Any]:
                     cycle["hdr_summary"][workload]["color"].update({"percentile_90": "red"})
                 else:
                     cycle["hdr_summary"][workload]["color"].update({"percentile_90": ""})
+                if results["percentile_95"] > LATENCY_ERROR_THRESHOLDS[top_limit_operation]["percentile_95"]:
+                    cycle["hdr_summary"][workload]["color"].update({"percentile_95": "red"})
+                else:
+                    cycle["hdr_summary"][workload]["color"].update({"percentile_95": ""})
                 if results["percentile_99"] > LATENCY_ERROR_THRESHOLDS[top_limit_operation]["percentile_99"]:
                     cycle["hdr_summary"][workload]["color"].update({"percentile_99": "red"})
                 else:
@@ -161,6 +165,10 @@ def analyze_hdr_percentiles(result_stats: dict[str, Any]) -> dict[str, Any]:
                         results["color"].update({"percentile_90": "red"})
                     else:
                         results["color"].update({"percentile_90": ""})
+                    if results["percentile_95"] > LATENCY_ERROR_THRESHOLDS[top_limit_operation]["percentile_95"]:
+                        results["color"].update({"percentile_95": "red"})
+                    else:
+                        results["color"].update({"percentile_95": ""})
                     if results["percentile_99"] > LATENCY_ERROR_THRESHOLDS[top_limit_operation]["percentile_99"]:
                         results["color"].update({"percentile_99": "red"})
                     else:

--- a/unit_tests/unit/test_argus_results.py
+++ b/unit_tests/unit/test_argus_results.py
@@ -16,7 +16,13 @@ from unittest.mock import MagicMock, call
 
 from argus.client.generic_result import Cell, Status
 
-from sdcm.argus_results import ReactorStallStatsResult, send_result_to_argus, LatencyCalculatorMixedResult
+from sdcm.argus_results import (
+    LATENCY_ERROR_THRESHOLDS,
+    LatencyCalculatorMixedResult,
+    ReactorStallStatsResult,
+    send_result_to_argus,
+)
+from sdcm.utils.latency import analyze_hdr_percentiles
 
 
 def test_send_latency_decorator_result_to_argus(test_data_dir):
@@ -42,6 +48,7 @@ def test_send_latency_decorator_result_to_argus(test_data_dir):
                 sut_timestamp=0,
                 results=[
                     Cell(column="P90 write", row=row_name, value=2.15, status=Status.UNSET),
+                    Cell(column="P95 write", row=row_name, value=2.36, status=Status.UNSET),
                     Cell(column="P99 write", row=row_name, value=3.62, status=Status.UNSET),
                     Cell(column="duration", row=row_name, value=2654, status=Status.UNSET),
                     Cell(column="start time", row=row_name, value="12:14:23", status=Status.UNSET),
@@ -61,6 +68,7 @@ def test_send_latency_decorator_result_to_argus(test_data_dir):
                         status=Status.UNSET,
                     ),
                     Cell(column="P90 read", row=row_name, value=2.86, status=Status.UNSET),
+                    Cell(column="P95 read", row=row_name, value=3.53, status=Status.UNSET),
                     Cell(column="P99 read", row=row_name, value=5.36, status=Status.UNSET),
                 ],
             )
@@ -78,3 +86,50 @@ def test_send_latency_decorator_result_to_argus(test_data_dir):
         ),
     ]
     argus_mock.submit_results.assert_has_calls(expected_calls, any_order=True)
+
+
+def test_analyze_hdr_percentiles_p95_threshold_colors():
+    """P95 latencies must be colored 'red' above the threshold and '' at/below it.
+
+    Covers both the ``hdr_summary`` (per-cycle) and interval ``hdr`` values on each
+    side of the P95 threshold so incorrect or missing color assignments are detected.
+    """
+    p95_threshold = LATENCY_ERROR_THRESHOLDS["default"]["percentile_95"]
+    below_p95 = p95_threshold - 1
+    above_p95 = p95_threshold + 1
+
+    def _percentiles(percentile_95):
+        # Keep P90/P99 below their thresholds so only P95 color varies.
+        return {"percentile_90": 1, "percentile_95": percentile_95, "percentile_99": 1}
+
+    result_stats = {
+        "unknown_operation": {  # falls back to the "default" thresholds
+            "cycles": [
+                {
+                    "hdr_summary": {
+                        "WRITE": _percentiles(below_p95),
+                        "READ": _percentiles(above_p95),
+                    },
+                    "hdr": [
+                        {
+                            "WRITE": _percentiles(below_p95),
+                            "READ": _percentiles(above_p95),
+                        },
+                    ],
+                },
+            ],
+        },
+    }
+
+    analyzed = analyze_hdr_percentiles(result_stats)
+
+    cycle = analyzed["unknown_operation"]["cycles"][0]
+
+    # hdr_summary colors
+    assert cycle["hdr_summary"]["WRITE"]["color"]["percentile_95"] == ""
+    assert cycle["hdr_summary"]["READ"]["color"]["percentile_95"] == "red"
+
+    # interval hdr colors
+    interval = cycle["hdr"][0]
+    assert interval["WRITE"]["color"]["percentile_95"] == ""
+    assert interval["READ"]["color"]["percentile_95"] == "red"


### PR DESCRIPTION
Add P95 (95th percentile) latency tracking to Argus results alongside existing P90 and P99 percentiles:

- Add percentile_95 threshold (value 7) to LATENCY_ERROR_THRESHOLDS
- Add P95 write/read ColumnMetadata to all four latency result table classes (Mixed, Write, Read, ReadDiskOnly)
- Expand percentile loop in send_result_to_argus to include '95'
- Add percentile_95 color assignment in analyze_hdr_percentiles for both hdr_summary and hdr interval loops
- Update unit test expectations with P95 cells

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
