### PR TITLE
Add investigating-perf-regression skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -305,6 +305,7 @@ Modular, task-specific guidance for AI agents lives in the `skills/` directory. 
 | writing-integration-tests | Guides writing integration tests that interact with real external services. Use when creating tests requiring Docker, AWS, GCE, Azure, OCI, or Kubernetes backends. | `skills/writing-integration-tests/SKILL.md` |
 | commit-summary | Generate weekly commit summary reports for the SCT repository | `skills/commit-summary/SKILL.md` |
 | writing-nemesis | Guides writing new nemesis (chaos disruptions). Use when creating NemesisBaseClass subclasses or implementing disruption logic. | `skills/writing-nemesis/SKILL.md` |
+| investigating-perf-regression | Investigate SCT performance regression test failures by comparing failed and passed runs via Prometheus metrics, Argus CLI logs, and HDR histograms. | `skills/investigating-perf-regression/SKILL.md` |
 
 When creating a new skill, follow the process in `skills/designing-skills/workflows/create-a-skill.md`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,3 +28,4 @@ Available skills (invoke via Skill tool or `/skill-name`):
 - `commit-summary` — Generate weekly commit summary reports
 - `writing-nemesis` — Create new chaos engineering disruptions
 - `code-review` — Review PRs for correctness and convention compliance
+- `investigating-perf-regression` — Investigate performance regression test failures by comparing runs

