### PR TITLE
fix(gce-provision): align cloud-init SSH timeout to 300s

### DIFF
--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -732,6 +732,7 @@ class AWSNode(cluster.BaseNode):
                 self._is_zero_token_node = True
 
     def wait_for_cloud_init(self):
+        self.remoter.is_up(timeout=300)
         if self.remoter.sudo("bash -c 'command -v cloud-init'", ignore_status=True).ok:
             wait_cloud_init_completes(self.remoter, self)
 

--- a/sdcm/cluster_gce.py
+++ b/sdcm/cluster_gce.py
@@ -126,6 +126,7 @@ class GCENode(cluster.BaseNode):
         super().init()
 
     def wait_for_cloud_init(self):
+        self.remoter.is_up(timeout=300)
         if self.remoter.sudo("bash -c 'command -v cloud-init'", ignore_status=True).ok:
             wait_cloud_init_completes(self.remoter, self)
 


### PR DESCRIPTION
## Summary
- Add `remoter.is_up(timeout=300)` before the `command -v cloud-init` guard in both `cluster_gce.py` and `cluster_aws.py`
- Aligns the SSH timeout with what `wait_cloud_init_completes()` uses internally
- Fixes intermittent `SSHConnectTimeoutError` during GCE provisioning when metadata service is slow (observed 273s on affected nodes)

Fixes: SCT-282