### PR TITLE
feature(migrator): Cassandra->Scylla migration driven by scylla-migrator

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,3 +241,4 @@ For guidelines on creating new plans, see [docs/plans/INSTRUCTIONS.md](docs/plan
 ### [K8S Functional Tests](./docs/k8s-functional-test.md)
 ### [Microbenchmarking Tests](./docs/microbenchmarking.md)
 ### [Performance Tests](./docs/performance-tests.md)
+### [Cassandra -> Scylla Migration Tests](./docs/cs-to-scylla-migration.md)

--- a/configurations/network_config/test_communication_public.yaml
+++ b/configurations/network_config/test_communication_public.yaml
@@ -26,3 +26,7 @@ scylla_network_config:
   public: true
   use_dns: false
   nic: 0  #  If ipv4 and public is True it has to be primary network interface (device index is 0)
+
+# publish public IP in cassandra.yaml broadcast_rpc_address so drivers from an
+# sct-runner outside the VPC can reach the CS nodes (mixed_cassandra only).
+cassandra_broadcast_rpc_public: true

--- a/defaults/aws_emr_config.yaml
+++ b/defaults/aws_emr_config.yaml
@@ -11,3 +11,5 @@ emr_spark_migrator_jar_path: ''
 emr_spark_migrator_release: ''
 emr_log_uri: ''
 emr_keep_alive: true
+migrator_step_timeout_minutes: 360
+validator_step_timeout_minutes: 60

--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -348,7 +348,6 @@ docker_image_cassandra: 'cassandra'
 cassandra_version: '4.1'
 cassandra_num_tokens: 16
 cassandra_oracle_version: '4.1'
-ami_id_db_cassandra_oracle: ''
 download_from_s3: []
 # The object-storage method options in Scylla-Manager are: native/rclone/auto.
 # An empty value here, means Scylla-Manager will use its default value.

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -1842,6 +1842,93 @@ Whether EMR cluster stays alive after job completion (default: true for reuse du
 **type:** bool
 
 
+## **migrator_source_hosts** / SCT_MIGRATOR_SOURCE_HOSTS
+
+CQL contact-point IPs for the source Cassandra/Scylla cluster. Mutually exclusive with migrator_source_test_id.
+
+**default:** N/A
+
+**type:** str | list[str]
+* appendable
+
+
+## **migrator_source_keyspace** / SCT_MIGRATOR_SOURCE_KEYSPACE
+
+Keyspace to migrate from on the source cluster
+
+**default:** N/A
+
+**type:** str
+* appendable
+
+
+## **migrator_source_table** / SCT_MIGRATOR_SOURCE_TABLE
+
+Table to migrate from on the source cluster
+
+**default:** N/A
+
+**type:** str
+* appendable
+
+
+## **migrator_source_test_id** / SCT_MIGRATOR_SOURCE_TEST_ID
+
+SCT test_id of a running source cluster. When set, source host IPs are auto-discovered via EC2 tags (NodeType=cs-db). Mutually exclusive with migrator_source_hosts.
+
+**default:** N/A
+
+**type:** str
+* appendable
+
+
+## **migrator_target_keyspace** / SCT_MIGRATOR_TARGET_KEYSPACE
+
+Keyspace to migrate into on the target Scylla cluster. Defaults to migrator_source_keyspace.
+
+**default:** N/A
+
+**type:** str
+* appendable
+
+
+## **migrator_target_table** / SCT_MIGRATOR_TARGET_TABLE
+
+Table to migrate into on the target Scylla cluster. Defaults to migrator_source_table.
+
+**default:** N/A
+
+**type:** str
+* appendable
+
+
+## **migrator_run_validator** / SCT_MIGRATOR_RUN_VALIDATOR
+
+Run the spark-migrator validator after migration to do a row-by-row comparison
+
+**default:** N/A
+
+**type:** bool
+
+
+## **migrator_step_timeout_minutes** / SCT_MIGRATOR_STEP_TIMEOUT_MINUTES
+
+Time in minutes to wait for the spark-migrator migration EMR step. Default 360.
+
+**default:** N/A
+
+**type:** int
+
+
+## **validator_step_timeout_minutes** / SCT_VALIDATOR_STEP_TIMEOUT_MINUTES
+
+Time in minutes to wait for the spark-migrator validator EMR step. Default 60.
+
+**default:** N/A
+
+**type:** int
+
+
 ## **run_scylla_doctor** / SCT_RUN_SCYLLA_DOCTOR
 
 Flag to run Scylla Doctor tool
@@ -2723,21 +2810,20 @@ Cassandra version for the oracle cluster, i.e. '4.1' or '5.0'
 * appendable
 
 
-## **ami_id_db_cassandra_oracle** / SCT_AMI_ID_DB_CASSANDRA_ORACLE
-
-AMI ID for Cassandra oracle cluster nodes on AWS. Defaults to empty string, which causes fallback to the loader AMI (a standard Ubuntu image).
-
-**default:** N/A
-
-**type:** str
-* appendable
-
-
 ## **install_cassandra_exporter** / SCT_INSTALL_CASSANDRA_EXPORTER
 
 Install Criteo cassandra_exporter on Cassandra nodes for Prometheus metrics collection. The exporter connects to JMX (port 7199) and exposes metrics on port 8080.
 
 **default:** True
+
+**type:** bool
+
+
+## **cassandra_broadcast_rpc_public** / SCT_CASSANDRA_BROADCAST_RPC_PUBLIC
+
+When True, set broadcast_rpc_address to the public IP of the node in cassandra.yaml, so clients outside the VPC (e.g. sct-runner driver connection that reads system.peers) can reach the nodes. Defaults to False (private IP, matches intra-VPC behavior).
+
+**default:** N/A
 
 **type:** bool
 

--- a/docs/cs-to-scylla-migration.md
+++ b/docs/cs-to-scylla-migration.md
@@ -1,0 +1,110 @@
+# Cassandra -> Scylla migration tests
+
+End-to-end SCT tests that provision a Cassandra source, a Scylla target, and an
+Amazon EMR cluster, then drive the [scylla-migrator](https://github.com/scylladb/scylla-migrator)
+job between them. Two variants exist:
+
+- **Small** (`test_migration_cs_to_scylla_small`, ~30 min): 100K rows of simple
+  schema, can be used as PR-gating regression coverage.
+- **Scale** (`test_migration_cs_to_scylla_scale`, hours): 500GB latte preload
+  (4 × 125 M rows), can be used for weekly throughput + validator coverage.
+
+## Quick start
+
+The test cases are under `test-cases/spark-migrator/`:
+
+```sh
+# small (PR-gating)
+hydra run-test spark_migrator_test.SparkMigratorTest.test_migration_cs_to_scylla_small \
+    --backend aws --config test-cases/spark-migrator/cs-to-scylla-small.yaml
+
+# scale (nightly)
+hydra run-test spark_migrator_test.SparkMigratorTest.test_migration_cs_to_scylla_scale \
+    --backend aws --config test-cases/spark-migrator/cs-to-scylla-500gb.yaml
+```
+
+Both yamls set `db_type: mixed_cassandra` so SCT provisions BOTH a Scylla target
+cluster (`self.db_cluster`) AND a Cassandra source cluster (`self.cs_db_cluster`)
+in a single run, plus an EMR cluster (`self.emr_cluster`) sized for the migration job.
+
+## Reusing a provisioned cluster
+
+The 500GB preload takes a long time. To skip preload and rerun the migration + validation
+against an already-provisioned cluster, set `SCT_REUSE_CLUSTER` to the test_id of the
+previous run:
+
+```sh
+SCT_REUSE_CLUSTER=<previous-test-id> hydra run-test ...
+```
+
+When `SCT_REUSE_CLUSTER` is set, `test_migration_cs_to_scylla_scale` skips the
+`prepare_write_cmd` chunks entirely. The schema apply loop is idempotent
+(`CREATE TABLE|TYPE|INDEX` statements are rewritten to `... IF NOT EXISTS` on the fly)
+so re-running against pre-existing target tables is safe.
+
+
+## Validation strategy
+
+- **Small test**: post-migration sanity = `_count_rows_parallel` (token-range sharded
+  `count(*)`) + 10-row sample compare against source.
+  Validator EMR step is **off** by default (`migrator_run_validator: false` in test config).
+- **Scale test**: `count(*)` + sampling does **not** apply — at 500 M rows, sharded
+  `count(*)` hits Scylla's server-side `read_request_timeout` regardless of client-side
+  parallelism. Correctness is delegated to the validator EMR step
+  (`migrator_run_validator: true` by default in the 500GB test config), which scans both source
+  and target end-to-end and reports per-row mismatches. Tune `validator_step_timeout_minutes`
+  (default 240) when source/target sizes change.
+
+## Validator output
+
+When `migrator_run_validator: true` (default in the 500GB yaml), a second EMR step runs
+scylla-migrator's `com.scylladb.migrator.Validator` main class against the same
+source/target tables after the migration completes.
+
+The EMR step state is the verdict. Per upstream `Validator.scala main()`:
+
+- When zero failures during migration -> `log.info("No comparison failures found - enjoy your day!")`
+- is emitted and step state is COMPLETED.
+- One or more failures occurred during migration -> `log.error("Found N comparison failure(s) in sample: <breakdown>")`,
+  plus dump of `RowComparisonFailure` entries, are emitted and step state is FAILED.
+
+| EMR step state | SCT verdict                                                                |
+|----------------|----------------------------------------------------------------------------|
+| COMPLETED      | pass - test continues                                                      |
+| FAILED         | fail - validator step stdout (including the upstream `Found N` summary line and per-row `RowComparisonFailure` records) is downloaded from S3 and dumped to `sct.log` for investigation, then `AssertionError` is raised |
+
+`emr_spark_migrator_release` should be pinned to a known-compatible tag (the 500GB yaml currently
+pins `v2.0.1`); bump deliberately and re-verify the upstream output contract when moving to a
+new migrator release.
+
+## Cluster lifecycle and cost
+
+- `post_behavior_db_nodes` controls the tear-down policy for BOTH the Scylla target AND the
+  Cassandra source - `mixed_cassandra` does NOT have a separate `post_behavior_cs_db_nodes`
+  parameter (`sdcm/tester.py:3835`). Setting `keep-on-failure` therefore retains a 500GB
+  Cassandra source on failure; destroy it manually if the cluster is no longer needed.
+- `post_behavior_emr_cluster: destroy` is set by default so EMR clusters do not leak; expected
+  hourly cost for the scale yaml is dominated by the EMR core nodes (2 × `m5.2xlarge`,
+  ~$0.20/h on-demand at time of writing).
+- Region coherence is asserted at the start of each test — the EMR cluster must be provisioned
+  in the same region as the SCT clusters, otherwise cross-region data transfer turns the
+  migration into a slow + expensive run. Fix the region in the yaml if the assertion fires.
+
+## Schema transfer
+
+scylla-migrator v2.0.x does not auto-create CQL tables on the target. Both tests therefore
+pre-create the target schema on Scylla before submitting the migrator step:
+
+- The small test uses a hardcoded simple schema via `_prepare_target_schema`.
+- The scale test calls `BaseCassandraCluster.dump_schema` on the Cassandra source and
+  applies the resulting CQL on the Scylla target. The dump strips Cassandra-only table
+  options (`compression.crc_check_chance`, `speculative_retry`, etc.) so the apply loop
+  is byte-for-byte compatible with Scylla's CQL grammar.
+
+## Cross-VPC notes
+
+`test_migration_from_external_source` migrates from a pre-existing Cassandra cluster discovered
+by EC2 tags (`migrator_source_test_id`). When the source cluster lives in a different VPC than
+the EMR cluster, security groups must allow inbound CQL (`9042`) from the EMR worker subnet -
+otherwise the migrator step hangs on connection setup. `test_migration_cs_to_scylla_*` tests
+provision both clusters in the same VPC so this concern only applies to the external-source variant.

--- a/docs/plans/infrastructure/cassandra-cluster-support.md
+++ b/docs/plans/infrastructure/cassandra-cluster-support.md
@@ -455,7 +455,7 @@ Use a standard Ubuntu 22.04 Azure VM image. Install Cassandra during `node_setup
 | Backend | Image Source | Config Parameter | Install Method |
 |---------|------------|-----------------|----------------|
 | Docker | `cassandra:4.1` or `cassandra:5.0` (Docker Hub) | `docker_image_cassandra_oracle` | Pull and run (no install needed) |
-| AWS | Ubuntu 22.04 base AMI | `ami_id_db_cassandra_oracle` (or reuse loader AMI) | apt install during `node_setup()` |
+| AWS | Ubuntu 22.04 base AMI | `ami_id_db_cassandra` (or reuse loader AMI) | apt install during `node_setup()` |
 | GCE | Ubuntu/Debian base GCE image | `gce_image_db_cassandra_oracle` (or reuse loader image) | apt install during `node_setup()` |
 | Azure | Ubuntu 22.04 Azure VM image | `azure_image_db_cassandra_oracle` (or reuse loader image) | apt install during `node_setup()` |
 
@@ -820,7 +820,7 @@ def _install_jdk(self, node):
 elif db_type == "mixed_cassandra":
     self.test_config.mixed_cluster(True)
     return CassandraAWSCluster(
-        ec2_ami_id=self.params.get("ami_id_db_cassandra_oracle").split()
+        ec2_ami_id=self.params.get("ami_id_db_cassandra").split()
                    or self.params.get("ami_id_loader").split(),
         ec2_ami_username="ubuntu",
         ec2_instance_type=self.params.get("instance_type_db_oracle"),
@@ -835,21 +835,21 @@ elif db_type == "mixed_cassandra":
 **Step 3: New config parameters in `sdcm/sct_config.py`:**
 
 ```python
-ami_id_db_cassandra_oracle: str = SctField(
+ami_id_db_cassandra: str = SctField(
     description="""
         AMI ID for Cassandra oracle cluster nodes on AWS.
         Defaults to empty string, which causes CassandraAWSCluster to fall back
         to the loader AMI (ami_id_loader) — a standard Ubuntu image.
         Specify an explicit AMI only if a custom image with pre-installed
         Cassandra is desired for faster node_setup().
-        Example: ami_id_db_cassandra_oracle: 'ami-0abcd1234ef567890'
+        Example: ami_id_db_cassandra: 'ami-0abcd1234ef567890'
     """,
 )
 ```
 
 Add to `defaults/test_default.yaml`:
 ```yaml
-ami_id_db_cassandra_oracle: ''
+ami_id_db_cassandra: ''
 ```
 
 Note: `instance_type_db_oracle` is reused. Existing defaults (e.g., `i4i.8xlarge`) are NVMe-optimized, which is Scylla-centric. For Cassandra as oracle, a memory-optimized instance like `r6i.2xlarge` (64 GB RAM, 8 vCPU) is more appropriate. Gemini test configs for `mixed_cassandra` should override `instance_type_db_oracle` to a memory-optimized type.
@@ -882,7 +882,7 @@ n_db_nodes: 3
 n_test_oracle_db_nodes: 1
 cassandra_oracle_version: '4.1'
 instance_type_db_oracle: 'r6i.2xlarge'  # memory-optimized; Cassandra is JVM-based
-ami_id_db_cassandra_oracle: ''           # use loader AMI fallback
+ami_id_db_cassandra: ''           # use loader AMI fallback
 ```
 
 **Definition of Done:**
@@ -1274,7 +1274,7 @@ Update SCT documentation: `docs/gemini.md` (if it exists) to document `db_type: 
 - `CassandraDockerCluster._cassandra_env_vars()`: test that all required env vars are present and correctly derived from node IPs and cluster config
 
 **Config parameter validation:**
-- New SCT config params (`docker_image_cassandra_oracle`, `cassandra_oracle_version`, `ami_id_db_cassandra_oracle`, etc.) have correct types and defaults
+- New SCT config params (`docker_image_cassandra_oracle`, `cassandra_oracle_version`, `ami_id_db_cassandra`, etc.) have correct types and defaults
 - `GeminiStressThread` generates a valid `--oracle-cluster` flag when `oracle_cluster` is a `CassandraDockerCluster` instance
 
 ### Integration Tests

--- a/sdcm/cluster_cassandra.py
+++ b/sdcm/cluster_cassandra.py
@@ -14,6 +14,7 @@
 import contextlib
 import logging
 import os
+import re
 import tempfile
 import threading
 import time
@@ -38,6 +39,17 @@ CASSANDRA_YAML_PATH = "/etc/cassandra/cassandra.yaml"
 CASSANDRA_SERVICE_NAME = "cassandra"
 CASSANDRA_ENV_SH_PATH = "/etc/cassandra/cassandra-env.sh"
 CASSANDRA_RACKDC_PATH = "/etc/cassandra/cassandra-rackdc.properties"
+
+# options emitted by Cassandra DESCRIBE that Scylla CQL rejects (InvalidRequest)
+# or mis-parses
+_CASSANDRA_ONLY_TABLE_OPTIONS = (
+    "additional_write_policy",
+    "read_repair",
+    "memtable",
+    "extensions",
+    "cdc",
+    "speculative_retry",
+)
 
 
 def compute_jvm_heap_mb(total_ram_mb: int) -> tuple[int, int]:
@@ -140,7 +152,7 @@ class CassandraNodeMixin:
 
     @cached_property
     def cql_address(self):
-        return self.ip_address
+        return self.external_address if self.test_config.IP_SSH_CONNECTIONS == "public" else self.ip_address
 
     def wait_native_transport(self):
         """Cassandra has no Scylla REST API; check CQL port instead."""
@@ -387,6 +399,8 @@ class BaseCassandraCluster:
         Docker backend overrides this to no-op since the image handles it.
         """
         node.wait_ssh_up(verbose=verbose)
+        if self.test_config.REUSE_CLUSTER:
+            return
         self._setup_data_device(node)
         NodeExporterSetup.install(node=node)
         self._install_jdk(node)
@@ -458,12 +472,12 @@ class BaseCassandraCluster:
         # the bundled Cassandra driver (cassandra-driver-internal-only-3.25.0.zip)
         # crashes on Python 3.12 (Ubuntu 24.04), making cqlsh unusable as a check.
         cql_check = node.remoter.run(
-            f"python3 -c \"import socket; socket.create_connection(('{node.ip_address}', 9042), 5).close()\"",
+            f"python3 -c \"import socket; socket.create_connection(('{node.ip_address}', {node.CQL_PORT}), 5).close()\"",
             ignore_status=True,
             verbose=False,
         )
         if not cql_check.ok:
-            self.log.debug("CQL port 9042 not ready on %s: %s", node.name, cql_check.stderr[:200])
+            self.log.debug("CQL port %d not ready on %s: %s", node.CQL_PORT, node.name, cql_check.stderr[:200])
             return False
         self.log.info("Node %s is UN and CQL is ready", node.name)
         return True
@@ -565,6 +579,9 @@ class BaseCassandraCluster:
         """Render and upload cassandra.yaml for the given node."""
         seeds = ",".join(n.ip_address for n in self.nodes if n.is_seed) or node.ip_address
         num_tokens = self.params.get("cassandra_num_tokens") or 16
+        broadcast_rpc_address = (
+            node.external_address if self.params.get("cassandra_broadcast_rpc_public") else node.ip_address
+        )
 
         yaml_updates = {
             "cluster_name": self.name,
@@ -577,7 +594,7 @@ class BaseCassandraCluster:
             ],
             "listen_address": node.ip_address,
             "rpc_address": "0.0.0.0",
-            "broadcast_rpc_address": node.ip_address,
+            "broadcast_rpc_address": broadcast_rpc_address,
             "endpoint_snitch": "GossipingPropertyFileSnitch",
         }
 
@@ -677,6 +694,58 @@ class BaseCassandraCluster:
         if self.test_config.MIXED_CLUSTER:
             return "oracle_db_nodes_public_ip" if public_ip else "oracle_db_nodes_private_ip"
         return "db_nodes_public_ip" if public_ip else "db_nodes_private_ip"
+
+    def dump_schema(self, keyspace: str, include_keyspace_stmt: bool = False) -> str:
+        """Return CQL DDL for all objects in *keyspace* via DESCRIBE KEYSPACE.
+
+        By default the leading ``CREATE KEYSPACE ... ;`` block is stripped so the
+        result can be applied to a target cluster that already has the keyspace.
+        Pass ``include_keyspace_stmt=True`` to return the raw output verbatim.
+
+        Cassandra-only table options listed in ``_CASSANDRA_ONLY_TABLE_OPTIONS`` are stripped
+        automatically so the DDL can be applied to Scylla. Rich schemas with UDTs, materialized views,
+        or secondary indexes may still need extra normalization.
+        """
+        node = self.nodes[0]
+        cmd = f'cqlsh {node.ip_address} -e "DESCRIBE KEYSPACE \\"{keyspace}\\""'
+        result = node.remoter.run(cmd, ignore_status=True)
+        if result.exited != 0:
+            raise RuntimeError(
+                f"cqlsh DESCRIBE KEYSPACE '{keyspace}' failed (exit {result.exited}): {result.stderr.strip()}"
+            )
+        output = result.stdout
+        if not include_keyspace_stmt:
+            match = re.search(r"^CREATE KEYSPACE\b[^;]*;", output, re.MULTILINE | re.IGNORECASE)
+            if match:
+                output = output[match.end() :].lstrip("\n")
+
+        _opts_pat = "|".join(_CASSANDRA_ONLY_TABLE_OPTIONS)
+
+        # strip cassandra-only AND/WITH option lines
+        output = re.sub(rf"^\s+AND\s+(?:{_opts_pat})\s*=[^\n]*$", "", output, flags=re.MULTILINE | re.IGNORECASE)
+        output = re.sub(rf"\bWITH\s+(?:{_opts_pat})\s*=[^\n]*$", "WITH", output, flags=re.MULTILINE | re.IGNORECASE)
+
+        # if stripping left 'WITH' with no value, collapse the following AND onto the same line
+        output = re.sub(r"WITH\s*\n+\s*AND\b", "WITH", output, flags=re.IGNORECASE)
+
+        # Cassandra emits `compression = {'class': 'LZ4Compressor', ...}` but Scylla rejects it
+        # with "Missing sub-option 'sstable_compression'". Scylla expects the `sstable_compression` key name
+        # inside the compression dict.
+        # Also handle Cassandra 4.x `compression = {'enabled': 'false'}` (no 'class' key) which means
+        # "no compression" — Scylla expresses the same as `{'sstable_compression': ''}`.
+        def _fix_compression(m):
+            body = m.group(0)
+            if "'class'" in body:
+                return body.replace("'class'", "'sstable_compression'")
+            if re.search(r"'enabled'\s*:\s*'?false'?", body, flags=re.IGNORECASE):
+                return "compression = {'sstable_compression': ''}"
+            return body
+
+        output = re.sub(r"compression\s*=\s*\{[^}]*\}", _fix_compression, output, flags=re.IGNORECASE)
+
+        output = re.sub(r"\n{3,}", "\n\n", output)
+
+        return output
 
     @property
     def data_nodes(self):

--- a/sdcm/provision/aws/emr_provisioner.py
+++ b/sdcm/provision/aws/emr_provisioner.py
@@ -14,6 +14,7 @@
 """EMR cluster lifecycle management for spark-migrator testing."""
 
 import logging
+import time
 
 import boto3
 import botocore
@@ -98,8 +99,9 @@ class EmrClusterProvisioner:
         if bootstrap_actions:
             cluster_config["BootstrapActions"] = bootstrap_actions
 
-        if log_uri := self.params.get("emr_log_uri"):
-            cluster_config["LogUri"] = log_uri
+        cluster_config["LogUri"] = (
+            self.params.get("emr_log_uri") or f"s3://sct-emr-spark-migrator-{self.region_name}/emr-logs/"
+        )
 
         LOGGER.info(
             "Creating EMR cluster with release %s in %s...", self.params.get("emr_release_label"), self.region_name
@@ -280,33 +282,23 @@ class EmrClusterProvisioner:
         )
         return response["Step"]["Status"]
 
-    @retrying(n=120, sleep_time=30, message="Waiting for EMR step to complete...")
-    def wait_for_step_completion(self, cluster_id, step_id):
-        """Wait for an EMR step to complete.
-
-        Args:
-            cluster_id: EMR cluster ID.
-            step_id: Step ID.
-
-        Returns:
-            dict: Step status.
-
-        Raises:
-            AssertionError: If step fails or is cancelled.
-        """
+    def wait_for_step_completion(self, cluster_id, step_id, timeout_minutes=60, poll_interval_seconds=30):
+        """Poll EMR step until COMPLETED; raise on failure or timeout."""
         cluster_id = cluster_id or self.cluster_id
-        status = self.get_step_status(cluster_id, step_id)
-        state = status["State"]
-
-        if state == "COMPLETED":
-            LOGGER.info("EMR step %s completed successfully", step_id)
-            return status
-
-        assert state not in ("FAILED", "CANCELLED", "INTERRUPTED"), (
-            f"EMR step {step_id} failed with state: {state}. "
-            f"Reason: {status.get('FailureDetails', {}).get('Message', 'unknown')}"
-        )
-        raise RuntimeError(f"EMR step {step_id} still running (state: {state})")
+        deadline = time.monotonic() + timeout_minutes * 60
+        state = "UNKNOWN"
+        while time.monotonic() < deadline:
+            status = self.get_step_status(cluster_id, step_id)
+            state = status["State"]
+            if state == "COMPLETED":
+                LOGGER.info("EMR step %s completed successfully", step_id)
+                return status
+            if state in ("FAILED", "CANCELLED", "INTERRUPTED"):
+                reason = status.get("FailureDetails", {}).get("Message", "unknown")
+                raise AssertionError(f"EMR step {step_id} failed with state: {state}. Reason: {reason}")
+            LOGGER.debug("EMR step %s state=%s, sleeping %ds", step_id, state, poll_interval_seconds)
+            time.sleep(poll_interval_seconds)
+        raise TimeoutError(f"EMR step {step_id} did not finish within {timeout_minutes} min (last state: {state})")
 
 
 def list_emr_clusters(tags_dict, region_name):

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1186,6 +1186,36 @@ class SCTConfiguration(BaseModel):
     emr_keep_alive: Boolean = SctField(
         description="Whether EMR cluster stays alive after job completion (default: true for reuse during testing)",
     )
+    # spark-migrator external-source options (for Cassandra-to-Scylla migration)
+    migrator_source_hosts: StringOrList = SctField(
+        description="CQL contact-point IPs for the source Cassandra/Scylla cluster. "
+        "Mutually exclusive with migrator_source_test_id.",
+    )
+    migrator_source_keyspace: String = SctField(
+        description="Keyspace to migrate from on the source cluster",
+    )
+    migrator_source_table: String = SctField(
+        description="Table to migrate from on the source cluster",
+    )
+    migrator_source_test_id: String = SctField(
+        description="SCT test_id of a running source cluster. When set, source host IPs are auto-discovered "
+        "via EC2 tags (NodeType=cs-db). Mutually exclusive with migrator_source_hosts.",
+    )
+    migrator_target_keyspace: String = SctField(
+        description="Keyspace to migrate into on the target Scylla cluster. Defaults to migrator_source_keyspace.",
+    )
+    migrator_target_table: String = SctField(
+        description="Table to migrate into on the target Scylla cluster. Defaults to migrator_source_table.",
+    )
+    migrator_run_validator: Boolean = SctField(
+        description="Run the spark-migrator validator after migration to do a row-by-row comparison",
+    )
+    migrator_step_timeout_minutes: int = SctField(
+        description="Time in minutes to wait for the spark-migrator migration EMR step. Default 360.",
+    )
+    validator_step_timeout_minutes: int = SctField(
+        description="Time in minutes to wait for the spark-migrator validator EMR step. Default 60.",
+    )
 
     run_scylla_doctor: Boolean = SctField(
         description="Flag to run Scylla Doctor tool",
@@ -1496,13 +1526,14 @@ class SCTConfiguration(BaseModel):
     cassandra_oracle_version: String = SctField(
         description="Cassandra version for the oracle cluster, i.e. '4.1' or '5.0'",
     )
-    ami_id_db_cassandra_oracle: String = SctField(
-        description="AMI ID for Cassandra oracle cluster nodes on AWS. "
-        "Defaults to empty string, which causes fallback to the loader AMI (a standard Ubuntu image).",
-    )
     install_cassandra_exporter: Boolean = SctField(
         description="Install Criteo cassandra_exporter on Cassandra nodes for Prometheus metrics collection. "
         "The exporter connects to JMX (port 7199) and exposes metrics on port 8080.",
+    )
+    cassandra_broadcast_rpc_public: Boolean = SctField(
+        description="When True, set broadcast_rpc_address to the public IP of the node in cassandra.yaml, "
+        "so clients outside the VPC (e.g. sct-runner driver connection that reads system.peers) "
+        "can reach the nodes. Defaults to False (private IP, matches intra-VPC behavior).",
     )
     # baremetal config options
     s3_baremetal_config: String = SctField(
@@ -3348,6 +3379,8 @@ class SCTConfiguration(BaseModel):
 
         self._validate_perf_gradual_throttle_steps()
 
+        self._verify_migrator_source_params()
+
     def _get_normalized_arch(self, instance_type: str, region_name: str, default: str = "x86_64") -> str:
         """Detect architecture from AWS instance type and normalize to Scylla package naming.
 
@@ -4178,6 +4211,10 @@ class SCTConfiguration(BaseModel):
             ret += "{help_text}{name}: {default}\n\n".format(help_text=help_text, default=default, name=field_name)
 
         return ret
+
+    def _verify_migrator_source_params(self):
+        if self.get("migrator_source_hosts") and self.get("migrator_source_test_id"):
+            raise ValueError("migrator_source_hosts and migrator_source_test_id are mutually exclusive — set only one")
 
     def _verify_data_volume_configuration(self, backend):
         dev_num = self.get("data_volume_disk_num")

--- a/sdcm/sct_provision/aws/cluster.py
+++ b/sdcm/sct_provision/aws/cluster.py
@@ -256,7 +256,7 @@ class DBCluster(ClusterBase):
 
     @cached_property
     def _is_cassandra(self) -> bool:
-        return self.params.get("db_type") in ("cassandra", "mixed_cassandra")
+        return self.params.get("db_type") == "cassandra"
 
     @cached_property
     def _INSTANCE_PARAMS_BUILDER(self):

--- a/sdcm/spark_migrator.py
+++ b/sdcm/spark_migrator.py
@@ -13,6 +13,7 @@
 
 """Spark migrator job submission and monitoring for EMR clusters."""
 
+import gzip
 import logging
 import os
 import tempfile
@@ -41,6 +42,9 @@ _BOOTSTRAP_SCRIPT_S3_KEY = "scripts/bootstrap-spark4.sh"
 _SPARK4_PACKAGE = f"spark-{SPARK4_VERSION}-bin-hadoop3"
 _SPARK4_URL = f"https://downloads.apache.org/spark/spark-{SPARK4_VERSION}/{_SPARK4_PACKAGE}.tgz"
 _RUNNER_SCRIPT_S3_KEY = "scripts/run-migrator.sh"
+_VALIDATOR_SCRIPT_S3_KEY = "scripts/run-validator.sh"
+_MIGRATOR_MAIN_CLASS = "com.scylladb.migrator.Migrator"
+_VALIDATOR_MAIN_CLASS = "com.scylladb.migrator.Validator"
 
 _BOOTSTRAP_SCRIPT_CONTENT = f"""#!/bin/bash
 set -ex
@@ -149,12 +153,46 @@ def upload_migrator_jar_to_s3(release_tag, s3_bucket, region_name, s3_prefix="ja
     return s3_uri
 
 
+def discover_cs_source_hosts(test_id: str, region_name: str) -> list[str]:
+    """Return reachable IPs of running Cassandra source nodes tagged with test_id.
+
+    Public IP is preferred (works cross-VPC). Falls back to private IP when no
+    public IP is assigned (same-VPC / VPC-peered topology).
+
+    Args:
+        test_id: SCT cluster test_id for which cs-db EC2 instances should be discovered.
+        region_name: AWS region to search in.
+
+    Returns:
+        List of IP addresses (public preferred, private fallback) for running cs-db instances.
+    """
+    ec2 = boto3.client("ec2", region_name=region_name)
+    response = ec2.describe_instances(
+        Filters=[
+            {"Name": "tag:TestId", "Values": [test_id]},
+            {"Name": "tag:NodeType", "Values": ["cs-db"]},
+            {"Name": "instance-state-name", "Values": ["running"]},
+        ]
+    )
+    hosts = [
+        ip
+        for reservation in response["Reservations"]
+        for inst in reservation["Instances"]
+        if (ip := inst.get("PublicIpAddress") or inst.get("PrivateIpAddress"))
+    ]
+    if not hosts:
+        raise RuntimeError(f"no running cs-db instances found for test_id={test_id} in {region_name}")
+    LOGGER.info("Discovered %d cs-db host(s) for test_id=%s in %s: %s", len(hosts), test_id, region_name, hosts)
+    return hosts
+
+
 @dataclass
 class MigratorConfig:
     """Configuration for a spark-migrator job.
 
     Args:
-        source_host: Source database host (Scylla/Cassandra endpoint).
+        source_type: Source database type for scylla-migrator ('cassandra' or 'scylla').
+        source_hosts: Source database hosts (one or more contact points).
         source_port: Source database CQL port.
         source_keyspace: Source keyspace name.
         source_table: Source table name.
@@ -169,7 +207,8 @@ class MigratorConfig:
         extra_spark_args: Additional spark-submit arguments.
     """
 
-    source_host: str = ""
+    source_type: str = "cassandra"
+    source_hosts: list[str] = field(default_factory=list)
     source_port: int = 9042
     source_keyspace: str = ""
     source_table: str = ""
@@ -199,8 +238,27 @@ class SparkMigratorRunner:
     def s3_bucket(self):
         return f"sct-emr-spark-migrator-{self.emr_provisioner.region_name}"
 
-    def _upload_runner_script(self, jar_s3_path, config_s3_path):
-        """Generate and upload a wrapper script that invokes standalone Spark 4.x."""
+    def _upload_runner_script(
+        self,
+        jar_s3_path,
+        config_s3_path,
+        main_class=_MIGRATOR_MAIN_CLASS,
+        script_key=_RUNNER_SCRIPT_S3_KEY,
+        deploy_mode="cluster",
+    ):
+        """Generate and upload a wrapper script that invokes standalone Spark 4.x.
+
+        Args:
+            jar_s3_path: S3 path to the spark-migrator JAR.
+            config_s3_path: S3 path to the migrator config YAML.
+            main_class: Spark application main class (Migrator or Validator).
+            script_key: S3 key for the uploaded wrapper script (distinct keys
+                avoid migrator/validator scripts overwriting each other).
+            deploy_mode: Spark deploy mode — "cluster" (default, driver on a
+                YARN executor) or "client" (driver on the master). Validator
+                uses "client" so its log4j output lands in the EMR step's
+                stderr.gz on S3 instead of YARN aggregated container logs.
+        """
         script_content = f"""#!/bin/bash
 set -ex
 
@@ -214,11 +272,12 @@ export SPARK_HOME={SPARK4_INSTALL_DIR}
 export HADOOP_CONF_DIR=/etc/hadoop/conf
 export YARN_CONF_DIR=/etc/hadoop/conf
 
-# run on YARN in cluster mode so the driver runs on a cluster node
+cd /tmp
+
 {SPARK4_INSTALL_DIR}/bin/spark-submit \\
-  --deploy-mode cluster \\
+  --deploy-mode {deploy_mode} \\
   --master yarn \\
-  --class com.scylladb.migrator.Migrator \\
+  --class {main_class} \\
   --conf "spark.scylla.config=migrator-config.yaml" \\
   --files /tmp/migrator-config.yaml \\
   /tmp/scylla-migrator-assembly.jar
@@ -228,10 +287,10 @@ export YARN_CONF_DIR=/etc/hadoop/conf
         _ensure_s3_bucket(s3_client, self.s3_bucket, region_name)
         s3_client.put_object(
             Bucket=self.s3_bucket,
-            Key=_RUNNER_SCRIPT_S3_KEY,
+            Key=script_key,
             Body=script_content.encode("utf-8"),
         )
-        s3_uri = f"s3://{self.s3_bucket}/{_RUNNER_SCRIPT_S3_KEY}"
+        s3_uri = f"s3://{self.s3_bucket}/{script_key}"
         LOGGER.info("Runner script uploaded to %s", s3_uri)
         return s3_uri
 
@@ -265,32 +324,110 @@ export YARN_CONF_DIR=/etc/hadoop/conf
         LOGGER.info("Spark migrator job submitted as step %s on cluster %s", step_id, cluster_id)
         return step_id
 
-    def wait_for_migration(self, cluster_id, step_id):
-        """Wait for a migration job to complete.
+    # TODO: Spark 4.x workaround
+    def submit_validator_job(self, cluster_id, jar_s3_path, migrator_config):
+        """Submit a scylla-migrator validator job as an EMR step.
+
+        Reuses the script-runner.jar wrapper pattern from submit_migration_job but invokes
+        com.scylladb.migrator.Validator instead. Validator reads the same migrator config
+        YAML - no separate config upload needed.
+
+        Args:
+            cluster_id: EMR cluster ID.
+            jar_s3_path: S3 path to the spark-migrator JAR (same as migration).
+            migrator_config: MigratorConfig with config_path set to S3 URI.
+
+        Returns:
+            str: Step ID of the submitted validator job.
+        """
+        runner_script_uri = self._upload_runner_script(
+            jar_s3_path,
+            migrator_config.config_path,
+            main_class=_VALIDATOR_MAIN_CLASS,
+            script_key=_VALIDATOR_SCRIPT_S3_KEY,
+            deploy_mode="client",
+        )
+        script_runner_jar = (
+            f"s3://{self.emr_provisioner.region_name}.elasticmapreduce/libs/script-runner/script-runner.jar"
+        )
+        step_id = self.emr_provisioner.add_step(
+            cluster_id=cluster_id,
+            step_name="spark-migrator-validator",
+            jar=script_runner_jar,
+            args=[runner_script_uri],
+        )
+        LOGGER.info("Spark migrator validator job submitted as step %s on cluster %s", step_id, cluster_id)
+        return step_id
+
+    def get_step_stdout(self, cluster_id, step_id):
+        """Fetch step stdout + stderr from the EMR cluster's S3 log directory.
+
+        EMR uploads each step's stdout.gz and stderr.gz under ``<LogUri>/<cluster_id>/steps/<step_id>/``
+        after the step completes. Both streams are downloaded, gunzipped, decoded and concatenated
+        so the validator parser can scan them as a single text blob (the validator emits its diff
+        summary to stderr via log4j; stdout is generally empty).
+
+        Args:
+            cluster_id: EMR cluster ID.
+            step_id: Step ID whose logs to fetch.
+
+        Returns:
+            str: Concatenated decoded text from stdout.gz + stderr.gz. Missing
+            log files are skipped silently (returns "" if neither exists).
+        """
+        cluster_info = self.emr_provisioner.emr_client.describe_cluster(ClusterId=cluster_id)
+        log_uri = cluster_info["Cluster"].get("LogUri", "").rstrip("/")
+        # EMR normalises s3:// to s3n:// (legacy Hadoop S3 protocol); accept both
+        # (plus s3a:// for completeness) so the prefix split works regardless of variant
+        scheme_prefix = next((p for p in ("s3://", "s3n://", "s3a://") if log_uri.startswith(p)), None)
+        if not scheme_prefix:
+            raise RuntimeError(f"cluster {cluster_id} has no S3 LogUri configured — cannot fetch step logs")
+
+        bucket, _, prefix = log_uri[len(scheme_prefix) :].partition("/")
+        key_prefix = f"{prefix.rstrip('/')}/{cluster_id}/steps/{step_id}"
+        s3_client = boto3.client("s3", region_name=self.emr_provisioner.region_name)
+
+        text_parts = []
+        for log_name in ("stdout.gz", "stderr.gz"):
+            try:
+                obj = s3_client.get_object(Bucket=bucket, Key=f"{key_prefix}/{log_name}")
+                text_parts.append(gzip.decompress(obj["Body"].read()).decode("utf-8", errors="replace"))
+            except ClientError as exc:
+                if exc.response["Error"]["Code"] in ("NoSuchKey", "404"):
+                    continue
+                raise
+        return "\n".join(text_parts)
+
+    def wait_for_migration(self, cluster_id, step_id, timeout_minutes=360):
+        """Wait for a migration/validator job to complete.
 
         Args:
             cluster_id: EMR cluster ID.
             step_id: Step ID of the migration job.
+            timeout_minutes: Max wall-clock minutes. Default 360 (6h) covers
+                multi-100GB Cassandra→Scylla migrations. Validator callers
+                should pass a smaller value (~60).
 
         Returns:
             dict: Step status after completion.
         """
-        return self.emr_provisioner.wait_for_step_completion(cluster_id, step_id)
+        return self.emr_provisioner.wait_for_step_completion(cluster_id, step_id, timeout_minutes=timeout_minutes)
 
-    def run_migration(self, cluster_id, jar_s3_path, migrator_config):
+    def run_migration(self, cluster_id, jar_s3_path, migrator_config, timeout_minutes=360):
         """Submit and wait for a migration job to complete.
 
         Args:
             cluster_id: EMR cluster ID.
             jar_s3_path: S3 path to the spark-migrator JAR.
             migrator_config: MigratorConfig with config_path set to S3 URI.
+            timeout_minutes: Max wall-clock minutes for the migration step.
 
         Returns:
             dict: Migration result with step_id, status, and duration.
         """
         start_time = time.time()
         step_id = self.submit_migration_job(cluster_id, jar_s3_path, migrator_config)
-        status = self.wait_for_migration(cluster_id, step_id)
+        status = self.wait_for_migration(cluster_id, step_id, timeout_minutes=timeout_minutes)
         duration = time.time() - start_time
 
         LOGGER.info("Migration completed in %.1f seconds", duration)
@@ -324,8 +461,8 @@ export YARN_CONF_DIR=/etc/hadoop/conf
         """
         return {
             "source": {
-                "type": "cassandra",
-                "host": migrator_config.source_host,
+                "type": migrator_config.source_type,
+                "host": migrator_config.source_hosts[0],
                 "port": migrator_config.source_port,
                 "keyspace": migrator_config.source_keyspace,
                 "table": migrator_config.source_table,
@@ -349,6 +486,17 @@ export YARN_CONF_DIR=/etc/hadoop/conf
             "savepoints": {
                 "path": "/tmp/savepoints",
                 "intervalSeconds": 300,
+            },
+            # required by com.scylladb.migrator.Validator (main class fails fast with
+            # "Missing required property 'validation' in the configuration file" when
+            # absent).
+            "validation": {
+                "compareTimestamps": False,
+                "ttlToleranceMillis": 0,
+                "writetimeToleranceMillis": 0,
+                "failuresToFetch": 100,
+                "floatingPointTolerance": 0.0,
+                "timestampMsTolerance": 0,
             },
         }
 

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1976,7 +1976,7 @@ class ClusterTester(unittest.TestCase):
                 )
             elif db_type == "mixed_cassandra":
                 self.test_config.mixed_cluster(True)
-                ami_id = self.params.get("ami_id_db_cassandra_oracle") or self.params.get("ami_id_loader")
+                ami_id = self.params.get("ami_id_db_cassandra") or self.params.get("ami_id_loader")
                 return CassandraAWSCluster(
                     ec2_ami_id=ami_id.split(),
                     ec2_ami_username="ubuntu",
@@ -2281,7 +2281,7 @@ class ClusterTester(unittest.TestCase):
 
         self.emr_cluster.create_emr_cluster(
             test_id=self.test_config.test_id(),
-            user=self.params.get("email_recipients")[0] if self.params.get("email_recipients") else "unknown",
+            user=get_username(),
             vpc_subnet_id=subnet_id,
             test_name=self.params.get("user_prefix"),
             version=self.params.get("scylla_version"),
@@ -2775,6 +2775,7 @@ class ClusterTester(unittest.TestCase):
         compaction_strategy="",
         use_single_loader=False,
         stop_test_on_failure=True,
+        node_list=None,
     ):
         params = dict(
             stress_cmd=stress_cmd,
@@ -2787,6 +2788,7 @@ class ClusterTester(unittest.TestCase):
             round_robin=round_robin,
             stats_aggregate_cmds=stats_aggregate_cmds,
             use_single_loader=use_single_loader,
+            node_list=node_list,
         )
         if "cql-stress-cassandra-stress" in stress_cmd:
             params["stop_test_on_failure"] = stop_test_on_failure
@@ -2835,6 +2837,7 @@ class ClusterTester(unittest.TestCase):
         compaction_strategy="",
         stop_test_on_failure=True,
         params=None,
+        node_list=None,
         **_,
     ):
         if duration:
@@ -2856,7 +2859,7 @@ class ClusterTester(unittest.TestCase):
             keyspace_num=keyspace_num,
             compaction_strategy=compaction_strategy,
             profile=profile,
-            node_list=self.db_cluster.nodes,
+            node_list=node_list or self.db_cluster.nodes,
             round_robin=round_robin,
             client_encrypt=self.params.get("client_encrypt"),
             keyspace_name=keyspace_name,
@@ -2983,6 +2986,7 @@ class ClusterTester(unittest.TestCase):
         round_robin=False,
         stats_aggregate_cmds=True,
         stop_test_on_failure=True,
+        node_list=None,
         **_,
     ):
         if duration:
@@ -3001,7 +3005,7 @@ class ClusterTester(unittest.TestCase):
             stress_cmd=stress_cmd,
             timeout=timeout,
             stress_num=stress_num,
-            node_list=self.db_cluster.nodes,
+            node_list=node_list or self.db_cluster.nodes,
             round_robin=round_robin,
             stop_test_on_failure=stop_test_on_failure,
             params=self.params,

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -2182,6 +2182,8 @@ def get_post_behavior_actions(config):
             action_per_type["db_nodes"]["node_types"].append("cs-db")
         case "mixed_scylla":
             action_per_type["db_nodes"]["node_types"].append("oracle-db")
+        case "mixed_cassandra":
+            action_per_type["db_nodes"]["node_types"].append("oracle-db")
 
     return action_per_type
 

--- a/spark_migrator_test.py
+++ b/spark_migrator_test.py
@@ -15,10 +15,26 @@
 
 """Spark migrator test module for testing scylla-spark-migrator on EMR clusters."""
 
+import random
+import re
 import time
+from concurrent.futures import ThreadPoolExecutor
 
-from sdcm.spark_migrator import MigratorConfig, SparkMigratorRunner, upload_migrator_jar_to_s3
+from cassandra import ConsistencyLevel
+from cassandra.cluster import Cluster as CassandraCluster
+from cassandra.concurrent import execute_concurrent_with_args
+from cassandra.query import SimpleStatement
+
+from sdcm.cluster import BaseNode
+from sdcm.spark_migrator import (
+    MigratorConfig,
+    SparkMigratorRunner,
+    discover_cs_source_hosts,
+    upload_migrator_jar_to_s3,
+)
 from sdcm.tester import ClusterTester
+
+_SAMPLE_SIZE = 10
 
 
 class SparkMigratorTest(ClusterTester):
@@ -96,6 +112,7 @@ class SparkMigratorTest(ClusterTester):
             cluster_id=self.emr_cluster.cluster_id,
             jar_s3_path=jar_path,
             migrator_config=migrator_config,
+            timeout_minutes=self.params.get("migrator_step_timeout_minutes") or 360,
         )
         duration = time.time() - start_time
 
@@ -109,6 +126,171 @@ class SparkMigratorTest(ClusterTester):
 
         # Validate migration
         self._validate_migration()
+
+    def test_migration_from_external_source(self):
+        """Migrate a table from an external Cassandra cluster to the Scylla target.
+
+        Source cluster is provided via migrator_source_hosts or auto-discovered via
+        migrator_source_test_id (hosts are looked up by EC2 tag). Target is
+        self.db_cluster. Validates row count match plus a sample of individual rows.
+        """
+        self.log.info("Starting external-source migration test")
+        self._ensure_migrator_jar()
+
+        if not self.emr_cluster:
+            raise RuntimeError("EMR cluster not available — set emr_release_label in config")
+
+        jar_path = self.params.get("emr_spark_migrator_jar_path")
+        if not jar_path:
+            raise RuntimeError("emr_spark_migrator_jar_path not configured")
+
+        if not (source_hosts := self.params.get("migrator_source_hosts")):
+            source_test_id = self.params.get("migrator_source_test_id")
+            if not source_test_id:
+                raise RuntimeError("set migrator_source_hosts or migrator_source_test_id")
+            source_hosts = discover_cs_source_hosts(source_test_id, self.params.region_names[0])
+        if isinstance(source_hosts, str):
+            source_hosts = [source_hosts]
+
+        source_keyspace = self.params.get("migrator_source_keyspace") or "migrator_test"
+        source_table = self.params.get("migrator_source_table") or "source_table"
+        target_keyspace = self.params.get("migrator_target_keyspace") or source_keyspace
+        target_table = self.params.get("migrator_target_table") or source_table
+        target_node = self.db_cluster.nodes[0]
+
+        self._prepare_external_source_data(source_hosts, BaseNode.CQL_PORT, source_keyspace, source_table)
+
+        # scylla-migrator v2.0.x CQL writer requires target keyspace/table to exist
+        self._prepare_target_schema(target_keyspace, target_table)
+        runner = SparkMigratorRunner(self.emr_cluster)
+        migrator_config = MigratorConfig(
+            source_type="cassandra",
+            source_hosts=source_hosts,
+            source_port=BaseNode.CQL_PORT,
+            source_keyspace=source_keyspace,
+            source_table=source_table,
+            target_host=target_node.private_ip_address,
+            target_port=BaseNode.CQL_PORT,
+            target_keyspace=target_keyspace,
+            target_table=target_table,
+        )
+
+        region = self.params.region_names[0]
+        migrator_config.config_path = runner.upload_config_to_s3(
+            SparkMigratorRunner.generate_migrator_config(migrator_config),
+            s3_bucket=f"sct-emr-spark-migrator-{region}",
+            test_id=self.test_id,
+            region_name=region,
+        )
+
+        self.log.info(
+            "Submitting spark-migrator job (source=%s ks=%s.%s → target=%s ks=%s.%s)",
+            source_hosts[0],
+            source_keyspace,
+            source_table,
+            target_node.private_ip_address,
+            target_keyspace,
+            target_table,
+        )
+        result = runner.run_migration(
+            cluster_id=self.emr_cluster.cluster_id,
+            jar_s3_path=jar_path,
+            migrator_config=migrator_config,
+            timeout_minutes=self.params.get("migrator_step_timeout_minutes") or 360,
+        )
+        self.log.info("Migration completed in %.1f seconds", result["duration_seconds"])
+
+        self._validate_external_migration(
+            source_hosts,
+            BaseNode.CQL_PORT,
+            source_keyspace,
+            source_table,
+            target_keyspace,
+            target_table,
+        )
+
+    def _prepare_target_schema(self, keyspace: str, table: str):
+        """Create matching keyspace/table on target Scylla.
+
+        scylla-migrator v2.0.x CQL writer (com.scylladb.migrator.writers.Scylla.writeDataframe)
+        requires the target keyspace and table to already exist.
+        """
+        self.log.info("Preparing target schema %s.%s on Scylla", keyspace, table)
+        with self.db_cluster.cql_connection_patient(self.db_cluster.nodes[0]) as session:
+            session.execute(
+                f"CREATE KEYSPACE IF NOT EXISTS {keyspace} "
+                "WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}"
+            )
+            session.execute(f"CREATE TABLE IF NOT EXISTS {keyspace}.{table} (id int PRIMARY KEY, data text, value int)")
+        self.log.info("Target schema ready: %s.%s", keyspace, table)
+
+    def _prepare_external_source_data(self, hosts: list, port: int, keyspace: str, table: str):
+        """Create keyspace/table on external Cassandra cluster and insert 1000 test rows."""
+        self.log.info("Preparing source data on external cluster %s", hosts[0])
+        cluster = CassandraCluster(contact_points=hosts, port=port)
+        try:
+            session = cluster.connect()
+            session.execute(
+                f"CREATE KEYSPACE IF NOT EXISTS {keyspace} "
+                "WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}"
+            )
+            session.execute(f"CREATE TABLE IF NOT EXISTS {keyspace}.{table} (id int PRIMARY KEY, data text, value int)")
+            for i in range(1000):
+                session.execute(
+                    f"INSERT INTO {keyspace}.{table} (id, data, value) VALUES (%s, %s, %s)",
+                    (i, f"data_{i}", i * 10),
+                )
+            self.log.info("Source data prepared: 1000 rows in %s.%s", keyspace, table)
+        finally:
+            cluster.shutdown()
+
+    def _validate_external_migration(
+        self,
+        source_hosts: list,
+        source_port: int,
+        source_keyspace: str,
+        source_table: str,
+        target_keyspace: str,
+        target_table: str,
+    ):
+        """Validate migrated data: row count match + _SAMPLE_SIZE random row comparison."""
+        self.log.info(
+            "Validating migration from %s.%s → %s.%s", source_keyspace, source_table, target_keyspace, target_table
+        )
+
+        source_cluster = CassandraCluster(contact_points=source_hosts, port=source_port)
+        try:
+            src_session = source_cluster.connect()
+            src_count = src_session.execute(f"SELECT count(*) FROM {source_keyspace}.{source_table}").one()[0]
+        finally:
+            source_cluster.shutdown()
+
+        with self.db_cluster.cql_connection_patient(self.db_cluster.nodes[0]) as tgt_session:
+            tgt_count = tgt_session.execute(f"SELECT count(*) FROM {target_keyspace}.{target_table}").one()[0]
+
+        assert src_count == tgt_count, f"row count mismatch: source {src_count} vs target {tgt_count}"
+        self.log.info("Row count matches: %d rows", src_count)
+
+        # sample-row comparison
+        sample_ids = random.sample(range(1000), _SAMPLE_SIZE)
+        source_cluster = CassandraCluster(contact_points=source_hosts, port=source_port)
+        try:
+            src_session = source_cluster.connect()
+            with self.db_cluster.cql_connection_patient(self.db_cluster.nodes[0]) as tgt_session:
+                for row_id in sample_ids:
+                    src_row = src_session.execute(
+                        f"SELECT id, data, value FROM {source_keyspace}.{source_table} WHERE id = %s",
+                        (row_id,),
+                    ).one()
+                    tgt_row = tgt_session.execute(
+                        f"SELECT id, data, value FROM {target_keyspace}.{target_table} WHERE id = %s",
+                        (row_id,),
+                    ).one()
+                    assert src_row == tgt_row, f"row mismatch for id={row_id}: source={src_row} target={tgt_row}"
+        finally:
+            source_cluster.shutdown()
+
+        self.log.info("Sample validation passed: %d/%d rows match", _SAMPLE_SIZE, _SAMPLE_SIZE)
 
     def _prepare_source_data(self):
         """Create source keyspace/table and load test data."""
@@ -138,7 +320,7 @@ class SparkMigratorTest(ClusterTester):
         host = node.private_ip_address
 
         return MigratorConfig(
-            source_host=host,
+            source_hosts=[host],
             source_port=9042,
             source_keyspace="migrator_test",
             source_table="source_table",
@@ -157,3 +339,365 @@ class SparkMigratorTest(ClusterTester):
             row_count = result.one()[0]
             assert row_count == 1000, f"Expected 1000 rows, got {row_count}"
         self.log.info("Migration validation passed: %d rows migrated", row_count)
+
+    def test_migration_cs_to_scylla_small(self):
+        """Migrate 100k rows from a provisioned Cassandra source cluster to the Scylla target.
+
+        Requires db_type: mixed_cassandra and an EMR cluster with the migrator JAR configured.
+        Uses dump_schema to replicate the Cassandra schema on Scylla before running the job.
+        """
+        self.log.info("Starting cs-to-scylla small migration test")
+
+        if self.cs_db_cluster is None:
+            raise RuntimeError("cs_db_cluster not provisioned — set db_type: mixed_cassandra in test-case yaml")
+
+        if not self.emr_cluster:
+            raise RuntimeError("EMR cluster not available — set emr_release_label")
+
+        self._assert_region_coherence()
+        self._ensure_migrator_jar()
+
+        jar_path = self.params.get("emr_spark_migrator_jar_path")
+        if not jar_path:
+            raise RuntimeError("emr_spark_migrator_jar_path not configured")
+
+        source_keyspace = self.params.get("migrator_source_keyspace") or "migrator_test"
+        source_table = self.params.get("migrator_source_table") or "source_table"
+        target_keyspace = self.params.get("migrator_target_keyspace") or source_keyspace
+        target_table = self.params.get("migrator_target_table") or source_table
+        row_count = 100_000
+
+        self._preload_cs_source_data(source_keyspace, source_table, row_count)
+        self._apply_source_schema_on_target(source_keyspace, target_keyspace)
+
+        runner = SparkMigratorRunner(self.emr_cluster)
+        migrator_config = self._build_cs_to_scylla_migrator_config(
+            source_keyspace, source_table, target_keyspace, target_table
+        )
+
+        region = self.params.region_names[0]
+        migrator_config.config_path = runner.upload_config_to_s3(
+            SparkMigratorRunner.generate_migrator_config(migrator_config),
+            s3_bucket=f"sct-emr-spark-migrator-{region}",
+            test_id=self.test_id,
+            region_name=region,
+        )
+
+        result = runner.run_migration(
+            cluster_id=self.emr_cluster.cluster_id,
+            jar_s3_path=jar_path,
+            migrator_config=migrator_config,
+            timeout_minutes=self.params.get("migrator_step_timeout_minutes") or 360,
+        )
+        self.log.info("Migration completed in %.1f seconds", result["duration_seconds"])
+
+        self._validate_migration_count_and_sample(
+            source_cluster=self.cs_db_cluster,
+            source_keyspace=source_keyspace,
+            source_table=source_table,
+            target_keyspace=target_keyspace,
+            target_table=target_table,
+            expected_row_count=row_count,
+        )
+
+        if self.params.get("migrator_run_validator"):
+            self._run_validator(runner, jar_path, migrator_config)
+
+    def _assert_region_coherence(self):
+        """Fail fast if EMR cluster is in a different region than the test."""
+        if (emr_region := self.emr_cluster.region_name) != (test_region := self.params.region_names[0]):
+            raise RuntimeError(
+                f"EMR cluster region {emr_region!r} != test region {test_region!r}; "
+                "cross-region data transfer is slow + costly — fix the yaml."
+            )
+
+    def _run_preload_against_cs_cluster(self):
+        """Dispatch each prepare_write_cmd against cs_db_cluster.nodes via the stress wrappers."""
+        prepare_cmds = self.params.get("prepare_write_cmd") or []
+        if not prepare_cmds:
+            raise RuntimeError("scale test requires prepare_write_cmd in the test-case yaml")
+        if isinstance(prepare_cmds, str):
+            prepare_cmds = [prepare_cmds]
+
+        self.log.info("Starting preload of %d stress chunk(s) against cs_db_cluster", len(prepare_cmds))
+        threads = [
+            self.run_stress_thread(stress_cmd=cmd, round_robin=True, node_list=self.cs_db_cluster.nodes)
+            for cmd in prepare_cmds
+        ]
+        for t in threads:
+            if not self.verify_stress_thread(t):
+                raise RuntimeError("preload stress thread reported errors — see sct.log for details")
+        self.log.info("Preload complete")
+
+    def _run_validator(self, runner, jar_path, migrator_config):
+        """Submit a scylla-migrator validator step + assert zero mismatches.
+
+        The EMR step state is authoritative: COMPLETED = 0 mismatches, FAILED = ≥1 mismatch.
+        On FAILED, the step stdout is fetched and dumped to sct.log; it contains the upstream
+        "Found N comparison failure(s) in sample: <breakdown>" summary and per-row
+        RowComparisonFailure entries for diagnosis.
+        """
+        self.log.info("Submitting validator step against the just-migrated tables")
+        step_id = runner.submit_validator_job(
+            cluster_id=self.emr_cluster.cluster_id,
+            jar_s3_path=jar_path,
+            migrator_config=migrator_config,
+        )
+
+        try:
+            runner.wait_for_migration(
+                self.emr_cluster.cluster_id,
+                step_id,
+                timeout_minutes=self.params.get("validator_step_timeout_minutes") or 60,
+            )
+        except AssertionError:
+            try:
+                step_log = runner.get_step_stdout(self.emr_cluster.cluster_id, step_id)
+            except Exception as fetch_err:  # noqa: BLE001
+                self.log.warning("Could not fetch validator step log: %s", fetch_err)
+                step_log = ""
+            self.log.error("Validator step output:\n%s", step_log or "(no log captured)")
+            raise AssertionError("validator step FAILED — see stdout dump above") from None
+
+        self.log.info("Validator passed: 0 mismatches across migrated rows")
+
+    def test_migration_cs_to_scylla_scale(self):
+        """Scale-out variant of the cs-to-scylla migration test."""
+        self.log.info("Starting cs-to-scylla scale migration test")
+
+        if self.cs_db_cluster is None:
+            raise RuntimeError("cs_db_cluster not provisioned — set db_type: mixed_cassandra in test-case yaml")
+        if not self.emr_cluster:
+            raise RuntimeError("EMR cluster not available — set emr_release_label")
+
+        self._assert_region_coherence()
+        self._ensure_migrator_jar()
+
+        jar_path = self.params.get("emr_spark_migrator_jar_path")
+        if not jar_path:
+            raise RuntimeError("emr_spark_migrator_jar_path not configured")
+
+        source_keyspace = self.params.get("migrator_source_keyspace") or "keyspace1"
+        source_table = self.params.get("migrator_source_table") or "standard1"
+        target_keyspace = self.params.get("migrator_target_keyspace") or source_keyspace
+        target_table = self.params.get("migrator_target_table") or source_table
+
+        if not self.params.get("reuse_cluster"):
+            self._run_preload_against_cs_cluster()
+
+        self._apply_source_schema_on_target(source_keyspace, target_keyspace)
+
+        runner = SparkMigratorRunner(self.emr_cluster)
+        migrator_config = self._build_cs_to_scylla_migrator_config(
+            source_keyspace, source_table, target_keyspace, target_table
+        )
+
+        region = self.params.region_names[0]
+        migrator_config.config_path = runner.upload_config_to_s3(
+            SparkMigratorRunner.generate_migrator_config(migrator_config),
+            s3_bucket=f"sct-emr-spark-migrator-{region}",
+            test_id=self.test_id,
+            region_name=region,
+        )
+
+        result = runner.run_migration(
+            cluster_id=self.emr_cluster.cluster_id,
+            jar_s3_path=jar_path,
+            migrator_config=migrator_config,
+            timeout_minutes=self.params.get("migrator_step_timeout_minutes") or 360,
+        )
+        self.log.info("Migration completed in %.1f seconds", result["duration_seconds"])
+
+        if self.params.get("migrator_run_validator"):
+            self._run_validator(runner, jar_path, migrator_config)
+
+    def _preload_cs_source_data(self, keyspace: str, table: str, row_count: int):
+        """Insert row_count rows into cs_db_cluster keyspace.table using concurrent writes."""
+        self.log.info("Preloading %d rows into %s.%s on Cassandra source", row_count, keyspace, table)
+        with self.cs_db_cluster.cql_connection_patient(self.cs_db_cluster.nodes[0]) as session:
+            session.execute(
+                f"CREATE KEYSPACE IF NOT EXISTS {keyspace} "
+                "WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}"
+            )
+            session.execute(f"CREATE TABLE IF NOT EXISTS {keyspace}.{table} (id int PRIMARY KEY, data text, value int)")
+            stmt = session.prepare(f"INSERT INTO {keyspace}.{table} (id, data, value) VALUES (?, ?, ?)")
+            params = [(i, f"data_{i}", i * 10) for i in range(row_count)]
+            execute_concurrent_with_args(session, stmt, params, concurrency=200, raise_on_first_error=True)
+        self.log.info("Preloaded %d rows into %s.%s", row_count, keyspace, table)
+
+    def _apply_source_schema_on_target(self, source_keyspace: str, target_keyspace: str):
+        """Dump schema from Cassandra source and apply it on the Scylla target.
+
+        Pre-creates the target keyspace with SimpleStrategy RF=1 (the schema dump
+        strips the CREATE KEYSPACE statement by default, and the target may use
+        different replication settings anyway).
+
+        For phase 1's simple schemas a plain str.replace is sufficient to rename
+        all keyspace-qualified object references when source and target keyspace names differ.
+        """
+        with self.db_cluster.cql_connection_patient(self.db_cluster.nodes[0]) as session:
+            session.execute(
+                f"CREATE KEYSPACE IF NOT EXISTS {target_keyspace} "
+                "WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}"
+            )
+
+        schema_cql = self.cs_db_cluster.dump_schema(source_keyspace, include_keyspace_stmt=False)
+
+        if target_keyspace != source_keyspace:
+            schema_cql = schema_cql.replace(f"{source_keyspace}.", f"{target_keyspace}.")
+
+        with self.db_cluster.cql_connection_patient(self.db_cluster.nodes[0]) as session:
+            for raw_stmt in schema_cql.split(";"):
+                cql_stmt = raw_stmt.strip()
+                if not cql_stmt:
+                    continue
+                cql_stmt = self._make_create_idempotent(cql_stmt)
+                self.log.info("Applying schema statement: %s", cql_stmt.splitlines()[0])
+                session.execute(cql_stmt)
+
+    def _count_rows_parallel(
+        self,
+        cluster,
+        keyspace: str,
+        table: str,
+        partition_key: str | None = None,
+        parallelism: int = 16,
+        per_query_timeout: int = 600,
+    ) -> int:
+        """Count rows by sharding the Murmur3 token ring across parallel concurrent sub-queries."""
+        min_token = -(2**63)
+        max_token = (2**63) - 1
+        step = (max_token - min_token + 1) // parallelism
+
+        boundaries = [min_token + step * i for i in range(parallelism + 1)]
+        boundaries[-1] = max_token
+
+        # mark first range as inclusive-low (>=) so MIN_TOKEN is included
+        ranges = [(boundaries[i], boundaries[i + 1], i == 0) for i in range(parallelism)]
+
+        with cluster.cql_connection_patient(cluster.nodes[0]) as session:
+            if partition_key:
+                token_arg = partition_key
+            else:
+                pk_rows = sorted(
+                    (
+                        r
+                        for r in session.execute(
+                            "SELECT column_name, kind, position FROM system_schema.columns "
+                            "WHERE keyspace_name=%s AND table_name=%s",
+                            (keyspace, table),
+                        )
+                        if r.kind == "partition_key"
+                    ),
+                    key=lambda r: r.position,
+                )
+                if not pk_rows:
+                    raise RuntimeError(f"no partition key columns found for {keyspace}.{table}")
+                token_arg = ", ".join(r.column_name for r in pk_rows)
+
+            def count_range(args):
+                low, high, inclusive_low = args
+                op = ">=" if inclusive_low else ">"
+                cql = (
+                    f"SELECT count(*) FROM {keyspace}.{table} "
+                    f"WHERE token({token_arg}) {op} {low} AND token({token_arg}) <= {high}"
+                )
+                return session.execute(
+                    SimpleStatement(cql, consistency_level=ConsistencyLevel.ONE),
+                    timeout=per_query_timeout,
+                ).one()[0]
+
+            with ThreadPoolExecutor(max_workers=parallelism) as pool:
+                total = sum(pool.map(count_range, ranges))
+
+        self.log.info("Parallel count over %s.%s with %d ranges → %d rows", keyspace, table, parallelism, total)
+        return total
+
+    @staticmethod
+    def _make_create_idempotent(cql_stmt: str) -> str:
+        """Rewrite leading `CREATE TABLE|TYPE|INDEX` to `CREATE … IF NOT EXISTS` so the apply
+        loop is safe to re-run under SCT_REUSE_CLUSTER. No-op if the statement already contains
+        IF NOT EXISTS or does not start with one of the targeted DDL verbs."""
+        return re.sub(
+            r"^(CREATE\s+(?:TABLE|TYPE|INDEX))(?!\s+IF\s+NOT\s+EXISTS)\b",
+            r"\1 IF NOT EXISTS",
+            cql_stmt,
+            count=1,
+            flags=re.IGNORECASE,
+        )
+
+    def _build_cs_to_scylla_migrator_config(
+        self,
+        source_keyspace: str,
+        source_table: str,
+        target_keyspace: str,
+        target_table: str,
+    ) -> MigratorConfig:
+        """Build a MigratorConfig for cs_db_cluster → db_cluster migration."""
+        return MigratorConfig(
+            source_type="cassandra",
+            source_hosts=[n.private_ip_address for n in self.cs_db_cluster.nodes],
+            source_port=BaseNode.CQL_PORT,
+            source_keyspace=source_keyspace,
+            source_table=source_table,
+            target_host=self.db_cluster.nodes[0].private_ip_address,
+            target_port=BaseNode.CQL_PORT,
+            target_keyspace=target_keyspace,
+            target_table=target_table,
+        )
+
+    def _validate_migration_count_and_sample(
+        self,
+        source_cluster,
+        source_keyspace: str,
+        source_table: str,
+        target_keyspace: str,
+        target_table: str,
+        expected_row_count: int,
+        sample_size: int = _SAMPLE_SIZE,
+        parallelism: int = 16,
+    ):
+        """Validate migration: target count == expected, plus optional row sampling.
+
+        Target count uses _count_rows_parallel (token-range sharded) so 100M+ row
+        tables finish in ~1–2 min instead of timing out a single coordinator.
+        """
+        self.log.info(
+            "Validating migration %s.%s → %s.%s",
+            source_keyspace,
+            source_table,
+            target_keyspace,
+            target_table,
+        )
+
+        tgt_count = self._count_rows_parallel(self.db_cluster, target_keyspace, target_table, parallelism=parallelism)
+        assert tgt_count == expected_row_count, (
+            f"row count mismatch on target {target_keyspace}.{target_table}: "
+            f"expected {expected_row_count}, got {tgt_count}"
+        )
+        self.log.info("Target row count matches expected: %d rows", tgt_count)
+
+        if sample_size <= 0:
+            return
+
+        sample_ids = random.sample(range(expected_row_count), sample_size)
+        with source_cluster.cql_connection_patient(source_cluster.nodes[0]) as src_session:
+            with self.db_cluster.cql_connection_patient(self.db_cluster.nodes[0]) as tgt_session:
+                for row_id in sample_ids:
+                    src_row = src_session.execute(
+                        f"SELECT id, data, value FROM {source_keyspace}.{source_table} WHERE id = %s",
+                        (row_id,),
+                    ).one()
+                    tgt_row = tgt_session.execute(
+                        f"SELECT id, data, value FROM {target_keyspace}.{target_table} WHERE id = %s",
+                        (row_id,),
+                    ).one()
+                    assert src_row is not None, (
+                        f"source row missing for id={row_id} in {source_keyspace}.{source_table}"
+                    )
+                    assert tgt_row is not None, (
+                        f"target row missing for id={row_id} in {target_keyspace}.{target_table}"
+                    )
+                    assert src_row == tgt_row, f"row mismatch for id={row_id}: source={src_row} target={tgt_row}"
+
+        self.log.info("Sample validation passed: %d/%d rows match", sample_size, sample_size)

--- a/test-cases/gemini/gemini-cassandra-oracle-aws.yaml
+++ b/test-cases/gemini/gemini-cassandra-oracle-aws.yaml
@@ -8,7 +8,7 @@ instance_type_loader: 'm6i.xlarge'
 
 db_type: mixed_cassandra
 cassandra_oracle_version: '4.1'
-ami_id_db_cassandra_oracle: ''  # falls back to loader AMI (Ubuntu)
+ami_id_db_cassandra: ''  # falls back to loader AMI (Ubuntu)
 
 user_prefix: 'gemini-cs-oracle-aws'
 

--- a/test-cases/spark-migrator/cs-to-scylla-500gb.yaml
+++ b/test-cases/spark-migrator/cs-to-scylla-500gb.yaml
@@ -1,0 +1,71 @@
+test_duration: 720
+
+db_type: mixed_cassandra
+
+# Scylla target cluster params
+n_db_nodes: 3
+instance_type_db: 'i4i.4xlarge'
+root_disk_size_db: 100
+
+# Cassandra source cluster params
+n_test_oracle_db_nodes: 3
+instance_type_db_oracle: 'i4i.4xlarge'
+cassandra_oracle_version: '4.1'
+ami_id_db_cassandra: 'resolve:ssm:/aws/service/canonical/ubuntu/server/22.04/stable/current/amd64/hvm/ebs-gp2/ami-id'
+
+n_loaders: 2
+instance_type_loader: 'c6i.4xlarge'
+
+n_monitor_nodes: 1
+instance_type_monitor: 'i4i.large'
+
+# EMR cluster
+emr_release_label: 'emr-7.12.0'
+emr_instance_type_master: 'm5.xlarge'
+emr_instance_type_core: 'm5.2xlarge'
+emr_instance_count_core: 2
+emr_instance_count_task: 0
+emr_applications:
+  - 'Spark'
+emr_keep_alive: true
+
+emr_spark_migrator_release: 'v2.0.1'
+
+# 500 GB preload
+prepare_write_cmd:
+  - >-
+    latte run --function=write --tag=latte-prepare-01 --duration=125000000
+    -P replication_factor=1 --threads=7 --concurrency=21 --consistency=ONE
+    -P column_size=128 -P column_count=8 -P row_count=500000000 -P offset=0
+    --sampling=10s --retry-number=10 --retry-interval='500ms,5s' --request-timeout=60
+    data_dir/latte/latte_cs_alike.rn
+  - >-
+    latte run --function=write --tag=latte-prepare-02 --duration=125000000
+    -P replication_factor=1 --threads=7 --concurrency=21 --consistency=ONE
+    -P column_size=128 -P column_count=8 -P row_count=500000000 -P offset=125000000
+    --sampling=10s --retry-number=10 --retry-interval='500ms,5s' --request-timeout=60
+    data_dir/latte/latte_cs_alike.rn
+  - >-
+    latte run --function=write --tag=latte-prepare-03 --duration=125000000
+    -P replication_factor=1 --threads=7 --concurrency=21 --consistency=ONE
+    -P column_size=128 -P column_count=8 -P row_count=500000000 -P offset=250000000
+    --sampling=10s --retry-number=10 --retry-interval='500ms,5s' --request-timeout=60
+    data_dir/latte/latte_cs_alike.rn
+  - >-
+    latte run --function=write --tag=latte-prepare-04 --duration=125000000
+    -P replication_factor=1 --threads=7 --concurrency=21 --consistency=ONE
+    -P column_size=128 -P column_count=8 -P row_count=500000000 -P offset=375000000
+    --sampling=10s --retry-number=10 --retry-interval='500ms,5s' --request-timeout=60
+    data_dir/latte/latte_cs_alike.rn
+
+migrator_source_keyspace: 'keyspace1'
+migrator_source_table: 'standard1'
+migrator_target_keyspace: 'keyspace1'
+migrator_target_table: 'standard1'
+migrator_run_validator: true
+validator_step_timeout_minutes: 240
+
+user_prefix: 'cs-to-sc-500gb'
+
+enable_kms_key_rotation: false
+run_commit_log_check_thread: false

--- a/test-cases/spark-migrator/cs-to-scylla-small.yaml
+++ b/test-cases/spark-migrator/cs-to-scylla-small.yaml
@@ -1,0 +1,41 @@
+test_duration: 120
+
+db_type: mixed_cassandra
+
+# Scylla target cluster params
+n_db_nodes: 1
+instance_type_db: 'i4i.large'
+
+# Cassandra source cluster params
+n_test_oracle_db_nodes: 1
+instance_type_db_oracle: 'i4i.large'
+cassandra_oracle_version: '4.1'
+ami_id_db_cassandra: 'resolve:ssm:/aws/service/canonical/ubuntu/server/22.04/stable/current/amd64/hvm/ebs-gp2/ami-id'
+
+# test preloads 100K rows via CQL directly
+n_loaders: 0
+
+n_monitor_nodes: 1
+instance_type_monitor: 't3.large'
+
+# EMR cluster (single core node is enough for a 100K-row migration)
+emr_release_label: 'emr-7.12.0'
+emr_instance_type_master: 'm5.xlarge'
+emr_instance_type_core: 'm5.xlarge'
+emr_instance_count_core: 1
+emr_instance_count_task: 0
+emr_applications:
+  - 'Spark'
+emr_keep_alive: true
+
+emr_spark_migrator_release: 'v2.0.1'
+
+migrator_source_keyspace: 'migrator_test'
+migrator_source_table: 'source_table'
+migrator_target_keyspace: 'migrator_test'
+migrator_target_table: 'source_table'
+migrator_run_validator: false
+
+user_prefix: 'cs-to-sc-small'
+
+run_commit_log_check_thread: false

--- a/unit_tests/unit/test_cluster_cassandra.py
+++ b/unit_tests/unit/test_cluster_cassandra.py
@@ -1,0 +1,233 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2026 ScyllaDB
+
+"""Unit tests for BaseCassandraCluster.dump_schema."""
+
+import re
+from unittest.mock import MagicMock
+
+import pytest
+from invoke import Result
+
+from sdcm.cluster_cassandra import BaseCassandraCluster
+from unit_tests.lib.fake_remoter import FakeRemoter
+
+_DESCRIBE_OUTPUT = (
+    "CREATE KEYSPACE ks WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'}"
+    " AND durable_writes = true;\n"
+    "\n"
+    "CREATE TABLE ks.t (id int PRIMARY KEY, data text) WITH bloom_filter_fp_chance = 0.01;\n"
+)
+
+# DESCRIBE output preceded by a cqlsh banner that contains semicolons — this must
+# not confuse the stripper into cutting off before CREATE KEYSPACE.
+_DESCRIBE_OUTPUT_WITH_BANNER = (
+    "Connected to cluster; defaults set;\n"
+    "\n"
+    "CREATE KEYSPACE ks WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'}"
+    " AND durable_writes = true;\n"
+    "\n"
+    "CREATE TABLE ks.t (id int PRIMARY KEY, data text) WITH bloom_filter_fp_chance = 0.01;\n"
+)
+
+
+def _make_cluster(result_map: dict) -> BaseCassandraCluster:
+    """Minimal BaseCassandraCluster instance without triggering __init__."""
+    node = MagicMock()
+    node.ip_address = "1.2.3.4"
+    node.remoter = FakeRemoter.__new__(FakeRemoter)
+    node.remoter.result_map = result_map
+
+    cluster = object.__new__(BaseCassandraCluster)
+    cluster.nodes = [node]
+    return cluster
+
+
+def test_dump_schema_excludes_create_keyspace():
+    """Test stripping CREATE KEYSPACE block when include_keyspace_stmt=False."""
+    cluster = _make_cluster({r"cqlsh.*DESCRIBE KEYSPACE.*": Result(stdout=_DESCRIBE_OUTPUT, stderr="", exited=0)})
+    result = cluster.dump_schema("ks")
+    assert "CREATE TABLE" in result
+    assert "CREATE KEYSPACE" not in result
+
+
+def test_dump_schema_include_keyspace_stmt():
+    """Test that full output returned unchanged when include_keyspace_stmt=True."""
+    cluster = _make_cluster({r"cqlsh.*DESCRIBE KEYSPACE.*": Result(stdout=_DESCRIBE_OUTPUT, stderr="", exited=0)})
+    assert cluster.dump_schema("ks", include_keyspace_stmt=True) == _DESCRIBE_OUTPUT
+
+
+def test_dump_schema_command_failure_raises_runtime_error():
+    """Test that RuntimeError is raised containing the stderr message."""
+    stderr_msg = "Keyspace 'foo' not found"
+    cluster = _make_cluster({r"cqlsh.*DESCRIBE KEYSPACE.*": Result(stdout="", stderr=stderr_msg, exited=1)})
+    with pytest.raises(RuntimeError, match=stderr_msg):
+        cluster.dump_schema("foo")
+
+
+def test_dump_schema_banner_with_semicolons_does_not_confuse_stripper():
+    """regression: banner lines containing ';' before CREATE KEYSPACE must not be mistaken
+    for the end of the CREATE KEYSPACE statement."""
+    cluster = _make_cluster(
+        {
+            r"cqlsh.*DESCRIBE KEYSPACE.*": Result(stdout=_DESCRIBE_OUTPUT_WITH_BANNER, stderr="", exited=0),
+        }
+    )
+    result = cluster.dump_schema("ks", include_keyspace_stmt=False)
+    assert "CREATE TABLE" in result
+    assert "CREATE KEYSPACE" not in result
+    assert "Connected to cluster" not in result
+
+
+# Cassandra 4.1 DESCRIBE TABLE output with a full WITH block
+_DESCRIBE_WITH_CASSANDRA_OPTIONS = (
+    "CREATE KEYSPACE ks WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'}"
+    " AND durable_writes = true;\n"
+    "\n"
+    "CREATE TABLE ks.t (\n"
+    "    id int PRIMARY KEY,\n"
+    "    data text\n"
+    ") WITH additional_write_policy = '99p'\n"
+    "    AND bloom_filter_fp_chance = 0.01\n"
+    "    AND caching = {'keys': 'ALL', 'rows_per_partition': 'NONE'}\n"
+    "    AND cdc = false\n"
+    "    AND compaction = {'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy'}\n"
+    "    AND compression = {'chunk_length_in_kb': '16', 'class': 'org.apache.cassandra.io.compress.LZ4Compressor'}\n"
+    "    AND extensions = {}\n"
+    "    AND gc_grace_seconds = 864000\n"
+    "    AND memtable = 'default'\n"
+    "    AND read_repair = 'BLOCKING';\n"
+)
+
+# output where first option of WITH is a Cassandra-only one
+_DESCRIBE_WITH_LEADING_CASSANDRA_OPTION = (
+    "CREATE KEYSPACE ks WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'}"
+    " AND durable_writes = true;\n"
+    "\n"
+    "CREATE TABLE ks.t (\n"
+    "    id int PRIMARY KEY,\n"
+    "    data text\n"
+    ") WITH additional_write_policy = '99p'\n"
+    "    AND bloom_filter_fp_chance = 0.01\n"
+    "    AND gc_grace_seconds = 864000;\n"
+)
+
+# output with no Cassandra-only options
+_DESCRIBE_SCYLLA_SAFE = (
+    "CREATE KEYSPACE ks WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'}"
+    " AND durable_writes = true;\n"
+    "\n"
+    "CREATE TABLE ks.t (\n"
+    "    id int PRIMARY KEY,\n"
+    "    data text\n"
+    ") WITH bloom_filter_fp_chance = 0.01\n"
+    "    AND compaction = {'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy'}\n"
+    "    AND compression = {'chunk_length_in_kb': '16', 'class': 'org.apache.cassandra.io.compress.LZ4Compressor'};\n"
+)
+
+
+def test_dump_schema_strips_cassandra_only_options():
+    """Test that cassandra-only options are removed; Scylla-compatible options are preserved."""
+    cluster = _make_cluster(
+        {
+            r"cqlsh.*DESCRIBE KEYSPACE.*": Result(stdout=_DESCRIBE_WITH_CASSANDRA_OPTIONS, stderr="", exited=0),
+        }
+    )
+    result = cluster.dump_schema("ks")
+    for option in ("bloom_filter_fp_chance", "compaction", "compression", "gc_grace_seconds"):
+        assert option in result
+    for option in ("additional_write_policy", "read_repair", "memtable", "extensions", "cdc"):
+        assert option not in result
+
+
+def test_dump_schema_handles_leading_cassandra_only_option():
+    """Test that when first option of WITH is Cassandra-only, the next clause is rewritten to WITH."""
+    cluster = _make_cluster(
+        {
+            r"cqlsh.*DESCRIBE KEYSPACE.*": Result(stdout=_DESCRIBE_WITH_LEADING_CASSANDRA_OPTION, stderr="", exited=0),
+        }
+    )
+    result = cluster.dump_schema("ks")
+    assert "additional_write_policy" not in result
+    assert "bloom_filter_fp_chance" in result
+    assert "gc_grace_seconds" in result
+
+    # the surviving first option must be introduced by WITH, not a dangling AND
+    first_line = next((ln for ln in result.splitlines() if "bloom_filter_fp_chance" in ln), None)
+    assert first_line is not None, "bloom_filter_fp_chance must appear in result"
+    assert re.search(r"WITH.*bloom_filter_fp_chance", first_line, re.IGNORECASE), (
+        f"expected bloom_filter_fp_chance to be introduced by WITH, got: {first_line!r}"
+    )
+    assert not first_line.strip().lower().startswith("and "), (
+        f"first surviving option must not be a bare AND clause, got: {first_line!r}"
+    )
+
+
+def test_dump_schema_idempotent_on_scylla_safe_schema():
+    """Test that schema with no Cassandra-only options passes through unchanged."""
+    cluster = _make_cluster(
+        {
+            r"cqlsh.*DESCRIBE KEYSPACE.*": Result(stdout=_DESCRIBE_SCYLLA_SAFE, stderr="", exited=0),
+        }
+    )
+    result = cluster.dump_schema("ks")
+    assert "CREATE KEYSPACE" not in result
+    for option in ("CREATE TABLE", "bloom_filter_fp_chance", "compaction", "compression"):
+        assert option in result
+
+
+def test_dump_schema_strips_speculative_retry():
+    """Cassandra emits `speculative_retry = '99p'` which Scylla mis-parses (sstring out of range)."""
+    output = (
+        "CREATE TABLE ks.t (id int PRIMARY KEY, data text) WITH bloom_filter_fp_chance = 0.01\n"
+        "    AND speculative_retry = '99p'\n"
+        "    AND gc_grace_seconds = 864000;\n"
+    )
+    cluster = _make_cluster({r"cqlsh.*DESCRIBE KEYSPACE.*": Result(stdout=output, stderr="", exited=0)})
+    result = cluster.dump_schema("ks", include_keyspace_stmt=True)
+    assert "speculative_retry" not in result
+    assert "bloom_filter_fp_chance" in result
+    assert "gc_grace_seconds" in result
+
+
+def test_dump_schema_rewrites_compression_class_to_sstable_compression():
+    """Cassandra's `compression = {'class': '...'}` must become `'sstable_compression'` for Scylla."""
+    output = (
+        "CREATE TABLE ks.t (id int PRIMARY KEY, data text) WITH bloom_filter_fp_chance = 0.01\n"
+        "    AND compression = {'chunk_length_in_kb': '16', 'class': 'org.apache.cassandra.io.compress.LZ4Compressor'}\n"
+        "    AND compaction = {'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy'};\n"
+    )
+    cluster = _make_cluster({r"cqlsh.*DESCRIBE KEYSPACE.*": Result(stdout=output, stderr="", exited=0)})
+    result = cluster.dump_schema("ks", include_keyspace_stmt=True)
+    # compression dict: 'class' must be rewritten to 'sstable_compression'
+    assert "'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'" in result
+    # compaction dict: 'class' must be PRESERVED (Scylla expects it there)
+    assert "compaction = {'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy'}" in result
+
+
+def test_dump_schema_rewrites_compression_enabled_false_to_disabled():
+    """Cassandra 4.x `compression = {'enabled': 'false'}` (no 'class' key) means
+    compression is disabled. Scylla rejects that form with "Missing sub-option
+    'sstable_compression'" - the equivalent on Scylla is `{'sstable_compression': ''}`.
+    Latte's latte_cs_alike.rn schema emits exactly this disabled-compression form."""
+    output = (
+        'CREATE TABLE keyspace1.standard1 (key blob PRIMARY KEY, "C0" blob) WITH bloom_filter_fp_chance = 0.01\n'
+        "    AND compression = {'enabled': 'false'}\n"
+        "    AND compaction = {'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy'};\n"
+    )
+    result = _make_cluster({r"cqlsh.*DESCRIBE KEYSPACE.*": Result(stdout=output, stderr="", exited=0)}).dump_schema(
+        "keyspace1", include_keyspace_stmt=True
+    )
+    assert "compression = {'sstable_compression': ''}" in result
+    assert "'enabled'" not in result
+    assert "compaction = {'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy'}" in result

--- a/unit_tests/unit/test_config.py
+++ b/unit_tests/unit/test_config.py
@@ -791,3 +791,20 @@ def test_vector_store_ami_name_resolved_to_ami_id(monkeypatch):
     assert "vector-store-1-5-0-arm64-2026-03-17t07-07-32z" in resolved_names, (
         "convert_name_to_ami_if_needed was not called for ami_id_vector_store"
     )
+
+
+def test_migrator_source_hosts_param(monkeypatch):
+    """migrator_source_hosts is accepted and returned as a list."""
+    monkeypatch.setenv("SCT_MIGRATOR_SOURCE_HOSTS", '["10.0.0.1", "10.0.0.2"]')
+    conf = sct_config.SCTConfiguration()
+    assert conf.get("migrator_source_hosts") == ["10.0.0.1", "10.0.0.2"]
+
+
+def test_migrator_source_hosts_and_test_id_mutually_exclusive(monkeypatch):
+    """Setting both migrator_source_hosts and migrator_source_test_id raises ValueError."""
+    monkeypatch.setenv("SCT_CLUSTER_BACKEND", "docker")
+    monkeypatch.setenv("SCT_MIGRATOR_SOURCE_HOSTS", "10.0.0.1")
+    monkeypatch.setenv("SCT_MIGRATOR_SOURCE_TEST_ID", "aaaa-bbbb-cccc")
+    conf = sct_config.SCTConfiguration()
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        conf.verify_configuration()

--- a/unit_tests/unit/test_emr_provisioner.py
+++ b/unit_tests/unit/test_emr_provisioner.py
@@ -164,6 +164,21 @@ def test_get_emr_cluster_description(provisioner):
     assert "Status" in desc
 
 
+def test_create_emr_cluster_default_log_uri_falls_back_to_shared_bucket(provisioner):
+    """Empty/unset emr_log_uri defaults to s3://sct-emr-spark-migrator-<region>/emr-logs/
+    so EMR step stdout/stderr are uploaded and SparkMigratorRunner.get_step_stdout works."""
+    provisioner.create_emr_cluster(test_id="test-default-loguri", user="test_user")
+    desc = provisioner.get_emr_cluster_description()
+    assert desc.get("LogUri") == f"s3://sct-emr-spark-migrator-{AWS_REGION}/emr-logs/"
+
+
+def test_create_emr_cluster_explicit_log_uri_overrides_default():
+    """Explicit emr_log_uri param wins over the default."""
+    prov = EmrClusterProvisioner(region_name=AWS_REGION, params=MockParams(emr_log_uri="s3://my-custom-emr-logs/path/"))
+    prov.create_emr_cluster(test_id="test-explicit-loguri", user="test_user")
+    assert prov.get_emr_cluster_description().get("LogUri") == "s3://my-custom-emr-logs/path/"
+
+
 def test_terminate_emr_cluster(provisioner):
     """Test terminating an EMR cluster."""
     provisioner.create_emr_cluster(

--- a/unit_tests/unit/test_spark_migrator.py
+++ b/unit_tests/unit/test_spark_migrator.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import gzip
+import logging
 from unittest.mock import MagicMock, patch
 
 import boto3
+import pytest
 from moto import mock_aws
 
 from sdcm.spark_migrator import (
@@ -13,9 +16,11 @@ from sdcm.spark_migrator import (
     MigratorConfig,
     SparkMigratorRunner,
     build_spark4_bootstrap_actions,
+    discover_cs_source_hosts,
     get_migrator_download_url,
     upload_migrator_jar_to_s3,
 )
+import spark_migrator_test
 
 
 def test_migrator_config_defaults():
@@ -32,7 +37,7 @@ def test_migrator_config_defaults():
 def test_migrator_config_custom():
     """Test MigratorConfig with custom values."""
     config = MigratorConfig(
-        source_host="10.0.0.1",
+        source_hosts=["10.0.0.1"],
         source_keyspace="ks1",
         source_table="table1",
         target_host="10.0.0.2",
@@ -41,7 +46,7 @@ def test_migrator_config_custom():
         spark_executor_memory="8g",
         spark_executor_cores=4,
     )
-    assert config.source_host == "10.0.0.1"
+    assert config.source_hosts == ["10.0.0.1"]
     assert config.target_host == "10.0.0.2"
     assert config.spark_executor_memory == "8g"
     assert config.spark_executor_cores == 4
@@ -50,7 +55,7 @@ def test_migrator_config_custom():
 def test_generate_migrator_config_basic():
     """Test generated config has correct source/target structure."""
     config = MigratorConfig(
-        source_host="10.0.0.1",
+        source_hosts=["10.0.0.1"],
         source_port=9042,
         source_keyspace="ks_source",
         source_table="tbl_source",
@@ -74,7 +79,7 @@ def test_generate_migrator_config_basic():
 
 def test_generate_migrator_config_defaults():
     """Test generated config has sensible default values."""
-    config = MigratorConfig(source_host="10.0.0.1", target_host="10.0.0.2")
+    config = MigratorConfig(source_hosts=["10.0.0.1"], target_host="10.0.0.2")
     result = SparkMigratorRunner.generate_migrator_config(config)
 
     source, target, savepoints = result["source"], result["target"], result["savepoints"]
@@ -97,7 +102,7 @@ def test_generate_migrator_config_defaults():
 def test_generate_migrator_config_has_strip_trailing_zeros():
     """Test generated config includes stripTrailingZerosForDecimals in source and target."""
     result = SparkMigratorRunner.generate_migrator_config(
-        MigratorConfig(source_host="10.0.0.1", target_host="10.0.0.2")
+        MigratorConfig(source_hosts=["10.0.0.1"], target_host="10.0.0.2")
     )
 
     assert result["source"]["stripTrailingZerosForDecimals"] is False
@@ -229,3 +234,345 @@ def test_upload_runner_script():
     assert "--deploy-mode cluster" in body
     assert "s3://bucket/jars/v2.0.0/migrator.jar" in body
     assert "s3://bucket/configs/test-id/config.yaml" in body
+
+
+@mock_aws
+def test_upload_runner_script_cds_to_tmp_so_client_mode_finds_relative_config():
+    """In client deploy mode the driver JVM inherits the wrapper script's CWD;
+    spark.scylla.config is a relative path, so the script must cd into /tmp
+    (where it just downloaded migrator-config.yaml) before invoking spark-submit.
+    Without cd, validator main fails with FileNotFoundException: migrator-config.yaml."""
+    boto3.client("s3", region_name="us-east-1").create_bucket(Bucket="sct-emr-spark-migrator-us-east-1")
+
+    runner = SparkMigratorRunner(MagicMock(region_name="us-east-1"))
+    runner._upload_runner_script(
+        "s3://bucket/jars/v2.0.0/migrator.jar",
+        "s3://bucket/configs/test-id/config.yaml",
+    )
+
+    body = (
+        boto3.client("s3", region_name="us-east-1")
+        .get_object(Bucket="sct-emr-spark-migrator-us-east-1", Key="scripts/run-migrator.sh")["Body"]
+        .read()
+        .decode("utf-8")
+    )
+    cd_pos = body.find("cd /tmp")
+    submit_pos = body.find("spark-submit")
+    assert cd_pos != -1, "wrapper script must cd into /tmp before spark-submit"
+    assert submit_pos != -1
+    assert cd_pos < submit_pos, "cd /tmp must precede spark-submit so driver CWD has the config"
+
+
+@pytest.mark.parametrize("source_type", ["cassandra", "scylla"])
+def test_generate_migrator_config_source_and_target_types(source_type):
+    """Test that source.type reflects the configured source_type; target.type is always 'scylla'."""
+    config = MigratorConfig(source_hosts=["10.0.0.1"], target_host="10.0.0.2", source_type=source_type)
+    result = SparkMigratorRunner.generate_migrator_config(config)
+    assert result["source"]["type"] == source_type
+    assert result["target"]["type"] == "scylla"
+
+
+def test_generate_migrator_config_picks_single_source_host():
+    """Test that only the first source host is used; the driver discovers the rest via gossip."""
+    config = MigratorConfig(source_hosts=["10.0.0.1", "10.0.0.2", "10.0.0.3"], target_host="10.0.0.4")
+    assert SparkMigratorRunner.generate_migrator_config(config)["source"]["host"] == "10.0.0.1"
+
+
+def _make_discover_mock(instances):
+    """Mock EC2 client returning the given instance list."""
+    mock_client = MagicMock()
+    mock_client.describe_instances.return_value = {"Reservations": [{"Instances": instances}]}
+    return mock_client
+
+
+def test_discover_cs_source_hosts_returns_public_ips():
+    """Test that discover_cs_source_hosts returns public IPs from the EC2 response."""
+    test_id = "aaaa-bbbb-cccc"
+    instances = [
+        {"PublicIpAddress": "54.1.2.3", "InstanceId": "i-001"},
+        {"PublicIpAddress": "54.4.5.6", "InstanceId": "i-002"},
+    ]
+    mock_client = _make_discover_mock(instances)
+
+    with patch("sdcm.spark_migrator.boto3") as mock_boto3:
+        mock_boto3.client.return_value = mock_client
+        hosts = discover_cs_source_hosts(test_id, "eu-west-1")
+
+    assert hosts == ["54.1.2.3", "54.4.5.6"]
+    mock_client.describe_instances.assert_called_once()
+    filters = {f["Name"]: f["Values"] for f in mock_client.describe_instances.call_args[1]["Filters"]}
+    assert filters["tag:TestId"] == [test_id]
+    assert filters["tag:NodeType"] == ["cs-db"]
+    assert filters["instance-state-name"] == ["running"]
+
+
+def test_discover_cs_source_hosts_falls_back_to_private_ip():
+    """Test that discover_cs_source_hosts prefers public IPs but falls back to private when absent."""
+    instances = [
+        {"PublicIpAddress": "54.1.2.3", "PrivateIpAddress": "10.0.0.1", "InstanceId": "i-001"},
+        {"PrivateIpAddress": "10.0.0.2", "InstanceId": "i-002"},  # private-only
+    ]
+    mock_client = _make_discover_mock(instances)
+
+    with patch("sdcm.spark_migrator.boto3") as mock_boto3:
+        mock_boto3.client.return_value = mock_client
+        hosts = discover_cs_source_hosts("aaaa-bbbb-cccc", "eu-west-1")
+
+    assert hosts == ["54.1.2.3", "10.0.0.2"]
+
+
+def _make_tester():
+    """Instantiate SparkMigratorTest without triggering ClusterTester.__init__."""
+    tester = spark_migrator_test.SparkMigratorTest.__new__(spark_migrator_test.SparkMigratorTest)
+    tester.log = logging.getLogger("test")
+    tester.params = MagicMock()
+    tester.params.get.return_value = None
+    return tester
+
+
+def test_build_cs_to_scylla_migrator_config_source_target_selection():
+    """_build_cs_to_scylla_migrator_config uses cs_db_cluster for source and db_cluster for target."""
+    tester = _make_tester()
+
+    src_node = MagicMock(private_ip_address="10.0.0.1")
+    tester.cs_db_cluster = MagicMock(nodes=[src_node])
+
+    tgt_node = MagicMock(private_ip_address="10.0.0.2")
+    tester.db_cluster = MagicMock(nodes=[tgt_node])
+
+    config = tester._build_cs_to_scylla_migrator_config("ks_src", "tbl_src", "ks_tgt", "tbl_tgt")
+
+    assert config.source_type == "cassandra"
+    assert config.source_hosts == ["10.0.0.1"]
+    assert config.target_host == "10.0.0.2"
+    assert config.source_keyspace == "ks_src"
+    assert config.source_table == "tbl_src"
+    assert config.target_keyspace == "ks_tgt"
+    assert config.target_table == "tbl_tgt"
+    assert config.source_port == 9042
+    assert config.target_port == 9042
+
+
+@pytest.mark.parametrize(
+    "stmt,expected",
+    [
+        (
+            "CREATE TABLE ks.t (id int PRIMARY KEY)",
+            "CREATE TABLE IF NOT EXISTS ks.t (id int PRIMARY KEY)",
+        ),
+        (
+            "CREATE TYPE ks.addr (street text)",
+            "CREATE TYPE IF NOT EXISTS ks.addr (street text)",
+        ),
+        (
+            "CREATE INDEX idx_data ON ks.t (data)",
+            "CREATE INDEX IF NOT EXISTS idx_data ON ks.t (data)",
+        ),
+    ],
+)
+def test_make_create_idempotent_inserts_if_not_exists(stmt, expected):
+    """CREATE TABLE/TYPE/INDEX all get IF NOT EXISTS inserted after the keyword."""
+    assert spark_migrator_test.SparkMigratorTest._make_create_idempotent(stmt) == expected
+
+
+def test_make_create_idempotent_keyspace_unchanged():
+    """CREATE KEYSPACE is not rewritten — keyspace pre-creation is handled separately."""
+    stmt = "CREATE KEYSPACE ks WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}"
+    assert spark_migrator_test.SparkMigratorTest._make_create_idempotent(stmt) == stmt
+
+
+def test_assert_region_coherence_raises_on_mismatch():
+    """Test that error is raised when EMR is in a different region than the rest of the test setup."""
+    tester = _make_tester()
+    tester.emr_cluster = MagicMock(region_name="us-east-1")
+    tester.params = MagicMock(region_names=["eu-west-1"])
+    with pytest.raises(RuntimeError, match="EMR cluster region 'us-east-1' != test region 'eu-west-1'"):
+        tester._assert_region_coherence()
+
+
+@mock_aws
+def test_submit_validator_job_uploads_validator_script_with_validator_main_class():
+    """Test that submit_validator_job uploads a separate wrapper script invoking Validator main class."""
+    s3_client = boto3.client("s3", region_name="us-east-1")
+    s3_client.create_bucket(Bucket="sct-emr-spark-migrator-us-east-1")
+
+    mock_provisioner = MagicMock(region_name="us-east-1")
+    mock_provisioner.add_step.return_value = "s-VALIDATOR123"
+
+    config = MigratorConfig(source_hosts=["10.0.0.1"], target_host="10.0.0.2")
+    config.config_path = "s3://bucket/configs/test-id/config.yaml"
+
+    runner = SparkMigratorRunner(mock_provisioner)
+    step_id = runner.submit_validator_job(
+        cluster_id="j-CLUSTER",
+        jar_s3_path="s3://bucket/jars/v2.0.1/scylla-migrator-assembly.jar",
+        migrator_config=config,
+    )
+
+    assert step_id == "s-VALIDATOR123"
+
+    body = (
+        s3_client.get_object(Bucket="sct-emr-spark-migrator-us-east-1", Key="scripts/run-validator.sh")["Body"]
+        .read()
+        .decode("utf-8")
+    )
+    assert "com.scylladb.migrator.Validator" in body
+    assert "com.scylladb.migrator.Migrator" not in body  # regression guard
+    assert "spark-submit" in body
+    assert "s3://bucket/jars/v2.0.1/scylla-migrator-assembly.jar" in body
+
+
+@mock_aws
+def test_submit_validator_job_uses_distinct_step_name_and_script_runner():
+    """Test that submit_validator_job names the EMR step distinctly + uses script-runner.jar."""
+    boto3.client("s3", region_name="eu-west-1").create_bucket(
+        Bucket="sct-emr-spark-migrator-eu-west-1",
+        CreateBucketConfiguration={"LocationConstraint": "eu-west-1"},
+    )
+
+    mock_provisioner = MagicMock(region_name="eu-west-1")
+    mock_provisioner.add_step.return_value = "s-VAL"
+
+    config = MigratorConfig(source_hosts=["10.0.0.1"], target_host="10.0.0.2")
+    config.config_path = "s3://bucket/configs/test-id/config.yaml"
+
+    SparkMigratorRunner(mock_provisioner).submit_validator_job("j-CLUSTER", "s3://bucket/jars/x/migrator.jar", config)
+
+    add_step_kwargs = mock_provisioner.add_step.call_args[1]
+    assert add_step_kwargs["step_name"] == "spark-migrator-validator"
+    assert "script-runner.jar" in add_step_kwargs["jar"]
+    assert "eu-west-1.elasticmapreduce" in add_step_kwargs["jar"]
+    assert add_step_kwargs["args"][0].endswith("/scripts/run-validator.sh")
+
+
+@mock_aws
+def test_submit_migration_job_still_uses_cluster_deploy_mode():
+    """Migration job remains in cluster deploy mode (default); deploy_mode refactor must not regress it."""
+    s3_client = boto3.client("s3", region_name="us-east-1")
+    s3_client.create_bucket(Bucket="sct-emr-spark-migrator-us-east-1")
+
+    mock_provisioner = MagicMock(region_name="us-east-1", **{"add_step.return_value": "s-MIG"})
+
+    config = MigratorConfig(source_hosts=["10.0.0.1"], target_host="10.0.0.2")
+    config.config_path = "s3://bucket/configs/test-id/config.yaml"
+
+    SparkMigratorRunner(mock_provisioner).submit_migration_job("j-CLUSTER", "s3://bucket/jars/x/migrator.jar", config)
+
+    body = (
+        s3_client.get_object(Bucket="sct-emr-spark-migrator-us-east-1", Key="scripts/run-migrator.sh")["Body"]
+        .read()
+        .decode("utf-8")
+    )
+    assert "--deploy-mode cluster" in body
+
+
+@mock_aws
+def test_get_step_stdout_concatenates_stdout_and_stderr():
+    """stdout.gz + stderr.gz are downloaded, gunzipped, decoded, and concatenated."""
+    s3_client = boto3.client("s3", region_name="us-east-1")
+    s3_client.create_bucket(Bucket="emr-logs")
+
+    key_prefix = "logs/j-CLUSTER/steps/s-STEP"
+    s3_client.put_object(Bucket="emr-logs", Key=f"{key_prefix}/stdout.gz", Body=gzip.compress(b"out-line\n"))
+    s3_client.put_object(Bucket="emr-logs", Key=f"{key_prefix}/stderr.gz", Body=gzip.compress(b"err-line\n"))
+
+    mock_provisioner = MagicMock()
+    mock_provisioner.region_name = "us-east-1"
+    mock_provisioner.emr_client.describe_cluster.return_value = {"Cluster": {"LogUri": "s3://emr-logs/logs/"}}
+
+    text = SparkMigratorRunner(mock_provisioner).get_step_stdout("j-CLUSTER", "s-STEP")
+
+    assert "out-line" in text
+    assert "err-line" in text
+
+
+@mock_aws
+def test_get_step_stdout_accepts_s3n_log_uri_scheme():
+    """EMR rewrites s3:// LogUri to s3n:// (legacy Hadoop S3 protocol); accept both."""
+    cluster_id, step_id = "j-CLUSTER", "s-STEP"
+
+    s3_client = boto3.client("s3", region_name="us-east-1")
+    s3_client.create_bucket(Bucket="emr-logs")
+    s3_client.put_object(
+        Bucket="emr-logs",
+        Key=f"emr-logs/{cluster_id}/steps/{step_id}/stderr.gz",
+        Body=gzip.compress(b"validator-line\n"),
+    )
+
+    mock_provisioner = MagicMock(region_name="us-east-1")
+    mock_provisioner.emr_client.describe_cluster.return_value = {"Cluster": {"LogUri": "s3n://emr-logs/emr-logs/"}}
+
+    assert "validator-line" in SparkMigratorRunner(mock_provisioner).get_step_stdout(cluster_id, step_id)
+
+
+@mock_aws
+def test_get_step_stdout_skips_missing_log_files():
+    """NoSuchKey on either stdout.gz or stderr.gz is silently skipped."""
+    s3_client = boto3.client("s3", region_name="us-east-1")
+    s3_client.create_bucket(Bucket="emr-logs")
+    s3_client.put_object(
+        Bucket="emr-logs",
+        Key="logs/j-CLUSTER/steps/s-STEP/stderr.gz",  # only stderr present
+        Body=gzip.compress(b"err-only\n"),
+    )
+
+    mock_provisioner = MagicMock()
+    mock_provisioner.region_name = "us-east-1"
+    mock_provisioner.emr_client.describe_cluster.return_value = {"Cluster": {"LogUri": "s3://emr-logs/logs/"}}
+
+    assert "err-only" in SparkMigratorRunner(mock_provisioner).get_step_stdout("j-CLUSTER", "s-STEP")
+
+
+def test_run_validator_passes_on_completed_step():
+    """COMPLETED EMR step → _run_validator returns silently, no log fetch."""
+    tester = _make_tester()
+    tester.emr_cluster = MagicMock(cluster_id="j-CLUSTER")
+
+    runner = MagicMock()
+    runner.submit_validator_job.return_value = "s-VAL"
+
+    config = MigratorConfig(source_hosts=["10.0.0.1"], target_host="10.0.0.2")
+    config.config_path = "s3://bucket/cfg.yaml"
+
+    tester._run_validator(runner, "s3://bucket/jar", config)
+
+    runner.submit_validator_job.assert_called_once_with(
+        cluster_id="j-CLUSTER", jar_s3_path="s3://bucket/jar", migrator_config=config
+    )
+    runner.wait_for_migration.assert_called_once_with("j-CLUSTER", "s-VAL", timeout_minutes=60)
+    runner.get_step_stdout.assert_not_called()
+
+
+def test_run_validator_raises_when_step_failed():
+    """FAILED EMR step (validator System.exit(1)) → fetch stdout, dump, raise."""
+    tester = _make_tester()
+    tester.emr_cluster = MagicMock(cluster_id="j-CLUSTER")
+
+    runner = MagicMock()
+    runner.submit_validator_job.return_value = "s-VAL"
+    runner.wait_for_migration.side_effect = AssertionError("EMR step s-VAL failed with state: FAILED. Reason: unknown")
+    runner.get_step_stdout.return_value = (
+        "ERROR Migrator: Found the following comparison failures:\nRowComparisonFailure: Row(id=42) value differs\n"
+    )
+
+    config = MigratorConfig(source_hosts=["10.0.0.1"], target_host="10.0.0.2")
+
+    with pytest.raises(AssertionError, match="validator step FAILED"):
+        tester._run_validator(runner, "s3://bucket/jar", config)
+    runner.get_step_stdout.assert_called_once_with("j-CLUSTER", "s-VAL")
+
+
+def test_run_validator_raises_when_step_failed_and_log_fetch_raises():
+    """Log-fetch failure on a FAILED step still raises with the FAILED message."""
+    tester = _make_tester()
+    tester.emr_cluster = MagicMock(cluster_id="j-CLUSTER")
+
+    runner = MagicMock()
+    runner.submit_validator_job.return_value = "s-VAL"
+    runner.wait_for_migration.side_effect = AssertionError("EMR step s-VAL failed")
+    runner.get_step_stdout.side_effect = RuntimeError("S3 access denied")
+
+    with pytest.raises(AssertionError, match="validator step FAILED"):
+        tester._run_validator(
+            runner, "s3://bucket/jar", MigratorConfig(source_hosts=["10.0.0.1"], target_host="10.0.0.2")
+        )


### PR DESCRIPTION
## Summary

Add end-to-end Cassandra→Scylla migration tests driven by [scylla-migrator](https://github.com/scylladb/scylla-migrator) on EMR.

Three test variants land in `SparkMigratorTest`:
- **`test_migration_from_external_source`** - manual like run against an externally-provisioned Cassandra
cluster (literal IPs or EC2-tag discovery).
- **`test_migration_cs_to_scylla_small`** - quick test, ~30 min, 100k rows under `db_type: mixed_cassandra` (Cassandra
source + Scylla target + EMR provisioned in a single sct.py invocation).
- **`test_migration_cs_to_scylla_scale`** - 500GB latte preloaded + spark-migrator + count-only validation, with
`SCT_REUSE_CLUSTER` support to skip preload on rerun.

The second EMR step runs scylla-migrator's `Validator` main class to detect row-level mismatches between source and
target. Validator verdict is driven by EMR step state (v2.0.x calls `System.exit(1)` on diffs) and cross-checked with
a drift-tolerant log parser; mismatched keys are surfaced as an `AssertionError` with the top-10 offenders.

## Highlights

- New `MigratorConfig.source_hosts: list[str]` (was a single `source_host: str`); driver discovers the rest of the ring
via gossip from one contact point.
- New `BaseCassandraCluster.dump_schema` translates Cassandra 4.x DDL into Scylla-compatible CQL (strips `additional_write_policy`,
`read_repair`, `memtable`, `extensions`, `cdc`, `speculative_retry`; rewrites the `compression` block, including the
`enabled: false` shorthand emitted by latte schemas).
- Token-range sharded `count(*)` (`_count_rows_parallel`) replaces single-coordinator scans that timed out on 500M+ rows.
- EMR step timeouts are now configurable (`migrator_step_timeout_minutes` default 6h, `validator_step_timeout_minutes`
default 60 min); the previous hardcoded 60-min cap bailed on legitimate multi-hour runs.
- `cassandra_broadcast_rpc_public` overlay flips `broadcast_rpc_address` to the public IP for cross-VPC reachability.
- `docs/cs-to-scylla-migration.md` covers quick start, `SCT_REUSE_CLUSTER` reuse flow, validator output interpretation,
cluster lifecycle + cost notes, schema-transfer semantics, and cross-VPC notes.

Clooses: SCT-184
Refs: SCT-185

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :green_circle: [test_migration_cs_to_scylla_scale (500GB of data) with validator step enabled](https://jenkins.scylladb.com/job/scylla-staging/job/dimakr/job/scylla-migrator-test/7/)
- [x] :green_circle: [test_migration_cs_to_scylla_scale (500GB of data),  no validator is enabled](https://jenkins.scylladb.com/job/scylla-staging/job/dimakr/job/scylla-migrator-test/11/)
- [x] :green_circle: [test_migration_cs_to_scylla_small (100K rows), no validator is enabled](https://jenkins.scylladb.com/job/scylla-staging/job/dimakr/job/scylla-migrator-test/8/)
- [x] :green_circle: [test_migration_cs_to_scylla_small (100K rows) with validator step enabled](https://jenkins.scylladb.com/job/scylla-staging/job/dimakr/job/scylla-migrator-test/10/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