--- a/skills/investigating-perf-regression/SKILL.md
+++ b/skills/investigating-perf-regression/SKILL.md
@@ -1,0 +1,188 @@
+---
+name: investigating-perf-regression
+description: >-
+  Guides investigation of SCT performance regression test failures by comparing
+  failed and passed runs. Use when a perf-regression test fails with high P99
+  latency, when comparing two SCT performance test runs, when querying Prometheus
+  metrics from SCT monitoring stacks, when downloading and analyzing Scylla logs
+  via Argus CLI, or when diagnosing read queuing, cache eviction, reactor stalls,
+  or compaction-related latency spikes. Covers predefined-throughput-steps tests,
+  gradual-grow-throughput tests, and HDR histogram analysis.
+---
+
+# Investigating Performance Regression Failures
+
+Systematically compare failed and passed SCT performance test runs to identify root causes of latency regressions.
+
+## Essential Principles
+
+### Compare, Don't Assume
+
+**Always compare the failed run against a known-good passed run.**
+
+A single metric in isolation is meaningless without a baseline. A max queued reads count of 29 looks bad until you see the passed run had 16. Every query must be run against both runs to establish what's normal vs anomalous. Without comparison, you risk chasing red herrings.
+
+### Server-Side vs Client-Side Latency
+
+**Distinguish between Scylla-reported latency and cassandra-stress-reported latency.**
+
+The P99 reported by the test result (from HDR histograms / cassandra-stress) includes network round-trip, client-side queuing, and coordinator overhead. The Scylla-side P99 (from `rlatencyp99` Prometheus metric) only measures server processing time. A huge gap between them (e.g., 57ms server vs 1754ms client) points to read queuing, network issues, or client-side bottlenecks rather than raw Scylla performance.
+
+### Follow the Queuing Chain
+
+**Latency regressions are almost always caused by queuing, not raw slowness.**
+
+The investigation order should follow the queuing chain: `scylla_database_queued_reads` -> `scylla_cache_row_evictions` -> `scylla_lsa_memory_compacted` -> `scylla_reactor_utilization` -> `scylla_io_queue_*`. A node with 1600 queued reads and 79% reactor utilization tells a different story than one with 0 queued reads and 99% utilization. Start from queued reads and work backward to the cause.
+
+### Identify the Offending Node
+
+**Performance regressions are usually caused by a single node, not the whole cluster.**
+
+Always break down metrics by instance. A cluster-wide average hides single-node spikes. Query with `by (instance)` and look for outliers. Map node IPs to node names using `scylla.yaml` from the downloaded logs to make findings actionable.
+
+### Correlate Timestamps
+
+**Every spike must be correlated with a specific time window.**
+
+Don't just report "max queued reads was 1601." Report "max queued reads was 1601 at 05:57:48 on node-3." Then check what else happened at that exact time: cache evictions, compaction activity, reactor stalls, memtable flushes. The HDR histogram intervals from cassandra-stress provide natural time boundaries for correlation.
+
+## When to Use
+
+- A perf-regression test (predefined-throughput-steps, gradual-grow-throughput) fails with high P99 latency
+- Comparing metrics between two SCT performance test runs (failed vs passed)
+- Investigating latency spikes during a specific load step (e.g., 1200000 op/s)
+- Diagnosing whether a regression is caused by Scylla (server-side) or infrastructure (network, disk, client)
+- Analyzing HDR histogram data from cassandra-stress results
+- Querying Prometheus metrics from SCT monitoring stacks that are still running
+
+## When NOT to Use
+
+- Investigating functional test failures (non-performance) -- use standard SCT debugging
+- Writing or modifying performance test code -- use the codebase directly
+- Profiling SCT framework code itself -- use the profiling-sct-code skill
+- Analyzing tests that don't use Prometheus monitoring (e.g., unit tests)
+- Infrastructure provisioning issues (instance launch failures, network setup) -- these are not perf regressions
+
+## Investigation Workflow Overview
+
+The full step-by-step process is in [workflows/investigate-perf-regression.md](workflows/investigate-perf-regression.md).
+
+**Phase summary:**
+
+1. **Gather run metadata** -- Use Argus CLI to get run details, events, and identify both runs
+2. **Query Prometheus metrics** -- Compare key metrics between failed and passed runs
+3. **Identify the offending node** -- Break down metrics by instance, find outliers
+4. **Correlate with HDR histograms** -- Map Prometheus spikes to cassandra-stress intervals
+5. **Download and analyze logs** -- Use Argus to get system.log, check for stalls, errors
+6. **Write root cause analysis** -- Document findings in structured markdown
+
+## Key Metrics Priority Order
+
+Query these metrics in order. Each level explains a different layer of the problem:
+
+| Priority | Metric | What It Reveals |
+|----------|--------|-----------------|
+| 1 | `rlatencyp99` (per instance) | Server-side tail latency -- is Scylla itself slow? |
+| 2 | `scylla_database_queued_reads` | Read admission control -- are reads being throttled? |
+| 3 | `scylla_cache_row_evictions` | Memory pressure -- is the cache being evicted? |
+| 4 | `scylla_reactor_utilization` | CPU saturation -- is the reactor overloaded? |
+| 5 | `scylla_lsa_memory_compacted` | LSA pressure -- is memory compaction active? |
+| 6 | `scylla_io_queue_total_delay_sec` | I/O delays -- is disk I/O the bottleneck? |
+| 7 | `node_netstat_Tcp_RetransSegs` | Network issues -- are packets being retransmitted? |
+
+See [references/prometheus-queries.md](references/prometheus-queries.md) for exact query syntax.
+
+## Argus CLI Quick Reference
+
+See [references/argus-commands.md](references/argus-commands.md) for the full command reference.
+
+**Essential commands:**
+
+```bash
+# Get run metadata
+argus run get --run-id <UUID>
+
+# Get error/critical events
+argus run events --run-id <UUID>
+
+# List available logs
+argus run logs list --run-id <UUID>
+
+# Download and extract logs
+argus run logs download <log-name> --run-id <UUID> --dest <directory>
+```
+
+## Node IP Mapping
+
+After downloading DB cluster logs, map node numbers to IPs:
+
+```bash
+for n in 1 2 3; do
+  echo "=== Node $n ==="
+  grep "broadcast_rpc_address" <logs-dir>/db-node-*-$n/scylla.yaml
+done
+```
+
+This is critical because Prometheus metrics use IPs while Argus logs use node names.
+
+## HDR Histogram Interpretation
+
+The SCT log contains HDR histogram data split into 10-minute intervals. Key fields:
+
+- `percentile_50/90/95/99` -- Latency percentiles in milliseconds
+- `throughput` -- Actual ops/s achieved in that interval
+- `stddev` -- Standard deviation (high values indicate instability)
+- `color` -- SCT's own regression detection (`red` = regression)
+
+When the first interval shows extreme latency but later intervals are normal, the cause is typically startup transient (compaction catch-up, cache warming).
+
+## Output Format
+
+The final analysis should be a markdown document with:
+
+1. **Header** -- Test name, step, run IDs, Jenkins links
+2. **Run environment comparison** -- Region, instance type, Scylla version, AMI, SCM revision
+3. **Key findings table** -- Side-by-side metrics comparison
+4. **Timeline** -- Timestamped events on the offending node
+5. **Root cause chain** -- Sequence of events leading to the failure
+6. **HDR histogram breakdown** -- Per-interval latency data
+7. **Log analysis** -- Reactor stalls, kernel messages, system events
+8. **Contributing factors** -- Infrastructure, code, data distribution differences
+9. **Recommendations** -- Immediate investigation steps and long-term improvements
+
+## Reference Index
+
+| File | Content |
+|------|---------|
+| [references/prometheus-queries.md](references/prometheus-queries.md) | Exact Prometheus HTTP API queries for all key metrics |
+| [references/argus-commands.md](references/argus-commands.md) | Argus CLI commands for run inspection and log retrieval |
+
+| Workflow | Purpose |
+|----------|---------|
+| [workflows/investigate-perf-regression.md](workflows/investigate-perf-regression.md) | 6-phase investigation process from run IDs to root cause analysis |
+
+## Trigger Eval Queries
+
+**Should trigger:**
+- "Compare these two perf regression runs"
+- "Why did the predefined throughput steps test fail?"
+- "Investigate high P99 latency in run 5a958af9"
+- "Check Prometheus metrics for the failed performance test"
+- "Download logs from Argus for run X and analyze them"
+- "What caused the latency spike at the 1200000 op/s step?"
+
+**Should NOT trigger:**
+- "Write a new performance test" (use codebase directly)
+- "Profile the SCT framework code" (use profiling-sct-code)
+- "Fix a unit test failure" (use writing-unit-tests)
+- "Review this PR" (use code-review)
+
+## Success Criteria
+
+- [ ] Both failed and passed runs are compared side-by-side
+- [ ] Metrics are broken down per-node to identify the offender
+- [ ] Prometheus spikes are correlated with HDR histogram intervals
+- [ ] System logs are checked for reactor stalls and errors
+- [ ] Root cause chain is documented (not just symptoms)
+- [ ] Recommendations include both immediate and long-term actions
+- [ ] Analysis is saved as structured markdown

