### PR TITLE
Monitoring 4.15.0-rc0

### DIFF
--- a/configurations/manager/debian12.yaml
+++ b/configurations/manager/debian12.yaml
@@ -1,3 +1,3 @@
 ami_id_monitor: 'resolve:ssm:/aws/service/debian/release/12/latest/amd64'  # Debian Bookworm latest image
 ami_monitor_user: 'admin'
-monitor_branch: 'branch-4.14'  # Pass it as debian image is not the formal monitor image
+monitor_branch: 'branch-4.15'  # Pass it as debian image is not the formal monitor image

--- a/configurations/manager/rocky8.yaml
+++ b/configurations/manager/rocky8.yaml
@@ -1,3 +1,3 @@
 ami_id_monitor: 'ami-011ef2017d41cb239'  # Rocky Linux 8 (Official) image, region - us-east-1
 ami_monitor_user: 'rocky'
-monitor_branch: 'branch-4.14'  # Pass it as rocky image is not the formal monitor image
+monitor_branch: 'branch-4.15'  # Pass it as rocky image is not the formal monitor image

--- a/configurations/manager/rocky9.yaml
+++ b/configurations/manager/rocky9.yaml
@@ -1,3 +1,3 @@
 ami_id_monitor: 'ami-09fb459fad4613d55'  # Rocky Linux 9 (Official) image, region - us-east-1
 ami_monitor_user: 'rocky'
-monitor_branch: 'branch-4.14'  # Pass it as rocky image is not the formal monitor image
+monitor_branch: 'branch-4.15'  # Pass it as rocky image is not the formal monitor image

--- a/configurations/manager/ubuntu24.yaml
+++ b/configurations/manager/ubuntu24.yaml
@@ -1,3 +1,3 @@
 ami_id_monitor: 'resolve:ssm:/aws/service/canonical/ubuntu/server/24.04/stable/current/amd64/hvm/ebs-gp3/ami-id'  # Canonical, Ubuntu, 24.04 LTS, amd64 focal latest image
 ami_monitor_user: 'ubuntu'
-monitor_branch: 'branch-4.14'  # Pass it as the image is not the formal monitor image
+monitor_branch: 'branch-4.15'  # Pass it as the image is not the formal monitor image

--- a/defaults/aws_config.yaml
+++ b/defaults/aws_config.yaml
@@ -7,7 +7,7 @@ instance_type_loader: 'c6i.xlarge'
 instance_type_monitor: 't3.large'
 ami_id_loader: 'resolve:ssm:/aws/service/canonical/ubuntu/server/24.04/stable/current/amd64/hvm/ebs-gp3/ami-id'
 # manual on updating monitor images see: docs/monitoring-images.md
-ami_id_monitor: 'scylladb-monitor-4-14-1-2026-02-25t09-17-49z'
+ami_id_monitor: 'scylladb-monitor-4-14-3-2026-04-13t06-26-19z'
 
 availability_zone: 'a'
 root_disk_size_monitor: 50  # GB, remove this field if default disk size should be used

--- a/defaults/aws_config.yaml
+++ b/defaults/aws_config.yaml
@@ -7,7 +7,7 @@ instance_type_loader: 'c6i.xlarge'
 instance_type_monitor: 't3.large'
 ami_id_loader: 'resolve:ssm:/aws/service/canonical/ubuntu/server/24.04/stable/current/amd64/hvm/ebs-gp3/ami-id'
 # manual on updating monitor images see: docs/monitoring-images.md
-ami_id_monitor: 'scylladb-monitor-4-14-3-2026-04-13t06-26-19z'
+ami_id_monitor: 'scylladb-monitor-4-15-0-rc0-2026-04-30t01-12-58z'
 
 availability_zone: 'a'
 root_disk_size_monitor: 50  # GB, remove this field if default disk size should be used

--- a/defaults/gce_config.yaml
+++ b/defaults/gce_config.yaml
@@ -5,7 +5,7 @@ gce_project: '' # empty mean default one, can be overwritten to use different on
 
 gce_image_db: '' # so we can use `scylla_version` as needed
 gce_image_loader: 'https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/family/ubuntu-2404-lts-amd64'
-gce_image_monitor: 'https://www.googleapis.com/compute/v1/projects/scylla-images/global/images/scylladb-monitor-4-14-1-2026-02-25t09-17-49z'
+gce_image_monitor: 'https://www.googleapis.com/compute/v1/projects/scylla-images/global/images/scylladb-monitor-4-14-3-2026-04-13t06-26-19z'
 
 gce_image_username: 'scylla-test'
 

--- a/defaults/gce_config.yaml
+++ b/defaults/gce_config.yaml
@@ -5,7 +5,7 @@ gce_project: '' # empty mean default one, can be overwritten to use different on
 
 gce_image_db: '' # so we can use `scylla_version` as needed
 gce_image_loader: 'https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/family/ubuntu-2404-lts-amd64'
-gce_image_monitor: 'https://www.googleapis.com/compute/v1/projects/scylla-images/global/images/scylladb-monitor-4-14-3-2026-04-13t06-26-19z'
+gce_image_monitor: 'https://www.googleapis.com/compute/v1/projects/scylla-images/global/images/scylladb-monitor-4-15-0-rc0-2026-04-30t01-12-58z'
 
 gce_image_username: 'scylla-test'
 

--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -31,7 +31,7 @@ scylla_linux_distro: 'ubuntu-focal'
 scylla_linux_distro_loader: 'ubuntu-jammy'
 ssh_transport: 'libssh2'
 
-monitor_branch: 'branch-4.14'
+monitor_branch: 'branch-4.15'
 
 space_node_threshold: 0
 

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -561,7 +561,7 @@ A local directory of rpms to install a custom version on top of<br>the scylla in
 
 The port of scylla management
 
-**default:** branch-4.14
+**default:** branch-4.15
 
 **type:** str
 * appendable


### PR DESCRIPTION
### Testing
- [ https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/amnon/job/byo-longevity-test/74/]

### PR pre-checks (self review)
- [v ] I added the relevant `backport` labels
- [ v] I didn't leave commented-out/debugging code

Trying to release an RC0 for the monitoring to make life easier for image management.
We need version 4.15.0 for 2026.2 support