### PR TITLE
fix(jenkins): prioritize requested_by_user param in getRunningUserId

### DIFF
--- a/vars/tagBuilder.groovy
+++ b/vars/tagBuilder.groovy
@@ -62,13 +62,23 @@ private String GetBillingProjectTag() {
 }
 
 def getRunningUserId () {
-    def buildCause = currentBuild.getBuildCauses('hudson.model.Cause$UserIdCause')
     String runningUserID = "jenkins"
-    echo "Build cause: |${buildCause.toString()}|"
 
-    if (buildCause != null && !buildCause.isEmpty()) {
-        runningUserID = buildCause[0].userId
+    try {
+        if (params.requested_by_user) {
+            runningUserID = params.requested_by_user
+        }
+    } catch (ignored) {
     }
+
+    if (runningUserID == "jenkins") {
+        def buildCause = currentBuild.getBuildCauses('hudson.model.Cause$UserIdCause')
+        echo "Build cause: |${buildCause.toString()}|"
+        if (buildCause != null && !buildCause.isEmpty()) {
+            runningUserID = buildCause[0].userId
+        }
+    }
+
     if (runningUserID?.contains('@')) {
         runningUserID = runningUserID.split('@')[0]
     }


### PR DESCRIPTION
## Summary
- `getRunningUserId()` now checks the `requested_by_user` pipeline parameter first
- Falls back to Jenkins `UserIdCause` build cause only when the parameter is empty/missing
- Handles jobs without the parameter via try/catch

## Motivation
Scheduled and parameterized builds should attribute the run to the user specified in `requested_by_user`, not to whoever (or whatever) triggered the Jenkins job.