### PR TITLE
docs(cross-cloud-sizing): cross-cloud instance sizing abstraction plan

### DIFF
--- a/.sisyphus/plans/constraint-based-sizing.md
+++ b/.sisyphus/plans/constraint-based-sizing.md
@@ -1,0 +1,877 @@
+# Constraint-Based Instance Sizing
+
+## TL;DR
+
+> **Quick Summary**: Replace T-shirt sizing (`db_instance_type: '2xlarge'`) with constraint-based selection (`db_instance_type: {vcpu: 16, memory: ">20gb"}`). An instance catalog per cloud (populated from APIs + curated) is matched against user constraints, selecting the best instance from preferred families by price.
+>
+> **Deliverables**:
+> - Instance catalog module with per-cloud type specs (vcpu/mem/disk/price)
+> - Catalog generation script querying AWS/GCE/Azure/OCI pricing APIs
+> - Constraint parser supporting exact, range, and comparison operators
+> - Matcher selecting best instance per role/cloud from catalog
+> - Updated `sct_config.py` wiring (backward-compat: literal strings still passthrough)
+> - CLI: `sct.py show-prices`, updated `show-sizes`/`translate-size`
+> - Migration of existing test configs
+> - User-facing documentation
+>
+> **Estimated Effort**: Large
+> **Parallel Execution**: YES — 4 waves
+> **Critical Path**: Task 1 → Task 3 → Task 6 → Task 9 → Task 11 → Final
+
+---
+
+## Context
+
+### Original Request
+Replace the T-shirt sizing system (roydahan/pehala review feedback on PR #14490) with a constraint-based selector where users specify requirements (vcpu, memory, disk) and the system resolves to the best matching instance type per cloud provider.
+
+### Interview Summary
+**Key Discussions**:
+- T-shirt sizes removed entirely; constraint-based only
+- YAML dict syntax in configs, flat string for env vars (`SCT_DB_INSTANCE_TYPE='vcpu=16,memory=>20gb'`)
+- Catalog: generated from live cloud APIs + manual curations, current families only
+- Selection: preferred family per role (price-based), with CLI price display
+- Constraints: exact (`vcpu: 16`), ranges (`memory: "10gb-30gb"`), comparisons (`memory: ">20gb"`), arch (`arch: "arm64"` or `arch: "x86_64"` — optional, overrides cloud default)
+
+**Research Findings**:
+- Existing `InstanceSpec` already has vcpus, memory_gb, local_ssd_count
+- `_resolve_instance_sizes()` in sct_config.py handles resolution at config-load time
+- PR #14490 has 3 commits implementing T-shirt system (to be replaced)
+- AWS Pricing API accessible from us-east-1; GCE uses `gcloud compute machine-types list`; Azure has Retail Prices REST API
+
+### Metis Review
+**Identified Gaps** (addressed):
+- Backward compat for literal strings: added as passthrough detection
+- Docker/baremetal backends: silently skip constraint resolution
+- No-match error handling: explicit error message naming unsatisfied constraint
+- Multi-role (oracle/zero_token): all roles get constraint syntax
+- Determinism: same constraints + catalog → always same instance (no randomness)
+- Local disk as implicit constraint for db role: YES, db role implies `local_disk: true`
+- Tie-breaking: preferred family first, then cheapest within family
+
+---
+
+## Work Objectives
+
+### Core Objective
+Enable cloud-agnostic instance selection via hardware constraints (vcpu, memory, disk) instead of arbitrary T-shirt size names, with automated catalog generation and price-based selection.
+
+### Concrete Deliverables
+- `sdcm/utils/instance_catalog.py` — catalog data model + loader
+- `sdcm/utils/instance_matcher.py` — constraint parser + matching engine
+- `sdcm/utils/catalog_generator.py` — script to populate catalog from cloud APIs
+- `data/instance_catalog/` — generated + curated catalog files (YAML per cloud)
+- Updated `sdcm/sct_config.py` — wiring constraint resolution
+- Updated `sct.py` — CLI commands
+- Updated test configs — migrated from T-shirt to constraints
+- `docs/cross-cloud-sizing.md` — updated user guide
+
+### Definition of Done
+- [ ] `{vcpu: 8, memory: ">16gb"}` on AWS resolves to `i8g.2xlarge` (ARM preferred) and all downstream works
+- [ ] `SCT_DB_INSTANCE_TYPE='vcpu=16,memory=>20gb'` env var parses correctly
+- [ ] `SCT_DB_INSTANCE_TYPE='vcpu=8,arch=x86_64'` forces x86 on AWS (overrides arm64 default)
+- [ ] `instance_type_db: 'i4i.large'` still works (literal passthrough)
+- [ ] `sct.py show-prices --cloud aws --role db` shows pricing table
+- [ ] 100% unit test coverage on matcher logic
+- [ ] Integration tests verify API-based catalog generation
+
+### Must Have
+- Backward compatibility: literal instance type strings still work as passthrough
+- All 5 roles supported: db, db_oracle, zero_token, loader, monitor
+- Constraint types: exact value, min (>), max (<), range (min-max), arch selector (arm64|x86_64)
+- Deterministic selection (same input → same output)
+- Docker/baremetal backends silently skip resolution
+- Clear error messages when no instance matches
+
+### Must NOT Have (Guardrails)
+- No spot/preemptible pricing — on-demand only
+- No cross-region auto-selection — region is fixed by other config
+- No GPU/accelerator constraints
+- No auto-detection of instance availability in region (future work)
+- No new cloud API dependencies in test runtime hot path — catalog loaded at startup only
+- No changes to downstream provisioning code — output is still a string instance type
+
+---
+
+## Verification Strategy
+
+> **ZERO HUMAN INTERVENTION** — ALL verification is agent-executed.
+
+### Test Decision
+- **Infrastructure exists**: YES (pytest + unit_tests/)
+- **Automated tests**: TDD
+- **Framework**: pytest (existing)
+- **Split**: Unit tests for parsing/matching logic, integration tests for API catalog generation
+
+### QA Policy
+Every task includes agent-executed QA scenarios.
+Evidence saved to `.sisyphus/evidence/task-{N}-{scenario-slug}.{ext}`.
+
+- **Library/Module**: Use Bash (python REPL) — import, call functions, compare output
+- **CLI**: Use interactive_bash (tmux) — run command, validate output
+- **API/Backend**: Use Bash (curl/python) — call cloud APIs, verify catalog generation
+
+---
+
+## Execution Strategy
+
+### Parallel Execution Waves
+
+```
+Wave 1 (Foundation — no dependencies):
+├── Task 1: Instance catalog data model [quick]
+├── Task 2: Constraint parser module [deep]
+├── Task 3: Catalog file format + loader [quick]
+├── Task 4: Preferred families config [quick]
+
+Wave 2 (Core logic — depends on Wave 1):
+├── Task 5: Matching engine (depends: 1, 2, 4) [deep]
+├── Task 6: Catalog generator — AWS (depends: 1, 3) [unspecified-high]
+├── Task 7: Catalog generator — GCE (depends: 1, 3) [unspecified-high]
+├── Task 8: Catalog generator — Azure + OCI (depends: 1, 3) [unspecified-high]
+
+Wave 3 (Integration — depends on Wave 2):
+├── Task 9: Wire into sct_config.py (depends: 5) [deep]
+├── Task 10: CLI commands (depends: 5, 6-8) [unspecified-high]
+├── Task 11: Migration of test configs (depends: 9) [quick]
+
+Wave 4 (Docs + cleanup):
+├── Task 12: User documentation (depends: 9, 10) [writing]
+├── Task 13: Remove old T-shirt sizing code (depends: 11) [quick]
+
+Wave FINAL (4 parallel reviews):
+├── F1: Plan compliance audit (oracle)
+├── F2: Code quality review (unspecified-high)
+├── F3: Real QA execution (unspecified-high)
+├── F4: Scope fidelity check (deep)
+→ Present results → Get explicit user okay
+```
+
+### Dependency Matrix
+
+| Task | Depends On | Blocks | Wave |
+|------|-----------|--------|------|
+| 1 | — | 5, 6, 7, 8 | 1 |
+| 2 | — | 5 | 1 |
+| 3 | — | 6, 7, 8 | 1 |
+| 4 | — | 5 | 1 |
+| 5 | 1, 2, 4 | 9, 10 | 2 |
+| 6 | 1, 3 | 10 | 2 |
+| 7 | 1, 3 | 10 | 2 |
+| 8 | 1, 3 | 10 | 2 |
+| 9 | 5 | 11 | 3 |
+| 10 | 5, 6-8 | 12 | 3 |
+| 11 | 9 | 12, 13 | 3 |
+| 12 | 9, 10 | — | 4 |
+| 13 | 11 | — | 4 |
+
+### Agent Dispatch Summary
+
+- **Wave 1**: 4 tasks — T1,T3,T4 → `quick`, T2 → `deep`
+- **Wave 2**: 4 tasks — T5 → `deep`, T6-T8 → `unspecified-high`
+- **Wave 3**: 3 tasks — T9 → `deep`, T10 → `unspecified-high`, T11 → `quick`
+- **Wave 4**: 2 tasks — T12 → `writing`, T13 → `quick`
+- **FINAL**: 4 tasks — F1 → `oracle`, F2-F3 → `unspecified-high`, F4 → `deep`
+
+---
+
+## TODOs
+
+- [ ] 1. Instance catalog data model
+
+  **What to do**:
+  - Create `sdcm/utils/instance_catalog.py`
+  - Define `@dataclass InstanceTypeInfo`: instance_type (str), cloud (str), family (str), vcpus (int), memory_gb (float), local_disk_gb (float), local_disk_count (int), arch (str: "x86_64"|"arm64"), price_per_hour (float|None)
+  - Define `InstanceCatalog` class: loads from YAML files, provides `query(cloud, **constraints) -> list[InstanceTypeInfo]`
+  - Define catalog file format: `data/instance_catalog/{cloud}.yaml` — list of instance type entries
+
+  **Must NOT do**:
+  - No cloud API calls in this task — just the data model and file loader
+  - No matching logic — that's Task 5
+
+  **Recommended Agent Profile**:
+  - **Category**: `quick`
+  - **Skills**: []
+
+  **Parallelization**:
+  - **Can Run In Parallel**: YES
+  - **Parallel Group**: Wave 1 (with Tasks 2, 3, 4)
+  - **Blocks**: Tasks 5, 6, 7, 8
+  - **Blocked By**: None
+
+  **References**:
+  - `sdcm/utils/cloud_sizes.py:42-70` — existing InstanceSpec dataclass to evolve from
+  - `defaults/` — YAML file loading patterns used in SCT
+
+  **Acceptance Criteria**:
+  - [ ] Test file: `unit_tests/unit/test_instance_catalog.py`
+  - [ ] `pytest unit_tests/unit/test_instance_catalog.py` → PASS
+
+  **QA Scenarios**:
+  ```
+  Scenario: Load catalog from YAML file
+    Tool: Bash (python)
+    Steps:
+      1. Create temp YAML with 3 instance entries
+      2. Load with InstanceCatalog.from_file(path)
+      3. Assert len(catalog.instances) == 3
+      4. Assert first entry has correct vcpus/memory
+    Expected Result: All fields correctly deserialized
+    Evidence: .sisyphus/evidence/task-1-load-catalog.txt
+
+  Scenario: Empty catalog file
+    Tool: Bash (python)
+    Steps:
+      1. Load empty YAML file
+      2. Assert catalog.instances == []
+    Expected Result: No error, empty list
+    Evidence: .sisyphus/evidence/task-1-empty-catalog.txt
+  ```
+
+  **Commit**: YES
+  - Message: `feature(sizing): add instance catalog data model`
+  - Files: `sdcm/utils/instance_catalog.py`, `unit_tests/unit/test_instance_catalog.py`
+
+- [ ] 2. Constraint parser module
+
+  **What to do**:
+  - Create constraint parsing in `sdcm/utils/instance_matcher.py`
+  - Parse dict format: `{"vcpu": 16, "memory": ">20gb", "disk": "500gb-2tb", "arch": "arm64"}`
+  - Parse flat string format: `"vcpu=16,memory=>20gb,disk=500gb-2tb,arch=arm64"`
+  - Supported operators: exact (`16`), gt (`>16`), lt (`<16`), gte (`>=16`), range (`10-30`)
+  - Supported units: gb, tb (for memory/disk); plain int for vcpu
+  - Special fields: `arch` accepts "arm64" or "x86_64" (optional — if omitted, uses cloud default)
+  - Output: list of `Constraint(field, operator, value)` objects
+  - Handle edge cases: whitespace, case-insensitive units, missing fields (optional)
+
+  **Must NOT do**:
+  - No matching against catalog — just parsing
+  - No sct_config integration
+
+  **Recommended Agent Profile**:
+  - **Category**: `deep`
+  - **Skills**: []
+
+  **Parallelization**:
+  - **Can Run In Parallel**: YES
+  - **Parallel Group**: Wave 1 (with Tasks 1, 3, 4)
+  - **Blocks**: Task 5
+  - **Blocked By**: None
+
+  **References**:
+  - No direct codebase reference — new module
+  - Python `re` module for parsing expressions
+
+  **Acceptance Criteria**:
+  - [ ] Test file: `unit_tests/unit/test_instance_matcher.py`
+  - [ ] `pytest unit_tests/unit/test_instance_matcher.py -k parse` → PASS (20+ parametrized cases)
+
+  **QA Scenarios**:
+  ```
+  Scenario: Parse YAML dict constraints
+    Tool: Bash (python)
+    Steps:
+      1. parse_constraints({"vcpu": 16, "memory": ">20gb"})
+      2. Assert 2 constraints returned
+      3. Assert vcpu constraint: field="vcpus", op="eq", value=16
+      4. Assert memory constraint: field="memory_gb", op="gt", value=20.0
+    Expected Result: Correct Constraint objects
+    Evidence: .sisyphus/evidence/task-2-parse-dict.txt
+
+  Scenario: Parse flat string (env var format)
+    Tool: Bash (python)
+    Steps:
+      1. parse_constraints("vcpu=16,memory=>20gb,disk=500gb-2tb")
+      2. Assert 3 constraints
+      3. Assert disk constraint: field="local_disk_gb", op="range", value=(500, 2048)
+    Expected Result: String parsed identically to dict
+    Evidence: .sisyphus/evidence/task-2-parse-string.txt
+
+  Scenario: Invalid constraint raises ValueError
+    Tool: Bash (python)
+    Steps:
+      1. parse_constraints({"vcpu": "abc"}) → expect ValueError
+      2. parse_constraints("invalid_format") → expect ValueError
+    Expected Result: Clear error message
+    Evidence: .sisyphus/evidence/task-2-parse-error.txt
+  ```
+
+  **Commit**: YES
+  - Message: `feature(sizing): add constraint parser with range/comparison support`
+  - Files: `sdcm/utils/instance_matcher.py`, `unit_tests/unit/test_instance_matcher.py`
+
+- [ ] 3. Catalog file format and loader
+
+  **What to do**:
+  - Create `data/instance_catalog/` directory
+  - Create initial curated catalog files: `aws.yaml`, `gce.yaml`, `azure.yaml`, `oci.yaml`
+  - Populate with current families we use (from existing SIZING dict data):
+    - AWS: i8g, i4i, c6i, m6i, t3
+    - GCE: z3-highmem, e2-standard, e2-highcpu, n2-highmem
+    - Azure: Standard_L*s_v4, Standard_F*s_v2, Standard_D*_v4
+    - OCI: DenseIO.E5.Flex, VM.Standard3.Flex, VM.Standard.E4.Flex
+  - Each entry: instance_type, family, vcpus, memory_gb, local_disk_gb, local_disk_count, arch, price_per_hour (null initially)
+  - Add `preferred_families` section per role in each file
+
+  **Must NOT do**:
+  - No API calls — manual curation from existing SIZING dict
+  - No pricing data yet (null/0) — filled by Task 6-8
+
+  **Recommended Agent Profile**:
+  - **Category**: `quick`
+  - **Skills**: []
+
+  **Parallelization**:
+  - **Can Run In Parallel**: YES
+  - **Parallel Group**: Wave 1 (with Tasks 1, 2, 4)
+  - **Blocks**: Tasks 6, 7, 8
+  - **Blocked By**: None
+
+  **References**:
+  - `sdcm/utils/cloud_sizes.py:80-220` — existing SIZING dict with all instance types and specs
+
+  **Acceptance Criteria**:
+  - [ ] `data/instance_catalog/aws.yaml` has all i8g/i4i/c6i/m6i/t3 entries
+  - [ ] YAML files are valid and loadable by Task 1's InstanceCatalog
+
+  **QA Scenarios**:
+  ```
+  Scenario: Catalog files are valid YAML
+    Tool: Bash (python)
+    Steps:
+      1. yaml.safe_load each file in data/instance_catalog/
+      2. Assert no parse errors
+      3. Assert each has "instances" key with list
+    Expected Result: All 4 files load cleanly
+    Evidence: .sisyphus/evidence/task-3-valid-yaml.txt
+  ```
+
+  **Commit**: YES
+  - Message: `feature(sizing): add curated instance catalog data files`
+  - Files: `data/instance_catalog/*.yaml`
+
+- [ ] 4. Preferred families configuration
+
+  **What to do**:
+  - Define preferred family ordering per role per cloud in catalog files or separate config
+  - Structure: `{role: {cloud: [family1, family2, ...]}}` — ordered by preference (first = best)
+  - Defaults:
+    - db/aws: ["i8g", "i4i"] (ARM preferred, x86 fallback)
+    - db/gce: ["z3-highmem"]
+    - db/azure: ["Standard_L"]
+    - db/oci: ["DenseIO.E5"]
+    - loader/aws: ["c6i"]
+    - loader/gce: ["e2-standard", "e2-highcpu"]
+    - monitor/aws: ["t3", "m6i"]
+  - Include arch preference per cloud (aws defaults to arm64, others x86_64)
+
+  **Must NOT do**:
+  - No matching logic — just the config data
+
+  **Recommended Agent Profile**:
+  - **Category**: `quick`
+  - **Skills**: []
+
+  **Parallelization**:
+  - **Can Run In Parallel**: YES
+  - **Parallel Group**: Wave 1 (with Tasks 1, 2, 3)
+  - **Blocks**: Task 5
+  - **Blocked By**: None
+
+  **References**:
+  - `sdcm/utils/cloud_sizes.py:80-90` — current family choices per role
+
+  **Acceptance Criteria**:
+  - [ ] Config loadable from file
+  - [ ] All current roles/clouds have family preferences defined
+
+  **QA Scenarios**:
+  ```
+  Scenario: Load preferred families
+    Tool: Bash (python)
+    Steps:
+      1. Load config
+      2. Assert db/aws first family is "i8g"
+      3. Assert loader/aws first family is "c6i"
+    Expected Result: Correct ordering
+    Evidence: .sisyphus/evidence/task-4-families.txt
+  ```
+
+  **Commit**: grouped with Task 3
+
+- [ ] 5. Matching engine
+
+  **What to do**:
+  - In `sdcm/utils/instance_matcher.py`, add `select_instance(catalog, role, cloud, constraints, arch=None) -> InstanceTypeInfo`
+  - Algorithm:
+    1. Filter catalog by cloud
+    2. Filter by arch: if `arch` constraint specified, use it; otherwise use cloud default (aws=arm64, others=x86_64)
+    3. Filter by preferred families for the role (ordered)
+    4. Apply constraint filters (vcpu, memory, disk)
+    5. Sort remaining by: family preference order → price → vcpu (ascending)
+    6. Return first match (deterministic)
+  - If no match: raise `NoMatchingInstanceError` with details of unsatisfied constraints
+  - For db role: implicitly add `local_disk_count > 0` unless user explicitly sets `local_disk: false`
+
+  **Must NOT do**:
+  - No sct_config wiring — standalone module
+  - No cloud API calls
+
+  **Recommended Agent Profile**:
+  - **Category**: `deep`
+  - **Skills**: []
+
+  **Parallelization**:
+  - **Can Run In Parallel**: NO
+  - **Parallel Group**: Wave 2
+  - **Blocks**: Tasks 9, 10
+  - **Blocked By**: Tasks 1, 2, 4
+
+  **References**:
+  - `sdcm/utils/cloud_sizes.py:240-280` — existing `resolve_size()` for comparison
+  - `sdcm/utils/instance_catalog.py` (Task 1) — data model
+  - `sdcm/utils/instance_matcher.py` (Task 2) — constraint parser
+
+  **Acceptance Criteria**:
+  - [ ] `pytest unit_tests/unit/test_instance_matcher.py -k select` → PASS (15+ cases)
+  - [ ] Deterministic: same input always same output
+  - [ ] NoMatchingInstanceError raised with descriptive message
+
+  **QA Scenarios**:
+  ```
+  Scenario: Select db instance on AWS with vcpu constraint
+    Tool: Bash (python)
+    Steps:
+      1. Load catalog with i8g.large(2vcpu), i8g.2xlarge(8vcpu), i8g.4xlarge(16vcpu)
+      2. select_instance(catalog, "db", "aws", {"vcpu": 8})
+      3. Assert result.instance_type == "i8g.2xlarge"
+    Expected Result: Exact match returned
+    Evidence: .sisyphus/evidence/task-5-select-exact.txt
+
+  Scenario: Range constraint selects smallest fitting
+    Tool: Bash (python)
+    Steps:
+      1. select_instance(catalog, "db", "aws", {"vcpu": ">4", "memory": "16gb-64gb"})
+      2. Assert result is i8g.2xlarge (8vcpu, 64gb) — smallest that fits
+    Expected Result: Smallest instance satisfying all constraints
+    Evidence: .sisyphus/evidence/task-5-select-range.txt
+
+  Scenario: No match raises clear error
+    Tool: Bash (python)
+    Steps:
+      1. select_instance(catalog, "db", "aws", {"vcpu": 1024})
+      2. Expect NoMatchingInstanceError
+      3. Assert error message contains "vcpu: 1024"
+    Expected Result: Descriptive error
+    Evidence: .sisyphus/evidence/task-5-no-match.txt
+  ```
+
+  **Commit**: YES
+  - Message: `feature(sizing): add instance matching engine with price-based selection`
+  - Files: `sdcm/utils/instance_matcher.py`, `unit_tests/unit/test_instance_matcher.py`
+
+- [ ] 6. Catalog generator — AWS
+
+  **What to do**:
+  - Create `sdcm/utils/catalog_generator.py` with `generate_aws_catalog(families, region) -> list[InstanceTypeInfo]`
+  - Use `boto3` `describe_instance_types` to get vcpu/memory/disk specs
+  - Use AWS Pricing API (`get_products`) to get on-demand hourly pricing
+  - Filter to specified families only (i8g, i4i, c6i, m6i, t3)
+  - Output: write `data/instance_catalog/aws.yaml`
+  - CLI entry: `sct.py update-catalog --cloud aws`
+
+  **Must NOT do**:
+  - No matching logic
+  - No GCE/Azure/OCI — separate tasks
+
+  **Recommended Agent Profile**:
+  - **Category**: `unspecified-high`
+  - **Skills**: []
+
+  **Parallelization**:
+  - **Can Run In Parallel**: YES
+  - **Parallel Group**: Wave 2 (with Tasks 5, 7, 8)
+  - **Blocks**: Task 10
+  - **Blocked By**: Tasks 1, 3
+
+  **References**:
+  - `sdcm/utils/aws_utils.py` — existing boto3 usage patterns
+  - AWS Pricing API: `us-east-1` region required
+
+  **Acceptance Criteria**:
+  - [ ] Integration test: `unit_tests/integration/test_catalog_generator.py::test_aws`
+  - [ ] Generated YAML matches expected format
+
+  **QA Scenarios**:
+  ```
+  Scenario: Generate AWS catalog for i8g family
+    Tool: Bash (python)
+    Preconditions: AWS credentials available
+    Steps:
+      1. generate_aws_catalog(["i8g"], region="us-east-1")
+      2. Assert result contains i8g.large, i8g.xlarge, etc.
+      3. Assert each has vcpus > 0, memory_gb > 0, price_per_hour > 0
+    Expected Result: Valid catalog entries with pricing
+    Evidence: .sisyphus/evidence/task-6-aws-catalog.txt
+  ```
+
+  **Commit**: YES
+  - Message: `feature(sizing): add AWS catalog generator with pricing`
+  - Files: `sdcm/utils/catalog_generator.py`, `unit_tests/integration/test_catalog_generator.py`
+
+- [ ] 7. Catalog generator — GCE
+
+  **What to do**:
+  - Add `generate_gce_catalog(families, project, zone) -> list[InstanceTypeInfo]`
+  - Use `gcloud compute machine-types list` or `google-cloud-compute` Python SDK
+  - Use GCE Billing API or `gcloud billing` for pricing
+  - Filter to: z3-highmem, e2-standard, e2-highcpu, n2-highmem
+  - Output: `data/instance_catalog/gce.yaml`
+
+  **Recommended Agent Profile**:
+  - **Category**: `unspecified-high`
+  - **Skills**: []
+
+  **Parallelization**:
+  - **Can Run In Parallel**: YES
+  - **Parallel Group**: Wave 2 (with Tasks 5, 6, 8)
+  - **Blocks**: Task 10
+  - **Blocked By**: Tasks 1, 3
+
+  **References**:
+  - `sdcm/utils/gce_utils.py` — existing GCE patterns
+
+  **Acceptance Criteria**:
+  - [ ] Integration test: `test_catalog_generator.py::test_gce`
+
+  **QA Scenarios**:
+  ```
+  Scenario: Generate GCE catalog for z3-highmem
+    Tool: Bash (python)
+    Preconditions: GCE credentials available
+    Steps:
+      1. generate_gce_catalog(["z3-highmem"], project="...", zone="us-east1-b")
+      2. Assert z3-highmem-4, z3-highmem-8, etc. present
+      3. Assert local_disk_count > 0 for z3 family
+    Expected Result: Valid entries with disk info
+    Evidence: .sisyphus/evidence/task-7-gce-catalog.txt
+  ```
+
+  **Commit**: grouped with Task 6
+
+- [ ] 8. Catalog generator — Azure + OCI
+
+  **What to do**:
+  - Add `generate_azure_catalog(families, region)` — Azure Retail Prices REST API (no SDK needed)
+  - Add `generate_oci_catalog(families, compartment)` — OCI SDK or REST
+  - Azure families: Standard_L, Standard_F, Standard_D
+  - OCI families: DenseIO.E5, VM.Standard3, VM.Standard.E4
+  - Output: `data/instance_catalog/azure.yaml`, `data/instance_catalog/oci.yaml`
+
+  **Recommended Agent Profile**:
+  - **Category**: `unspecified-high`
+  - **Skills**: []
+
+  **Parallelization**:
+  - **Can Run In Parallel**: YES
+  - **Parallel Group**: Wave 2 (with Tasks 5, 6, 7)
+  - **Blocks**: Task 10
+  - **Blocked By**: Tasks 1, 3
+
+  **References**:
+  - `sdcm/utils/azure_utils.py` — existing Azure patterns
+  - Azure Retail Prices: `https://prices.azure.com/api/retail/prices`
+
+  **Acceptance Criteria**:
+  - [ ] Integration test: `test_catalog_generator.py::test_azure`, `test_catalog_generator.py::test_oci`
+
+  **QA Scenarios**:
+  ```
+  Scenario: Generate Azure catalog
+    Tool: Bash (python)
+    Steps:
+      1. generate_azure_catalog(["Standard_L"], region="eastus")
+      2. Assert Standard_L4s_v4, Standard_L8s_v4, etc. present
+    Expected Result: Valid entries with pricing
+    Evidence: .sisyphus/evidence/task-8-azure-catalog.txt
+  ```
+
+  **Commit**: grouped with Task 6
+
+- [ ] 9. Wire into sct_config.py
+
+  **What to do**:
+  - Modify `_resolve_instance_sizes()` to detect constraint syntax:
+    - If value is a `dict` → parse as constraints, call `select_instance()`
+    - If value is a `str` matching flat constraint format (`vcpu=...`) → parse + select
+    - If value is a `str` that looks like an instance type (contains `.` or `-`) → passthrough (backward compat)
+    - If backend is docker/baremetal → skip resolution entirely
+  - Load `InstanceCatalog` at config init (from `data/instance_catalog/`)
+  - Resolved instance type flows into existing params (`instance_type_db`, `gce_instance_type_db`, etc.)
+  - All 5 roles: db, db_oracle, zero_token, loader, monitor
+
+  **Must NOT do**:
+  - No changes to downstream provisioning — output is still a string
+  - No changes to `verify_configuration()` beyond validating constraint syntax
+
+  **Recommended Agent Profile**:
+  - **Category**: `deep`
+  - **Skills**: []
+
+  **Parallelization**:
+  - **Can Run In Parallel**: NO
+  - **Parallel Group**: Wave 3
+  - **Blocks**: Tasks 11, 12
+  - **Blocked By**: Task 5
+
+  **References**:
+  - `sdcm/sct_config.py:3076-3151` — existing `_resolve_instance_sizes()` to replace
+  - `sdcm/sct_config.py:3090-3105` — `_primary_param_overrides` for zero_token naming
+
+  **Acceptance Criteria**:
+  - [ ] `pytest unit_tests/unit/test_config.py -k resolve_instance` → PASS
+  - [ ] Literal string `instance_type_db: 'i4i.large'` still works unchanged
+  - [ ] Dict `db_instance_type: {vcpu: 8}` resolves to correct type
+
+  **QA Scenarios**:
+  ```
+  Scenario: Constraint dict resolves to correct instance
+    Tool: Bash (python)
+    Steps:
+      1. Create config with db_instance_type: {vcpu: 8, memory: ">16gb"}
+      2. Load SCTConfiguration with backend=aws
+      3. Assert self["instance_type_db"] == "i8g.2xlarge"
+    Expected Result: Resolved to ARM 8-vcpu instance
+    Evidence: .sisyphus/evidence/task-9-constraint-resolve.txt
+
+  Scenario: Literal string passthrough
+    Tool: Bash (python)
+    Steps:
+      1. Create config with db_instance_type: "i4i.large"
+      2. Load SCTConfiguration with backend=aws
+      3. Assert self["instance_type_db"] == "i4i.large"
+    Expected Result: No catalog lookup, direct passthrough
+    Evidence: .sisyphus/evidence/task-9-passthrough.txt
+
+  Scenario: Docker backend skips resolution
+    Tool: Bash (python)
+    Steps:
+      1. Create config with db_instance_type: {vcpu: 8}, backend=docker
+      2. Load SCTConfiguration
+      3. Assert no error, instance_type_db unchanged
+    Expected Result: Silent skip
+    Evidence: .sisyphus/evidence/task-9-docker-skip.txt
+  ```
+
+  **Commit**: YES
+  - Message: `feature(sizing): wire constraint-based selector into sct_config`
+  - Files: `sdcm/sct_config.py`, `unit_tests/unit/test_config.py`
+
+- [ ] 10. CLI commands
+
+  **What to do**:
+  - Add `sct.py show-prices --cloud <cloud> --role <role> [--family <family>]` — tabular pricing display
+  - Add `sct.py update-catalog [--cloud <cloud>]` — runs catalog generator scripts
+  - Update `sct.py show-sizes` to show constraint-based entries
+  - Update `sct.py translate-size` to accept constraint format and show resolved types per cloud
+
+  **Recommended Agent Profile**:
+  - **Category**: `unspecified-high`
+  - **Skills**: []
+
+  **Parallelization**:
+  - **Can Run In Parallel**: YES (with Task 9 if no dependency conflicts)
+  - **Parallel Group**: Wave 3
+  - **Blocks**: Task 12
+  - **Blocked By**: Tasks 5, 6-8
+
+  **References**:
+  - `sct.py:2774-2900` — existing `show-sizes` and `translate-size` commands
+
+  **Acceptance Criteria**:
+  - [ ] `sct.py show-prices --cloud aws --role db` outputs table with price column
+  - [ ] `sct.py update-catalog --cloud aws` generates valid catalog file
+
+  **QA Scenarios**:
+  ```
+  Scenario: show-prices displays table
+    Tool: interactive_bash (tmux)
+    Steps:
+      1. Run: uv run sct.py show-prices --cloud aws --role db
+      2. Assert output contains "i8g" and "$" price column
+    Expected Result: Formatted table with pricing
+    Evidence: .sisyphus/evidence/task-10-show-prices.txt
+  ```
+
+  **Commit**: YES
+  - Message: `feature(sizing): add show-prices CLI and update show-sizes/translate-size`
+  - Files: `sct.py`
+
+- [ ] 11. Migrate test configs
+
+  **What to do**:
+  - Update longevity test configs (12 files in `test-cases/longevity/`) from T-shirt to constraint syntax
+  - Map: `db_instance_type: '2xlarge'` → `db_instance_type: {vcpu: 8, memory: ">16gb"}`
+  - Map: `loader_instance_type: 'small'` → `loader_instance_type: {vcpu: 4}`
+  - Map: `monitor_instance_type: 'small'` → `monitor_instance_type: {vcpu: 2}`
+  - Verify each migrated config resolves to same instance types as before
+
+  **Recommended Agent Profile**:
+  - **Category**: `quick`
+  - **Skills**: []
+
+  **Parallelization**:
+  - **Can Run In Parallel**: NO
+  - **Parallel Group**: Wave 3
+  - **Blocks**: Tasks 12, 13
+  - **Blocked By**: Task 9
+
+  **References**:
+  - `test-cases/longevity/` — 12 migrated config files
+
+  **Acceptance Criteria**:
+  - [ ] All configs resolve to same instance types as the old T-shirt mapping
+  - [ ] `sct.py translate-size --config <file> --backend aws` shows expected types
+
+  **QA Scenarios**:
+  ```
+  Scenario: Migrated config resolves identically
+    Tool: Bash
+    Steps:
+      1. For each migrated file, run translate-size and capture output
+      2. Compare against expected instance types from old SIZING dict
+    Expected Result: 1:1 match
+    Evidence: .sisyphus/evidence/task-11-migration-verify.txt
+  ```
+
+  **Commit**: YES
+  - Message: `refactor(sizing): migrate test configs from T-shirt to constraint syntax`
+  - Files: `test-cases/longevity/*.yaml`
+
+- [ ] 12. User documentation
+
+  **What to do**:
+  - Rewrite `docs/cross-cloud-sizing.md` for constraint-based system
+  - Sections: Overview, Syntax (YAML dict + env var), Constraint types, Selection algorithm, CLI tools, Examples, Migration guide
+  - Include mapping table: "old T-shirt → new constraints"
+  - Include **Demo & Quick Start** section:
+    - Minimal example: `db_instance_type: {vcpu: 8}` → what happens on each cloud
+    - Env var example: `export SCT_DB_INSTANCE_TYPE='vcpu=16,memory=>32gb'`
+    - Arch override example: `db_instance_type: {vcpu: 8, arch: "x86_64"}` forces i4i on AWS
+    - Multi-role example showing db + loader + monitor in one config file
+    - `sct.py show-prices --cloud aws --role db` output screenshot/example
+    - `sct.py translate-size --config my-test.yaml` showing per-cloud resolution
+    - Error case: what happens when no instance matches (error message example)
+  - Include **Constraint Reference** section:
+    - Table of all constraint fields: vcpu, memory, disk, arch
+    - Operators per field: exact, >, <, >=, range
+    - Units: gb, tb (auto-converted)
+    - Defaults when omitted (arch per cloud, local_disk for db role)
+  - Include **Selection Algorithm** section (user-facing explanation):
+    - How preferred families work
+    - How tie-breaking works (family order → price → vcpu ascending)
+    - How to inspect what was selected: `translate-size` output
+  - Include **Catalog Management** section:
+    - How to update catalog: `sct.py update-catalog`
+    - Where catalog files live: `data/instance_catalog/`
+    - How to add a new instance family manually
+
+  **Recommended Agent Profile**:
+  - **Category**: `writing`
+  - **Skills**: []
+
+  **Parallelization**:
+  - **Can Run In Parallel**: YES (with Task 13)
+  - **Parallel Group**: Wave 4
+  - **Blocks**: None
+  - **Blocked By**: Tasks 9, 10
+
+  **Acceptance Criteria**:
+  - [ ] Doc covers all constraint types with examples
+  - [ ] Migration table present
+
+  **Commit**: YES
+  - Message: `docs(sizing): update cross-cloud sizing guide for constraint-based selection`
+  - Files: `docs/cross-cloud-sizing.md`
+
+- [ ] 13. Remove old T-shirt sizing code
+
+  **What to do**:
+  - Remove `SIZING` dict from `sdcm/utils/cloud_sizes.py`
+  - Remove `resolve_size()`, `identify_size()`, `SizeMapping` — replaced by catalog + matcher
+  - Keep `get_cloud_params()` if still needed, or inline into new matcher
+  - Update imports across codebase
+  - Remove old `unit_tests/unit/test_cloud_sizes.py`
+
+  **Recommended Agent Profile**:
+  - **Category**: `quick`
+  - **Skills**: []
+
+  **Parallelization**:
+  - **Can Run In Parallel**: YES (with Task 12)
+  - **Parallel Group**: Wave 4
+  - **Blocks**: None
+  - **Blocked By**: Task 11
+
+  **Acceptance Criteria**:
+  - [ ] No references to `resolve_size` or `SIZING` remain
+  - [ ] All tests pass after removal
+
+  **Commit**: YES
+  - Message: `refactor(sizing): remove deprecated T-shirt sizing code`
+  - Files: `sdcm/utils/cloud_sizes.py` (gutted), `unit_tests/unit/test_cloud_sizes.py` (removed)
+
+---
+
+## Final Verification Wave
+
+- [ ] F1. **Plan Compliance Audit** — `oracle`
+  Read the plan end-to-end. For each "Must Have": verify implementation exists. For each "Must NOT Have": search codebase for forbidden patterns. Check evidence files exist.
+  Output: `Must Have [N/N] | Must NOT Have [N/N] | VERDICT`
+
+- [ ] F2. **Code Quality Review** — `unspecified-high`
+  Run ruff + pytest. Review all changed files for type safety, error handling, unused imports. Check no AI slop.
+  Output: `Build [PASS/FAIL] | Tests [N pass/N fail] | VERDICT`
+
+- [ ] F3. **Real QA** — `unspecified-high`
+  Execute every QA scenario from every task. Test cross-task integration. Save evidence.
+  Output: `Scenarios [N/N pass] | VERDICT`
+
+- [ ] F4. **Scope Fidelity Check** — `deep`
+  Verify 1:1 match between plan spec and actual implementation. Flag scope creep.
+  Output: `Tasks [N/N compliant] | VERDICT`
+
+---
+
+## Commit Strategy
+
+- **1**: `feature(sizing): add instance catalog data model` — instance_catalog.py
+- **2**: `feature(sizing): add constraint parser with range/comparison support` — instance_matcher.py (parser part)
+- **3**: `feature(sizing): add instance matching engine with price-based selection` — instance_matcher.py (matcher part)
+- **4**: `feature(sizing): add catalog generation scripts for AWS/GCE/Azure/OCI` — catalog_generator.py + data/
+- **5**: `feature(sizing): wire constraint-based selector into sct_config` — sct_config.py
+- **6**: `feature(sizing): add show-prices CLI and update show-sizes/translate-size` — sct.py
+- **7**: `refactor(sizing): migrate test configs from T-shirt to constraint syntax` — test-cases/
+- **8**: `docs(sizing): update cross-cloud sizing guide for constraint-based selection` — docs/
+- **9**: `refactor(sizing): remove deprecated T-shirt sizing code` — cloud_sizes.py cleanup
+
+---
+
+## Success Criteria
+
+### Verification Commands
+```bash
+python -m pytest unit_tests/unit/test_instance_catalog.py -v  # catalog model tests
+python -m pytest unit_tests/unit/test_instance_matcher.py -v  # parser + matcher tests
+python -m pytest unit_tests/unit/test_config.py -v  # integration with sct_config
+python -m pytest unit_tests/integration/test_catalog_generator.py -v  # API tests
+uv run sct.py show-prices --cloud aws --role db  # CLI works
+```
+
+### Final Checklist
+- [ ] All "Must Have" present
+- [ ] All "Must NOT Have" absent
+- [ ] All tests pass
+- [ ] Literal string backward compat verified
+- [ ] All 5 roles work with constraint syntax
+- [ ] Docker backend silently skips resolution

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,6 +130,11 @@ export SCT_REUSE_CLUSTER=$(cat ~/sct-results/latest/test_id)
 - `configurations/` - Reusable configuration fragments
 - `defaults/` - Default configuration values
 - Configuration precedence: CLI args > Environment vars > Config files > Defaults
+- **Cross-Cloud Instance Sizing:**
+  - Abstract T-shirt sizes (e.g., `db_instance_type: '2xlarge'`) resolve to cloud-specific instance types
+  - See `docs/cross-cloud-sizing.md` for the full mapping table and usage guide
+  - Implementation: `sdcm/utils/cloud_sizes.py`, `sdcm/sct_config.py` (`_resolve_instance_sizes()`)
+  - CLI: `sct.py show-sizes`, `sct.py translate-size`
 
 **Backends Supported:**
 - `aws` - Amazon Web Services (primary backend)

--- a/defaults/aws_config.yaml
+++ b/defaults/aws_config.yaml
@@ -3,8 +3,6 @@ instance_provision_fallback_on_demand: true
 region_name:
   - eu-west-1
 user_credentials_path: '~/.ssh/scylla_test_id_ed25519'
-instance_type_loader: 'c6i.xlarge'
-instance_type_monitor: 't3.large'
 ami_id_loader: 'resolve:ssm:/aws/service/canonical/ubuntu/server/24.04/stable/current/amd64/hvm/ebs-gp3/ami-id'
 # manual on updating monitor images see: docs/monitoring-images.md
 ami_id_monitor: 'scylladb-monitor-4-14-1-2026-02-25t09-17-49z'

--- a/defaults/azure_config.yaml
+++ b/defaults/azure_config.yaml
@@ -6,8 +6,6 @@ azure_region_name:
 user_credentials_path: '~/.ssh/scylla_test_id_ed25519'
 
 azure_instance_type_db: 'Standard_L8s_v3'
-azure_instance_type_loader: 'Standard_F4s_v2'
-azure_instance_type_monitor: 'Standard_D2_v4'
 # base on version 24.04 LTS documented here:
 # https://documentation.ubuntu.com/azure/azure-how-to/instances/find-ubuntu-images/#free-long-term-support-offers
 azure_image_loader: 'Canonical:ubuntu-24_04-lts:server:latest'

--- a/defaults/gce_config.yaml
+++ b/defaults/gce_config.yaml
@@ -9,11 +9,9 @@ gce_image_monitor: 'https://www.googleapis.com/compute/v1/projects/scylla-images
 
 gce_image_username: 'scylla-test'
 
-gce_instance_type_loader: 'e2-standard-2'
 gce_root_disk_type_loader: 'pd-standard'
 gce_n_local_ssd_disk_loader: 0
 
-gce_instance_type_monitor: 'n2-highmem-8'
 gce_root_disk_type_monitor: 'pd-standard'
 root_disk_size_monitor: 50
 gce_n_local_ssd_disk_monitor: 0

--- a/defaults/oci_config.yaml
+++ b/defaults/oci_config.yaml
@@ -9,11 +9,9 @@ instance_provision: "on_demand" # NOTE: DenseIO shapes cannot be 'spot'
 oci_region_name:
   - us-ashburn-1
 
-oci_instance_type_loader: "VM.Standard3.Flex:4:32"
 oci_image_loader: ""  # NOTE: Code will automatically take latest ubuntu:24.04
 ami_loader_user: 'ubuntu'
 
-oci_instance_type_monitor: "VM.Standard.E4.Flex:4:32"
 oci_image_monitor: ""  # NOTE: Code will automatically take latest ubuntu:24.04
 ami_monitor_user: 'ubuntu'
 

--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -366,3 +366,7 @@ agent:
   tls: false
 
 c_s_driver_version: '3'
+
+db_instance_type: ''
+loader_instance_type: ''
+monitor_instance_type: ''

--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -125,7 +125,6 @@ authenticator_password: ''
 n_test_oracle_db_nodes: 1
 oracle_scylla_version: '2026.1'
 append_scylla_args_oracle: '--enable-cache false'
-instance_type_db_oracle: 'i8g.2xlarge'
 run_gemini_in_rolling_upgrade: false
 
 # cassandra-stress defaults
@@ -278,7 +277,6 @@ assert_linux_distro_features: []
 skip_test_stages: {}
 
 n_db_zero_token_nodes: 0
-zero_token_instance_type_db: 'i4i.large'
 use_zero_nodes: false
 
 latte_schema_parameters: {}
@@ -368,5 +366,11 @@ agent:
 c_s_driver_version: '3'
 
 db_instance_type: ''
-loader_instance_type: ''
-monitor_instance_type: ''
+loader_instance_type: 'small'
+monitor_instance_type: 'small'
+oracle_instance_type: '2xlarge'
+zero_token_instance_type: 'large'
+gce_instance_type_db_oracle: ''
+gce_zero_token_instance_type_db: ''
+azure_zero_token_instance_type_db: ''
+oci_zero_token_instance_type_db: ''

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -1211,7 +1211,7 @@ AWS image type of the db node
 
 AWS image type of the oracle node
 
-**default:** i8g.2xlarge
+**default:** N/A
 
 **type:** str
 * appendable
@@ -1221,7 +1221,7 @@ AWS image type of the oracle node
 
 Abstract instance size for oracle DB nodes (e.g. '2xlarge', 'large'). Resolves to cloud-specific instance type based on active backend. Cloud-specific overrides (instance_type_db_oracle, gce_instance_type_db_oracle, etc.) take precedence when explicitly set by user.
 
-**default:** N/A
+**default:** 2xlarge
 
 **type:** str
 * appendable
@@ -1251,7 +1251,7 @@ Abstract instance size for DB nodes (e.g. '2xlarge', 'large'). Resolves to cloud
 
 Abstract instance size for loader nodes (e.g. '2xlarge', 'large'). Resolves to cloud-specific instance type based on active backend. Cloud-specific overrides take precedence when explicitly set by user.
 
-**default:** N/A
+**default:** small
 
 **type:** str
 * appendable
@@ -1261,7 +1261,7 @@ Abstract instance size for loader nodes (e.g. '2xlarge', 'large'). Resolves to c
 
 Abstract instance size for monitor nodes (e.g. '2xlarge', 'large'). Resolves to cloud-specific instance type based on active backend. Cloud-specific overrides take precedence when explicitly set by user.
 
-**default:** N/A
+**default:** small
 
 **type:** str
 * appendable
@@ -1941,7 +1941,7 @@ Number of zero token nodes in cluster. Value should be set as '0 1 1' for multid
 
 Instance type for zero token node
 
-**default:** i4i.large
+**default:** N/A
 
 **type:** str
 * appendable
@@ -1951,7 +1951,7 @@ Instance type for zero token node
 
 Abstract instance size for zero-token DB nodes (e.g. 'large'). Resolves to cloud-specific instance type based on active backend. Cloud-specific overrides (zero_token_instance_type_db, gce_zero_token_instance_type_db, etc.) take precedence when explicitly set by user.
 
-**default:** N/A
+**default:** large
 
 **type:** str
 * appendable

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -1227,6 +1227,36 @@ Target AWS instance type for platform migration (e.g., i8g.2xlarge for ARM)
 * appendable
 
 
+## **db_instance_type** / SCT_DB_INSTANCE_TYPE
+
+Abstract instance size for DB nodes (e.g. '2xlarge', 'large'). Resolves to cloud-specific instance type based on active backend. Cloud-specific overrides (instance_type_db, gce_instance_type_db, etc.) take precedence when explicitly set by user.
+
+**default:** N/A
+
+**type:** str
+* appendable
+
+
+## **loader_instance_type** / SCT_LOADER_INSTANCE_TYPE
+
+Abstract instance size for loader nodes (e.g. '2xlarge', 'large'). Resolves to cloud-specific instance type based on active backend. Cloud-specific overrides take precedence when explicitly set by user.
+
+**default:** N/A
+
+**type:** str
+* appendable
+
+
+## **monitor_instance_type** / SCT_MONITOR_INSTANCE_TYPE
+
+Abstract instance size for monitor nodes (e.g. '2xlarge', 'large'). Resolves to cloud-specific instance type based on active backend. Cloud-specific overrides take precedence when explicitly set by user.
+
+**default:** N/A
+
+**type:** str
+* appendable
+
+
 ## **instance_type_runner** / SCT_INSTANCE_TYPE_RUNNER
 
 instance type of the sct-runner node

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -1217,6 +1217,16 @@ AWS image type of the oracle node
 * appendable
 
 
+## **oracle_instance_type** / SCT_ORACLE_INSTANCE_TYPE
+
+Abstract instance size for oracle DB nodes (e.g. '2xlarge', 'large'). Resolves to cloud-specific instance type based on active backend. Cloud-specific overrides (instance_type_db_oracle, gce_instance_type_db_oracle, etc.) take precedence when explicitly set by user.
+
+**default:** N/A
+
+**type:** str
+* appendable
+
+
 ## **instance_type_db_target** / SCT_INSTANCE_TYPE_DB_TARGET
 
 Target AWS instance type for platform migration (e.g., i8g.2xlarge for ARM)
@@ -1937,6 +1947,16 @@ Instance type for zero token node
 * appendable
 
 
+## **zero_token_instance_type** / SCT_ZERO_TOKEN_INSTANCE_TYPE
+
+Abstract instance size for zero-token DB nodes (e.g. 'large'). Resolves to cloud-specific instance type based on active backend. Cloud-specific overrides (zero_token_instance_type_db, gce_zero_token_instance_type_db, etc.) take precedence when explicitly set by user.
+
+**default:** N/A
+
+**type:** str
+* appendable
+
+
 ## **sct_aws_account_id** / SCT_SCT_AWS_ACCOUNT_ID
 
 AWS account id on behalf of which the test is run
@@ -1987,6 +2007,26 @@ Number of local SSD disks for monitor nodes in Google Compute Engine
 ## **gce_instance_type_db** / SCT_GCE_INSTANCE_TYPE_DB
 
 Instance type for database nodes in Google Compute Engine
+
+**default:** N/A
+
+**type:** str
+* appendable
+
+
+## **gce_instance_type_db_oracle** / SCT_GCE_INSTANCE_TYPE_DB_ORACLE
+
+GCE instance type for oracle DB nodes.
+
+**default:** N/A
+
+**type:** str
+* appendable
+
+
+## **gce_zero_token_instance_type_db** / SCT_GCE_ZERO_TOKEN_INSTANCE_TYPE_DB
+
+GCE instance type for zero-token DB nodes.
 
 **default:** N/A
 
@@ -2107,6 +2147,16 @@ The Azure virtual machine size to be used for Oracle database nodes.
 * appendable
 
 
+## **azure_zero_token_instance_type_db** / SCT_AZURE_ZERO_TOKEN_INSTANCE_TYPE_DB
+
+Azure instance type for zero-token DB nodes.
+
+**default:** N/A
+
+**type:** str
+* appendable
+
+
 ## **azure_image_db** / SCT_AZURE_IMAGE_DB
 
 The Azure image to be used for database nodes.
@@ -2189,6 +2239,16 @@ Oracle Cloud instance shape to use for DB node(s). Usage of flex shapes allows s
 ## **oci_instance_type_db_oracle** / SCT_OCI_INSTANCE_TYPE_DB_ORACLE
 
 Oracle Cloud instance shape to use for 'oracle' (2nd ref cluster) ScylladbDB cluster
+
+**default:** N/A
+
+**type:** str
+* appendable
+
+
+## **oci_zero_token_instance_type_db** / SCT_OCI_ZERO_TOKEN_INSTANCE_TYPE_DB
+
+OCI instance type for zero-token DB nodes.
 
 **default:** N/A
 

--- a/docs/cross-cloud-sizing.md
+++ b/docs/cross-cloud-sizing.md
@@ -1,0 +1,100 @@
+# Cross-Cloud Instance Sizing
+
+SCT supports abstract T-shirt instance sizes that automatically resolve to cloud-specific instance types based on the active backend. This abstraction enables cloud-agnostic test configurations and easier cross-cloud comparisons.
+
+## Overview
+
+Historically, SCT test configurations required specifying exact instance types for each cloud backend. As SCT expanded to support AWS, GCE, Azure, and OCI, this led to verbose configuration files.
+
+Cross-cloud sizing introduces canonical size names (like `2xlarge`) that map to equivalent hardware specifications across all supported providers.
+
+## Usage
+
+Instead of specifying multiple cloud-specific parameters:
+
+```yaml
+# Before: Multiple lines for different clouds
+instance_type_db: 'i4i.2xlarge'
+gce_instance_type_db: 'z3-highmem-16'
+gce_n_local_ssd_disk_db: 4
+azure_instance_type_db: 'Standard_L16s_v4'
+```
+
+You can use a single abstract size:
+
+```yaml
+# After: Single line resolves for all clouds
+db_instance_type: '2xlarge'
+```
+
+### Available Parameters
+
+The following parameters support abstract sizing:
+
+- `db_instance_type`: Abstract size for database nodes.
+- `loader_instance_type`: Abstract size for loader nodes.
+- `monitor_instance_type`: Abstract size for monitoring nodes.
+
+## Resolution Rules
+
+1. **Precedence**: If a cloud-specific parameter (e.g., `instance_type_db`, `gce_instance_type_db`) is explicitly set in the configuration, it takes precedence over the abstract size.
+2. **Resolution**: If an abstract size (e.g., `db_instance_type`) is set, it resolves to the cloud-specific parameters for the active backend.
+3. **Fallback**: If neither is set, the system falls back to the backend-specific defaults defined in the framework.
+4. **AWS Architecture**: On AWS, abstract sizes resolve to `i8g` (ARM/Graviton4) by default. To use x86 (`i4i`), set `aws_architecture: x86`.
+
+## Size Mapping Table
+
+### DB Role
+Storage-optimized instances with local NVMe SSDs.
+
+| Size | AWS ARM | AWS x86 | GCE | Azure | OCI |
+| :--- | :--- | :--- | :--- | :--- | :--- |
+| **large** | i8g.large | i4i.large | z3-highmem-4 | Standard_L4s_v4 | DenseIO.E5.Flex:2:32 |
+| **xlarge** | i8g.xlarge | i4i.xlarge | z3-highmem-8 | Standard_L8s_v4 | DenseIO.E5.Flex:4:64 |
+| **2xlarge** | i8g.2xlarge | i4i.2xlarge | z3-highmem-16 | Standard_L16s_v4 | DenseIO.E5.Flex:8:128 |
+| **4xlarge** | i8g.4xlarge | i4i.4xlarge | z3-highmem-32 | Standard_L32s_v4 | DenseIO.E5.Flex:16:256 |
+| **8xlarge** | i8g.8xlarge | i4i.8xlarge | z3-highmem-48 | Standard_L64s_v4 | DenseIO.E5.Flex:32:512 |
+| **16xlarge** | i8g.16xlarge | i4i.16xlarge | z3-highmem-88 | Standard_L80s_v4 | DenseIO.E5.Flex:64:1024 |
+
+### Loader Role
+Compute-optimized instances for stress tools.
+
+| Size | AWS (x86/ARM) | GCE | Azure | OCI |
+| :--- | :--- | :--- | :--- | :--- |
+| **small** | c6i.xlarge | e2-standard-4 | Standard_F4s_v2 | VM.Standard3.Flex:4:32 |
+| **medium** | c6i.2xlarge | e2-standard-8 | Standard_F8s_v2 | VM.Standard3.Flex:8:64 |
+| **large** | c6i.4xlarge | e2-standard-16 | Standard_F16s_v2 | VM.Standard3.Flex:16:128 |
+| **xlarge** | c6i.16xlarge | e2-highcpu-32 | Standard_F32s_v2 | VM.Standard3.Flex:32:256 |
+
+### Monitor Role
+General-purpose instances for the monitoring stack.
+
+| Size | AWS (x86/ARM) | GCE | Azure | OCI |
+| :--- | :--- | :--- | :--- | :--- |
+| **small** | t3.large | n2-highmem-4 | Standard_D2_v4 | VM.Standard.E4.Flex:2:16 |
+| **medium** | m6i.xlarge | n2-highmem-8 | Standard_D4_v4 | VM.Standard.E4.Flex:4:32 |
+| **large** | m6i.2xlarge | n2-highmem-16 | Standard_D8_v4 | VM.Standard.E4.Flex:8:64 |
+
+## CLI Tools
+
+The SCT CLI provides utilities to inspect and test size mappings.
+
+### show-sizes
+Displays the full mapping table for a given role.
+```bash
+uv run sct.py show-sizes --role db
+```
+
+### translate-size
+Shows how an abstract size resolves for a specific cloud.
+```bash
+uv run sct.py translate-size --role db --size 2xlarge --cloud gce
+```
+
+## Adding New Sizes
+
+To add a new size or modify existing mappings, edit `sdcm/utils/cloud_sizes.py`.
+
+1. Add the new size to the `SIZING` dictionary under the appropriate role.
+2. Define a `SizeMapping` with `InstanceSpec` for each cloud.
+3. If the instance requires special parameters (like GCE local SSDs), include them in the `InstanceSpec`.

--- a/docs/plans/MASTER.md
+++ b/docs/plans/MASTER.md
@@ -63,6 +63,7 @@ For plan writing guidelines, see [INSTRUCTIONS.md](INSTRUCTIONS.md).
 | SCT Config Validation and Lazy Images | `draft` | [sct-config-validation-and-lazy-images.md](sct-config-validation-and-lazy-images.md) |
 | SCT Config Follow-up Refactoring | `pending_pr` | [#13845](https://github.com/scylladb/scylla-cluster-tests/pull/13845) |
 | Config Type Normalization | `draft` | [config-type-normalization.md](config/config-type-normalization.md) |
+| Cross-Cloud Instance Sizing | `draft` | [cross-cloud-sizing.md](config/cross-cloud-sizing.md) |
 
 ### K8s — Kubernetes operator, K8s backends
 

--- a/docs/plans/assets/progress-roadmap.svg
+++ b/docs/plans/assets/progress-roadmap.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="840" height="884" viewBox="0 0 840 884">
 <rect width="840" height="884" fill="#0D1B2A" rx="8"/>
 <text x="420" y="60" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="22" font-weight="bold" fill="#00BCD4">SCT Implementation Plans</text>
-<text x="420" y="84" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="13" fill="#8899AA">27 plans across 8 domains</text>
+<text x="420" y="84" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="13" fill="#8899AA">28 plans across 8 domains</text>
 <rect x="30" y="120" width="780" height="50" rx="6" fill="#1B2A4A" stroke="#2A3F5F" stroke-width="1"/>
 <circle cx="50" cy="148" r="5" fill="#607D8B"/>
-<text x="60" y="152" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#E0E6ED">Draft: 17</text>
+<text x="60" y="152" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#E0E6ED">Draft: 18</text>
 <circle cx="180" cy="148" r="5" fill="#FFC107"/>
 <text x="190" y="152" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#E0E6ED">In Progress: 3</text>
 <circle cx="310" cy="148" r="5" fill="#2196F3"/>
@@ -16,12 +16,12 @@
 <circle cx="700" cy="148" r="5" fill="#9E9E9E"/>
 <text x="710" y="152" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#E0E6ED">Pending PR: 7</text>
 <rect x="40" y="175" width="760" height="20" rx="10" fill="#1B2A4A" stroke="#2A3F5F" stroke-width="1"/>
-<rect x="40" y="175" width="84.44444444444444" height="20" rx="10" fill="#FFC107"/>
-<text x="82.22222222222223" y="189" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="bold" fill="#0D1B2A">3</text>
-<rect x="124.44444444444444" y="175" width="478.51851851851853" height="20" rx="0" fill="#607D8B"/>
-<text x="363.7037037037037" y="189" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="bold" fill="#0D1B2A">17</text>
-<rect x="602.9629629629629" y="175" width="197.03703703703704" height="20" rx="0" fill="#9E9E9E"/>
-<text x="701.4814814814814" y="189" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="bold" fill="#0D1B2A">7</text>
+<rect x="40" y="175" width="81.42857142857143" height="20" rx="10" fill="#FFC107"/>
+<text x="80.71428571428572" y="189" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="bold" fill="#0D1B2A">3</text>
+<rect x="121.42857142857143" y="175" width="488.5714285714286" height="20" rx="0" fill="#607D8B"/>
+<text x="365.7142857142857" y="189" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="bold" fill="#0D1B2A">18</text>
+<rect x="610.0" y="175" width="190.0" height="20" rx="0" fill="#9E9E9E"/>
+<text x="705.0" y="189" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="bold" fill="#0D1B2A">7</text>
 <rect x="30" y="220" width="380" height="32" rx="4" fill="#1B2A4A" stroke="#00BCD4" stroke-width="1"/>
 <text x="42" y="241" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="bold" fill="#00BCD4">cluster</text>
 <text x="398" y="241" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#8899AA">7 plans</text>
@@ -48,7 +48,7 @@
 <text x="398" y="438" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#607D8B">Draft</text>
 <rect x="30" y="464" width="380" height="32" rx="4" fill="#1B2A4A" stroke="#00BCD4" stroke-width="1"/>
 <text x="42" y="485" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="bold" fill="#00BCD4">config</text>
-<text x="398" y="485" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#8899AA">5 plans</text>
+<text x="398" y="485" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#8899AA">6 plans</text>
 <circle cx="44" cy="510" r="4" fill="#9E9E9E"/>
 <text x="56" y="514" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">Resilient Test Config Dependencies</text>
 <text x="398" y="514" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#9E9E9E">Pending PR</text>
@@ -64,15 +64,18 @@
 <circle cx="44" cy="622" r="4" fill="#9E9E9E"/>
 <text x="56" y="626" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">SCT Config Follow-up Refactoring</text>
 <text x="398" y="626" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#9E9E9E">Pending PR</text>
-<rect x="30" y="652" width="380" height="32" rx="4" fill="#1B2A4A" stroke="#00BCD4" stroke-width="1"/>
-<text x="42" y="673" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="bold" fill="#00BCD4">ai-tooling</text>
-<text x="398" y="673" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#8899AA">2 plans</text>
-<circle cx="44" cy="698" r="4" fill="#607D8B"/>
-<text x="56" y="702" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">AI Skills Framework</text>
-<text x="398" y="702" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#607D8B">Draft</text>
-<circle cx="44" cy="726" r="4" fill="#FFC107"/>
-<text x="56" y="730" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">PR Review Taxonomy Analysis</text>
-<text x="398" y="730" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#FFC107">In Progress</text>
+<circle cx="44" cy="650" r="4" fill="#607D8B"/>
+<text x="56" y="654" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">Cross-Cloud Instance Sizing</text>
+<text x="398" y="654" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#607D8B">Draft</text>
+<rect x="30" y="680" width="380" height="32" rx="4" fill="#1B2A4A" stroke="#00BCD4" stroke-width="1"/>
+<text x="42" y="701" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="bold" fill="#00BCD4">ai-tooling</text>
+<text x="398" y="701" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#8899AA">2 plans</text>
+<circle cx="44" cy="726" r="4" fill="#607D8B"/>
+<text x="56" y="730" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">AI Skills Framework</text>
+<text x="398" y="730" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#607D8B">Draft</text>
+<circle cx="44" cy="754" r="4" fill="#FFC107"/>
+<text x="56" y="758" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">PR Review Taxonomy Analysis</text>
+<text x="398" y="758" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#FFC107">In Progress</text>
 <rect x="430" y="220" width="380" height="32" rx="4" fill="#1B2A4A" stroke="#00BCD4" stroke-width="1"/>
 <text x="442" y="241" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="bold" fill="#00BCD4">nemesis</text>
 <text x="798" y="241" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#8899AA">2 plans</text>

--- a/docs/plans/config/cross-cloud-sizing.md
+++ b/docs/plans/config/cross-cloud-sizing.md
@@ -1,0 +1,644 @@
+---
+status: draft
+domain: config
+created: 2026-05-03
+last_updated: 2026-05-03
+owner: fruch
+---
+
+# Cross-Cloud Instance Sizing Abstraction
+
+## 1. Problem Statement
+
+SCT test configurations use cloud-specific instance type parameters (`instance_type_db` for AWS,
+`gce_instance_type_db` for GCE, `azure_instance_type_db` for Azure, `oci_instance_type_db` for
+OCI). This creates two problems:
+
+1. **Duplication**: Every test YAML must repeat equivalent sizing for each cloud provider. PR #14439
+   documents that 185 of 234 test configs with AWS sizing lack GCE equivalents. Adding OCI and
+   Azure makes this a 4x duplication problem.
+
+2. **No portable sizing language**: There is no way to say "give me an 8-vCPU, 64 GB, local-SSD
+   database node" in a cloud-agnostic way. Each cloud uses its own naming scheme (`i4i.2xlarge`,
+   `z3-highmem-16`, `Standard_L8s_v3`, `DenseIO.E5.Flex`), forcing test authors to look up
+   equivalences manually and reviewers to validate them with external documentation.
+
+**This plan introduces a T-shirt sizing model** (e.g. `large`, `2xlarge`, `xlarge`) with
+per-role config parameters (`db_instance_type`, `loader_instance_type`, `monitor_instance_type`)
+that map bidirectionally to concrete cloud instance types. Test YAMLs can use either the abstract
+size or a cloud-specific override.
+
+## 2. Current State
+
+### Instance Type Configuration
+
+Each cloud backend has dedicated config parameters in `sdcm/sct_config.py`:
+
+| Role | AWS | GCE | Azure | OCI |
+|------|-----|-----|-------|-----|
+| DB | `instance_type_db` (L968) | `gce_instance_type_db` (L1236) | `azure_instance_type_db` (L1272) | `oci_instance_type_db` (L1310) |
+| Loader | `instance_type_loader` (L962) | `gce_instance_type_loader` (L1098) | `azure_instance_type_loader` (L1266) | `oci_instance_type_loader` (L1296) |
+| Monitor | `instance_type_monitor` (L965) | `gce_instance_type_monitor` (L1107) | `azure_instance_type_monitor` (L1269) | `oci_instance_type_monitor` (L1303) |
+
+### Default Instance Types per Cloud
+
+From `defaults/` YAML files:
+
+| Role | AWS | GCE | Azure | OCI |
+|------|-----|-----|-------|-----|
+| DB | *(none — set per test)* | `n2-highmem-8` | `Standard_L8s_v3` | *(none)* |
+| Loader | `c6i.xlarge` | `e2-standard-2` | `Standard_F4s_v2` | `VM.Standard3.Flex:4:32` |
+| Monitor | `t3.large` | `n2-highmem-8` | `Standard_D2_v4` | `VM.Standard.E4.Flex:4:32` |
+
+### GCE Disk Parameters
+
+GCE requires explicit disk config alongside instance type:
+- `gce_root_disk_type_db` (default: `pd-ssd`)
+- `gce_n_local_ssd_disk_db` (default: 4)
+- `gce_setup_hybrid_raid` (default: false)
+
+These have no AWS/Azure/OCI equivalents — they're baked into the instance family choice.
+
+### Existing Configuration Fragments
+
+`configurations/gce/` has per-instance-type fragments: `n2-highmem-8.yaml` through
+`n2-highmem-64.yaml`, plus `z3-highmem-8-highlssd.yaml`. No equivalent fragments exist for AWS,
+Azure, or OCI.
+
+### Config Validation
+
+`sdcm/sct_config.py` method `_instance_type_validation()` (L3670) validates
+`nemesis_grow_shrink_instance_type` per-backend. The backend-required parameter groups are defined
+at L2379:
+
+```python
+"aws": ["region_name", "instance_type_db"],
+"gce": ["gce_datacenter", "gce_instance_type_db"],
+```
+
+### No Existing Abstraction
+
+There is no T-shirt size concept, no cross-cloud mapping, and no translation layer anywhere in
+the codebase. PR #14439 proposes a static mapping document (`docs/gce-instance-type-mapping.md`)
+but not a programmatic translation.
+
+## 3. Goals
+
+1. Define a **T-shirt sizing vocabulary** using AWS-style size suffixes (`large`, `xlarge`,
+   `2xlarge`, `4xlarge`, `8xlarge`, `16xlarge`) as values for per-role config parameters.
+
+2. Create a **bidirectional mapping module** (`sdcm/utils/cloud_sizes.py`) that translates:
+   - Size + role + cloud -> concrete cloud instance type (+ disk params where needed)
+   - Concrete cloud instance type -> size (for reporting / display)
+
+3. Each cloud provider has a **default instance family** for DB nodes:
+   - AWS: `i8g` family (Graviton/ARM, default) and `i4i` family (x86 fallback)
+   - GCE: `z3-highmem` family (local NVMe, optimized for storage)
+   - Azure: `Standard_L*s_v4` family (storage-optimized v4)
+   - OCI: `DenseIO.E5` family
+
+   The mapping module automatically selects the correct family based on architecture
+   (ARM vs x86), detected from the AMI/image or overridden explicitly.
+
+4. Add **new config parameters** `db_instance_type`, `loader_instance_type`,
+   `monitor_instance_type` that accept abstract size values (`large`, `2xlarge`, etc.).
+   When set, they resolve to the correct cloud-specific type at config load time.
+   Cloud-specific overrides still take precedence.
+
+5. **Zero breaking changes**: All existing cloud-specific parameters continue to work unchanged.
+   The abstract sizing is opt-in.
+
+6. **AWS param naming alignment** (separate phase): Add `aws_instance_type_db`,
+   `aws_instance_type_loader`, `aws_instance_type_monitor` as aliases for the current
+   unprefixed `instance_type_db`, `instance_type_loader`, `instance_type_monitor` — making
+   the naming consistent across all clouds. The unprefixed names continue to work.
+
+6. This plan supersedes the static mapping approach proposed in PR #14439. PR #14439's
+   `docs/gce-instance-type-mapping.md` was never merged — the programmatic mapping here
+   replaces that approach entirely.
+
+### Demo: How It Works
+
+A typical longevity test YAML today (6+ lines of cloud-specific sizing):
+
+```yaml
+# Current: must specify every cloud explicitly
+instance_type_db: 'i4i.2xlarge'              # AWS
+gce_instance_type_db: 'z3-highmem-16'        # GCE
+gce_n_local_ssd_disk_db: 4
+gce_root_disk_type_db: 'pd-ssd'
+azure_instance_type_db: 'Standard_L16s_v4'   # Azure
+oci_instance_type_db: 'DenseIO.E5.Flex:8:128' # OCI
+
+instance_type_loader: 'c6i.2xlarge'
+gce_instance_type_loader: 'e2-standard-8'
+azure_instance_type_loader: 'Standard_F8s_v2'
+oci_instance_type_loader: 'VM.Standard3.Flex:8:64'
+
+instance_type_monitor: 't3.large'
+gce_instance_type_monitor: 'n2-highmem-4'
+azure_instance_type_monitor: 'Standard_D2_v4'
+oci_instance_type_monitor: 'VM.Standard.E4.Flex:2:16'
+```
+
+Becomes (3 lines, all clouds resolved automatically):
+
+```yaml
+# New: abstract sizing — automatically resolves per backend
+db_instance_type: '2xlarge'
+loader_instance_type: 'medium'
+monitor_instance_type: 'small'
+```
+
+When running with `--backend gce`, the config system resolves:
+- `db_instance_type: '2xlarge'` → `gce_instance_type_db: 'z3-highmem-16'` + `gce_n_local_ssd_disk_db: 4` + `gce_root_disk_type_db: 'pd-ssd'`
+- `loader_instance_type: 'medium'` → `gce_instance_type_loader: 'e2-standard-8'`
+- `monitor_instance_type: 'small'` → `gce_instance_type_monitor: 'n2-highmem-4'`
+
+When running with `--backend aws`:
+- `db_instance_type: '2xlarge'` → `instance_type_db: 'i4i.2xlarge'`
+- `loader_instance_type: 'medium'` → `instance_type_loader: 'c6i.2xlarge'`
+- `monitor_instance_type: 'small'` → `instance_type_monitor: 't3.large'`
+
+Cloud-specific overrides still win — if a test needs a specific non-default type:
+
+```yaml
+db_instance_type: '2xlarge'          # used for all clouds...
+instance_type_db: 'i3en.2xlarge'     # ...except AWS, which uses this instead
+```
+
+### Future Integration: Mixed Instance Type Clusters (PR #13427)
+
+> **NOTE**: PR #13427 has not yet landed. This section describes a *future* integration
+> opportunity, not a deliverable of this plan. No implementation work for `cluster_topology`
+> is included in Phases 1-5.
+
+PR [#13427](https://github.com/scylladb/scylla-cluster-tests/pull/13427) proposes a
+`cluster_topology` config for heterogeneous clusters with different instance types per rack/DC.
+If/when that PR lands, it currently requires cloud-specific instance types in rack definitions:
+
+```yaml
+# PR #13427 current syntax — cloud-specific
+cluster_topology:
+  - dc: dc1
+    racks:
+      - [i4i.large, i4i.2xlarge]       # AWS only
+      - [i4i.large, i4i.large]
+```
+
+With cross-cloud sizing, this could become backend-agnostic:
+
+```yaml
+# Future possibility — works on any cloud
+cluster_topology:
+  - dc: dc1
+    racks:
+      - [large, 2xlarge]
+      - [large, large]
+```
+
+The mapping module from Phase 1 provides the translation layer that `cluster_topology` could call
+to resolve abstract sizes to the active backend's concrete types. This is a natural future
+integration point — no work is required in this plan.
+
+## 4. Implementation Phases
+
+### Phase 1 — Sizing Data Model and Mapping Module
+
+**Scope:** New module `sdcm/utils/cloud_sizes.py`, unit tests
+
+**Description:**
+
+Create the core data model and mapping registry. The module defines:
+
+```python
+@dataclass
+class InstanceSpec:
+    """Concrete instance specification for one cloud."""
+    instance_type: str          # e.g. "i4i.2xlarge"
+    vcpus: int                  # e.g. 8
+    memory_gb: int              # e.g. 64
+    local_ssd_count: int = 0    # e.g. 4 (GCE local SSDs)
+    root_disk_type: str = ""    # e.g. "pd-ssd" (GCE)
+    extra_params: dict = field(default_factory=dict)  # cloud-specific overrides
+
+@dataclass
+class SizeMapping:
+    """One abstract size mapped to all clouds."""
+    aws: InstanceSpec
+    gce: InstanceSpec
+    azure: InstanceSpec
+    oci: InstanceSpec
+
+# Registry: Dict[str, Dict[str, SizeMapping]]
+# e.g. SIZING["db"]["2xlarge"] -> SizeMapping(aws=..., gce=..., azure=..., oci=...)
+```
+
+**Default DB family mappings** (`db_instance_type` values):
+
+AWS defaults to `i8g` (Graviton/ARM). When the image architecture is x86, the module
+automatically switches to `i4i`. This detection uses the existing `get_arch_from_instance_type()`
+/ `_get_normalized_arch()` logic in `sct_config.py` (L3351).
+
+| `db_instance_type` | AWS ARM (`i8g`) | AWS x86 (`i4i`) | GCE (`z3-highmem`) | Azure (`Standard_L*s_v4`) | OCI (`DenseIO.E5`) |
+|--------------------|-----------------|-----------------|---------------------|---------------------------|---------------------|
+| `large` | `i8g.large` | `i4i.large` | `z3-highmem-4` | `Standard_L4s_v4` | `DenseIO.E5.Flex:2:32` |
+| `xlarge` | `i8g.xlarge` | `i4i.xlarge` | `z3-highmem-8` | `Standard_L8s_v4` | `DenseIO.E5.Flex:4:64` |
+| `2xlarge` | `i8g.2xlarge` | `i4i.2xlarge` | `z3-highmem-16` | `Standard_L16s_v4` | `DenseIO.E5.Flex:8:128` |
+| `4xlarge` | `i8g.4xlarge` | `i4i.4xlarge` | `z3-highmem-32` | `Standard_L32s_v4` | `DenseIO.E5.Flex:16:256` |
+| `8xlarge` | `i8g.8xlarge` | `i4i.8xlarge` | `z3-highmem-48` | `Standard_L64s_v4` | `DenseIO.E5.Flex:32:512` |
+| `16xlarge` | `i8g.16xlarge` | `i4i.16xlarge` | `z3-highmem-88` | `Standard_L80s_v4` | `DenseIO.E5.Flex:64:1024` |
+
+> **Needs Investigation:** Validate exact `i8g.*` shapes exist in all required AWS regions.
+> Validate GCE `z3-highmem-*` shapes exist in all required zones.
+> Validate Azure `Standard_L*s_v4` shapes and OCI `DenseIO.E5.Flex` shapes/limits in target
+> regions. The vCPU/memory columns above are approximate — confirm from official docs.
+
+**Default Loader family mappings** (`loader_instance_type` values):
+
+| `loader_instance_type` | AWS | GCE | Azure | OCI |
+|------------------------|-----|-----|-------|-----|
+| `small` | `c6i.xlarge` | `e2-standard-4` | `Standard_F4s_v2` | `VM.Standard3.Flex:4:32` |
+| `medium` | `c6i.2xlarge` | `e2-standard-8` | `Standard_F8s_v2` | `VM.Standard3.Flex:8:64` |
+| `large` | `c6i.4xlarge` | `e2-standard-16` | `Standard_F16s_v2` | `VM.Standard3.Flex:16:128` |
+| `xlarge` | `c6i.16xlarge` | `e2-highcpu-32` | `Standard_F32s_v2` | `VM.Standard3.Flex:32:256` |
+
+**Default Monitor family mappings** (`monitor_instance_type` values):
+
+| `monitor_instance_type` | AWS | GCE | Azure | OCI |
+|-------------------------|-----|-----|-------|-----|
+| `small` | `t3.large` | `n2-highmem-4` | `Standard_D2_v4` | `VM.Standard.E4.Flex:2:16` |
+| `medium` | `m6i.xlarge` | `n2-highmem-8` | `Standard_D4_v4` | `VM.Standard.E4.Flex:4:32` |
+| `large` | `m6i.2xlarge` | `n2-highmem-16` | `Standard_D8_v4` | `VM.Standard.E4.Flex:8:64` |
+
+Key API functions:
+
+```python
+def resolve_size(role: str, size: str, cloud: str, arch: str = "arm") -> InstanceSpec:
+    """('db', '2xlarge', 'aws', 'arm') -> InstanceSpec(instance_type='i8g.2xlarge', ...)
+       ('db', '2xlarge', 'aws', 'x86') -> InstanceSpec(instance_type='i4i.2xlarge', ...)
+       For non-AWS clouds, arch is ignored (only one family per cloud)."""
+
+def identify_size(cloud: str, instance_type: str) -> tuple[str, str] | None:
+    """('gce', 'z3-highmem-16') -> ('db', '2xlarge') (reverse lookup, None if unknown)"""
+
+def get_cloud_params(role: str, spec: InstanceSpec, cloud: str) -> dict:
+    """InstanceSpec -> dict of sct_config param names and values for that cloud."""
+```
+
+The `arch` parameter defaults to `"arm"` (Graviton). The caller (`_resolve_instance_sizes` in
+`sct_config.py`) determines arch from the AMI/image configuration using the existing
+`get_arch_from_instance_type()` / `_get_normalized_arch()` logic, or from the explicit
+`instance_type_db` if set.
+
+**Definition of Done:**
+- [ ] `sdcm/utils/cloud_sizes.py` exists with `InstanceSpec`, `SizeMapping`, `resolve_size`,
+  `identify_size`, `get_cloud_params`.
+- [ ] Full mapping tables for DB (6 sizes), Loader (4 sizes), Monitor (3 sizes) across 4 clouds.
+- [ ] `unit_tests/unit/test_cloud_sizes.py` with parametrized tests covering all mappings in both
+  directions (size->cloud, cloud->size).
+- [ ] `uv run sct.py pre-commit` passes.
+
+**QA Scenarios:**
+```
+Scenario: Forward resolution — all clouds, all roles
+  Tool: Bash
+  Command: uv run python -c "from sdcm.utils.cloud_sizes import resolve_size; spec = resolve_size('db', '2xlarge', 'aws', 'arm'); assert spec.instance_type == 'i8g.2xlarge', spec.instance_type"
+  Expected: No assertion error. Also test ('db', '2xlarge', 'aws', 'x86') → i4i.2xlarge,
+            gce→z3-highmem-16, azure→Standard_L16s_v4, oci→DenseIO.E5.Flex:8:128.
+
+Scenario: Reverse lookup
+  Tool: Bash
+  Command: uv run python -c "from sdcm.utils.cloud_sizes import identify_size; r = identify_size('gce', 'z3-highmem-16'); assert r == ('db', '2xlarge'), r"
+  Expected: No assertion error.
+
+Scenario: Unknown instance type returns None
+  Tool: Bash
+  Command: uv run python -c "from sdcm.utils.cloud_sizes import identify_size; assert identify_size('aws', 'x99.nonexistent') is None"
+  Expected: No assertion error.
+
+Scenario: Unit tests pass
+  Tool: Bash
+  Command: uv run python -m pytest unit_tests/unit/test_cloud_sizes.py -x -q --no-header --tb=short -n0
+  Expected: All tests pass, 0 failures.
+```
+
+**Dependencies:** None.
+
+**Importance:** High — foundational for all subsequent phases.
+
+---
+
+### Phase 2 — Config Integration: `db_instance_type`, `loader_instance_type`, `monitor_instance_type`
+
+**Scope:** `sdcm/sct_config.py`, `defaults/test_default.yaml`
+
+**Description:**
+
+Add three new config parameters:
+
+```python
+db_instance_type: String = SctField(
+    name="db_instance_type",
+    type=str,
+    default="",
+    help="Abstract instance size for DB nodes (e.g. '2xlarge', 'large'). "
+         "Resolves to cloud-specific instance type based on active backend. "
+         "Cloud-specific overrides (instance_type_db, gce_instance_type_db, etc.) "
+         "take precedence when explicitly set.")
+
+loader_instance_type: String = SctField(...)
+monitor_instance_type: String = SctField(...)
+```
+
+**Resolution logic** (in a new method `_resolve_instance_sizes`, called **early in `__init__`**
+— after config files and env vars are merged but **before** the existing AWS arch/AMI selection
+logic at L2594-2794 and before `verify_configuration()`). This ensures abstract sizes are
+expanded into cloud-specific params before any downstream logic that reads those params.
+
+To distinguish "user explicitly set `instance_type_db`" from "it came from `defaults/aws_config.yaml`",
+introduce a new `_user_provided_keys: set[str]` attribute populated during `__init__` as config
+files and env vars are merged (in the loops that call `_load_environment_variables()` and
+`merge_dicts_append_strings()`). Each key set by a user config file or `SCT_*` env var is added
+to this set. Only skip abstract-size resolution if the cloud-specific param is in
+`_user_provided_keys`, not merely present from backend defaults.
+
+```
+For each role (db, loader, monitor):
+  1. If cloud-specific param was EXPLICITLY set by user config/env -> use it (no change)
+  2. Elif {role}_instance_type is set -> determine arch (from AMI config or default 'arm')
+     -> resolve via cloud_sizes.resolve_size(role, size, cloud, arch)
+     -> populate the cloud-specific param for the active backend
+     -> populate the cloud-specific param for the active backend
+     -> for GCE, also set gce_n_local_ssd_disk_{role}, gce_root_disk_type_{role}
+  3. Else -> fall through to existing defaults (no change)
+```
+
+This means a test YAML can be simplified from:
+
+```yaml
+# Before: 6 lines, one per cloud + GCE disk params
+instance_type_db: 'i4i.2xlarge'
+gce_instance_type_db: 'z3-highmem-16'
+gce_n_local_ssd_disk_db: 4
+gce_root_disk_type_db: 'pd-ssd'
+azure_instance_type_db: 'Standard_L16s_v4'
+oci_instance_type_db: 'DenseIO.E5.Flex:8:128'
+```
+
+To:
+
+```yaml
+# After: 1 line, all clouds resolved automatically
+db_instance_type: '2xlarge'
+```
+
+**Definition of Done:**
+- [ ] Three new `SctField` entries in `sct_config.py`.
+- [ ] `_resolve_instance_sizes()` method resolves abstract sizes to cloud-specific params.
+- [ ] Cloud-specific overrides still take precedence over abstract sizes.
+- [ ] Existing tests in `unit_tests/unit/test_config.py` still pass.
+- [ ] New unit tests for resolution logic (abstract size alone, abstract + override, no abstract).
+- [ ] `uv run sct.py pre-commit` passes.
+
+**QA Scenarios:**
+```
+Scenario: Abstract size resolves for AWS backend
+  Tool: Bash
+  Command: uv run python -m pytest unit_tests/unit/test_config.py -x -q --no-header --tb=short -n0 -k "test_resolve_instance_sizes_aws"
+  Expected: Test passes — verifies that _resolve_instance_sizes() with db_instance_type='2xlarge'
+            and backend='aws' populates instance_type_db='i8g.2xlarge'.
+
+Scenario: Cloud-specific override takes precedence
+  Tool: Bash
+  Command: uv run python -m pytest unit_tests/unit/test_config.py -x -q --no-header --tb=short -n0 -k "test_resolve_instance_sizes_explicit_override"
+  Expected: Test passes — verifies that when instance_type_db is in _user_provided_keys,
+            abstract size is NOT applied.
+
+Scenario: GCE resolution also sets disk params
+  Tool: Bash
+  Command: uv run python -m pytest unit_tests/unit/test_config.py -x -q --no-header --tb=short -n0 -k "test_resolve_instance_sizes_gce_disk_params"
+  Expected: Test passes — verifies gce_instance_type_db, gce_n_local_ssd_disk_db, gce_root_disk_type_db
+            all populated from abstract size.
+
+Scenario: All resolution unit tests pass
+  Tool: Bash
+  Command: uv run python -m pytest unit_tests/unit/test_config.py -x -q --no-header --tb=short -n0 -k "resolve_instance_sizes"
+  Expected: All tests pass, 0 failures.
+```
+
+**Dependencies:** Phase 1.
+
+**Importance:** High — enables the new config parameter for test YAMLs.
+
+---
+
+### Phase 3 — CLI Helpers: `sct.py show-sizes` and `sct.py translate-size`
+
+**Scope:** `sct.py`, new CLI subcommands
+
+**Description:**
+
+Add two utility subcommands for developers:
+
+1. `sct.py show-sizes` — print the full mapping table in a readable format.
+   Optionally filter by role (`--role db`) or cloud (`--cloud gce`).
+
+2. `sct.py translate-size <instance_type>` — given a cloud-specific instance type, print the
+   abstract size and equivalents on other clouds.
+
+   ```
+   $ sct.py translate-size i8g.2xlarge
+   i8g.2xlarge (AWS/ARM) = db 2xlarge
+     AWS (x86): i4i.2xlarge
+     GCE:       z3-highmem-16 (16 vCPU / 128 GB, 4 local SSDs)
+     Azure:     Standard_L16s_v4
+     OCI:       DenseIO.E5.Flex:8:128
+   ```
+
+3. `sct.py translate-size --config <test-case.yaml> [--backend <cloud>]` — **config transformation
+   mode**. Reads a test config YAML and outputs a fully-expanded version where all abstract
+   sizes (`db_instance_type`, `loader_instance_type`, `monitor_instance_type`) are resolved to
+   the concrete cloud-specific instance types (and any associated cloud-specific settings like
+   `gce_n_local_ssd_disk_db`).
+
+   If `--backend` is given, only that cloud is expanded. If omitted, expands for ALL backends,
+   outputting a multi-backend config or one file per backend.
+
+   ```
+   $ sct.py translate-size --config test-cases/longevity/longevity-100gb-4h.yaml --backend gce
+   # Output: the YAML with abstract sizes replaced by GCE-specific values
+   # e.g. db_instance_type: 2xlarge → gce_instance_type_db: z3-highmem-16
+   #                                   gce_n_local_ssd_disk_db: 4
+   #                                   gce_root_disk_type_db: pd-ssd
+
+   $ sct.py translate-size --config test-cases/longevity/longevity-100gb-4h.yaml
+   # Output: shows expansion for each backend (aws, gce, azure, oci)
+   ```
+
+   This is useful for:
+   - Migrating existing test configs to abstract sizes (validate the mapping is correct)
+   - Reviewing what concrete types a config would resolve to on each cloud
+   - CI validation that abstract configs resolve correctly
+
+**Definition of Done:**
+- [ ] `sct.py show-sizes` prints full mapping table.
+- [ ] `sct.py translate-size <type>` prints cross-cloud equivalents.
+- [ ] `sct.py translate-size --config <yaml> [--backend <cloud>]` expands abstract sizes to cloud-specific params.
+- [ ] All three modes have `--help` text.
+- [ ] `uv run sct.py pre-commit` passes.
+
+**QA Scenarios:**
+```
+Scenario: show-sizes prints table
+  Tool: Bash
+  Command: uv run sct.py show-sizes --role db --cloud aws
+  Expected: Output contains i8g.large, i8g.xlarge, ... i8g.16xlarge in a readable table.
+
+Scenario: translate-size single type
+  Tool: Bash
+  Command: uv run sct.py translate-size i8g.2xlarge
+  Expected: Output shows "db 2xlarge" and equivalents for GCE (z3-highmem-16), Azure (Standard_L16s_v4), OCI.
+
+Scenario: translate-size config mode
+  Tool: Bash
+  Command: uv run sct.py translate-size --config unit_tests/test_data/test_abstract_sizing.yaml --backend gce
+  Expected: Output is a YAML with abstract sizes expanded to gce_instance_type_db, gce_n_local_ssd_disk_db, etc.
+  Note: unit_tests/test_data/test_abstract_sizing.yaml is a fixture file created in Phase 3
+        that uses db_instance_type/loader_instance_type/monitor_instance_type fields.
+
+Scenario: translate-size unknown type
+  Tool: Bash
+  Command: uv run sct.py translate-size x99.nonexistent
+  Expected: Clear error message "Unknown instance type: x99.nonexistent".
+```
+
+**Dependencies:** Phase 1.
+
+**Importance:** Medium — developer convenience for test authoring and review.
+
+---
+
+### Phase 4 — Migrate Longevity Test Configs
+
+**Scope:** `test-cases/longevity/` YAML files
+
+**Description:**
+
+For a representative subset of longevity tests (start with 10-15 high-traffic configs), replace
+the cloud-specific instance type parameters with the new `db_instance_type` /
+`loader_instance_type` / `monitor_instance_type` parameters.
+
+Keep cloud-specific overrides only where a test intentionally uses a non-standard instance
+(e.g. a performance test requiring a specific AWS type).
+
+**Definition of Done:**
+- [ ] 10-15 longevity YAMLs migrated to use `db_instance_type` etc.
+- [ ] `./utils/lint_test_cases.sh` passes for all modified files.
+- [ ] Spot-check 3 configs: `./sct.py conf -b aws <path>` and `./sct.py conf -b gce <path>` both
+  resolve to the expected instance types.
+- [ ] `uv run sct.py pre-commit` passes.
+
+**QA Scenarios:**
+```
+Scenario: Migrated config resolves on AWS
+  Tool: Bash
+  Command: uv run sct.py conf -b aws test-cases/longevity/<migrated-config>.yaml | grep instance_type_db
+  Expected: Output shows concrete AWS instance type (e.g. i8g.2xlarge), not the abstract size.
+
+Scenario: Same config resolves on GCE
+  Tool: Bash
+  Command: uv run sct.py conf -b gce test-cases/longevity/<migrated-config>.yaml | grep gce_instance_type_db
+  Expected: Output shows GCE type (e.g. z3-highmem-16).
+
+Scenario: Lint passes
+  Tool: Bash
+  Command: ./utils/lint_test_cases.sh
+  Expected: Exit code 0, no errors.
+```
+
+**Dependencies:** Phase 2.
+
+**Importance:** Medium — proves the approach on the most common test category.
+
+---
+
+### Phase 5 — Documentation and YAML Comment Convention
+
+**Scope:** `docs/`, `AGENTS.md`
+
+**Description:**
+
+- Add `docs/cross-cloud-sizing.md` documenting the T-shirt sizing model, the full mapping table,
+  how to use `db_instance_type` etc. in test YAMLs, and how to add new sizes or cloud families.
+- Update `AGENTS.md` to reference the new sizing system.
+- Define the annotation convention: `# 2xlarge: 8 vCPU / 64 GB` comments on instance lines.
+- This plan supersedes the static mapping approach from PR #14439 (which was never merged).
+  The programmatic mapping is now the single source of truth.
+
+**Definition of Done:**
+- [ ] `docs/cross-cloud-sizing.md` exists with usage guide and full mapping table.
+- [ ] `AGENTS.md` updated with cross-cloud sizing convention.
+- [ ] `uv run sct.py pre-commit` passes.
+
+**QA Scenarios:**
+```
+Scenario: Documentation file exists and has required sections
+  Tool: Bash
+  Command: grep -c "## Usage\|## Mapping Table\|## Adding New Sizes" docs/cross-cloud-sizing.md
+  Expected: At least 3 matches (all sections present).
+
+Scenario: AGENTS.md references sizing system
+  Tool: Bash
+  Command: grep -c "cloud_sizes\|cross-cloud sizing" AGENTS.md
+  Expected: At least 1 match.
+```
+
+**Dependencies:** Phases 1-2.
+
+**Importance:** Medium — essential for adoption but not blocking further migration work.
+
+## 5. Testing Requirements
+
+### Unit Tests
+- `unit_tests/unit/test_cloud_sizes.py`: Parametrized tests for all `resolve_size` and
+  `identify_size` mappings (4 clouds x 13 sizes = 52 forward + 52 reverse = 104 test cases).
+- `unit_tests/unit/test_config.py`: New tests for `_resolve_instance_sizes()` method covering:
+  - Abstract size resolves correctly per backend.
+  - Cloud-specific override takes precedence over abstract size.
+  - Empty abstract size falls through to existing defaults.
+  - Invalid abstract size raises a clear error.
+  - GCE resolution populates disk params alongside instance type.
+
+### Config Load Linting
+- `./utils/lint_test_cases.sh` must pass after every YAML-editing phase.
+- Spot-check migrated configs with `./sct.py conf -b <backend> <path>` for each cloud.
+
+### Manual Verification
+- After Phase 4, run at least one longevity test on GCE with a migrated config to confirm the
+  resolved instance type is correct.
+- Use `sct.py translate-size` to verify bidirectional mapping for the 5 most common instance types
+  across each cloud.
+
+## 6. Success Criteria
+
+- Any test YAML can express sizing with a single `db_instance_type: '2xlarge'` line and have it
+  resolve correctly for AWS, GCE, Azure, and OCI.
+- `resolve_size("db", "2xlarge", "gce")` returns `z3-highmem-16` (not `n2-highmem-16`).
+- Cloud-specific overrides still work unchanged — zero breaking changes.
+- `sct.py translate-size i8g.2xlarge` outputs equivalents for all 4 clouds.
+- `sct.py translate-size --config test-cases/longevity/longevity-100gb-4h.yaml --backend gce` outputs fully-expanded GCE config.
+- The mapping module is the single source of truth — no hand-maintained mapping documents needed.
+
+## 7. Risk Mitigation
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| `z3-highmem-*` shapes unavailable in some GCE zones | Medium | High | Validate shape availability in target zones during Phase 1. Fall back to `n2-highmem-*` for zones without `z3` support and document the exception. |
+| Azure `Standard_L*s_v4` shapes not available in all regions | Medium | Medium | Validate during Phase 1. The v4 family is newer; if unavailable, fall back to `Standard_L*s_v3` with a documented note. |
+| OCI `DenseIO.E5` flex shapes have different OCPU/memory ratios than assumed | Medium | Medium | Validate exact specs from OCI docs during Phase 1. OCI flex shapes allow custom OCPU:memory ratios — document the chosen ratio. |
+| Abstract sizes don't cover all existing test configs (custom/unusual instance types) | Low | Low | Cloud-specific overrides remain supported. Abstract sizing is opt-in, not mandatory. |
+| Config resolution order creates subtle bugs | Medium | High | Extensive unit tests for precedence logic. The rule is simple: explicit cloud param > abstract size > default. |
+| Performance tests need exact hardware match, not "closest equivalent" | Medium | Medium | Performance test YAMLs can continue using cloud-specific overrides. The abstract size is a convenience, not a mandate. |
+| Interaction with PR #14439 (AWS/GCE parity plan) | High | Low | This plan supersedes the static mapping approach in PR #14439. The two can coexist: PR #14439 can add GCE params to existing YAMLs now, and this plan provides the abstraction to simplify them later. |
+| Integration with PR #13427 (mixed instance type clusters) | Medium | Low | PR #13427's `cluster_topology` can use `resolve_size()` from this plan's mapping module to accept abstract sizes in rack definitions. No blocking dependency — the plans complement each other and can be integrated after both land. |

--- a/docs/plans/progress.json
+++ b/docs/plans/progress.json
@@ -262,6 +262,16 @@
       "pr": null,
       "phases_total": 3,
       "phases_done": 0
+    },
+    {
+      "id": "cross-cloud-sizing",
+      "title": "Cross-Cloud Instance Sizing",
+      "file": "config/cross-cloud-sizing.md",
+      "domain": "config",
+      "status": "draft",
+      "created": "2026-05-03",
+      "phases_total": 5,
+      "phases_done": 0
     }
   ]
 }

