### PR TITLE
fix(gemini): respect stress_duration override and fix seed reporting in Argus

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -724,11 +724,8 @@ class ClusterTester(unittest.TestCase):
             seed = self.params.get("gemini_seed")
             gemini_command, *_ = self.gemini_results["cmd"]
             if not seed:
-                seed_match = re.search(r"--seed (?P<seed>\d+) ", gemini_command)
-                if seed_match:
-                    seed = seed_match.groupdict().get("seed", -1)
-                else:
-                    seed = -1
+                seed_match = re.search(r"--seed[= ](\d+)", gemini_command)
+                seed = seed_match.group(1) if seed_match else -1
 
             results = self.gemini_results["results"]
             results = results[0] if len(results) > 0 else None

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -3103,9 +3103,12 @@ class ClusterTester(unittest.TestCase):
     def run_gemini(self, cmd, duration=None):
         if duration:
             timeout = self.get_duration(duration)
-        elif self._stress_duration and "--duration" in cmd:
+        elif self._stress_duration:
             timeout = self.get_duration(self._stress_duration)
-            cmd = re.sub(r"(^|\s)--duration\s+\S+", f"\\1--duration {self._stress_duration}m", cmd)
+            if "--duration" in cmd:
+                cmd = re.sub(r"(^|\s)--duration\s+\S+", f"\\1--duration {self._stress_duration}m", cmd)
+            else:
+                cmd = cmd + f" --duration {self._stress_duration}m"
         else:
             timeout = get_timeout_from_stress_cmd(cmd) or self.get_duration(duration)
         return GeminiStressThread(

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -3109,7 +3109,6 @@ class ClusterTester(unittest.TestCase):
         elif self._stress_duration and "--duration" in cmd:
             timeout = self.get_duration(self._stress_duration)
             cmd = re.sub(r"(^|\s)--duration\s+\S+", f"\\1--duration {self._stress_duration}m", cmd)
-            cmd = re.sub(r"\s--warmup\s+\d+[mhd]\s", f" --warmup {int(self._stress_duration * 0.2)}m ", cmd)
         else:
             timeout = get_timeout_from_stress_cmd(cmd) or self.get_duration(duration)
         return GeminiStressThread(

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -3106,9 +3106,9 @@ class ClusterTester(unittest.TestCase):
     def run_gemini(self, cmd, duration=None):
         if duration:
             timeout = self.get_duration(duration)
-        elif self._stress_duration and " --duration" in cmd:
+        elif self._stress_duration and "--duration" in cmd:
             timeout = self.get_duration(self._stress_duration)
-            cmd = re.sub(r"\s--duration\s+\d+[mhd]\s", f" --duration {self._stress_duration}m ", cmd)
+            cmd = re.sub(r"(^|\s)--duration\s+\S+", f"\\1--duration {self._stress_duration}m", cmd)
             cmd = re.sub(r"\s--warmup\s+\d+[mhd]\s", f" --warmup {int(self._stress_duration * 0.2)}m ", cmd)
         else:
             timeout = get_timeout_from_stress_cmd(cmd) or self.get_duration(duration)

--- a/unit_tests/unit/test_stress_thread_functions.py
+++ b/unit_tests/unit/test_stress_thread_functions.py
@@ -65,7 +65,10 @@ def test_get_timeout_from_stress_cmd(stress_cmd, timeout):
 
 def _apply_gemini_stress_duration(cmd: str, stress_duration: int) -> str:
     """Mirror of the substitution logic in ClusterTester.run_gemini()."""
-    cmd = re.sub(r"(^|\s)--duration\s+\S+", f"\\1--duration {stress_duration}m", cmd)
+    if "--duration" in cmd:
+        cmd = re.sub(r"(^|\s)--duration\s+\S+", f"\\1--duration {stress_duration}m", cmd)
+    else:
+        cmd = cmd + f" --duration {stress_duration}m"
     return cmd
 
 
@@ -114,15 +117,22 @@ def _apply_gemini_stress_duration(cmd: str, stress_duration: int) -> str:
             "--duration 60m",
             id="10h-test-override-to-1h",
         ),
+        # stress_duration set but gemini_cmd has no --duration at all → must be injected
+        pytest.param(
+            "--concurrency 50\n--mode mixed",
+            90,
+            "--duration 90m",
+            id="no-duration-in-cmd-stress-duration-injected",
+        ),
     ],
 )
 def test_run_gemini_stress_duration_substitution(original_cmd, stress_duration, expected_duration):
-    """Verify the duration substitution in run_gemini() rewrites --duration correctly."""
-    assert "--duration" in original_cmd, "precondition: cmd must contain --duration"
-
+    """Verify stress_duration always takes precedence: replaces existing --duration or injects one."""
     result = _apply_gemini_stress_duration(original_cmd, stress_duration)
 
     assert expected_duration in result, f"Expected '{expected_duration}' in result, got: {result!r}"
