### PR TITLE
fix(install): handle nonroot case in node-exporter fallback setup

### DIFF
--- a/sdcm/node_exporter_setup.py
+++ b/sdcm/node_exporter_setup.py
@@ -18,6 +18,10 @@ class NodeExporterSetup:
             curl -L --retry 5 --retry-max-time 300 -O https://github.com/prometheus/node_exporter/releases/download/v{NODE_EXPORTER_VERSION}/node_exporter-{NODE_EXPORTER_VERSION}.linux-amd64.tar.gz
             tar -xzvf node_exporter-{NODE_EXPORTER_VERSION}.linux-amd64.tar.gz
             mv node_exporter-{NODE_EXPORTER_VERSION}.linux-amd64/node_exporter /usr/local/bin
+            # Restore SELinux context so the binary can be executed as a service on RHEL-based systems
+            if command -v restorecon > /dev/null 2>&1; then
+                restorecon -v /usr/local/bin/node_exporter
+            fi
 
             if [ -e /etc/systemd/system/node_exporter.service ]; then
                 rm /etc/systemd/system/node_exporter.service


### PR DESCRIPTION
On Rocky 9 with SELinux enforcing, the node_exporter binary downloaded from GitHub to `/usr/local/bin` lacks proper SELinux context, preventing it from binding to port 9100 when run as a systemd service.

Fix: add `restorecon` after installing the binary to restore the correct file context (`bin_t`). Debian is unaffected as it doesn't use SELinux, which explains why deb tests pass without this fix.

Fixes artifacts-rocky9-nonroot-test and artifacts-rocky9-test failures.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://jenkins.scylladb.com/job/releng-testing/job/artifacts-offline-install/job/artifacts-rocky9-test/908/
- [x] https://jenkins.scylladb.com/job/releng-testing/job/artifacts-offline-install/job/artifacts-rocky9-nonroot-test/910/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)