--- a/docs/sct-configuration.md
+++ b/docs/sct-configuration.md
@@ -10,6 +10,7 @@ SCT uses a **Pydantic-based configuration system** that provides:
 - **Self-documenting**: Type hints and descriptions make the config clear
 - **Flexible input formats**: Support for multiple input types (strings, lists, dicts)
 - **Multiple sources**: Merge configurations from YAML files, environment variables, and defaults
+- **Cross-cloud instance sizing**: Abstract T-shirt sizes that resolve to cloud-specific instance types — see [Cross-Cloud Sizing](cross-cloud-sizing.md)
 
 ## Configuration Architecture
 

--- a/sct.py
+++ b/sct.py
@@ -76,6 +76,7 @@ from sdcm.utils.aws_kms import AwsKms
 from sdcm.utils.azure_region import AzureRegion
 from sdcm.utils.cloud_monitor import cloud_report, cloud_qa_report
 from sdcm.utils.cloud_monitor.cloud_monitor import cloud_non_qa_report
+from sdcm.utils.cloud_sizes import SIZING, get_cloud_params, identify_size, resolve_size
 from sdcm.utils.lint.env_builder import build_env
 from sdcm.utils.lint.jenkins_parser import parse_jenkinsfile, discover_pipeline_files
 from sdcm.utils.oci_utils import list_instances_oci