+    # original flags unrelated to duration must survive
+    assert "--concurrency" in result, f"--concurrency must be preserved, got: {result!r}"
     # warmup flag must be left untouched
     if "--warmup" in original_cmd:
         assert "--warmup 30m" in result, f"--warmup should not be modified, got: {result!r}"

--- a/unit_tests/unit/test_stress_thread_functions.py
+++ b/unit_tests/unit/test_stress_thread_functions.py
@@ -11,6 +11,8 @@
 #
 # Copyright (c) 2022 ScyllaDB
 
+import re
+
 import pytest
 
 from sdcm.stress_thread import get_timeout_from_stress_cmd
@@ -59,3 +61,68 @@ def test_duration_str_to_seconds_function(duration, seconds):
 )
 def test_get_timeout_from_stress_cmd(stress_cmd, timeout):
     assert get_timeout_from_stress_cmd(stress_cmd) == timeout
+
+
+def _apply_gemini_stress_duration(cmd: str, stress_duration: int) -> str:
+    """Mirror of the substitution logic in ClusterTester.run_gemini()."""
+    cmd = re.sub(r"(^|\s)--duration\s+\S+", f"\\1--duration {stress_duration}m", cmd)
+    return cmd
+
+
+@pytest.mark.parametrize(
+    "original_cmd, stress_duration, expected_duration",
+    [
+        # Standard case with leading space before --duration
+        pytest.param(
+            " --duration 3h --concurrency 50",
+            60,
+            "--duration 60m",
+            id="leading-space-before-duration",
+        ),
+        # The actual bug: YAML block scalar puts --duration at start (no leading space)
+        pytest.param(
+            "--duration 3h\n--concurrency 50\n--mode mixed",
+            60,
+            "--duration 60m",
+            id="yaml-block-scalar-no-leading-space",
+        ),
+        # YAML block scalar with warmup present (warmup must be left untouched)
+        pytest.param(
+            "--duration 8h\n--warmup 30m\n--concurrency 50",
+            120,
+            "--duration 120m",
+            id="yaml-block-scalar-warmup-untouched",
+        ),
+        # Duration with seconds unit
+        pytest.param(
+            "--duration 600s\n--concurrency 10",
+            30,
+            "--duration 30m",
+            id="duration-in-seconds",
+        ),
+        # Duration at end of command (no trailing whitespace after value)
+        pytest.param(
+            "--concurrency 50\n--duration 3h",
+            45,
+            "--duration 45m",
+            id="duration-at-end-of-command",
+        ),
+        # gemini-1tb-10h.yaml scenario: 10h run should be overridden to custom duration
+        pytest.param(
+            "--duration 8h\n--concurrency 50\n--mode mixed\n--io-worker-pool 2048",
+            60,
+            "--duration 60m",
+            id="10h-test-override-to-1h",
+        ),
+    ],
+)
+def test_run_gemini_stress_duration_substitution(original_cmd, stress_duration, expected_duration):
+    """Verify the duration substitution in run_gemini() rewrites --duration correctly."""
+    assert "--duration" in original_cmd, "precondition: cmd must contain --duration"
+
+    result = _apply_gemini_stress_duration(original_cmd, stress_duration)
+
+    assert expected_duration in result, f"Expected '{expected_duration}' in result, got: {result!r}"
+    # warmup flag must be left untouched
+    if "--warmup" in original_cmd:
+        assert "--warmup 30m" in result, f"--warmup should not be modified, got: {result!r}"


### PR DESCRIPTION
Three bugs fixed:

1. run_gemini() ignored stress_duration when gemini_cmd used YAML block scalar format (|). The --duration flag appears at the start of the string with no leading space, so the old ' --duration' substring check always evaluated to False, falling through to get_timeout_from_stress_cmd() which parsed the original --duration value unchanged. Fix: drop the leading-space requirement and use a (^|\s) anchor in the replacement regex; use \S+ to match any time-unit format (h/m/s).

2. The --warmup substitution (stress_duration * 0.2) had no basis; removed.

3. Gemini seed was always reported as -1 in Argus. The generated command uses --seed=VALUE (equals sign) but the regex looked for '--seed VALUE ' (space-delimited with trailing space), which never matched. Fix: use r'--seed[= ](\d+)' for both --seed and the new --schema-seed.

Also adds gemini_schema_seed to GeminiResultsRequest and reports it separately from gemini_seed so runs with different run/schema seeds are represented correctly in Argus.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)


Fixes https://scylladb.atlassian.net/browse/SCT-196