### PR TITLE
fix(aws-provision): fix AwsFipsCiBuilder image creation and package install

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -125,7 +125,7 @@ from sdcm.monitorstack import (
 )
 from sdcm.utils.log import setup_stdout_logger, disable_loggers_during_startup
 from sdcm.utils.aws_region import AwsRegion
-from sdcm.utils.aws_builder import AwsCiBuilder, AwsBuilder
+from sdcm.utils.aws_builder import AwsCiBuilder, AwsBuilder, AwsFipsCiBuilder
 from sdcm.utils.gce_region import GceRegion
 from sdcm.utils.gce_builder import GceBuilder
 from sdcm.utils.oci_region import OciRegion
@@ -2476,6 +2476,7 @@ def configure_jenkins_builders(cloud_provider, regions):
     match cloud_provider:
         case "aws":
             AwsCiBuilder(AwsRegion("eu-west-1")).configure_auto_scaling_group()
+            AwsFipsCiBuilder(AwsRegion("us-east-1")).configure_auto_scaling_group()
             AwsBuilder.configure_in_all_region(regions=regions)
         case "gce":
             GceBuilder.configure_in_all_region(regions=regions)

--- a/sdcm/sct_runner.py
+++ b/sdcm/sct_runner.py
@@ -192,6 +192,14 @@ class SctRunner(ABC):
     IMAGE_BUILDER_INSTANCE_TYPE: str
     REGULAR_TEST_INSTANCE_TYPE: str
     LONGTERM_TEST_INSTANCE_TYPE: str
+    PREREQS_APT_PACKAGES: list[str] = [
+        "python3-pip",
+        "htop",
+        "screen",
+        "tree",
+        "systemd-coredump",
+        "rng-tools",
+    ]
 
     def __init__(self, region_name: str, availability_zone: str, params: SCTConfiguration):
         self.region_name = region_name
@@ -231,6 +239,10 @@ class SctRunner(ABC):
         return RemoteCmdRunnerBase.create_remoter(
             hostname=host, user=self.LOGIN_USER, key_file=self._ssh_pkey_file.name, connect_timeout=connect_timeout
         )
+
+    def _prereqs_apt_install_cmd(self) -> str:
+        packages = " ".join(self.PREREQS_APT_PACKAGES)
+        return f"apt-get -qq install --no-install-recommends {packages}"
 
     def install_prereqs(self, public_ip: str, connect_timeout: Optional[int] = None) -> None:
         LOGGER.info("Connecting instance...")
@@ -339,7 +351,7 @@ class SctRunner(ABC):
 
             apt-get -qq clean
             apt-get -qq update
-            apt-get -qq install --no-install-recommends python3-pip htop screen tree systemd-coredump rng-tools
+            {self._prereqs_apt_install_cmd()}
             pip3 install awscli
 
             # disable unattended-upgrades
@@ -757,7 +769,7 @@ class AwsSctRunner(SctRunner):
         self.instance = instance
 
         # If the SCT runner instance is used as a Docker backend for tests
-        if self.params.get("cluster_backend") == "docker":
+        if self.params and self.params.get("cluster_backend") == "docker":
             LOGGER.info("Configure unused disks to use as a persistent storage for Docker.")
             LOGGER.debug("Connecting to instance...")
             remoter = self.get_remoter(host=instance.public_ip_address, connect_timeout=120)
@@ -2174,3 +2186,13 @@ def clean_sct_runners(
 class AwsFipsSctRunner(AwsSctRunner):
     VERSION = f"{SctRunner.VERSION}-v1-fips"
     BASE_IMAGE = "resolve:ssm:/aws/service/marketplace/prod-k6fgbnayirmrc/latest"
+    SOURCE_IMAGE_REGION = "us-east-1"  # FIPS marketplace AMI is only available in us-east-1
+
+    def _prereqs_apt_install_cmd(self) -> str:
+        lines = []
+        for pkg in self.PREREQS_APT_PACKAGES:
+            lines.append(
+                f"apt-get -qq install --no-install-recommends {pkg}"
+                f' || echo "WARNING: {pkg} install failed (may conflict with FIPS-held packages), skipping"'
+            )
+        return "\n            ".join(lines)


### PR DESCRIPTION
## Summary

- Fix `AttributeError: 'NoneType' object has no attribute 'get'` when `self.params` is `None` in the CI builder path
- Set `SOURCE_IMAGE_REGION = "us-east-1"` for `AwsFipsSctRunner` since the FIPS marketplace AMI is only available there (was inheriting `eu-west-2` causing `copy_image` to fail)
- Override `_prereqs_apt_install_cmd` in `AwsFipsSctRunner` to install packages one-by-one with graceful fallback, since FIPS AMIs have held packages that break batch `apt-get install`
- Extract `PREREQS_APT_PACKAGES` class attribute and `_prereqs_apt_install_cmd()` method on `SctRunner` base class so subclasses can customize package installation behavior
- Non-FIPS runners retain strict fail-fast behavior

## Backends Affected
- [x] AWS - Modified sct_runner.py and sct.py

### Testing
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-master/job/artifacts/job/artifacts-docker-fips-test/ - all jobs started running after being stuck for days