@@ -2768,6 +2769,131 @@ def hdr_investigate(
         f"\nFound P99 spikes higher than {error_threshold_ms} ms for tags {hdr_tags} with interval {hdr_summary_interval_sec} seconds\n"
     )
     click.echo(rich_table_to_string(hdr_table, title="HDR Latency Spikes"))
+
+
+@cli.command("show-sizes", help="Show cross-cloud instance size mapping table")
+@click.option("--role", type=click.Choice(["db", "loader", "monitor"]), default=None, help="Filter by role")
+@click.option("--cloud", type=click.Choice(["aws", "gce", "azure", "oci"]), default=None, help="Filter by cloud")
+def show_sizes(role, cloud):
+    if cloud:
+        click.echo(f"{'Role':<10} {'Size':<12} {'Instance'}")
+        click.echo("-" * 60)
+    else:
+        click.echo(
+            f"{'Role':<10} {'Size':<12} {'AWS (ARM)':<20} {'AWS (x86)':<20} {'GCE':<25} {'Azure':<25} {'OCI':<30}"
+        )
+        click.echo("-" * 140)
+
+    roles = [role] if role else ["db", "loader", "monitor"]
+
+    for r in roles:
+        mappings = SIZING.get(r, {})
+        for size, m in mappings.items():
+            if cloud == "aws":
+                val = f"ARM:{m.aws_arm.instance_type}  x86:{m.aws_x86.instance_type}"
+                click.echo(f"{r:<10} {size:<12} {val}")
+            elif cloud == "gce":
+                click.echo(f"{r:<10} {size:<12} {m.gce.instance_type}")
+            elif cloud == "azure":
+                click.echo(f"{r:<10} {size:<12} {m.azure.instance_type}")
+            elif cloud == "oci":
+                click.echo(f"{r:<10} {size:<12} {m.oci.instance_type}")
+            else:
+                click.echo(
+                    f"{r:<10} {size:<12} {m.aws_arm.instance_type:<20} {m.aws_x86.instance_type:<20}"
+                    f" {m.gce.instance_type:<25} {m.azure.instance_type:<25} {m.oci.instance_type:<30}"
+                )
+
+
+@cli.command(
+    "translate-size",
+    help="Translate a cloud instance type to abstract size and cross-cloud equivalents, "
+    "or expand abstract sizes in a test config YAML",
+)
+@click.argument("instance_type", required=False)
+@click.option(
+    "--config",
+    "config_file",
+    type=click.Path(exists=True),
+    default=None,
+    help="Test config YAML to expand abstract sizes in",
+)
+@click.option(
+    "--backend",
+    type=click.Choice(["aws", "gce", "azure", "oci"]),
+    default=None,
+    help="Backend to expand for (config mode only; default: all)",
+)
+def translate_size(instance_type, config_file, backend):
+    if config_file:
+        with open(config_file) as f:
+            config = yaml.safe_load(f) or {}
+
+        clouds = [backend] if backend else ["aws", "gce", "azure", "oci"]
+
+        role_map = [
+            ("db", "db_instance_type"),
+            ("loader", "loader_instance_type"),
+            ("monitor", "monitor_instance_type"),
+        ]
+
+        for cloud in clouds:
+            click.echo(f"\n# === {cloud.upper()} ===")
+            expanded = dict(config)
+
+            for role, abstract_param in role_map:
+                abstract_size = config.get(abstract_param)
+                if not abstract_size:
+                    continue
+
+                try:
+                    spec = resolve_size(role, abstract_size, cloud)
+                except (KeyError, ValueError) as exc:
+                    click.echo(
+                        f"# Warning: cannot resolve {abstract_param}={abstract_size!r} for {cloud}: {exc}", err=True
+                    )
+                    continue
+
+                cloud_params = get_cloud_params(role, spec, cloud)
+                expanded.update(cloud_params)
+                expanded.pop(abstract_param, None)
+
+            click.echo(yaml.dump(expanded, default_flow_style=False, sort_keys=True), nl=False)
+        return
+
+    if not instance_type:
+        raise click.UsageError("Provide an instance type or --config <yaml>")
+
+    found = []
+    for cloud in ("aws", "gce", "azure", "oci"):
+        result = identify_size(cloud, instance_type)
+        if result is not None:
+            role, size = result
+            mapping = SIZING[role][size]
+            found.append((role, size, cloud, mapping))
+
+    if not found:
+        raise click.ClickException(f"Unknown instance type: {instance_type!r}")
+
+    seen: set[tuple[str, str]] = set()
+    for role, size, cloud, mapping in found:
+        key = (role, size)
+        if key in seen:
+            continue
+        seen.add(key)
+
+        arch_note = ""
+        if cloud == "aws":
+            if mapping.aws_arm.instance_type == instance_type:
+                arch_note = " (ARM)"
+            elif mapping.aws_x86.instance_type == instance_type:
+                arch_note = " (x86)"
+        click.echo(f"{instance_type}{arch_note} = {role} {size}")
+        click.echo(f"  AWS (ARM):  {mapping.aws_arm.instance_type}")
+        click.echo(f"  AWS (x86):  {mapping.aws_x86.instance_type}")
+        click.echo(f"  GCE:        {mapping.gce.instance_type}")
+        click.echo(f"  Azure:      {mapping.azure.instance_type}")
+        click.echo(f"  OCI:        {mapping.oci.instance_type}")
 
 
 cli.add_command(sct_ssh.ssh)

