### PR TITLE
fix(jenkins-pipeline): stop pullRequestSetResult from poisoning overall build result

### DIFF
--- a/vars/pullRequestSetResult.groovy
+++ b/vars/pullRequestSetResult.groovy
@@ -7,7 +7,4 @@ def call(String status, String context, String description){
 			description: description,
 			targetUrl: "${env.BUILD_URL}pipeline-overview")
 	}
-	if (status == 'failure') {
-		currentBuild.result = 'FAILURE'
-	}
 }


### PR DESCRIPTION
## Summary
- Removed the `currentBuild.result = 'FAILURE'` side-effect from `pullRequestSetResult.groovy`
- This function's sole responsibility should be reporting per-stage status to GitHub via `pullRequest.createStatus()`, not controlling the overall build result

## Problem
`pullRequestSetResult()` unconditionally set `currentBuild.result = 'FAILURE'` whenever it reported any stage failure to GitHub. This undermined the `catchError(buildResult: 'SUCCESS')` pattern used by precommit, unittest, lint, and integration-tests stages.

**Most visible symptom**: When integration-tests failed (e.g. due to expired cloud images for `branch-2024.1`), all provision test checks on GitHub showed as failed — even though their pytest runs passed successfully. The cascade:

1. Integration tests fail → `pullRequestSetResult('failure', 'jenkins/integration-tests', ...)` called
2. That sets `currentBuild.result = 'FAILURE'` (the bug)
3. Provision tests all pass → each calls `pullRequestSetResult('success', 'jenkins/provision_*', ...)`
4. But `currentBuild.result` is already `FAILURE` from step 2
5. Jenkins GitHub plugin sends overall build-level FAILURE notification, overriding per-stage success

## Fix
Remove `currentBuild.result = 'FAILURE'` from `pullRequestSetResult.groovy`. Stages that need to fail the build already do so explicitly:

- **Provision stage**: Sets `currentBuild.result = 'FAILURE'` on lines 417 and 452-453 of Jenkinsfile
- **Monitoring restore failure**: Sets `currentBuild.result = 'FAILURE'` on line 417
- **Pre-commit/unittest/lint/integration-tests**: Use `catchError(buildResult: 'SUCCESS')` — intentionally designed to NOT fail the build

## Testing
- Verified all 14 call sites of `pullRequestSetResult` in the Jenkinsfile
- Confirmed no stage relies on `pullRequestSetResult` for build-result control
- The provision stage has its own explicit `currentBuild.result = 'FAILURE'` + `sh "exit 1"` pattern