### PR TITLE
fix(gce-provision): tolerate slow GCE metadata service during cloud-init

### DIFF
--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -732,8 +732,7 @@ class AWSNode(cluster.BaseNode):
                 self._is_zero_token_node = True
 
     def wait_for_cloud_init(self):
-        if self.remoter.sudo("bash -c 'command -v cloud-init'", ignore_status=True).ok:
-            wait_cloud_init_completes(self.remoter, self)
+        wait_cloud_init_completes(self.remoter, self)
 
     @property
     def short_hostname(self):

--- a/sdcm/cluster_gce.py
+++ b/sdcm/cluster_gce.py
@@ -126,8 +126,7 @@ class GCENode(cluster.BaseNode):
         super().init()
 
     def wait_for_cloud_init(self):
-        if self.remoter.sudo("bash -c 'command -v cloud-init'", ignore_status=True).ok:
-            wait_cloud_init_completes(self.remoter, self)
+        wait_cloud_init_completes(self.remoter, self)
 
     @cached_property
     def tags(self) -> Dict[str, str]:

--- a/sdcm/provision/helpers/cloud_init.py
+++ b/sdcm/provision/helpers/cloud_init.py
@@ -17,7 +17,7 @@ from packaging.version import Version
 
 from sdcm.provision.provisioner import VmInstance
 from sdcm.provision.user_data import CLOUD_INIT_SCRIPTS_PATH
-from sdcm.remote import RemoteCmdRunnerBase
+from sdcm.remote import RemoteCmdRunnerBase, SSHConnectTimeoutError
 from sdcm.utils.decorators import retrying
 
 LOGGER = logging.getLogger(__name__)
@@ -27,7 +27,12 @@ class CloudInitError(Exception):
     pass
 
 
-@retrying(n=20, sleep_time=10, allowed_exceptions=(CloudInitError,), message="waiting for cloud-init to complete")
+@retrying(
+    n=20,
+    sleep_time=10,
+    allowed_exceptions=(CloudInitError, SSHConnectTimeoutError),
+    message="waiting for cloud-init to complete",
+)
 def wait_cloud_init_completes(remoter: RemoteCmdRunnerBase, instance: VmInstance):
     """Connects to VM with SSH and waits for cloud-init to complete. Verify if everything went ok."""
     LOGGER.info("Waiting for cloud-init to complete on node %s...", instance.name)


### PR DESCRIPTION
## Summary
- Fix SSHConnectTimeoutError during GCE/AWS provisioning when cloud-init is slow due to unresponsive GCE metadata service
- Remove redundant `command -v cloud-init` pre-check that used the short 60s timeout
- Add `SSHConnectTimeoutError` to the retry loop in `wait_cloud_init_completes` (retries up to 20 times with 10s sleep)

## Root Cause

Investigation of [SCT-282](https://scylladb.atlassian.net/browse/SCT-282) revealed the GCE metadata service (`metadata.google.internal`) was unresponsive for specific instances during boot:

| Node | Metadata fetch time |
|------|-------------------|
| node 0-1 | 1.0 seconds |
| node 0-2 | 0.5 seconds |
| node 0-3 (failing) | **273 seconds** |

Two HTTP requests to the metadata service each hung for ~2 minutes before timing out and succeeding on retry. This delayed cloud-init by 4.5 minutes, causing the SCT 60-second SSH connect timeout to fire.

## Changes

1. **`sdcm/cluster_gce.py` / `sdcm/cluster_aws.py`**: Remove the `remoter.sudo("bash -c 'command -v cloud-init'")` pre-check. This command went through `_run_pre_run` which checks `is_up(timeout=60)` — too short when metadata service is slow. Instead, call `wait_cloud_init_completes()` directly (which already checks if cloud-init is installed).

2. **`sdcm/provision/helpers/cloud_init.py`**: Add `SSHConnectTimeoutError` to the `@retrying` decorator's `allowed_exceptions`. This ensures that if SSH drops momentarily during the cloud-init wait period, the function retries instead of failing immediately.

## Testing

- This is a timeout/retry change — no functional behavior change when cloud-init completes normally
- The `wait_cloud_init_completes` function already had `remoter.is_up(300)` (5 min) and retries 20 times with 10s sleep

Fixes: SCT-282

[SCT-282]: https://scylladb.atlassian.net/browse/SCT-282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