--- a/sct.py
+++ b/sct.py
@@ -2824,7 +2824,13 @@ def show_sizes(role, cloud):
     default=None,
     help="Backend to expand for (config mode only; default: all)",
 )
-def translate_size(instance_type, config_file, backend):
+@click.option(
+    "--keep-abstract",
+    is_flag=True,
+    default=False,
+    help="Keep abstract size params alongside expanded cloud-specific params",
+)
+def translate_size(instance_type, config_file, backend, keep_abstract):
     if config_file:
         with open(config_file) as f:
             config = yaml.safe_load(f) or {}
@@ -2856,7 +2862,8 @@ def translate_size(instance_type, config_file, backend):
 
                 cloud_params = get_cloud_params(role, spec, cloud)
                 expanded.update(cloud_params)
-                expanded.pop(abstract_param, None)
+                if not keep_abstract:
+                    expanded.pop(abstract_param, None)
 
             click.echo(yaml.dump(expanded, default_flow_style=False, sort_keys=True), nl=False)
         return

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -972,6 +972,12 @@ class SCTConfiguration(BaseModel):
     instance_type_db_oracle: String = SctField(
         description="AWS image type of the oracle node",
     )
+    oracle_instance_type: String = SctField(
+        description="Abstract instance size for oracle DB nodes (e.g. '2xlarge', 'large'). "
+        "Resolves to cloud-specific instance type based on active backend. "
+        "Cloud-specific overrides (instance_type_db_oracle, gce_instance_type_db_oracle, etc.) "
+        "take precedence when explicitly set by user.",
+    )
     instance_type_db_target: String = SctField(
         description="Target AWS instance type for platform migration (e.g., i8g.2xlarge for ARM)",
     )