--- a/skills/investigating-perf-regression/SKILL.md
+++ b/skills/investigating-perf-regression/SKILL.md
@@ -75,6 +75,7 @@ The full step-by-step process is in [workflows/investigate-perf-regression.md](w
 4. **Correlate with HDR histograms** -- Map Prometheus spikes to cassandra-stress intervals
 5. **Download and analyze logs** -- Use Argus to get system.log, check for stalls, errors
 6. **Write root cause analysis** -- Document findings in structured markdown
+7. **Root cause deep dive** -- Determine the exact bottleneck layer (admission control, memory, IO, transport)
 
 ## Key Metrics Priority Order
 
@@ -84,11 +85,14 @@ Query these metrics in order. Each level explains a different layer of the probl
 |----------|--------|-----------------|
 | 1 | `rlatencyp99` (per instance) | Server-side tail latency -- is Scylla itself slow? |
 | 2 | `scylla_database_queued_reads` | Read admission control -- are reads being throttled? |
-| 3 | `scylla_cache_row_evictions` | Memory pressure -- is the cache being evicted? |
-| 4 | `scylla_reactor_utilization` | CPU saturation -- is the reactor overloaded? |
-| 5 | `scylla_lsa_memory_compacted` | LSA pressure -- is memory compaction active? |
-| 6 | `scylla_io_queue_total_delay_sec` | I/O delays -- is disk I/O the bottleneck? |
-| 7 | `node_netstat_Tcp_RetransSegs` | Network issues -- are packets being retransmitted? |
+| 3 | `scylla_database_active_reads` | Admission saturation -- is the concurrency limit hit? |
+| 4 | `scylla_cache_row_evictions` | Memory pressure -- is the cache being evicted? |
+| 5 | `scylla_memory_allocated_memory` | Memory headroom -- is the node at 99%+ usage? |
+| 6 | `scylla_reactor_utilization` | CPU saturation -- is the reactor overloaded? |
+| 7 | `scylla_transport_requests_blocked_memory` | Transport layer -- is CQL backpressure the bottleneck? |
+| 8 | `scylla_lsa_memory_compacted` | LSA pressure -- is memory compaction active? |
+| 9 | `scylla_io_queue_total_delay_sec` | I/O delays -- is disk I/O the bottleneck? |
+| 10 | `node_netstat_Tcp_RetransSegs` | Network issues -- are packets being retransmitted? |
 
 See [references/prometheus-queries.md](references/prometheus-queries.md) for exact query syntax.
 
@@ -136,6 +140,46 @@ The SCT log contains HDR histogram data split into 10-minute intervals. Key fiel
 
 When the first interval shows extreme latency but later intervals are normal, the cause is typically startup transient (compaction catch-up, cache warming).
 
+## Common Root Cause Patterns
+
+### Pattern 1: Read Admission Control Saturation
+
+**Symptoms:** Client P99 >> Scylla P99 (e.g., 23s vs 12ms), queued reads in hundreds/thousands, active reads at limit (~93-94).
+
+**Mechanism:** Memory is at 99% capacity → cache evictions occur under load → some reads hold admission slots longer due to memory allocation pressure → queue builds up → new requests wait 10-20+ seconds in the admission queue before being processed (in 12ms).
+
+**Key insight:** Scylla's coordinator latency metric only measures processing time, NOT queue wait time. The gap between server and client P99 IS the queue wait time.
+
+**Distinguishing evidence:**
+- `scylla_transport_requests_blocked_memory` = 0 (transport is fine)
+- `scylla_database_active_reads` at limit on affected nodes
+- `scylla_memory_allocated_memory / scylla_memory_total_memory` > 99%
+- Cache hit rate = 100% (not a cold cache problem)
+
+### Pattern 2: Uneven Node Load
+
+**Symptoms:** 1-2 nodes show massive queued reads while others are near zero. All nodes have similar reactor utilization.
+
+**Cause:** Uneven tablet distribution, token-aware routing concentrating load, or specific EC2 instance with degraded performance (noisy neighbor).
+
+**Evidence:** Compare queued reads per node — healthy cluster shows uniform distribution.
+
+### Pattern 3: Compaction Interference
+
+**Symptoms:** Periodic latency spikes, reactor stalls in `compaction` scheduling group, elevated IO queue delays.
+
+**Cause:** Background compaction consuming IO bandwidth or CPU, competing with read path.
+
+**Evidence:** `scylla_compaction_manager_compactions > 0` during the step, reactor stalls timestamped during spikes.
+
+### Pattern 4: Disk IO Bottleneck
+
+**Symptoms:** Low cache hit rate, high IO queue delays, high disk queue length.
+
+**Cause:** Working set doesn't fit in memory, reads go to disk, NVMe performance degraded.
+
+**Evidence:** `scylla_cache_row_hits / (hits + misses) < 1.0`, `scylla_io_queue_total_delay_sec` rate > 0.
+
 ## Output Format
 
 The final analysis should be a markdown document with:
@@ -159,7 +203,7 @@ The final analysis should be a markdown document with:
 
 | Workflow | Purpose |
 |----------|---------|
-| [workflows/investigate-perf-regression.md](workflows/investigate-perf-regression.md) | 6-phase investigation process from run IDs to root cause analysis |
+| [workflows/investigate-perf-regression.md](workflows/investigate-perf-regression.md) | 7-phase investigation process from run IDs to root cause analysis |
 
 ## Trigger Eval Queries
 

--- a/skills/investigating-perf-regression/references/argus-commands.md
+++ b/skills/investigating-perf-regression/references/argus-commands.md
@@ -1,0 +1,162 @@
+# Argus CLI Commands for Performance Investigation
+
+Commands for retrieving SCT test run metadata, events, and logs using the Argus CLI.
+
+## Prerequisites
+
+The `argus` CLI must be installed and authenticated:
+
+```bash
+which argus          # verify installation
+argus auth           # authenticate via Cloudflare Access (if needed)
+argus auth-token     # save token to keyring (alternative)
+```
+
+## Run Metadata
+
+### Get run details
+
+Returns JSON with run ID, region, instance type, Scylla version, SCM revision, AMI, status, Jenkins URL, and events summary.
+
+```bash
+argus run get --run-id <UUID>
+```
+
+Key fields to extract for comparison:
+- `region` -- AWS region (us-east-1, eu-west-1, etc.)
+- `instance_type` -- EC2 instance type (e.g., i8g.4xlarge)
+- `scylla_version` -- Scylla version under test
+- `scm_revision_id` -- Git commit hash of the Scylla build
+- `image_id` -- AMI used for the nodes
+- `build_job_url` -- Jenkins build URL
+- `status` -- Run status (passed, failed)
+- `investigation_status` -- Whether the run has been investigated
+
+### Get run type
+
+```bash
+argus run get-type --run-id <UUID>
+```
+
+## Events
+
+### Get error and critical events
+
+Returns events with severity ERROR or CRITICAL. For perf regressions, look for `FailedResultEvent` entries.
+
+```bash
+argus run events --run-id <UUID>
+```
+
+The `message` field in `FailedResultEvent` identifies the failing step:
+
+```
+"Argus validation failed for the result in read - 1200000 - latencies"
+```
+
+This tells you: workload type (read), step rate (1200000), and what failed (latencies).
+
+## Results
+
+### Get test results
+
+Requires both run-id and test-id (get test-id from `argus run get`).
+
+```bash
+argus run results --run-id <UUID> --test-id <TEST_UUID>
+```
+
+## Logs
+
+### List available logs
+
+```bash
+argus run logs list --run-id <UUID>
+```
+
+Typical log files for performance tests:
+
+| Log Name | Contents |
+|----------|----------|
+| `db-cluster-<ID>.tar.zst` | Scylla system.log, scylla.yaml, mem_info, vmstat, dmesg for each node |
+| `sct-<ID>.log.tar.zst` | Main SCT test log with HDR histograms, stress commands, latency results |
+| `loader-set-<ID>.tar.zst` | Loader node logs (cassandra-stress output) |
+| `monitor-set-<ID>.tar.zst` | Monitoring stack logs |
+| `schema-logs-<ID>.tar.zst` | Schema change logs |
+| `sct-runner-events-<ID>.tar.zst` | SCT runner event logs |
+| `builder-<ID>.log.tar.gz` | Build/setup logs |
+
+### Download and extract logs
+
+```bash
+argus run logs download <log-name> --run-id <UUID> --dest <directory>
+```
+
+Example for downloading DB cluster logs for a failed run:
+
+```bash
+mkdir -p /tmp/investigation/failed
+argus run logs download db-cluster-5a958af9.tar.zst \
+  --run-id 5a958af9-8c9b-4b22-aa58-a347c1a0f70c \
+  --dest /tmp/investigation/failed
+```
+
+### Extracted directory structure
+
+After extracting `db-cluster-<ID>.tar.zst`:
+
+```
+db-cluster-<ID>/
+├── messages.log                    # Aggregated kernel/system messages
+├── kallsyms_*                      # Kernel symbol tables
+├── <node-name-1>/
+│   ├── system.log                  # Scylla log (reactor stalls, errors)
+│   ├── scylla.yaml                 # Scylla config (has broadcast_rpc_address for IP mapping)
+│   ├── mem_info                    # /proc/meminfo snapshot
+│   ├── vmstat                      # /proc/vmstat snapshot
+│   ├── cpu_info                    # CPU info
+│   ├── dmesg.log                   # Kernel ring buffer
+│   ├── io-properties.yaml          # I/O scheduler config
+│   ├── scylla_doctor.vitals.json   # Scylla doctor output (may be empty)
+│   └── ...
+├── <node-name-2>/
+│   └── ...
+└── <node-name-3>/
+    └── ...
+```
+
+## Comments
+
+### View run comments
+
+```bash
+argus run comments --run-id <UUID>
+```
+
+### Add a comment to a run
+
+```bash
+argus comment create --run-id <UUID> --message "RCA: read queuing on node-3 caused P99 regression"
+```
+
+## Activity Log
+
+### View run activity
+
+```bash
+argus run activity --run-id <UUID>
+```
+
+## Caching
+
+By default, Argus CLI caches API responses locally. To bypass the cache for fresh data:
+
+```bash
+argus --no-cache run get --run-id <UUID>
+```
+
+To override cache TTL:
+
+```bash
+argus --cache-ttl 5m run get --run-id <UUID>
+```

--- a/skills/investigating-perf-regression/references/prometheus-queries.md
+++ b/skills/investigating-perf-regression/references/prometheus-queries.md
@@ -156,6 +156,52 @@ Counter of coordinator-level read timeouts. Should be 0 for healthy runs.
 sum(scylla_storage_proxy_coordinator_read_timeouts) by (instance)
 ```
 
+## Admission Control & Memory Metrics
+
+### 12. Active Reads
+
+Current number of reads being actively processed (not queued). When this hits the internal limit (~100/shard), additional reads are queued.
+
+```
+max(scylla_database_active_reads) by (instance)
+```
+
+**Interpretation:** Compare offending nodes (hitting 93-94) vs healthy nodes (3-22). If a node is consistently at the limit, it's saturated.
+
+### 13. Transport Requests Blocked by Memory
+
+Counter of CQL requests that were blocked due to transport memory pressure. Zero means the bottleneck is NOT at the CQL connection layer.
+
+```
+max(scylla_transport_requests_blocked_memory) by (instance)
+```
+
+### 14. Memory Allocated vs Total (per shard)
+
+Shows memory headroom. If allocated/total > 99%, the node has no buffer for load spikes.
+
+```
+scylla_memory_allocated_memory{shard="0"}
+scylla_memory_total_memory{shard="0"}
+```
+
+### 15. Transport Connections Blocked/Shed
+
+Indicates if connections are being rejected or throttled at the CQL layer.
+
+```
+max(scylla_transport_connections_blocked) by (instance)
+max(scylla_transport_connections_shed) by (instance)
+```
+
+### 16. Compaction Manager Active Compactions
+
+Number of active compactions during the step. Non-zero during a performance step can steal IO/CPU.
+
+```
+sum(scylla_compaction_manager_compactions) by (instance)
+```
+
 ## Metric Discovery
 
 If a metric name doesn't return data, list all available metric names:

--- a/skills/investigating-perf-regression/references/prometheus-queries.md
+++ b/skills/investigating-perf-regression/references/prometheus-queries.md
@@ -1,0 +1,168 @@
+# Prometheus Queries for Performance Regression Investigation
+
+Exact queries for the Prometheus HTTP API used during performance regression investigations. All queries use the `query_range` endpoint.
+
+## API Endpoint
+
+```
+POST http://<MONITOR_HOST>:9090/api/v1/query_range
+```
+
+Parameters:
+- `query` -- PromQL expression
+- `start` -- ISO 8601 timestamp (e.g., `2026-04-26T05:53:28Z`)
+- `end` -- ISO 8601 timestamp
+- `step` -- Resolution (use `60s` for overview, `20s` for detailed timeline)
+
+## curl Template
+
+```bash
+curl -s --max-time 15 'http://<HOST>:9090/api/v1/query_range' \
+  --data-urlencode 'query=<PROMQL>' \
+  --data-urlencode 'start=<ISO_START>' \
+  --data-urlencode 'end=<ISO_END>' \
+  --data-urlencode 'step=60s'
+```
+
+## Python Parsing Script
+
+Use this pattern to parse query results into human-readable summaries:
+
+```python
+import json, sys
+data = json.load(sys.stdin)
+if data['status'] == 'success':
+    for r in data['data']['result']:
+        inst = r['metric'].get('instance', '?')
+        vals = [float(v[1]) for v in r['values'] if v[1] != 'NaN']
+        if vals:
+            print(f'{inst}: min={min(vals):.1f} max={max(vals):.1f} avg={sum(vals)/len(vals):.1f}')
+```
+
+For timestamped spike detection:
+
+```python
+import json, sys
+from datetime import datetime, timezone
+data = json.load(sys.stdin)
+if data['status'] == 'success':
+    for r in data['data']['result']:
+        inst = r['metric'].get('instance', '?')
+        vals = [(v[0], float(v[1])) for v in r['values'] if v[1] != 'NaN' and float(v[1]) > THRESHOLD]
+        for ts, v in vals:
+            t = datetime.fromtimestamp(ts, tz=timezone.utc).strftime('%H:%M:%S')
+            print(f'  {t}: {v:.0f}')
+```
+
+## Primary Metrics
+
+### 1. P99 Read Latency (Server-Side)
+
+The `rlatencyp99` metric is a pre-computed summary created by Prometheus relabel rules from `scylla_storage_proxy_coordinator_read_latency_summary`. Values are in **microseconds**.
+
+```
+max(rlatencyp99) by (instance)
+```
+
+To convert to milliseconds in the parsing script, divide by 1000.
+
+For per-shard breakdown (more detail but more data):
+
+```
+rlatencyp99{instance!=""}
+```
+
+### 2. Queued Reads
+
+The most important indicator of read admission throttling. Values represent the current queue depth (gauge).
+
+```
+max(scylla_database_queued_reads) by (instance)
+```
+
+**Thresholds:** 0-10 normal, 10-50 mild pressure, 50+ significant, 500+ severe.
+
+### 3. Cache Row Evictions
+
+Rate of cache row evictions per second. High rates indicate memory pressure forcing the cache to shrink.
+
+```
+sum(rate(scylla_cache_row_evictions[1m])) by (instance)
+```
+
+### 4. Reactor Utilization
+
+Average CPU utilization across all shards as a percentage (0-100).
+
+```
+avg(scylla_reactor_utilization) by (instance)
+```
+
+### 5. Cache Hit Rate
+
+Fraction of reads served from cache. Should be very close to 1.0 (100%) for read-only workloads.
+
+```
+1 - sum(rate(scylla_cache_row_misses[1m])) by (instance) / sum(rate(scylla_cache_reads[1m])) by (instance)
+```
+
+## Secondary Metrics
+
+### 6. LSA Memory Compaction
+
+Rate of log-structured allocator memory compaction in bytes/sec. High rates indicate memory fragmentation pressure.
+
+```
+sum(rate(scylla_lsa_memory_compacted[1m])) by (instance)
+```
+
+### 7. IO Queue Delays
+
+Cumulative I/O delay per I/O class. The rate gives seconds-of-delay-per-second-of-wall-time.
+
+```
+max(rate(scylla_io_queue_total_delay_sec[1m])) by (instance, class)
+```
+
+### 8. SSTable Read Queue Overloads
+
+Count of times the SSTable read queue was overloaded. Any non-zero rate is a problem.
+
+```
+sum(rate(scylla_database_sstable_read_queue_overloads[1m])) by (instance)
+```
+
+### 9. Disk Queue Length
+
+Current number of I/O operations queued at the disk level per I/O class.
+
+```
+max(scylla_io_queue_disk_queue_length) by (instance, class)
+```
+
+### 10. TCP Retransmissions
+
+Rate of TCP segment retransmissions. High rates indicate network instability.
+
+```
+rate(node_netstat_Tcp_RetransSegs[1m])
+```
+
+### 11. Read Timeouts
+
+Counter of coordinator-level read timeouts. Should be 0 for healthy runs.
+
+```
+sum(scylla_storage_proxy_coordinator_read_timeouts) by (instance)
+```
+
+## Metric Discovery
+
+If a metric name doesn't return data, list all available metric names:
+
+```bash
+curl -s 'http://<HOST>:9090/api/v1/label/__name__/values' | \
+  python3 -c "import json,sys; [print(n) for n in json.load(sys.stdin)['data'] if 'keyword' in n]"
+```
+
+Replace `keyword` with relevant terms: `timeout`, `queue`, `stall`, `compaction`, `cache`, `latency`, `evict`.

--- a/skills/investigating-perf-regression/workflows/investigate-perf-regression.md
+++ b/skills/investigating-perf-regression/workflows/investigate-perf-regression.md
@@ -1,6 +1,6 @@
 # Investigating a Performance Regression Failure
 
-A 6-phase process for comparing a failed and passed SCT performance regression test run to identify the root cause of a latency regression.
+A 7-phase process for comparing a failed and passed SCT performance regression test run to identify the root cause of a latency regression.
 
 ---
 
@@ -213,3 +213,62 @@ See [references/prometheus-queries.md](../references/prometheus-queries.md) for 
 7. **Save as markdown.** Use the output format defined in SKILL.md. Include all data sources (Prometheus URLs, Argus commands used).
 
 **Exit:** Root cause analysis document written and saved. All evidence referenced. Recommendations are actionable.
+
+---
+
+## Phase 7: Root Cause Deep Dive — Determine the Bottleneck Layer
+
+**Entry:** Phase 6 complete. You have the symptoms documented but need to determine exactly *where* in the stack the latency originates (client vs server, which Scylla subsystem).
+
+**Actions:**
+
+1. **Compare Scylla-reported latency vs client-reported latency.** The `latency_results` in the SCT log contain both:
+   - `Scylla P99_read - node-X` (from `rlatencyp99` Prometheus metric, coordinator processing time only)
+   - `c-s P99` (from cassandra-stress HDR histograms, end-to-end including queue wait time)
+
+   A large gap (e.g., Scylla reports 12ms but client sees 23,000ms) means the time is spent **waiting in a queue**, not in actual request processing.
+
+2. **Check read admission control saturation.** Query active reads to see if the concurrency limit is hit:
+   ```bash
+   # query: max(scylla_database_active_reads) by (instance)
+   ```
+   If active reads hit the internal limit (typically ~100 per shard), all additional reads queue. Compare the offending node (hitting 93-94) vs healthy nodes (3-22).
+
+3. **Check transport layer blocking.** Rule out CQL connection-level backpressure:
+   ```bash
+   # query: max(scylla_transport_requests_blocked_memory) by (instance)
+   ```
+   Zero means the transport layer is NOT the bottleneck — requests are accepted but queued internally.
+
+4. **Check memory headroom.** Compare allocated vs total memory per shard:
+   ```bash
+   # query: scylla_memory_allocated_memory{shard="0"}
+   # query: scylla_memory_total_memory{shard="0"}
+   ```
+   If allocated/total > 99%, there is no memory headroom. This contributes to admission control being more aggressive and evictions triggering under load.
+
+5. **Check cache hit rate.** If hit rate is 100% but evictions are occurring, the working set fits in cache but memory churn from evict-and-recache holds read slots longer:
+   ```bash
+   # query: sum(rate(scylla_cache_row_hits[1m])) by (instance) / (sum(rate(scylla_cache_row_hits[1m])) by (instance) + sum(rate(scylla_cache_row_misses[1m])) by (instance))
+   ```
+
+6. **Check for uneven load distribution.** If only some nodes are saturated while others are idle, this indicates uneven tablet ownership or topology-aware routing sending disproportionate traffic to specific nodes. Compare queued reads and active reads across all nodes — healthy nodes should have similar values.
+
+7. **Build the bottleneck layer table.** Summarize findings:
+
+   | Layer | Problem? | Evidence |
+   |-------|----------|----------|
+   | Client (cassandra-stress) | No/Yes | Reports latency correctly / thread contention |
+   | Network | No/Yes | No transport blocking / TCP retransmissions |
+   | Scylla transport/CQL layer | No/Yes | 0 requests blocked / connection shedding |
+   | **Scylla read admission control** | No/Yes | Queued reads count, active reads at limit |
+   | Scylla cache/memory | No/Yes | Memory %, eviction rate, hit rate |
+   | Disk IO | No/Yes | Cache hit rate, IO queue delays |
+
+8. **Classify the root cause.** Common patterns:
+   - **Admission control saturation + 99% memory + cache evictions + 100% hit rate:** Memory pressure causes reads to hold admission slots longer → cascading queue buildup. Server-side issue, transient if caused by specific instance/placement.
+   - **Low active reads + high IO delays + low cache hit rate:** Disk IO bottleneck from cold cache or data larger than memory.
+   - **Transport blocking + high connections:** Client overloading the CQL connection pool.
+   - **Uneven queued reads (1-2 nodes high, others zero):** Tablet/token distribution imbalance or noisy-neighbor on specific EC2 instance.
+
+**Exit:** Bottleneck layer identified and documented. The analysis explains not just *what* happened but *why* and at which layer the time was spent.

--- a/skills/investigating-perf-regression/workflows/investigate-perf-regression.md
+++ b/skills/investigating-perf-regression/workflows/investigate-perf-regression.md
@@ -1,0 +1,215 @@
+# Investigating a Performance Regression Failure
+
+A 6-phase process for comparing a failed and passed SCT performance regression test run to identify the root cause of a latency regression.
+
+---
+
+## Phase 1: Gather Run Metadata
+
+**Entry:** You have two run IDs (or URLs) -- one failed, one passed -- for the same performance test.
+
+**Actions:**
+
+1. **Get run details from Argus.** For both runs:
+   ```bash
+   argus run get --run-id <FAILED_UUID>
+   argus run get --run-id <PASSED_UUID>
+   ```
+   Extract: region, instance type, Scylla version, SCM revision, AMI, node count, status, Jenkins URL.
+
+2. **Check for code/AMI differences.** Compare `scm_revision_id` and `image_id` between runs. Different revisions mean potential code changes that could affect performance. Flag these immediately.
+
+3. **Get events for the failed run.** Look for `FailedResultEvent` entries:
+   ```bash
+   argus run events --run-id <FAILED_UUID>
+   ```
+   The event message identifies which step and metric failed (e.g., "read - 1200000 - latencies").
+
+4. **Identify the Prometheus endpoints.** The user should provide the Grafana/monitoring URLs. Extract the host IPs. Prometheus is typically on port 9090 of the same host. Verify connectivity:
+   ```bash
+   curl -s --max-time 10 "http://<HOST>:9090/api/v1/status/config"
+   ```
+
+5. **Determine the time window.** From the Grafana URLs or the test results, extract the start and end timestamps for the specific step being investigated. Convert to UTC ISO format for Prometheus queries.
+
+**Exit:** Both run details documented, Prometheus endpoints confirmed reachable, time windows identified for the step under investigation.
+
+---
+
+## Phase 2: Query Prometheus Metrics
+
+**Entry:** Phase 1 complete. Prometheus endpoints and time windows known.
+
+**Actions:**
+
+1. **Query P99 read latency per node.** This is the primary metric:
+   ```bash
+   curl -s 'http://<HOST>:9090/api/v1/query_range' \
+     --data-urlencode 'query=max(rlatencyp99) by (instance)' \
+     --data-urlencode 'start=<ISO_START>' \
+     --data-urlencode 'end=<ISO_END>' \
+     --data-urlencode 'step=20s'
+   ```
+   Run against both Prometheus instances. Compare max values. The `rlatencyp99` metric is a pre-computed summary (renamed by Prometheus relabel rules from `scylla_storage_proxy_coordinator_read_latency_summary`).
+
+2. **Query queued reads per node.** This is the #1 indicator of read admission throttling:
+   ```bash
+   # query: max(scylla_database_queued_reads) by (instance)
+   ```
+   Any value above ~20 is suspicious. Values in the hundreds or thousands indicate severe throttling.
+
+3. **Query cache evictions per node.** High eviction rates cause memory churn:
+   ```bash
+   # query: sum(rate(scylla_cache_row_evictions[1m])) by (instance)
+   ```
+   Compare max rates between runs. 10x difference is a strong signal.
+
+4. **Query reactor utilization.** Verify CPU isn't the bottleneck:
+   ```bash
+   # query: avg(scylla_reactor_utilization) by (instance)
+   ```
+   Similar utilization between runs means the regression isn't from CPU saturation.
+
+5. **Query secondary metrics.** If primary metrics don't explain the issue, check:
+   - LSA memory compaction: `sum(rate(scylla_lsa_memory_compacted[1m])) by (instance)`
+   - IO queue delays: `max(rate(scylla_io_queue_total_delay_sec[1m])) by (instance, class)`
+   - Cache hit rate: `1 - sum(rate(scylla_cache_row_misses[1m])) by (instance) / sum(rate(scylla_cache_reads[1m])) by (instance)`
+   - TCP retransmissions: `rate(node_netstat_Tcp_RetransSegs[1m])`
+
+See [references/prometheus-queries.md](../references/prometheus-queries.md) for complete query syntax with parsing scripts.
+
+**Exit:** Key metrics collected for both runs. Anomalous metrics identified. At least one clear signal found (e.g., queued reads, evictions, IO delays).
+
+---
+
+## Phase 3: Identify the Offending Node
+
+**Entry:** Phase 2 complete. Anomalous metrics identified.
+
+**Actions:**
+
+1. **Rank nodes by the anomalous metric.** For queued reads, find which node had the highest max value and at what time.
+
+2. **Get the detailed timeline for the offending node.** Query with `instance="<IP>"` and a finer step (20s) to pinpoint exact spike times:
+   ```bash
+   # query: max(scylla_database_queued_reads{instance="<IP>"})
+   # step=20s
+   ```
+   Record timestamps of all significant spikes.
+
+3. **Cross-reference with other nodes.** Verify the issue is localized to one node. If all nodes spike simultaneously, the cause is likely external (loader, network, coordinator).
+
+4. **Check correlated metrics on the offending node at spike times.** At each spike timestamp, check:
+   - Cache evictions (did they spike at the same time?)
+   - Reactor utilization (was CPU saturated?)
+   - IO queue delays (was disk slow?)
+
+**Exit:** Offending node identified with timestamped spikes. Correlated metrics documented. Single-node vs cluster-wide determination made.
+
+---
+
+## Phase 4: Correlate with HDR Histograms
+
+**Entry:** Phase 3 complete. Spike timestamps known.
+
+**Actions:**
+
+1. **Find the HDR data in the SCT log.** Search for the step name in the SCT log:
+   ```bash
+   grep -n "<STEP_RATE>" <sct-log-file> | grep "latency_results\|hdr"
+   ```
+   The log contains full HDR histogram data with per-interval breakdowns.
+
+2. **Parse the interval data.** Each step is split into ~10-minute intervals with:
+   - `start_time` / `end_time` (Unix timestamps in milliseconds)
+   - `percentile_50/90/95/99/99_9` (in milliseconds)
+   - `throughput` (actual ops/s)
+   - `stddev` (latency standard deviation)
+
+3. **Map Prometheus spikes to HDR intervals.** Convert the spike timestamps from Phase 3 to the HDR interval boundaries. Identify which intervals contain the spikes.
+
+4. **Determine the pattern.** Common patterns:
+   - **First-interval-only spike:** Startup transient (compaction catch-up, cache warming). The test may need a warmup period.
+   - **Periodic spikes:** Compaction cycles or background tasks interfering.
+   - **Progressive degradation:** Resource exhaustion (memory, disk space).
+   - **Random single spike:** Infrastructure event (noisy neighbor, EBS hiccup).
+
+**Exit:** HDR intervals mapped to Prometheus spikes. Degradation pattern identified and classified.
+
+---
+
+## Phase 5: Download and Analyze Logs
+
+**Entry:** Phase 4 complete. Spikes correlated with time windows.
+
+**Actions:**
+
+1. **Download DB cluster logs via Argus:**
+   ```bash
+   argus run logs list --run-id <UUID>
+   argus run logs download db-cluster-<ID>.tar.zst --run-id <UUID> --dest <dir>
+   ```
+
+2. **Map node numbers to IPs.** Check `scylla.yaml` for each node:
+   ```bash
+   grep "broadcast_rpc_address" <dir>/<node-dir>/scylla.yaml
+   ```
+
+3. **Check reactor stalls on the offending node.** Search the system.log:
+   ```bash
+   grep "Reactor stall" <node-dir>/system.log
+   ```
+   Note: stall timestamps, durations, scheduling groups (compaction, statement, etc.), and affected shards. Stalls in the `compaction` group during earlier steps indicate compaction pressure that may carry over.
+
+4. **Check for errors/warnings in system.log.** Look for:
+   - `large allocation` messages
+   - `Failed to delete` (SSTable cleanup issues)
+   - `oom` or memory-related messages
+   - Raft/group0 leadership changes
+
+5. **Check kernel/OS logs.** The `messages.log` may contain:
+   - OOM killer events
+   - NVMe/disk errors
+   - Network interface resets
+
+6. **Check memory state.** Review `mem_info` and `vmstat` files for the node:
+   - Total memory, free memory, swap usage
+   - Locked (mlock) memory amount
+   - Any swap activity indicates severe memory pressure
+
+7. **Optionally download the SCT log** for more context:
+   ```bash
+   argus run logs download sct-<ID>.log.tar.zst --run-id <UUID> --dest <dir>
+   ```
+
+**Exit:** Log evidence collected. Reactor stalls quantified. System-level anomalies (or lack thereof) documented.
+
+---
+
+## Phase 6: Write Root Cause Analysis
+
+**Entry:** Phase 5 complete. All evidence collected.
+
+**Actions:**
+
+1. **Document the run environment.** Create a comparison table: region, instance type, Scylla version, AMI, SCM revision, node count.
+
+2. **Document key findings.** Create a side-by-side metrics table (failed vs passed) for all queried metrics.
+
+3. **Build the root cause chain.** Start from the symptom (high client P99) and trace backward through the evidence:
+   - High client P99 <- queued reads on node X
+   - Queued reads <- cache eviction pressure
+   - Cache evictions <- memory pressure / compaction backlog
+   - etc.
+
+4. **Document the timeline.** List all significant events with timestamps on the offending node.
+
+5. **List contributing factors.** Include infrastructure differences (region, AMI), code differences (SCM revision), and data distribution questions.
+
+6. **Write recommendations.** Split into:
+   - **Immediate investigation:** Specific things to check next (diff SCM revisions, check tablet distribution, re-run in same region)
+   - **Long-term improvements:** Test methodology changes (warmup periods, per-node metric tracking, region pinning)
+
+7. **Save as markdown.** Use the output format defined in SKILL.md. Include all data sources (Prometheus URLs, Argus commands used).
+
+**Exit:** Root cause analysis document written and saved. All evidence referenced. Recommendations are actionable.


### PR DESCRIPTION
## Summary

- Add a new AI agent skill for systematically investigating SCT performance regression test failures
- Covers the full investigation workflow: Argus CLI for metadata/logs, Prometheus queries for metrics, HDR histogram analysis, and root cause documentation
- Includes reference docs for Prometheus query syntax and Argus CLI commands

## Skill Structure

```
skills/investigating-perf-regression/
├── SKILL.md                                    # Main skill definition
├── references/
│   ├── prometheus-queries.md                   # Exact PromQL queries for key metrics
│   └── argus-commands.md                       # Argus CLI command reference
└── workflows/
    └── investigate-perf-regression.md           # 6-phase investigation process
```

## Motivation

This skill codifies the investigation process used to diagnose a real performance regression failure (P99 read latency spike from 5ms to 1754ms at 1.2M op/s). The root cause was traced to read queuing on a single node caused by memory pressure and cache evictions, identified through systematic Prometheus metric comparison and Scylla log analysis.

The skill enables AI agents to reproduce this investigation process for future performance regression failures.