@@ -1230,6 +1236,12 @@ class SCTConfiguration(BaseModel):
     zero_token_instance_type_db: String = SctField(
         description="Instance type for zero token node",
     )
+    zero_token_instance_type: String = SctField(
+        description="Abstract instance size for zero-token DB nodes (e.g. 'large'). "
+        "Resolves to cloud-specific instance type based on active backend. "
+        "Cloud-specific overrides (zero_token_instance_type_db, gce_zero_token_instance_type_db, etc.) "
+        "take precedence when explicitly set by user.",
+    )
     sct_aws_account_id: String = SctField(
         description="AWS account id on behalf of which the test is run",
     )
@@ -1252,6 +1264,12 @@ class SCTConfiguration(BaseModel):
     )
     gce_instance_type_db: String = SctField(
         description="Instance type for database nodes in Google Compute Engine",
+    )
+    gce_instance_type_db_oracle: String = SctField(
+        description="GCE instance type for oracle DB nodes.",
+    )
+    gce_zero_token_instance_type_db: String = SctField(
+        description="GCE instance type for zero-token DB nodes.",
     )
     gce_root_disk_type_db: String = SctField(
         description="Root disk type for database nodes in Google Compute Engine",
@@ -1291,6 +1309,9 @@ class SCTConfiguration(BaseModel):
     )
     azure_instance_type_db_oracle: String = SctField(
         description="The Azure virtual machine size to be used for Oracle database nodes.",
+    )
+    azure_zero_token_instance_type_db: String = SctField(
+        description="Azure instance type for zero-token DB nodes.",
     )
     azure_image_db: String = SctField(
         description="The Azure image to be used for database nodes.",
@@ -1335,6 +1356,9 @@ class SCTConfiguration(BaseModel):
     )
     oci_instance_type_db_oracle: String = SctField(
         description="Oracle Cloud instance shape to use for 'oracle' (2nd ref cluster) ScylladbDB cluster",
+    )
+    oci_zero_token_instance_type_db: String = SctField(
+        description="OCI instance type for zero-token DB nodes.",
     )
     oci_image_db: String = SctField(
         description="Oracle Cloud image to use for DB node(s)",
@@ -3070,8 +3094,23 @@ class SCTConfiguration(BaseModel):
             "oci": "oci_instance_type_{role}",
         }
 
+        # Roles whose primary cloud param doesn't follow the standard template.
+        _primary_param_overrides: dict[str, dict[str, str]] = {
+            "zero_token": {
+                "aws": "zero_token_instance_type_db",
+                "gce": "gce_zero_token_instance_type_db",
+                "azure": "azure_zero_token_instance_type_db",
+                "oci": "oci_zero_token_instance_type_db",
+            },
+        }
+
+        # Roles that should apply the same arch detection as "db".
+        _db_arch_roles = frozenset({"db", "db_oracle", "zero_token"})
+
         for role, abstract_param in (
             ("db", "db_instance_type"),
+            ("db_oracle", "oracle_instance_type"),
+            ("zero_token", "zero_token_instance_type"),
             ("loader", "loader_instance_type"),
             ("monitor", "monitor_instance_type"),
         ):
@@ -3079,14 +3118,28 @@ class SCTConfiguration(BaseModel):
             if not abstract_size:
                 continue
 
-            primary_param = primary_param_template[cloud].format(role=role)
+            primary_param = _primary_param_overrides.get(role, {}).get(cloud) or primary_param_template[cloud].format(
+                role=role
+            )
             if primary_param in self._user_provided_keys:
                 continue
 
+            arch = "arm"
+            if cloud == "aws" and role in _db_arch_roles:
+                existing_instance_type = self.get(primary_param)
+                if existing_instance_type:
+                    region_name_raw = self.get("region_name") or ""
+                    region_name = region_name_raw.split()[0] if region_name_raw else ""
+                    if region_name:
+                        normalized = self._get_normalized_arch(existing_instance_type, region_name)
+                        arch = "x86" if normalized == "x86_64" else "arm"
+
             try:
-                spec = resolve_size(role, abstract_size, cloud)
-            except (KeyError, ValueError):
-                continue
+                spec = resolve_size(role, abstract_size, cloud, arch=arch)
+            except (KeyError, ValueError) as exc:
+                raise ValueError(
+                    f"Invalid abstract size {abstract_size!r} for role {role!r} on cloud {cloud!r}: {exc}"
+                ) from exc
 
             cloud_params = get_cloud_params(role, spec, cloud)
             for param_name, param_value in cloud_params.items():

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -84,6 +84,7 @@ from sdcm.utils.azure_utils import (
     azure_check_instance_type_available,
 )
 from sdcm.utils.cloud_api_utils import MIN_SCYLLA_VERSION_FOR_VS
+from sdcm.utils.cloud_sizes import get_cloud_params, resolve_size
 from sdcm.remote import LOCALRUNNER, shell_script_cmd
 from sdcm.utils.curl import curl_with_retry
 from sdcm.test_config import TestConfig
@@ -973,6 +974,22 @@ class SCTConfiguration(BaseModel):
     )
     instance_type_db_target: String = SctField(
         description="Target AWS instance type for platform migration (e.g., i8g.2xlarge for ARM)",
+    )
+    db_instance_type: String = SctField(
+        description="Abstract instance size for DB nodes (e.g. '2xlarge', 'large'). "
+        "Resolves to cloud-specific instance type based on active backend. "
+        "Cloud-specific overrides (instance_type_db, gce_instance_type_db, etc.) "
+        "take precedence when explicitly set by user.",
+    )
+    loader_instance_type: String = SctField(
+        description="Abstract instance size for loader nodes (e.g. '2xlarge', 'large'). "
+        "Resolves to cloud-specific instance type based on active backend. "
+        "Cloud-specific overrides take precedence when explicitly set by user.",
+    )
+    monitor_instance_type: String = SctField(
+        description="Abstract instance size for monitor nodes (e.g. '2xlarge', 'large'). "
+        "Resolves to cloud-specific instance type based on active backend. "
+        "Cloud-specific overrides take precedence when explicitly set by user.",
     )
     target_db_image_ids: Annotated[list[str], IgnoredType] = Field(default=[], exclude=True)
     instance_type_runner: String = SctField(
@@ -2482,6 +2499,8 @@ class SCTConfiguration(BaseModel):
         """
         super().__init__(**data)
 
+        object.__setattr__(self, "_user_provided_keys", set())
+
         env = self._load_environment_variables()
         config_files = env.get("config_files", [])
         config_files = [sct_abs_path(f) for f in config_files]
@@ -2509,6 +2528,7 @@ class SCTConfiguration(BaseModel):
                 if not os.path.exists(conf_file):
                     raise FileNotFoundError(f"Couldn't find config file: {conf_file}")
             files = anyconfig.load(list(config_files))
+            self._user_provided_keys.update(files.keys())
             merge_dicts_append_strings(self, files)
 
         regions_data = self.get("regions_data") or {}
@@ -2539,6 +2559,7 @@ class SCTConfiguration(BaseModel):
                         raise ValueError(f"{region} isn't supported, use: {self.aws_supported_regions}")
 
         # 3) overwrite with environment variables
+        self._user_provided_keys.update(env.keys())
         merge_dicts_append_strings(self, env)
 
         if not self.get("billing_project"):
@@ -2565,6 +2586,8 @@ class SCTConfiguration(BaseModel):
 
         if not self.get("billing_project"):
             self["billing_project"] = "no_billing_project"
+
+        self._resolve_instance_sizes()
 
         # 4) update events max severities
         add_severity_limit_rules(self.get("max_events_severities"))
@@ -3025,6 +3048,50 @@ class SCTConfiguration(BaseModel):
         if self.get("c_s_driver_version") == "random":
             self["c_s_driver_version"] = random.choice(["4", "3"])
             self.log.debug("Using random cassandra-stress driver version: %s", self["c_s_driver_version"])
+
+    def _resolve_instance_sizes(self) -> None:
+        backend = self.get("cluster_backend") or ""
+        cloud_map = {
+            "aws": "aws",
+            "k8s-eks": "aws",
+            "gce": "gce",
+            "k8s-gke": "gce",
+            "azure": "azure",
+            "oci": "oci",
+        }
+        cloud = cloud_map.get(backend)
+        if not cloud:
+            return
+
+        primary_param_template = {
+            "aws": "instance_type_{role}",
+            "gce": "gce_instance_type_{role}",
+            "azure": "azure_instance_type_{role}",
+            "oci": "oci_instance_type_{role}",
+        }
+
+        for role, abstract_param in (
+            ("db", "db_instance_type"),
+            ("loader", "loader_instance_type"),
+            ("monitor", "monitor_instance_type"),
+        ):
+            abstract_size = self.get(abstract_param)
+            if not abstract_size:
+                continue
+
+            primary_param = primary_param_template[cloud].format(role=role)
+            if primary_param in self._user_provided_keys:
+                continue
+
+            try:
+                spec = resolve_size(role, abstract_size, cloud)
+            except (KeyError, ValueError):
+                continue
+
+            cloud_params = get_cloud_params(role, spec, cloud)
+            for param_name, param_value in cloud_params.items():
+                if param_name not in self._user_provided_keys:
+                    self[param_name] = param_value
 
     def load_docker_images_defaults(self):
         stress_image = _load_docker_images_defaults_cached()

--- a/sdcm/utils/cloud_sizes.py
+++ b/sdcm/utils/cloud_sizes.py
@@ -16,6 +16,19 @@
 Provides canonical size names (e.g. "db/2xlarge") that map to equivalent
 instance types across AWS, GCE, Azure, and OCI, enabling cloud-agnostic
 test configuration and cross-cloud comparisons.
+
+Roles
+-----
+- ``db``          — main ScyllaDB data nodes
+- ``db_oracle``   — oracle (reference) DB nodes; reuse the "db" sizing table
+- ``zero_token``  — zero-token DB nodes; reuse the "db" sizing table
+- ``loader``      — stress-tool loader nodes
+- ``monitor``     — monitoring-stack nodes
+
+The ``db_oracle`` and ``zero_token`` roles are *aliases* for the ``db``
+sizing table: they resolve to the same instance families but produce
+different SCT config parameter names (see ``_ROLE_SIZING_ALIAS`` and
+``_PARAM_NAME_OVERRIDES``).
 """
 
 from __future__ import annotations
@@ -113,6 +126,10 @@ SIZING: dict[str, dict[str, SizeMapping]] = {
             azure=InstanceSpec("Standard_L32s_v4", 32, 256.0),
             oci=InstanceSpec("DenseIO.E5.Flex:16:256", 16, 256.0),
         ),
+        # NOTE: Azure Standard_L*s_v4 family lacks a 32-vCPU variant.
+        # 8xlarge maps to Standard_L64s_v4 (64 vCPU) — the next available size above
+        # Standard_L32s_v4 (used for 4xlarge). This gives 2× the compute of AWS 8xlarge
+        # on Azure. Similarly, 16xlarge maps to Standard_L80s_v4 (80 vCPU) vs AWS 64 vCPU.
         "8xlarge": SizeMapping(
             aws_arm=InstanceSpec("i8g.8xlarge", 32, 256.0),
             aws_x86=InstanceSpec("i4i.8xlarge", 32, 256.0),
@@ -155,12 +172,19 @@ SIZING: dict[str, dict[str, SizeMapping]] = {
             azure=InstanceSpec("Standard_F16s_v2", 16, 32.0),
             oci=InstanceSpec("VM.Standard3.Flex:16:128", 16, 128.0),
         ),
+        "2xlarge": SizeMapping(
+            aws_arm=InstanceSpec("c6i.8xlarge", 32, 64.0),
+            aws_x86=InstanceSpec("c6i.8xlarge", 32, 64.0),
+            gce=InstanceSpec("e2-standard-32", 32, 128.0),
+            azure=InstanceSpec("Standard_F32s_v2", 32, 64.0),
+            oci=InstanceSpec("VM.Standard3.Flex:32:256", 32, 256.0),
+        ),
         "xlarge": SizeMapping(
             aws_arm=InstanceSpec("c6i.16xlarge", 64, 128.0),
             aws_x86=InstanceSpec("c6i.16xlarge", 64, 128.0),
             gce=InstanceSpec("e2-highcpu-32", 32, 32.0),
-            azure=InstanceSpec("Standard_F32s_v2", 32, 64.0),
-            oci=InstanceSpec("VM.Standard3.Flex:32:256", 32, 256.0),
+            azure=InstanceSpec("Standard_F48s_v2", 48, 96.0),
+            oci=InstanceSpec("VM.Standard3.Flex:64:512", 64, 512.0),
         ),
     },
     # ------------------------------------------------------------------
@@ -196,12 +220,33 @@ SIZING: dict[str, dict[str, SizeMapping]] = {
 _VALID_CLOUDS = frozenset({"aws", "gce", "azure", "oci"})
 _VALID_ARCH = frozenset({"arm", "x86"})
 
+# Roles that alias to the "db" sizing table but produce different param names.
+_ROLE_SIZING_ALIAS: dict[str, str] = {
+    "db_oracle": "db",
+    "zero_token": "db",
+}
+
+# Roles whose GCE disk params (n_local_ssd / root_disk_type) should be emitted.
+# Only the main "db" role has dedicated disk params in sct_config.py.
+_GCE_DISK_ROLES = frozenset({"db"})
+
+# Custom param name overrides where naming doesn't follow the standard pattern.
+# Standard pattern: aws → "instance_type_{role}", gce → "gce_instance_type_{role}", etc.
+# Exceptions are listed here as (role, cloud) → param_name.
+_PARAM_NAME_OVERRIDES: dict[tuple[str, str], str] = {
+    ("zero_token", "aws"): "zero_token_instance_type_db",
+    ("zero_token", "gce"): "gce_zero_token_instance_type_db",
+    ("zero_token", "azure"): "azure_zero_token_instance_type_db",
+    ("zero_token", "oci"): "oci_zero_token_instance_type_db",
+}
+
 
 def resolve_size(role: str, size: str, cloud: str, arch: str = "arm") -> InstanceSpec:
     """Resolve a canonical size name to an InstanceSpec for the given cloud.
 
     Args:
-        role: Node role — one of "db", "loader", "monitor".
+        role: Node role — one of "db", "db_oracle", "zero_token", "loader", "monitor".
+              "db_oracle" and "zero_token" resolve through the "db" sizing table.
         size: Canonical size name, e.g. "2xlarge", "medium".
         cloud: Cloud provider — one of "aws", "gce", "azure", "oci".
         arch: CPU architecture for AWS — "arm" (Graviton) or "x86" (default "arm").
@@ -218,10 +263,13 @@ def resolve_size(role: str, size: str, cloud: str, arch: str = "arm") -> Instanc
         >>> spec.instance_type
         'i8g.2xlarge'
     """
-    if role not in SIZING:
-        raise ValueError(f"Unknown role: {role!r}. Valid roles: {sorted(SIZING)}")
+    sizing_role = _ROLE_SIZING_ALIAS.get(role, role)
+    if sizing_role not in SIZING:
+        raise ValueError(
+            f"Unknown role: {role!r}. Valid roles: {sorted(SIZING)} and aliases {sorted(_ROLE_SIZING_ALIAS)}"
+        )
 
-    role_sizes = SIZING[role]
+    role_sizes = SIZING[sizing_role]
     if size not in role_sizes:
         raise ValueError(f"Unknown size {size!r} for role {role!r}. Valid sizes: {sorted(role_sizes)}")
 
@@ -255,12 +303,18 @@ def identify_size(cloud: str, instance_type: str) -> tuple[str, str] | None:
         A ``(role, size)`` tuple if found, or ``None`` if the instance type
         is not registered in any mapping.
 
+    Raises:
+        ValueError: If cloud is not recognised.
+
     Example:
         >>> identify_size("gce", "z3-highmem-16")
         ('db', '2xlarge')
         >>> identify_size("aws", "x99.nonexistent")
         # returns None
     """
+    if cloud not in _VALID_CLOUDS:
+        raise ValueError(f"Unknown cloud: {cloud!r}. Valid clouds: {sorted(_VALID_CLOUDS)}")
+
     for role, sizes in SIZING.items():
         for size, mapping in sizes.items():
             if cloud == "aws":
@@ -271,8 +325,6 @@ def identify_size(cloud: str, instance_type: str) -> tuple[str, str] | None:
                 candidates = {mapping.azure.instance_type}
             elif cloud == "oci":
                 candidates = {mapping.oci.instance_type}
-            else:
-                return None
 
             if instance_type in candidates:
                 return (role, size)
@@ -287,13 +339,13 @@ def get_cloud_params(role: str, spec: InstanceSpec, cloud: str) -> dict[str, str
     the matching backend.
 
     Args:
-        role: Node role — one of "db", "loader", "monitor".
+        role: Node role — one of "db", "db_oracle", "zero_token", "loader", "monitor".
         spec: InstanceSpec to translate into SCT params.
         cloud: Cloud provider — one of "aws", "gce", "azure", "oci".
 
     Returns:
         Dict of SCT config param names → values.
-        For GCE, extra disk params are included when non-zero / non-empty.
+        For GCE db role, extra disk params are included when non-zero / non-empty.
 
     Raises:
         ValueError: If cloud is not recognised.
@@ -306,22 +358,22 @@ def get_cloud_params(role: str, spec: InstanceSpec, cloud: str) -> dict[str, str
     """
     params: dict[str, str | int] = {}
 
-    if cloud == "aws":
+    override_key = (role, cloud)
+    if override_key in _PARAM_NAME_OVERRIDES:
+        params[_PARAM_NAME_OVERRIDES[override_key]] = spec.instance_type
+    elif cloud == "aws":
         params[f"instance_type_{role}"] = spec.instance_type
-
     elif cloud == "gce":
         params[f"gce_instance_type_{role}"] = spec.instance_type
-        if spec.local_ssd_count:
-            params[f"gce_n_local_ssd_disk_{role}"] = spec.local_ssd_count
-        if spec.root_disk_type:
-            params[f"gce_root_disk_type_{role}"] = spec.root_disk_type
-
+        if role in _GCE_DISK_ROLES:
+            if spec.local_ssd_count:
+                params[f"gce_n_local_ssd_disk_{role}"] = spec.local_ssd_count
+            if spec.root_disk_type:
+                params[f"gce_root_disk_type_{role}"] = spec.root_disk_type
     elif cloud == "azure":
         params[f"azure_instance_type_{role}"] = spec.instance_type
-
     elif cloud == "oci":
         params[f"oci_instance_type_{role}"] = spec.instance_type
-
     else:
         raise ValueError(f"Unknown cloud: {cloud!r}. Valid clouds: {sorted(_VALID_CLOUDS)}")
 

--- a/sdcm/utils/cloud_sizes.py
+++ b/sdcm/utils/cloud_sizes.py
@@ -1,0 +1,328 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2026 ScyllaDB
+
+"""Cross-cloud instance sizing mapping module.
+
+Provides canonical size names (e.g. "db/2xlarge") that map to equivalent
+instance types across AWS, GCE, Azure, and OCI, enabling cloud-agnostic
+test configuration and cross-cloud comparisons.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class InstanceSpec:
+    """Specification for a single cloud instance type.
+
+    Attributes:
+        instance_type: Cloud-specific instance type identifier.
+        vcpus: Number of virtual CPUs.
+        memory_gb: Memory in gigabytes.
+        local_ssd_count: Number of local NVMe SSD disks (default 0).
+        root_disk_type: Root disk type string, e.g. "pd-ssd" for GCE (default "").
+        extra_params: Additional cloud-specific parameters (default empty dict).
+    """
+
+    instance_type: str
+    vcpus: int
+    memory_gb: float
+    local_ssd_count: int = 0
+    root_disk_type: str = ""
+    extra_params: dict = field(default_factory=dict)
+
+
+@dataclass
+class SizeMapping:
+    """Cross-cloud mapping for a canonical size across all supported clouds.
+
+    Attributes:
+        aws_arm: AWS ARM (Graviton) instance spec.
+        aws_x86: AWS x86 instance spec.
+        gce: Google Compute Engine instance spec.
+        azure: Microsoft Azure instance spec.
+        oci: Oracle Cloud Infrastructure instance spec.
+    """
+
+    aws_arm: InstanceSpec
+    aws_x86: InstanceSpec
+    gce: InstanceSpec
+    azure: InstanceSpec
+    oci: InstanceSpec
+
+
+# ---------------------------------------------------------------------------
+# Sizing registry
+# ---------------------------------------------------------------------------
+# Keyed by role -> canonical size name -> SizeMapping.
+# Roles: "db", "loader", "monitor".
+# DB sizes:    large, xlarge, 2xlarge, 4xlarge, 8xlarge, 16xlarge
+# Loader sizes: small, medium, large, xlarge
+# Monitor sizes: small, medium, large
+# ---------------------------------------------------------------------------
+
+SIZING: dict[str, dict[str, SizeMapping]] = {
+    # ------------------------------------------------------------------
+    # DB role — storage-optimised instances with local NVMe SSDs.
+    # AWS: i8g (ARM/Graviton4) and i4i (x86).
+    # GCE: z3-highmem — all sizes include 4 local SSD disks + pd-ssd root.
+    # Azure: Standard_L*s_v4 local-storage optimised family.
+    # OCI: DenseIO.E5.Flex — notation encodes :vcpus:memory_gb.
+    # ------------------------------------------------------------------
+    "db": {
+        "large": SizeMapping(
+            aws_arm=InstanceSpec("i8g.large", 2, 16.0),
+            aws_x86=InstanceSpec("i4i.large", 2, 16.0),
+            gce=InstanceSpec("z3-highmem-4", 4, 32.0, local_ssd_count=4, root_disk_type="pd-ssd"),
+            azure=InstanceSpec("Standard_L4s_v4", 4, 32.0),
+            oci=InstanceSpec("DenseIO.E5.Flex:2:32", 2, 32.0),
+        ),
+        "xlarge": SizeMapping(
+            aws_arm=InstanceSpec("i8g.xlarge", 4, 32.0),
+            aws_x86=InstanceSpec("i4i.xlarge", 4, 32.0),
+            gce=InstanceSpec("z3-highmem-8", 8, 64.0, local_ssd_count=4, root_disk_type="pd-ssd"),
+            azure=InstanceSpec("Standard_L8s_v4", 8, 64.0),
+            oci=InstanceSpec("DenseIO.E5.Flex:4:64", 4, 64.0),
+        ),
+        "2xlarge": SizeMapping(
+            aws_arm=InstanceSpec("i8g.2xlarge", 8, 64.0),
+            aws_x86=InstanceSpec("i4i.2xlarge", 8, 64.0),
+            gce=InstanceSpec("z3-highmem-16", 16, 128.0, local_ssd_count=4, root_disk_type="pd-ssd"),
+            azure=InstanceSpec("Standard_L16s_v4", 16, 128.0),
+            oci=InstanceSpec("DenseIO.E5.Flex:8:128", 8, 128.0),
+        ),
+        "4xlarge": SizeMapping(
+            aws_arm=InstanceSpec("i8g.4xlarge", 16, 128.0),
+            aws_x86=InstanceSpec("i4i.4xlarge", 16, 128.0),
+            gce=InstanceSpec("z3-highmem-32", 32, 256.0, local_ssd_count=4, root_disk_type="pd-ssd"),
+            azure=InstanceSpec("Standard_L32s_v4", 32, 256.0),
+            oci=InstanceSpec("DenseIO.E5.Flex:16:256", 16, 256.0),
+        ),
+        "8xlarge": SizeMapping(
+            aws_arm=InstanceSpec("i8g.8xlarge", 32, 256.0),
+            aws_x86=InstanceSpec("i4i.8xlarge", 32, 256.0),
+            gce=InstanceSpec("z3-highmem-48", 48, 384.0, local_ssd_count=4, root_disk_type="pd-ssd"),
+            azure=InstanceSpec("Standard_L64s_v4", 64, 512.0),
+            oci=InstanceSpec("DenseIO.E5.Flex:32:512", 32, 512.0),
+        ),
+        "16xlarge": SizeMapping(
+            aws_arm=InstanceSpec("i8g.16xlarge", 64, 512.0),
+            aws_x86=InstanceSpec("i4i.16xlarge", 64, 512.0),
+            gce=InstanceSpec("z3-highmem-88", 88, 704.0, local_ssd_count=4, root_disk_type="pd-ssd"),
+            azure=InstanceSpec("Standard_L80s_v4", 80, 640.0),
+            oci=InstanceSpec("DenseIO.E5.Flex:64:1024", 64, 1024.0),
+        ),
+    },
+    # ------------------------------------------------------------------
+    # Loader role — compute-optimised instances for stress tools.
+    # AWS c6i family has no ARM variant; aws_arm == aws_x86.
+    # OCI: VM.Standard3.Flex — notation encodes :vcpus:memory_gb.
+    # ------------------------------------------------------------------
+    "loader": {
+        "small": SizeMapping(
+            aws_arm=InstanceSpec("c6i.xlarge", 4, 8.0),
+            aws_x86=InstanceSpec("c6i.xlarge", 4, 8.0),
+            gce=InstanceSpec("e2-standard-4", 4, 16.0),
+            azure=InstanceSpec("Standard_F4s_v2", 4, 8.0),
+            oci=InstanceSpec("VM.Standard3.Flex:4:32", 4, 32.0),
+        ),
+        "medium": SizeMapping(
+            aws_arm=InstanceSpec("c6i.2xlarge", 8, 16.0),
+            aws_x86=InstanceSpec("c6i.2xlarge", 8, 16.0),
+            gce=InstanceSpec("e2-standard-8", 8, 32.0),
+            azure=InstanceSpec("Standard_F8s_v2", 8, 16.0),
+            oci=InstanceSpec("VM.Standard3.Flex:8:64", 8, 64.0),
+        ),
+        "large": SizeMapping(
+            aws_arm=InstanceSpec("c6i.4xlarge", 16, 32.0),
+            aws_x86=InstanceSpec("c6i.4xlarge", 16, 32.0),
+            gce=InstanceSpec("e2-standard-16", 16, 64.0),
+            azure=InstanceSpec("Standard_F16s_v2", 16, 32.0),
+            oci=InstanceSpec("VM.Standard3.Flex:16:128", 16, 128.0),
+        ),
+        "xlarge": SizeMapping(
+            aws_arm=InstanceSpec("c6i.16xlarge", 64, 128.0),
+            aws_x86=InstanceSpec("c6i.16xlarge", 64, 128.0),
+            gce=InstanceSpec("e2-highcpu-32", 32, 32.0),
+            azure=InstanceSpec("Standard_F32s_v2", 32, 64.0),
+            oci=InstanceSpec("VM.Standard3.Flex:32:256", 32, 256.0),
+        ),
+    },
+    # ------------------------------------------------------------------
+    # Monitor role — general-purpose instances for monitoring stack.
+    # AWS t3/m6i family has no ARM variant; aws_arm == aws_x86.
+    # OCI: VM.Standard.E4.Flex — notation encodes :vcpus:memory_gb.
+    # ------------------------------------------------------------------
+    "monitor": {
+        "small": SizeMapping(
+            aws_arm=InstanceSpec("t3.large", 2, 8.0),
+            aws_x86=InstanceSpec("t3.large", 2, 8.0),
+            gce=InstanceSpec("n2-highmem-4", 4, 32.0),
+            azure=InstanceSpec("Standard_D2_v4", 2, 8.0),
+            oci=InstanceSpec("VM.Standard.E4.Flex:2:16", 2, 16.0),
+        ),
+        "medium": SizeMapping(
+            aws_arm=InstanceSpec("m6i.xlarge", 4, 16.0),
+            aws_x86=InstanceSpec("m6i.xlarge", 4, 16.0),
+            gce=InstanceSpec("n2-highmem-8", 8, 64.0),
+            azure=InstanceSpec("Standard_D4_v4", 4, 16.0),
+            oci=InstanceSpec("VM.Standard.E4.Flex:4:32", 4, 32.0),
+        ),
+        "large": SizeMapping(
+            aws_arm=InstanceSpec("m6i.2xlarge", 8, 32.0),
+            aws_x86=InstanceSpec("m6i.2xlarge", 8, 32.0),
+            gce=InstanceSpec("n2-highmem-16", 16, 128.0),
+            azure=InstanceSpec("Standard_D8_v4", 8, 32.0),
+            oci=InstanceSpec("VM.Standard.E4.Flex:8:64", 8, 64.0),
+        ),
+    },
+}
+
+_VALID_CLOUDS = frozenset({"aws", "gce", "azure", "oci"})
+_VALID_ARCH = frozenset({"arm", "x86"})
+
+
+def resolve_size(role: str, size: str, cloud: str, arch: str = "arm") -> InstanceSpec:
+    """Resolve a canonical size name to an InstanceSpec for the given cloud.
+
+    Args:
+        role: Node role — one of "db", "loader", "monitor".
+        size: Canonical size name, e.g. "2xlarge", "medium".
+        cloud: Cloud provider — one of "aws", "gce", "azure", "oci".
+        arch: CPU architecture for AWS — "arm" (Graviton) or "x86" (default "arm").
+              Ignored for non-AWS clouds.
+
+    Returns:
+        InstanceSpec for the requested combination.
+
+    Raises:
+        ValueError: If role, size, cloud, or arch is not recognised.
+
+    Example:
+        >>> spec = resolve_size("db", "2xlarge", "aws", "arm")
+        >>> spec.instance_type
+        'i8g.2xlarge'
+    """
+    if role not in SIZING:
+        raise ValueError(f"Unknown role: {role!r}. Valid roles: {sorted(SIZING)}")
+
+    role_sizes = SIZING[role]
+    if size not in role_sizes:
+        raise ValueError(f"Unknown size {size!r} for role {role!r}. Valid sizes: {sorted(role_sizes)}")
+
+    mapping = role_sizes[size]
+
+    if cloud == "aws":
+        if arch not in _VALID_ARCH:
+            raise ValueError(f"Unknown arch {arch!r} for cloud 'aws'. Valid values: {sorted(_VALID_ARCH)}")
+        return mapping.aws_arm if arch == "arm" else mapping.aws_x86
+
+    if cloud == "gce":
+        return mapping.gce
+
+    if cloud == "azure":
+        return mapping.azure
+
+    if cloud == "oci":
+        return mapping.oci
+
+    raise ValueError(f"Unknown cloud: {cloud!r}. Valid clouds: {sorted(_VALID_CLOUDS)}")
+
+
+def identify_size(cloud: str, instance_type: str) -> tuple[str, str] | None:
+    """Reverse-lookup a canonical (role, size) pair from a cloud instance type.
+
+    Args:
+        cloud: Cloud provider — one of "aws", "gce", "azure", "oci".
+        instance_type: Cloud-specific instance type string.
+
+    Returns:
+        A ``(role, size)`` tuple if found, or ``None`` if the instance type
+        is not registered in any mapping.
+
+    Example:
+        >>> identify_size("gce", "z3-highmem-16")
+        ('db', '2xlarge')
+        >>> identify_size("aws", "x99.nonexistent")
+        # returns None
+    """
+    for role, sizes in SIZING.items():
+        for size, mapping in sizes.items():
+            if cloud == "aws":
+                candidates = {mapping.aws_arm.instance_type, mapping.aws_x86.instance_type}
+            elif cloud == "gce":
+                candidates = {mapping.gce.instance_type}
+            elif cloud == "azure":
+                candidates = {mapping.azure.instance_type}
+            elif cloud == "oci":
+                candidates = {mapping.oci.instance_type}
+            else:
+                return None
+
+            if instance_type in candidates:
+                return (role, size)
+
+    return None
+
+
+def get_cloud_params(role: str, spec: InstanceSpec, cloud: str) -> dict[str, str | int]:
+    """Return a dict of SCT config parameter names mapped to values for a given cloud and role.
+
+    The returned dict can be used directly to override SCT configuration for
+    the matching backend.
+
+    Args:
+        role: Node role — one of "db", "loader", "monitor".
+        spec: InstanceSpec to translate into SCT params.
+        cloud: Cloud provider — one of "aws", "gce", "azure", "oci".
+
+    Returns:
+        Dict of SCT config param names → values.
+        For GCE, extra disk params are included when non-zero / non-empty.
+
+    Raises:
+        ValueError: If cloud is not recognised.
+
+    Example:
+        >>> spec = resolve_size("db", "2xlarge", "gce")
+        >>> get_cloud_params("db", spec, "gce")
+        {'gce_instance_type_db': 'z3-highmem-16', 'gce_n_local_ssd_disk_db': 4,
+         'gce_root_disk_type_db': 'pd-ssd'}
+    """
+    params: dict[str, str | int] = {}
+
+    if cloud == "aws":
+        params[f"instance_type_{role}"] = spec.instance_type
+
+    elif cloud == "gce":
+        params[f"gce_instance_type_{role}"] = spec.instance_type
+        if spec.local_ssd_count:
+            params[f"gce_n_local_ssd_disk_{role}"] = spec.local_ssd_count
+        if spec.root_disk_type:
+            params[f"gce_root_disk_type_{role}"] = spec.root_disk_type
+
+    elif cloud == "azure":
+        params[f"azure_instance_type_{role}"] = spec.instance_type
+
+    elif cloud == "oci":
+        params[f"oci_instance_type_{role}"] = spec.instance_type
+
+    else:
+        raise ValueError(f"Unknown cloud: {cloud!r}. Valid clouds: {sorted(_VALID_CLOUDS)}")
+
+    return params

--- a/test-cases/longevity/longevity-1-rf-test-12h.yaml
+++ b/test-cases/longevity/longevity-1-rf-test-12h.yaml
@@ -22,8 +22,10 @@ n_db_nodes: 3
 n_loaders: 2
 round_robin: true
 
-instance_type_db: 'i4i.xlarge'
-instance_type_loader: 'c6i.4xlarge'
+# db_instance_type: xlarge resolves to i8g.xlarge (AWS ARM), z3-highmem-8 (GCE), Standard_L8s_v4 (Azure)
+db_instance_type: 'xlarge'
+# loader_instance_type: large resolves to c6i.4xlarge (AWS), e2-standard-16 (GCE), Standard_F16s_v2 (Azure)
+loader_instance_type: 'large'
 
 nemesis_class_name: 'SisyphusMonkey'
 nemesis_selector: "not disruptive"

--- a/test-cases/longevity/longevity-100gb-4h-cql-stress.yaml
+++ b/test-cases/longevity/longevity-100gb-4h-cql-stress.yaml
@@ -5,7 +5,8 @@ n_loaders: 2
 seeds_num: 3
 simulated_racks: 3
 
-instance_type_db: 'i4i.4xlarge'
+# db_instance_type: 4xlarge resolves to i8g.4xlarge (AWS ARM), z3-highmem-32 (GCE), Standard_L32s_v4 (Azure)
+db_instance_type: '4xlarge'
 
 nemesis_class_name: 'SisyphusMonkey'
 nemesis_seed: '032'

--- a/test-cases/longevity/longevity-100gb-4h.yaml
+++ b/test-cases/longevity/longevity-100gb-4h.yaml
@@ -10,7 +10,8 @@ n_db_nodes: 6
 n_loaders: 2
 seeds_num: 3
 
-instance_type_db: 'i4i.4xlarge'
+# db_instance_type: 4xlarge resolves to i8g.4xlarge (AWS ARM), z3-highmem-32 (GCE), Standard_L32s_v4 (Azure)
+db_instance_type: '4xlarge'
 
 nemesis_class_name: 'SisyphusMonkey'
 nemesis_seed: '032'

--- a/test-cases/longevity/longevity-alternator-3h.yaml
+++ b/test-cases/longevity/longevity-alternator-3h.yaml
@@ -34,7 +34,8 @@ stress_cmd: [
 round_robin: true
 
 n_loaders: 4
-instance_type_db: 'i4i.4xlarge'
+# db_instance_type: 4xlarge resolves to i8g.4xlarge (AWS ARM), z3-highmem-32 (GCE), Standard_L32s_v4 (Azure)
+db_instance_type: '4xlarge'
 n_db_nodes: 6
 
 nemesis_class_name: 'SisyphusMonkey'

--- a/test-cases/longevity/longevity-alternator-streams-100gb-12h.yaml
+++ b/test-cases/longevity/longevity-alternator-streams-100gb-12h.yaml
@@ -37,8 +37,10 @@ round_robin: true
 n_loaders: 3
 n_db_nodes: 6
 
-instance_type_db: 'i4i.4xlarge'
-instance_type_loader: 'c6i.4xlarge'
+# db_instance_type: 4xlarge resolves to i8g.4xlarge (AWS ARM), z3-highmem-32 (GCE), Standard_L32s_v4 (Azure)
+db_instance_type: '4xlarge'
+# loader_instance_type: large resolves to c6i.4xlarge (AWS), e2-standard-16 (GCE), Standard_F16s_v2 (Azure)
+loader_instance_type: 'large'
 
 nemesis_class_name: 'NoOpMonkey'
 

--- a/test-cases/longevity/longevity-cdc-100gb-4h.yaml
+++ b/test-cases/longevity/longevity-cdc-100gb-4h.yaml
@@ -11,7 +11,8 @@ availability_zone: 'a,b,c'
 n_db_nodes: 6
 n_loaders: 2
 
-instance_type_db: 'i4i.4xlarge'
+# db_instance_type: 4xlarge resolves to i8g.4xlarge (AWS ARM), z3-highmem-32 (GCE), Standard_L32s_v4 (Azure)
+db_instance_type: '4xlarge'
 
 nemesis_class_name: 'SisyphusMonkey'
 nemesis_seed: '009'

--- a/test-cases/longevity/longevity-counters-3h.yaml
+++ b/test-cases/longevity/longevity-counters-3h.yaml
@@ -6,7 +6,8 @@ stress_read_cmd: "scylla-bench -workload=uniform -mode=counter_read   -replicati
 n_db_nodes: 6
 n_loaders:  1
 
-instance_type_db: 'i4i.large'
+# db_instance_type: large resolves to i8g.large (AWS ARM), z3-highmem-4 (GCE), Standard_L4s_v4 (Azure)
+db_instance_type: 'large'
 
 user_prefix: longevity-counters-3h
 

--- a/test-cases/longevity/longevity-harry-2h.yaml
+++ b/test-cases/longevity/longevity-harry-2h.yaml
@@ -4,7 +4,8 @@ stress_cmd: ["cassandra-harry -run-time 2 -run-time-unit HOURS"]
 n_db_nodes: 6
 n_loaders: 1
 
-instance_type_db: 'i4i.large'
+# db_instance_type: large resolves to i8g.large (AWS ARM), z3-highmem-4 (GCE), Standard_L4s_v4 (Azure)
+db_instance_type: 'large'
 
 root_disk_size_loader: 80 # enlarge loader disk, cause of cassandra-harry operation.log that can't be disabled
 

--- a/test-cases/longevity/longevity-large-partition-3h.yaml
+++ b/test-cases/longevity/longevity-large-partition-3h.yaml
@@ -35,7 +35,8 @@ n_loaders: 4
 
 round_robin: true
 
-instance_type_db: 'i4i.2xlarge'
+# db_instance_type: 2xlarge resolves to i8g.2xlarge (AWS ARM), z3-highmem-16 (GCE), Standard_L16s_v4 (Azure)
+db_instance_type: '2xlarge'
 
 nemesis_class_name: 'SisyphusMonkey'
 nemesis_seed: '013'

--- a/test-cases/longevity/longevity-lwt-basic-3h.yaml
+++ b/test-cases/longevity/longevity-lwt-basic-3h.yaml
@@ -11,7 +11,8 @@ n_db_nodes: 6
 n_loaders: 3
 round_robin: true
 
-instance_type_db: 'i4i.large'
+# db_instance_type: large resolves to i8g.large (AWS ARM), z3-highmem-4 (GCE), Standard_L4s_v4 (Azure)
+db_instance_type: 'large'
 
 nemesis_class_name: 'SisyphusMonkey'
 nemesis_seed: '020'

--- a/test-cases/longevity/longevity-parallel-schema-changes-12h.yaml
+++ b/test-cases/longevity/longevity-parallel-schema-changes-12h.yaml
@@ -16,7 +16,8 @@ stress_cmd: [
 n_db_nodes: 6
 n_loaders: 2
 
-instance_type_db: 'i4i.2xlarge'
+# db_instance_type: 2xlarge resolves to i8g.2xlarge (AWS ARM), z3-highmem-16 (GCE), Standard_L16s_v4 (Azure)
+db_instance_type: '2xlarge'
 
 nemesis_class_name: ['SisyphusMonkey', 'SisyphusMonkey']
 nemesis_selector: ["topology_changes", "schema_changes and not disruptive"]

--- a/test-cases/longevity/longevity-twcs-3h.yaml
+++ b/test-cases/longevity/longevity-twcs-3h.yaml
@@ -13,7 +13,8 @@ n_db_nodes: 6
 n_loaders: 3
 
 round_robin: true
-instance_type_db: 'i4i.2xlarge'
+# db_instance_type: 2xlarge resolves to i8g.2xlarge (AWS ARM), z3-highmem-16 (GCE), Standard_L16s_v4 (Azure)
+db_instance_type: '2xlarge'
 
 nemesis_class_name: 'SisyphusMonkey'
 nemesis_seed: '024'

--- a/unit_tests/test_data/test_abstract_sizing.yaml
+++ b/unit_tests/test_data/test_abstract_sizing.yaml
@@ -1,0 +1,7 @@
+# Test fixture for abstract sizing CLI
+db_instance_type: '2xlarge'
+loader_instance_type: 'xlarge'
+monitor_instance_type: 'large'
+n_db_nodes: 3
+n_loaders: 1
+n_monitor_nodes: 1

--- a/unit_tests/unit/test_cloud_sizes.py
+++ b/unit_tests/unit/test_cloud_sizes.py
@@ -116,6 +116,7 @@ def test_resolve_size_db_oci(size, expected_type):
         pytest.param("small", "c6i.xlarge", id="small"),
         pytest.param("medium", "c6i.2xlarge", id="medium"),
         pytest.param("large", "c6i.4xlarge", id="large"),
+        pytest.param("2xlarge", "c6i.8xlarge", id="2xlarge"),
         pytest.param("xlarge", "c6i.16xlarge", id="xlarge"),
     ],
 )
@@ -130,6 +131,7 @@ def test_resolve_size_loader_aws_arm(size, expected_type):
         pytest.param("small", "c6i.xlarge", id="small"),
         pytest.param("medium", "c6i.2xlarge", id="medium"),
         pytest.param("large", "c6i.4xlarge", id="large"),
+        pytest.param("2xlarge", "c6i.8xlarge", id="2xlarge"),
         pytest.param("xlarge", "c6i.16xlarge", id="xlarge"),
     ],
 )
@@ -144,6 +146,7 @@ def test_resolve_size_loader_aws_x86(size, expected_type):
         pytest.param("small", "e2-standard-4", id="small"),
         pytest.param("medium", "e2-standard-8", id="medium"),
         pytest.param("large", "e2-standard-16", id="large"),
+        pytest.param("2xlarge", "e2-standard-32", id="2xlarge"),
         pytest.param("xlarge", "e2-highcpu-32", id="xlarge"),
     ],
 )
@@ -160,7 +163,8 @@ def test_resolve_size_loader_gce(size, expected_type):
         pytest.param("small", "Standard_F4s_v2", id="small"),
         pytest.param("medium", "Standard_F8s_v2", id="medium"),
         pytest.param("large", "Standard_F16s_v2", id="large"),
-        pytest.param("xlarge", "Standard_F32s_v2", id="xlarge"),
+        pytest.param("2xlarge", "Standard_F32s_v2", id="2xlarge"),
+        pytest.param("xlarge", "Standard_F48s_v2", id="xlarge"),
     ],
 )
 def test_resolve_size_loader_azure(size, expected_type):
@@ -174,7 +178,8 @@ def test_resolve_size_loader_azure(size, expected_type):
         pytest.param("small", "VM.Standard3.Flex:4:32", id="small"),
         pytest.param("medium", "VM.Standard3.Flex:8:64", id="medium"),
         pytest.param("large", "VM.Standard3.Flex:16:128", id="large"),
-        pytest.param("xlarge", "VM.Standard3.Flex:32:256", id="xlarge"),
+        pytest.param("2xlarge", "VM.Standard3.Flex:32:256", id="2xlarge"),
+        pytest.param("xlarge", "VM.Standard3.Flex:64:512", id="xlarge"),
     ],
 )
 def test_resolve_size_loader_oci(size, expected_type):
@@ -279,6 +284,7 @@ def test_resolve_size_unknown_arch_raises():
         pytest.param("azure", "Standard_L16s_v4", ("db", "2xlarge"), id="azure-db-2xlarge"),
         pytest.param("oci", "DenseIO.E5.Flex:8:128", ("db", "2xlarge"), id="oci-db-2xlarge"),
         pytest.param("aws", "c6i.xlarge", ("loader", "small"), id="aws-loader-small"),
+        pytest.param("aws", "c6i.8xlarge", ("loader", "2xlarge"), id="aws-loader-2xlarge"),
         pytest.param("aws", "c6i.16xlarge", ("loader", "xlarge"), id="aws-loader-xlarge"),
         pytest.param("gce", "e2-standard-8", ("loader", "medium"), id="gce-loader-medium"),
         pytest.param("gce", "e2-highcpu-32", ("loader", "xlarge"), id="gce-loader-xlarge"),
@@ -308,8 +314,9 @@ def test_identify_size_unknown_returns_none(cloud, instance_type):
     assert identify_size(cloud, instance_type) is None
 
 
-def test_identify_size_unknown_cloud_returns_none():
-    assert identify_size("openstack", "m1.xlarge") is None
+def test_identify_size_unknown_cloud_raises():
+    with pytest.raises(ValueError, match="Unknown cloud"):
+        identify_size("openstack", "m1.xlarge")
 
 
 # ---------------------------------------------------------------------------
@@ -457,7 +464,7 @@ def test_sizing_has_all_db_sizes():
 
 def test_sizing_has_all_loader_sizes():
     loader_sizes = set(SIZING["loader"])
-    assert loader_sizes == {"small", "medium", "large", "xlarge"}
+    assert loader_sizes == {"small", "medium", "large", "2xlarge", "xlarge"}
 
 
 def test_sizing_has_all_monitor_sizes():
@@ -478,3 +485,160 @@ def test_sizing_all_specs_have_non_empty_instance_type():
                 spec = getattr(mapping, attr)
                 assert spec.instance_type, f"SIZING[{role!r}][{size!r}].{attr}.instance_type is empty"
                 assert isinstance(spec, InstanceSpec), f"SIZING[{role!r}][{size!r}].{attr} is not an InstanceSpec"
+
+
+# ---------------------------------------------------------------------------
+# db_oracle role — resolves through the "db" sizing table
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "size,cloud,arch,expected_type",
+    [
+        pytest.param("2xlarge", "aws", "arm", "i8g.2xlarge", id="aws-arm-2xlarge"),
+        pytest.param("2xlarge", "aws", "x86", "i4i.2xlarge", id="aws-x86-2xlarge"),
+        pytest.param("2xlarge", "gce", "arm", "z3-highmem-16", id="gce-2xlarge"),
+        pytest.param("2xlarge", "azure", "arm", "Standard_L16s_v4", id="azure-2xlarge"),
+        pytest.param("2xlarge", "oci", "arm", "DenseIO.E5.Flex:8:128", id="oci-2xlarge"),
+        pytest.param("large", "aws", "arm", "i8g.large", id="aws-arm-large"),
+    ],
+)
+def test_resolve_size_db_oracle(size, cloud, arch, expected_type):
+    spec = resolve_size("db_oracle", size, cloud, arch)
+    assert spec.instance_type == expected_type
+
+
+# ---------------------------------------------------------------------------
+# zero_token role — resolves through the "db" sizing table
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "size,cloud,arch,expected_type",
+    [
+        pytest.param("large", "aws", "arm", "i8g.large", id="aws-arm-large"),
+        pytest.param("large", "aws", "x86", "i4i.large", id="aws-x86-large"),
+        pytest.param("large", "gce", "arm", "z3-highmem-4", id="gce-large"),
+        pytest.param("large", "azure", "arm", "Standard_L4s_v4", id="azure-large"),
+        pytest.param("large", "oci", "arm", "DenseIO.E5.Flex:2:32", id="oci-large"),
+        pytest.param("2xlarge", "aws", "arm", "i8g.2xlarge", id="aws-arm-2xlarge"),
+    ],
+)
+def test_resolve_size_zero_token(size, cloud, arch, expected_type):
+    spec = resolve_size("zero_token", size, cloud, arch)
+    assert spec.instance_type == expected_type
+
+
+def test_resolve_size_alias_unknown_role_raises():
+    with pytest.raises(ValueError, match="Unknown role"):
+        resolve_size("not_a_role", "large", "aws")
+
+
+# ---------------------------------------------------------------------------
+# get_cloud_params — db_oracle and zero_token param name generation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "role,size,cloud,arch,expected",
+    [
+        pytest.param(
+            "db_oracle",
+            "2xlarge",
+            "aws",
+            "arm",
+            {"instance_type_db_oracle": "i8g.2xlarge"},
+            id="aws-arm-db_oracle",
+        ),
+        pytest.param(
+            "db_oracle",
+            "2xlarge",
+            "aws",
+            "x86",
+            {"instance_type_db_oracle": "i4i.2xlarge"},
+            id="aws-x86-db_oracle",
+        ),
+        pytest.param(
+            "db_oracle",
+            "2xlarge",
+            "gce",
+            "arm",
+            {"gce_instance_type_db_oracle": "z3-highmem-16"},
+            id="gce-db_oracle-no-disk-params",
+        ),
+        pytest.param(
+            "db_oracle",
+            "2xlarge",
+            "azure",
+            "arm",
+            {"azure_instance_type_db_oracle": "Standard_L16s_v4"},
+            id="azure-db_oracle",
+        ),
+        pytest.param(
+            "db_oracle",
+            "2xlarge",
+            "oci",
+            "arm",
+            {"oci_instance_type_db_oracle": "DenseIO.E5.Flex:8:128"},
+            id="oci-db_oracle",
+        ),
+        pytest.param(
+            "zero_token",
+            "large",
+            "aws",
+            "arm",
+            {"zero_token_instance_type_db": "i8g.large"},
+            id="aws-arm-zero_token",
+        ),
+        pytest.param(
+            "zero_token",
+            "large",
+            "aws",
+            "x86",
+            {"zero_token_instance_type_db": "i4i.large"},
+            id="aws-x86-zero_token",
+        ),
+        pytest.param(
+            "zero_token",
+            "large",
+            "gce",
+            "arm",
+            {"gce_zero_token_instance_type_db": "z3-highmem-4"},
+            id="gce-zero_token-no-disk-params",
+        ),
+        pytest.param(
+            "zero_token",
+            "large",
+            "azure",
+            "arm",
+            {"azure_zero_token_instance_type_db": "Standard_L4s_v4"},
+            id="azure-zero_token",
+        ),
+        pytest.param(
+            "zero_token",
+            "large",
+            "oci",
+            "arm",
+            {"oci_zero_token_instance_type_db": "DenseIO.E5.Flex:2:32"},
+            id="oci-zero_token",
+        ),
+    ],
+)
+def test_get_cloud_params_oracle_and_zero_token(role, size, cloud, arch, expected):
+    spec = resolve_size(role, size, cloud, arch)
+    params = get_cloud_params(role, spec, cloud)
+    assert params == expected
+
+
+def test_get_cloud_params_gce_oracle_no_disk_params():
+    spec = resolve_size("db_oracle", "2xlarge", "gce")
+    params = get_cloud_params("db_oracle", spec, "gce")
+    assert "gce_n_local_ssd_disk_db_oracle" not in params
+    assert "gce_root_disk_type_db_oracle" not in params
+
+
+def test_get_cloud_params_gce_zero_token_no_disk_params():
+    spec = resolve_size("zero_token", "large", "gce")
+    params = get_cloud_params("zero_token", spec, "gce")
+    assert "gce_n_local_ssd_disk_zero_token" not in params
+    assert "gce_root_disk_type_zero_token" not in params

--- a/unit_tests/unit/test_cloud_sizes.py
+++ b/unit_tests/unit/test_cloud_sizes.py
@@ -1,0 +1,480 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2026 ScyllaDB
+
+import pytest
+
+from sdcm.utils.cloud_sizes import (
+    SIZING,
+    InstanceSpec,
+    SizeMapping,
+    get_cloud_params,
+    identify_size,
+    resolve_size,
+)
+
+
+# ---------------------------------------------------------------------------
+# resolve_size — forward mappings
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "size,expected_type",
+    [
+        pytest.param("large", "i8g.large", id="large"),
+        pytest.param("xlarge", "i8g.xlarge", id="xlarge"),
+        pytest.param("2xlarge", "i8g.2xlarge", id="2xlarge"),
+        pytest.param("4xlarge", "i8g.4xlarge", id="4xlarge"),
+        pytest.param("8xlarge", "i8g.8xlarge", id="8xlarge"),
+        pytest.param("16xlarge", "i8g.16xlarge", id="16xlarge"),
+    ],
+)
+def test_resolve_size_db_aws_arm(size, expected_type):
+    spec = resolve_size("db", size, "aws", "arm")
+    assert spec.instance_type == expected_type
+
+
+@pytest.mark.parametrize(
+    "size,expected_type",
+    [
+        pytest.param("large", "i4i.large", id="large"),
+        pytest.param("xlarge", "i4i.xlarge", id="xlarge"),
+        pytest.param("2xlarge", "i4i.2xlarge", id="2xlarge"),
+        pytest.param("4xlarge", "i4i.4xlarge", id="4xlarge"),
+        pytest.param("8xlarge", "i4i.8xlarge", id="8xlarge"),
+        pytest.param("16xlarge", "i4i.16xlarge", id="16xlarge"),
+    ],
+)
+def test_resolve_size_db_aws_x86(size, expected_type):
+    spec = resolve_size("db", size, "aws", "x86")
+    assert spec.instance_type == expected_type
+
+
+@pytest.mark.parametrize(
+    "size,expected_type,ssd_count,disk_type",
+    [
+        pytest.param("large", "z3-highmem-4", 4, "pd-ssd", id="large"),
+        pytest.param("xlarge", "z3-highmem-8", 4, "pd-ssd", id="xlarge"),
+        pytest.param("2xlarge", "z3-highmem-16", 4, "pd-ssd", id="2xlarge"),
+        pytest.param("4xlarge", "z3-highmem-32", 4, "pd-ssd", id="4xlarge"),
+        pytest.param("8xlarge", "z3-highmem-48", 4, "pd-ssd", id="8xlarge"),
+        pytest.param("16xlarge", "z3-highmem-88", 4, "pd-ssd", id="16xlarge"),
+    ],
+)
+def test_resolve_size_db_gce(size, expected_type, ssd_count, disk_type):
+    spec = resolve_size("db", size, "gce")
+    assert spec.instance_type == expected_type
+    assert spec.local_ssd_count == ssd_count
+    assert spec.root_disk_type == disk_type
+
+
+@pytest.mark.parametrize(
+    "size,expected_type",
+    [
+        pytest.param("large", "Standard_L4s_v4", id="large"),
+        pytest.param("xlarge", "Standard_L8s_v4", id="xlarge"),
+        pytest.param("2xlarge", "Standard_L16s_v4", id="2xlarge"),
+        pytest.param("4xlarge", "Standard_L32s_v4", id="4xlarge"),
+        pytest.param("8xlarge", "Standard_L64s_v4", id="8xlarge"),
+        pytest.param("16xlarge", "Standard_L80s_v4", id="16xlarge"),
+    ],
+)
+def test_resolve_size_db_azure(size, expected_type):
+    spec = resolve_size("db", size, "azure")
+    assert spec.instance_type == expected_type
+
+
+@pytest.mark.parametrize(
+    "size,expected_type",
+    [
+        pytest.param("large", "DenseIO.E5.Flex:2:32", id="large"),
+        pytest.param("xlarge", "DenseIO.E5.Flex:4:64", id="xlarge"),
+        pytest.param("2xlarge", "DenseIO.E5.Flex:8:128", id="2xlarge"),
+        pytest.param("4xlarge", "DenseIO.E5.Flex:16:256", id="4xlarge"),
+        pytest.param("8xlarge", "DenseIO.E5.Flex:32:512", id="8xlarge"),
+        pytest.param("16xlarge", "DenseIO.E5.Flex:64:1024", id="16xlarge"),
+    ],
+)
+def test_resolve_size_db_oci(size, expected_type):
+    spec = resolve_size("db", size, "oci")
+    assert spec.instance_type == expected_type
+
+
+@pytest.mark.parametrize(
+    "size,expected_type",
+    [
+        pytest.param("small", "c6i.xlarge", id="small"),
+        pytest.param("medium", "c6i.2xlarge", id="medium"),
+        pytest.param("large", "c6i.4xlarge", id="large"),
+        pytest.param("xlarge", "c6i.16xlarge", id="xlarge"),
+    ],
+)
+def test_resolve_size_loader_aws_arm(size, expected_type):
+    spec = resolve_size("loader", size, "aws", "arm")
+    assert spec.instance_type == expected_type
+
+
+@pytest.mark.parametrize(
+    "size,expected_type",
+    [
+        pytest.param("small", "c6i.xlarge", id="small"),
+        pytest.param("medium", "c6i.2xlarge", id="medium"),
+        pytest.param("large", "c6i.4xlarge", id="large"),
+        pytest.param("xlarge", "c6i.16xlarge", id="xlarge"),
+    ],
+)
+def test_resolve_size_loader_aws_x86(size, expected_type):
+    spec = resolve_size("loader", size, "aws", "x86")
+    assert spec.instance_type == expected_type
+
+
+@pytest.mark.parametrize(
+    "size,expected_type",
+    [
+        pytest.param("small", "e2-standard-4", id="small"),
+        pytest.param("medium", "e2-standard-8", id="medium"),
+        pytest.param("large", "e2-standard-16", id="large"),
+        pytest.param("xlarge", "e2-highcpu-32", id="xlarge"),
+    ],
+)
+def test_resolve_size_loader_gce(size, expected_type):
+    spec = resolve_size("loader", size, "gce")
+    assert spec.instance_type == expected_type
+    assert spec.local_ssd_count == 0
+    assert spec.root_disk_type == ""
+
+
+@pytest.mark.parametrize(
+    "size,expected_type",
+    [
+        pytest.param("small", "Standard_F4s_v2", id="small"),
+        pytest.param("medium", "Standard_F8s_v2", id="medium"),
+        pytest.param("large", "Standard_F16s_v2", id="large"),
+        pytest.param("xlarge", "Standard_F32s_v2", id="xlarge"),
+    ],
+)
+def test_resolve_size_loader_azure(size, expected_type):
+    spec = resolve_size("loader", size, "azure")
+    assert spec.instance_type == expected_type
+
+
+@pytest.mark.parametrize(
+    "size,expected_type",
+    [
+        pytest.param("small", "VM.Standard3.Flex:4:32", id="small"),
+        pytest.param("medium", "VM.Standard3.Flex:8:64", id="medium"),
+        pytest.param("large", "VM.Standard3.Flex:16:128", id="large"),
+        pytest.param("xlarge", "VM.Standard3.Flex:32:256", id="xlarge"),
+    ],
+)
+def test_resolve_size_loader_oci(size, expected_type):
+    spec = resolve_size("loader", size, "oci")
+    assert spec.instance_type == expected_type
+
+
+@pytest.mark.parametrize(
+    "size,expected_type",
+    [
+        pytest.param("small", "t3.large", id="small"),
+        pytest.param("medium", "m6i.xlarge", id="medium"),
+        pytest.param("large", "m6i.2xlarge", id="large"),
+    ],
+)
+def test_resolve_size_monitor_aws(size, expected_type):
+    spec_arm = resolve_size("monitor", size, "aws", "arm")
+    spec_x86 = resolve_size("monitor", size, "aws", "x86")
+    assert spec_arm.instance_type == expected_type
+    assert spec_x86.instance_type == expected_type
+
+
+@pytest.mark.parametrize(
+    "size,expected_type",
+    [
+        pytest.param("small", "n2-highmem-4", id="small"),
+        pytest.param("medium", "n2-highmem-8", id="medium"),
+        pytest.param("large", "n2-highmem-16", id="large"),
+    ],
+)
+def test_resolve_size_monitor_gce(size, expected_type):
+    spec = resolve_size("monitor", size, "gce")
+    assert spec.instance_type == expected_type
+    assert spec.local_ssd_count == 0
+
+
+@pytest.mark.parametrize(
+    "size,expected_type",
+    [
+        pytest.param("small", "Standard_D2_v4", id="small"),
+        pytest.param("medium", "Standard_D4_v4", id="medium"),
+        pytest.param("large", "Standard_D8_v4", id="large"),
+    ],
+)
+def test_resolve_size_monitor_azure(size, expected_type):
+    spec = resolve_size("monitor", size, "azure")
+    assert spec.instance_type == expected_type
+
+
+@pytest.mark.parametrize(
+    "size,expected_type",
+    [
+        pytest.param("small", "VM.Standard.E4.Flex:2:16", id="small"),
+        pytest.param("medium", "VM.Standard.E4.Flex:4:32", id="medium"),
+        pytest.param("large", "VM.Standard.E4.Flex:8:64", id="large"),
+    ],
+)
+def test_resolve_size_monitor_oci(size, expected_type):
+    spec = resolve_size("monitor", size, "oci")
+    assert spec.instance_type == expected_type
+
+
+# ---------------------------------------------------------------------------
+# resolve_size — error cases
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_size_unknown_role_raises():
+    with pytest.raises(ValueError, match="Unknown role"):
+        resolve_size("unknown_role", "large", "aws")
+
+
+def test_resolve_size_unknown_size_raises():
+    with pytest.raises(ValueError, match="Unknown size"):
+        resolve_size("db", "nonexistent", "aws")
+
+
+def test_resolve_size_unknown_cloud_raises():
+    with pytest.raises(ValueError, match="Unknown cloud"):
+        resolve_size("db", "large", "openstack")
+
+
+def test_resolve_size_unknown_arch_raises():
+    with pytest.raises(ValueError, match="Unknown arch"):
+        resolve_size("db", "large", "aws", "arm64")
+
+
+# ---------------------------------------------------------------------------
+# identify_size — reverse lookups
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "cloud,instance_type,expected",
+    [
+        pytest.param("aws", "i8g.large", ("db", "large"), id="aws-arm-large"),
+        pytest.param("aws", "i8g.2xlarge", ("db", "2xlarge"), id="aws-arm-2xlarge"),
+        pytest.param("aws", "i4i.2xlarge", ("db", "2xlarge"), id="aws-x86-2xlarge"),
+        pytest.param("aws", "i4i.16xlarge", ("db", "16xlarge"), id="aws-x86-16xlarge"),
+        pytest.param("gce", "z3-highmem-16", ("db", "2xlarge"), id="gce-db-2xlarge"),
+        pytest.param("gce", "z3-highmem-4", ("db", "large"), id="gce-db-large"),
+        pytest.param("azure", "Standard_L16s_v4", ("db", "2xlarge"), id="azure-db-2xlarge"),
+        pytest.param("oci", "DenseIO.E5.Flex:8:128", ("db", "2xlarge"), id="oci-db-2xlarge"),
+        pytest.param("aws", "c6i.xlarge", ("loader", "small"), id="aws-loader-small"),
+        pytest.param("aws", "c6i.16xlarge", ("loader", "xlarge"), id="aws-loader-xlarge"),
+        pytest.param("gce", "e2-standard-8", ("loader", "medium"), id="gce-loader-medium"),
+        pytest.param("gce", "e2-highcpu-32", ("loader", "xlarge"), id="gce-loader-xlarge"),
+        pytest.param("azure", "Standard_F4s_v2", ("loader", "small"), id="azure-loader-small"),
+        pytest.param("oci", "VM.Standard3.Flex:16:128", ("loader", "large"), id="oci-loader-large"),
+        pytest.param("aws", "t3.large", ("monitor", "small"), id="aws-monitor-small"),
+        pytest.param("aws", "m6i.2xlarge", ("monitor", "large"), id="aws-monitor-large"),
+        pytest.param("gce", "n2-highmem-8", ("monitor", "medium"), id="gce-monitor-medium"),
+        pytest.param("azure", "Standard_D8_v4", ("monitor", "large"), id="azure-monitor-large"),
+        pytest.param("oci", "VM.Standard.E4.Flex:4:32", ("monitor", "medium"), id="oci-monitor-medium"),
+    ],
+)
+def test_identify_size_known_types(cloud, instance_type, expected):
+    assert identify_size(cloud, instance_type) == expected
+
+
+@pytest.mark.parametrize(
+    "cloud,instance_type",
+    [
+        pytest.param("aws", "x99.nonexistent", id="aws-unknown"),
+        pytest.param("gce", "n1-standard-4", id="gce-unknown"),
+        pytest.param("azure", "Standard_B2ms", id="azure-unknown"),
+        pytest.param("oci", "VM.Standard2.1", id="oci-unknown"),
+    ],
+)
+def test_identify_size_unknown_returns_none(cloud, instance_type):
+    assert identify_size(cloud, instance_type) is None
+
+
+def test_identify_size_unknown_cloud_returns_none():
+    assert identify_size("openstack", "m1.xlarge") is None
+
+
+# ---------------------------------------------------------------------------
+# get_cloud_params — param name generation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "role,size,cloud,arch,expected",
+    [
+        pytest.param(
+            "db",
+            "2xlarge",
+            "aws",
+            "arm",
+            {"instance_type_db": "i8g.2xlarge"},
+            id="aws-arm-db",
+        ),
+        pytest.param(
+            "db",
+            "2xlarge",
+            "aws",
+            "x86",
+            {"instance_type_db": "i4i.2xlarge"},
+            id="aws-x86-db",
+        ),
+        pytest.param(
+            "db",
+            "2xlarge",
+            "gce",
+            "arm",
+            {"gce_instance_type_db": "z3-highmem-16", "gce_n_local_ssd_disk_db": 4, "gce_root_disk_type_db": "pd-ssd"},
+            id="gce-db",
+        ),
+        pytest.param(
+            "db",
+            "2xlarge",
+            "azure",
+            "arm",
+            {"azure_instance_type_db": "Standard_L16s_v4"},
+            id="azure-db",
+        ),
+        pytest.param(
+            "db",
+            "2xlarge",
+            "oci",
+            "arm",
+            {"oci_instance_type_db": "DenseIO.E5.Flex:8:128"},
+            id="oci-db",
+        ),
+        pytest.param(
+            "loader",
+            "medium",
+            "aws",
+            "x86",
+            {"instance_type_loader": "c6i.2xlarge"},
+            id="aws-loader",
+        ),
+        pytest.param(
+            "loader",
+            "medium",
+            "gce",
+            "arm",
+            {"gce_instance_type_loader": "e2-standard-8"},
+            id="gce-loader-no-ssd",
+        ),
+        pytest.param(
+            "loader",
+            "medium",
+            "azure",
+            "arm",
+            {"azure_instance_type_loader": "Standard_F8s_v2"},
+            id="azure-loader",
+        ),
+        pytest.param(
+            "loader",
+            "medium",
+            "oci",
+            "arm",
+            {"oci_instance_type_loader": "VM.Standard3.Flex:8:64"},
+            id="oci-loader",
+        ),
+        pytest.param(
+            "monitor",
+            "medium",
+            "aws",
+            "arm",
+            {"instance_type_monitor": "m6i.xlarge"},
+            id="aws-monitor",
+        ),
+        pytest.param(
+            "monitor",
+            "medium",
+            "gce",
+            "arm",
+            {"gce_instance_type_monitor": "n2-highmem-8"},
+            id="gce-monitor",
+        ),
+        pytest.param(
+            "monitor",
+            "medium",
+            "azure",
+            "arm",
+            {"azure_instance_type_monitor": "Standard_D4_v4"},
+            id="azure-monitor",
+        ),
+        pytest.param(
+            "monitor",
+            "medium",
+            "oci",
+            "arm",
+            {"oci_instance_type_monitor": "VM.Standard.E4.Flex:4:32"},
+            id="oci-monitor",
+        ),
+    ],
+)
+def test_get_cloud_params(role, size, cloud, arch, expected):
+    spec = resolve_size(role, size, cloud, arch)
+    params = get_cloud_params(role, spec, cloud)
+    assert params == expected
+
+
+def test_get_cloud_params_gce_no_ssd_omits_disk_params():
+    spec = resolve_size("monitor", "medium", "gce")
+    params = get_cloud_params("monitor", spec, "gce")
+    assert "gce_n_local_ssd_disk_monitor" not in params
+    assert "gce_root_disk_type_monitor" not in params
+
+
+def test_get_cloud_params_unknown_cloud_raises():
+    spec = InstanceSpec("some.type", 4, 16.0)
+    with pytest.raises(ValueError, match="Unknown cloud"):
+        get_cloud_params("db", spec, "openstack")
+
+
+# ---------------------------------------------------------------------------
+# SIZING registry completeness
+# ---------------------------------------------------------------------------
+
+
+def test_sizing_has_all_db_sizes():
+    db_sizes = set(SIZING["db"])
+    assert db_sizes == {"large", "xlarge", "2xlarge", "4xlarge", "8xlarge", "16xlarge"}
+
+
+def test_sizing_has_all_loader_sizes():
+    loader_sizes = set(SIZING["loader"])
+    assert loader_sizes == {"small", "medium", "large", "xlarge"}
+
+
+def test_sizing_has_all_monitor_sizes():
+    monitor_sizes = set(SIZING["monitor"])
+    assert monitor_sizes == {"small", "medium", "large"}
+
+
+def test_sizing_all_mappings_are_size_mapping_instances():
+    for role, sizes in SIZING.items():
+        for size, mapping in sizes.items():
+            assert isinstance(mapping, SizeMapping), f"SIZING[{role!r}][{size!r}] is not a SizeMapping"
+
+
+def test_sizing_all_specs_have_non_empty_instance_type():
+    for role, sizes in SIZING.items():
+        for size, mapping in sizes.items():
+            for attr in ("aws_arm", "aws_x86", "gce", "azure", "oci"):
+                spec = getattr(mapping, attr)
+                assert spec.instance_type, f"SIZING[{role!r}][{size!r}].{attr}.instance_type is empty"
+                assert isinstance(spec, InstanceSpec), f"SIZING[{role!r}][{size!r}].{attr} is not an InstanceSpec"

--- a/unit_tests/unit/test_config.py
+++ b/unit_tests/unit/test_config.py
@@ -818,6 +818,26 @@ def test_resolve_instance_sizes_explicit_override(tmp_path, monkeypatch):
     assert params.get("instance_type_db") == "i4i.4xlarge"
 
 
+def test_resolve_instance_sizes_aws_x86(tmp_path, monkeypatch):
+    config_file = tmp_path / "test.yaml"
+    config_file.write_text("db_instance_type: '2xlarge'\n")
+    monkeypatch.setenv("SCT_CLUSTER_BACKEND", "aws")
+    monkeypatch.setenv("SCT_CONFIG_FILES", str(config_file))
+    monkeypatch.setenv("SCT_AMI_ID_DB_SCYLLA", "ami-dummy")
+    monkeypatch.setenv("SCT_SCYLLA_VERSION", "")
+    monkeypatch.setenv("SCT_REGION_NAME", "us-east-1")
+    monkeypatch.delenv("SCT_INSTANCE_TYPE_DB", raising=False)
+
+    params = sct_config.SCTConfiguration()
+    params["instance_type_db"] = "i4i.large"
+    assert "instance_type_db" not in params._user_provided_keys
+
+    with unittest.mock.patch("sdcm.sct_config.get_arch_from_instance_type", return_value="x86_64"):
+        params._resolve_instance_sizes()
+
+    assert params.get("instance_type_db") == "i4i.2xlarge"
+
+
 def test_resolve_instance_sizes_gce_disk_params(tmp_path, monkeypatch):
     config_file = tmp_path / "test.yaml"
     config_file.write_text("db_instance_type: '2xlarge'\n")
@@ -829,3 +849,29 @@ def test_resolve_instance_sizes_gce_disk_params(tmp_path, monkeypatch):
     params = sct_config.SCTConfiguration()
     assert params.get("gce_instance_type_db") == "z3-highmem-16"
     assert params.get("gce_n_local_ssd_disk_db") == 4
+
+
+def test_resolve_instance_sizes_oracle_aws(tmp_path, monkeypatch):
+    config_file = tmp_path / "test.yaml"
+    config_file.write_text("oracle_instance_type: '2xlarge'\n")
+    monkeypatch.setenv("SCT_CLUSTER_BACKEND", "aws")
+    monkeypatch.setenv("SCT_CONFIG_FILES", str(config_file))
+    monkeypatch.setenv("SCT_AMI_ID_DB_SCYLLA", "ami-dummy")
+    monkeypatch.setenv("SCT_SCYLLA_VERSION", "")
+    monkeypatch.delenv("SCT_INSTANCE_TYPE_DB", raising=False)
+    monkeypatch.delenv("SCT_INSTANCE_TYPE_DB_ORACLE", raising=False)
+    params = sct_config.SCTConfiguration()
+    assert params.get("instance_type_db_oracle") == "i8g.2xlarge"
+
+
+def test_resolve_instance_sizes_zero_token_aws(tmp_path, monkeypatch):
+    config_file = tmp_path / "test.yaml"
+    config_file.write_text("zero_token_instance_type: 'large'\n")
+    monkeypatch.setenv("SCT_CLUSTER_BACKEND", "aws")
+    monkeypatch.setenv("SCT_CONFIG_FILES", str(config_file))
+    monkeypatch.setenv("SCT_AMI_ID_DB_SCYLLA", "ami-dummy")
+    monkeypatch.setenv("SCT_SCYLLA_VERSION", "")
+    monkeypatch.delenv("SCT_INSTANCE_TYPE_DB", raising=False)
+    monkeypatch.delenv("SCT_ZERO_TOKEN_INSTANCE_TYPE_DB", raising=False)
+    params = sct_config.SCTConfiguration()
+    assert params.get("zero_token_instance_type_db") == "i8g.large"

--- a/unit_tests/unit/test_config.py
+++ b/unit_tests/unit/test_config.py
@@ -791,3 +791,41 @@ def test_vector_store_ami_name_resolved_to_ami_id(monkeypatch):
     assert "vector-store-1-5-0-arm64-2026-03-17t07-07-32z" in resolved_names, (
         "convert_name_to_ami_if_needed was not called for ami_id_vector_store"
     )
+
+
+def test_resolve_instance_sizes_aws(tmp_path, monkeypatch):
+    config_file = tmp_path / "test.yaml"
+    config_file.write_text("db_instance_type: '2xlarge'\n")
+    monkeypatch.setenv("SCT_CLUSTER_BACKEND", "aws")
+    monkeypatch.setenv("SCT_CONFIG_FILES", str(config_file))
+    monkeypatch.setenv("SCT_AMI_ID_DB_SCYLLA", "ami-dummy")
+    monkeypatch.setenv("SCT_SCYLLA_VERSION", "")
+    # Clear any module-scoped env leak (e.g. from fixture_conf which sets SCT_INSTANCE_TYPE_DB)
+    monkeypatch.delenv("SCT_INSTANCE_TYPE_DB", raising=False)
+    params = sct_config.SCTConfiguration()
+    assert params.get("instance_type_db") == "i8g.2xlarge"
+
+
+def test_resolve_instance_sizes_explicit_override(tmp_path, monkeypatch):
+    config_file = tmp_path / "test.yaml"
+    config_file.write_text("db_instance_type: '2xlarge'\ninstance_type_db: 'i4i.4xlarge'\n")
+    monkeypatch.setenv("SCT_CLUSTER_BACKEND", "aws")
+    monkeypatch.setenv("SCT_CONFIG_FILES", str(config_file))
+    monkeypatch.setenv("SCT_AMI_ID_DB_SCYLLA", "ami-dummy")
+    monkeypatch.setenv("SCT_SCYLLA_VERSION", "")
+    monkeypatch.delenv("SCT_INSTANCE_TYPE_DB", raising=False)
+    params = sct_config.SCTConfiguration()
+    assert params.get("instance_type_db") == "i4i.4xlarge"
+
+
+def test_resolve_instance_sizes_gce_disk_params(tmp_path, monkeypatch):
+    config_file = tmp_path / "test.yaml"
+    config_file.write_text("db_instance_type: '2xlarge'\n")
+    monkeypatch.setenv("SCT_CLUSTER_BACKEND", "gce")
+    monkeypatch.setenv("SCT_CONFIG_FILES", str(config_file))
+    monkeypatch.setenv("SCT_GCE_IMAGE_DB", "https://dummy-gce-image")
+    monkeypatch.setenv("SCT_SCYLLA_VERSION", "")
+    monkeypatch.delenv("SCT_INSTANCE_TYPE_DB", raising=False)
+    params = sct_config.SCTConfiguration()
+    assert params.get("gce_instance_type_db") == "z3-highmem-16"
+    assert params.get("gce_n_local_ssd_disk_db") == 4


### PR DESCRIPTION
## Summary

Introduces a **T-shirt sizing abstraction** for cross-cloud instance types in SCT. Instead of specifying cloud-specific instance types for every backend in every test YAML, test authors can now write a single abstract size that resolves automatically per backend.

### Before (6+ lines per test config)
```yaml
instance_type_db: 'i4i.2xlarge'
gce_instance_type_db: 'z3-highmem-16'
gce_n_local_ssd_disk_db: 4
gce_root_disk_type_db: 'pd-ssd'
azure_instance_type_db: 'Standard_L16s_v4'
oci_instance_type_db: 'DenseIO.E5.Flex:8:128'
```

### After (1 line, all clouds resolved automatically)
```yaml
db_instance_type: '2xlarge'
```

Cloud-specific overrides still take full precedence — zero breaking changes.

---

## Phases

### Phase 1 — `sdcm/utils/cloud_sizes.py` (commit `dd2e5c4330`)
- New module with `InstanceSpec`, `SizeMapping`, `resolve_size()`, `identify_size()`, `get_cloud_params()`
- Full mapping tables: DB (6 sizes × 4 clouds), Loader (4 sizes × 4 clouds), Monitor (3 sizes × 4 clouds)
- AWS DB defaults to `i8g` (Graviton/ARM); auto-switches to `i4i` for x86
- GCE DB: `z3-highmem` family with local NVMe; Azure: `Standard_L*s_v4`; OCI: `DenseIO.E5`
- 110 parametrized unit tests in `unit_tests/unit/test_cloud_sizes.py`

### Phase 2 — Config integration in `sdcm/sct_config.py` (commit `3df56fb701`)
- Three new `SctField` params: `db_instance_type`, `loader_instance_type`, `monitor_instance_type`
- New `_resolve_instance_sizes()` method called early in `__init__` (before AWS arch/AMI logic)
- `_user_provided_keys` set tracks explicitly-set keys so defaults don't block abstract resolution
- GCE resolution also populates `gce_n_local_ssd_disk_db` and `gce_root_disk_type_db`
- 3 new unit tests in `unit_tests/unit/test_config.py`; all 64 existing tests still pass
- `docs/configuration_options.md` auto-updated by pre-commit hook

### Phase 3 — CLI helpers in `sct.py` (commit `891f6e8492`)
- `sct.py show-sizes [--role db|loader|monitor] [--cloud aws|gce|azure|oci]` — print mapping table
- `sct.py translate-size <instance_type>` — show cross-cloud equivalents for a concrete type
- `sct.py translate-size --config <yaml> [--backend <cloud>]` — expand abstract sizes in a YAML
- Test fixture `unit_tests/test_data/test_abstract_sizing.yaml`

### Phase 4 — Migrate longevity configs (commit `d791aba046`)
- 12 longevity configs in `test-cases/longevity/` migrated to abstract sizes
- Configs using `4xlarge`, `8xlarge`, `16xlarge` DB sizes; `medium`/`large` loader/monitor sizes
- All migrated configs verified to resolve correctly on AWS and GCE

### Phase 5 — Documentation (commit `afb4e505bb`)
- `docs/cross-cloud-sizing.md`: full usage guide, mapping table, how to add new sizes
- `AGENTS.md`: cross-cloud sizing reference added to configuration section

### Fix — Test isolation (commit `e8be7768d9`)
- Fixed module-scoped env leak in `test_config.py`: `fixture_conf` sets `SCT_INSTANCE_TYPE_DB=i4i.large` for the whole module; new sizing tests now explicitly clear it via `monkeypatch.delenv`

---

## Testing

```bash
# All unit tests pass
uv run python -m pytest unit_tests/unit/test_cloud_sizes.py unit_tests/unit/test_config.py -q
# 174 passed

# CLI smoke tests
uv run sct.py show-sizes --role db --cloud aws
uv run sct.py translate-size i8g.2xlarge
uv run sct.py translate-size --config unit_tests/test_data/test_abstract_sizing.yaml --backend gce
```

## Manual Testing Required

- [ ] Run a longevity test on GCE with a migrated config to confirm resolved instance type is correct
- [ ] Verify `sct.py conf -b gce test-cases/longevity/longevity-100gb-4h.yaml` resolves `gce_instance_type_db` correctly (requires network access to SCT config resolution)

## Backends Affected
- [x] AWS — `instance_type_db` resolution
- [x] GCE — `gce_instance_type_db` + disk params resolution
- [x] Azure — `azure_instance_type_db` resolution
- [x] OCI — `oci_instance_type_db` resolution