### PR TITLE
feat(loaders): detect dead loader nodes and fail test early

### DIFF
--- a/defaults/severities.yaml
+++ b/defaults/severities.yaml
@@ -153,3 +153,4 @@ ScrubValidationErrorEvent: ERROR
 PartitionRowsValidationEvent: CRITICAL
 FailedResultEvent: ERROR
 HDRFileMissed: ERROR
+LoaderNodeDownEvent: CRITICAL

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -171,6 +171,7 @@ from sdcm.sct_events.database import (
 from sdcm.sct_events.nodetool import NodetoolEvent
 from sdcm.sct_events.decorators import raise_event_on_failure
 from sdcm.sct_events.filters import EventsSeverityChangerFilter
+from sdcm.sct_events.loaders import LoaderNodeDownEvent
 from sdcm.utils.auto_ssh import AutoSshContainerMixin
 from sdcm.monitorstack.ui import AlternatorDashboard, GeminiDashboard
 from sdcm.logcollector import (
@@ -6494,12 +6495,19 @@ class BaseScyllaCluster:
         raise NotImplementedError("The method should come from siren-tests sct_plugin module")
 
 
+LOADER_HEALTH_CHECK_INTERVAL = 300  # seconds between SSH health checks per loader node
+LOADER_HEALTH_CHECK_TIMEOUT = 300  # seconds to wait for an SSH health-check command
+LOADER_HEALTH_CHECK_RETRIES = 3  # consecutive failures before declaring a loader dead
+
+
 class BaseLoaderSet:
     def __init__(self, params):
         self._loader_cycle = None
         self.params = params
         self._gemini_version = None
         self.sb_write_timeseries_ts = None
+        self._loader_health_check_stop_event = threading.Event()
+        self._loader_health_check_thread: Optional[threading.Thread] = None
 
     @property
     def gemini_version(self):
@@ -6594,6 +6602,104 @@ class BaseLoaderSet:
         if not self._loader_cycle:
             self._loader_cycle = itertools.cycle(self.nodes)
         return next(self._loader_cycle)
+
+    def _loader_health_check_loop(self):
+        """Background thread: periodically SSH-ping every loader node.
+
+        After LOADER_HEALTH_CHECK_RETRIES consecutive failures for a node a
+        LoaderNodeDownEvent with CRITICAL severity is published, which causes
+        EventsAnalyzer to kill the test immediately via SIGUSR2.
+        """
+        LOGGER.debug("Loader health check thread started")
+        consecutive_failures: dict[str, int] = {}
+        reported_down: set[str] = set()
+
+        while not self._loader_health_check_stop_event.wait(timeout=LOADER_HEALTH_CHECK_INTERVAL):
+            for node in list(self.nodes):
+                # Re-check on every node so that stop() takes effect mid-sweep
+                # rather than waiting for the rest of the node list to be scanned.
+                if self._loader_health_check_stop_event.is_set():
+                    break
+                if node.name in reported_down:
+                    continue
+                try:
+                    node.remoter.run(
+                        "true",
+                        timeout=LOADER_HEALTH_CHECK_TIMEOUT,
+                        ignore_status=False,
+                        verbose=False,
+                        retry=0,
+                    )
+                    # Successful ping — reset the failure counter
+                    consecutive_failures.pop(node.name, None)
+                except Exception as exc:  # noqa: BLE001
+                    count = consecutive_failures.get(node.name, 0) + 1
+                    consecutive_failures[node.name] = count
+                    LOGGER.warning(
+                        "Loader node %s failed SSH health check (%d/%d): %s",
+                        node.name,
+                        count,
+                        LOADER_HEALTH_CHECK_RETRIES,
+                        exc,
+                    )
+                    if count >= LOADER_HEALTH_CHECK_RETRIES:
+                        reported_down.add(node.name)
+                        LoaderNodeDownEvent(
+                            node=node.name,
+                            message=(
+                                f"Loader node {node.name} is unreachable after "
+                                f"{count} consecutive SSH health-check failures. "
+                                f"Last error: {exc}"
+                            ),
+                        ).publish()
+
+        LOGGER.debug("Loader health check thread stopped")
+
+    def start_loader_health_check(self):
+        """Start the background loader SSH health-check thread.
+
+        Safe to call multiple times — subsequent calls are no-ops if the thread
+        is already running.
+        """
+        if self._loader_health_check_thread and self._loader_health_check_thread.is_alive():
+            return
+        self._loader_health_check_stop_event.clear()
+        self._loader_health_check_thread = threading.Thread(
+            target=self._loader_health_check_loop,
+            name="LoaderHealthCheck",
+            daemon=True,
+        )
+        self._loader_health_check_thread.start()
+        LOGGER.info(
+            "Loader health check started (interval=%ds, retries=%d)",
+            LOADER_HEALTH_CHECK_INTERVAL,
+            LOADER_HEALTH_CHECK_RETRIES,
+        )
+
+    def stop_loader_health_check(self):
+        """Signal the health-check thread to stop and wait for it to exit.
+
+        The join timeout is based on LOADER_HEALTH_CHECK_TIMEOUT (the SSH
+        command timeout) rather than the interval, because a blocked remoter
+        call can hold the thread for up to that long.  If the thread is still
+        alive after the join we warn but keep the reference intact — clearing
+        it would allow a second thread to be spawned while the first is still
+        running.
+        """
+        self._loader_health_check_stop_event.set()
+        thread = self._loader_health_check_thread
+        if thread and thread.is_alive():
+            thread.join(timeout=LOADER_HEALTH_CHECK_TIMEOUT + 5)
+            if thread.is_alive():
+                LOGGER.warning(
+                    "Loader health check thread '%s' did not exit within %ds; "
+                    "it may still be blocked on a remoter call.",
+                    thread.name,
+                    LOADER_HEALTH_CHECK_TIMEOUT + 5,
+                )
+                return
+        self._loader_health_check_thread = None
+        LOGGER.info("Loader health check stopped")
 
     def kill_stress_thread(self):
         if self.nodes and self.nodes[0].is_kubernetes():
@@ -6798,7 +6904,7 @@ class BaseMonitorSet:
         self.configure_overview_template(node)
         try:
             self.start_scylla_monitoring(node)
-        except (Failure, UnexpectedExit):
+        except Failure, UnexpectedExit:
             self.restart_scylla_monitoring()
         # The time will be used in url of Grafana monitor,
         # the data from this point to the end of test will
@@ -7029,7 +7135,7 @@ class BaseMonitorSet:
                 variable["current"]["value"] = "instance"
                 by_instance_option = next(opt for opt in variable["options"] if opt["text"] == "Instance")
                 by_instance_option["selected"] = True
-            except (StopIteration, KeyError):
+            except StopIteration, KeyError:
                 LOGGER.warning("Unable to change defaults for the template", exc_info=True)
 
             template["dashboard"]["annotations"] = sct_addon_template["annotations"]

--- a/sdcm/sct_events/loaders.py
+++ b/sdcm/sct_events/loaders.py
@@ -27,6 +27,23 @@ from sdcm.sct_events.stress_events import BaseStressEvent, StressEvent, StressEv
 LOGGER = logging.getLogger(__name__)
 
 
+class LoaderNodeDownEvent(SctEvent):
+    """Published when a loader node stops responding to SSH health checks.
+
+    Severity is CRITICAL so that EventsAnalyzer immediately kills the test,
+    preventing it from hanging silently for the rest of the stress duration.
+    """
+
+    def __init__(self, node: Any, message: str, severity: Severity = Severity.CRITICAL):
+        super().__init__(severity=severity)
+        self.node = str(node)
+        self.message = message
+
+    @property
+    def msgfmt(self) -> str:
+        return super().msgfmt + ": node={0.node} message={0.message}"
+
+
 class GeminiStressEvent(BaseStressEvent):
     def __init__(
         self,

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1419,6 +1419,11 @@ class ClusterTester(unittest.TestCase):
             for future in as_completed(futures):
                 future.result()
 
+            # Start loader health monitoring only after all setup work is done
+            # so that a setup failure does not leak a background thread.
+            if self.loaders:
+                self.loaders.start_loader_health_check()
+
         # cancel reuse cluster - for new nodes added during the test
         self.test_config.reuse_cluster(False)
         if self.monitors and self.monitors.nodes:
@@ -3725,6 +3730,11 @@ class ClusterTester(unittest.TestCase):
             self.get_backtraces(self.db_cluster)
 
         if self.loaders:
+            # Stop the health-check thread first so that loader remoter
+            # teardown (stop_tasks_threads, kill_stress_thread) does not
+            # produce false LoaderNodeDownEvent CRITICAL events.
+            with silence(parent=self, name="Stop loader health check"):
+                self.loaders.stop_loader_health_check()
             self.get_backtraces(self.loaders)
             self.stop_resources_stop_tasks_threads(self.loaders)
 

--- a/unit_tests/unit/test_loader_health_check.py
+++ b/unit_tests/unit/test_loader_health_check.py
@@ -1,0 +1,334 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2026 ScyllaDB
+
+"""Unit tests for the BaseLoaderSet SSH health-check mechanism."""
+
+import threading
+from unittest.mock import MagicMock, patch
+
+from invoke import Result
+
+from sdcm.cluster import BaseLoaderSet, LOADER_HEALTH_CHECK_RETRIES, LOADER_HEALTH_CHECK_TIMEOUT
+from sdcm.sct_events import Severity
+from sdcm.sct_events.loaders import LoaderNodeDownEvent
+
+
+# ---------------------------------------------------------------------------
+# Minimal fakes
+# ---------------------------------------------------------------------------
+
+
+class FakeRemoterOK:
+    """Remoter that always succeeds; records each call's kwargs."""
+
+    def __init__(self):
+        self.calls = []
+
+    def run(self, cmd, **kwargs):
+        self.calls.append({"cmd": cmd, **kwargs})
+        return Result(stdout="", stderr="", exited=0)
+
+
+class FakeRemoterFail:
+    """Remoter that always raises ConnectionError."""
+
+    def run(self, cmd, **kwargs):
+        raise ConnectionError("SSH connection refused")
+
+
+class FakeRemoterFlaky:
+    """Remoter that follows a scripted sequence of success (True) / failure (False)."""
+
+    def __init__(self, sequence: list[bool]):
+        self._sequence = iter(sequence)
+
+    def run(self, cmd, **kwargs):
+        ok = next(self._sequence, True)  # default to success once exhausted
+        if not ok:
+            raise ConnectionError("temporary failure")
+        return Result(stdout="", stderr="", exited=0)
+
+
+class FakeNode:
+    def __init__(self, name, remoter):
+        self.name = name
+        self.remoter = remoter
+
+
+class FakeStopEvent:
+    """Replacement for threading.Event that returns False from wait() for the
+    first `iterations` calls and True thereafter, making the loop run exactly
+    `iterations` outer cycles deterministically.
+
+    is_set() mirrors the current state so that the per-node stop check also
+    works correctly.
+    """
+
+    def __init__(self, iterations: int):
+        self._remaining = iterations
+        self._stopped = False
+
+    def wait(self, timeout=None):  # noqa: ARG002
+        if self._remaining > 0:
+            self._remaining -= 1
+            return False  # keep looping
+        self._stopped = True
+        return True  # stop looping
+
+    def is_set(self) -> bool:
+        return self._stopped
+
+    def set(self):
+        self._stopped = True
+        self._remaining = 0
+
+    def clear(self):
+        self._stopped = False
+
+
+class FakeLoaderSet(BaseLoaderSet):
+    """Minimal concrete subclass of BaseLoaderSet for unit tests."""
+
+    def __init__(self, nodes):
+        super().__init__(params={})
+        self.nodes = nodes
+        self.log = MagicMock()
+        self.tags = {}
+
+
+# ---------------------------------------------------------------------------
+# Helper: run the loop with a scripted stop event
+# ---------------------------------------------------------------------------
+
+
+def _run_loop(loader_set, iterations, suppress_publish=True):
+    """Drive _loader_health_check_loop() for exactly `iterations` outer cycles.
+
+    Returns a list of published LoaderNodeDownEvent instances (or an empty
+    list when suppress_publish=True and no events are expected).
+    """
+    fake_event = FakeStopEvent(iterations)
+    loader_set._loader_health_check_stop_event = fake_event
+
+    published = []
+
+    def record(self_event):
+        published.append(self_event)
+
+    if suppress_publish:
+        ctx = patch.object(LoaderNodeDownEvent, "publish", record)
+    else:
+        ctx = patch.object(LoaderNodeDownEvent, "publish", record)
+
+    with ctx:
+        loader_set._loader_health_check_loop()
+
+    return published
+
+
+# ---------------------------------------------------------------------------
+# Event class tests
+# ---------------------------------------------------------------------------
+
+
+def test_loader_down_event_has_critical_severity():
+    """LoaderNodeDownEvent must default to CRITICAL to trigger EventsAnalyzer.kill_test."""
+    with patch.object(LoaderNodeDownEvent, "publish", MagicMock()):
+        event = LoaderNodeDownEvent(node="loader-1", message="test message")
+    assert event.severity == Severity.CRITICAL
+
+
+def test_loader_down_event_msgfmt_contains_node_and_message():
+    """The formatted message must expose both node name and free-text message."""
+    with patch.object(LoaderNodeDownEvent, "publish", MagicMock()):
+        event = LoaderNodeDownEvent(node="loader-42", message="gone away")
+    formatted = str(event)
+    assert "loader-42" in formatted
+    assert "gone away" in formatted
+
+
+# ---------------------------------------------------------------------------
+# Thread lifecycle tests (exercise start/stop wrappers, not the loop)
+# ---------------------------------------------------------------------------
+
+
+def test_start_health_check_spawns_daemon_thread():
+    """start_loader_health_check should spawn exactly one alive daemon thread."""
+    loader_set = FakeLoaderSet(nodes=[FakeNode("l-1", FakeRemoterOK())])
+    try:
+        loader_set.start_loader_health_check()
+        thread = loader_set._loader_health_check_thread
+        assert thread is not None
+        assert thread.is_alive()
+        assert thread.daemon is True
+    finally:
+        loader_set.stop_loader_health_check()
+
+
+def test_start_health_check_is_idempotent():
+    """Calling start_loader_health_check twice must not spawn a second thread."""
+    loader_set = FakeLoaderSet(nodes=[FakeNode("l-1", FakeRemoterOK())])
+    try:
+        loader_set.start_loader_health_check()
+        first_thread = loader_set._loader_health_check_thread
+        loader_set.start_loader_health_check()
+        second_thread = loader_set._loader_health_check_thread
+        assert first_thread is second_thread
+    finally:
+        loader_set.stop_loader_health_check()
+
+
+def test_stop_health_check_terminates_thread():
+    """stop_loader_health_check must join the thread and clear the reference."""
+    loader_set = FakeLoaderSet(nodes=[FakeNode("l-1", FakeRemoterOK())])
+    loader_set.start_loader_health_check()
+    assert loader_set._loader_health_check_thread is not None
+    loader_set.stop_loader_health_check()
+    assert loader_set._loader_health_check_thread is None
+
+
+def test_stop_health_check_preserves_thread_ref_on_join_timeout():
+    """If the thread is still alive after join, the reference must be kept so
+    that a second thread is not accidentally spawned."""
+    loader_set = FakeLoaderSet(nodes=[])
+    fake_thread = MagicMock(spec=threading.Thread)
+    fake_thread.name = "LoaderHealthCheck"
+    fake_thread.is_alive.return_value = True  # still alive after join
+
+    loader_set._loader_health_check_thread = fake_thread
+
+    loader_set.stop_loader_health_check()
+
+    # Thread reference must NOT have been cleared
+    assert loader_set._loader_health_check_thread is fake_thread
+    # join must have been called with the correct timeout
+    fake_thread.join.assert_called_once_with(timeout=LOADER_HEALTH_CHECK_TIMEOUT + 5)
+
+
+# ---------------------------------------------------------------------------
+# Loop behaviour tests (call the real _loader_health_check_loop)
+# ---------------------------------------------------------------------------
+
+
+def test_loop_pre_stopped_event_skips_all_nodes():
+    """If the stop event is already set before the loop runs, no remoter call
+    should be made (the while condition fires False immediately)."""
+    remoter = FakeRemoterOK()
+    loader_set = FakeLoaderSet(nodes=[FakeNode("l-1", remoter)])
+    # 0 iterations → loop body never runs
+    _run_loop(loader_set, iterations=0)
+    assert remoter.calls == []
+
+
+def test_loop_uses_correct_remoter_call_contract():
+    """The health-check must call remoter.run with the contracted keyword args."""
+    remoter = FakeRemoterOK()
+    loader_set = FakeLoaderSet(nodes=[FakeNode("l-1", remoter)])
+    _run_loop(loader_set, iterations=1)
+
+    assert len(remoter.calls) == 1
+    call = remoter.calls[0]
+    assert call["cmd"] == "true"
+    assert call["timeout"] == LOADER_HEALTH_CHECK_TIMEOUT
+    assert call["ignore_status"] is False
+    assert call["verbose"] is False
+    assert call["retry"] == 0
+
+
+def test_loop_no_event_on_healthy_node():
+    """No LoaderNodeDownEvent must be published when SSH checks succeed."""
+    loader_set = FakeLoaderSet(nodes=[FakeNode("loader-alive", FakeRemoterOK())])
+    published = _run_loop(loader_set, iterations=LOADER_HEALTH_CHECK_RETRIES + 1)
+    assert published == []
+
+
+def test_loop_no_event_before_retry_threshold():
+    """LOADER_HEALTH_CHECK_RETRIES - 1 failures must NOT publish an event."""
+    loader_set = FakeLoaderSet(nodes=[FakeNode("loader-flaky", FakeRemoterFail())])
+    published = _run_loop(loader_set, iterations=LOADER_HEALTH_CHECK_RETRIES - 1)
+    assert published == []
+
+
+def test_loop_event_published_at_retry_threshold():
+    """Exactly LOADER_HEALTH_CHECK_RETRIES consecutive failures must publish one event."""
+    loader_set = FakeLoaderSet(nodes=[FakeNode("loader-dead", FakeRemoterFail())])
+    published = _run_loop(loader_set, iterations=LOADER_HEALTH_CHECK_RETRIES)
+    assert len(published) == 1
+    event = published[0]
+    assert event.severity == Severity.CRITICAL
+    assert "loader-dead" in event.node
+    assert "loader-dead" in event.message
+
+
+def test_loop_event_published_only_once_per_node():
+    """A down node must be reported exactly once even over many iterations."""
+    loader_set = FakeLoaderSet(nodes=[FakeNode("loader-dead", FakeRemoterFail())])
+    published = _run_loop(loader_set, iterations=LOADER_HEALTH_CHECK_RETRIES * 5)
+    assert len(published) == 1
+
+
+def test_loop_failure_counter_resets_on_success():
+    """A node that fails < threshold times, then succeeds, then fails again
+    needs a fresh full retry streak before triggering an event."""
+    # Fail RETRIES-1 times, succeed once, then fail RETRIES more times
+    n = LOADER_HEALTH_CHECK_RETRIES
+    sequence = [False] * (n - 1) + [True] + [False] * n
+    node = FakeNode("loader-flaky", FakeRemoterFlaky(sequence))
+    loader_set = FakeLoaderSet(nodes=[node])
+
+    published = _run_loop(loader_set, iterations=len(sequence))
+
+    # Exactly one event after the second complete failure streak
+    assert len(published) == 1
+
+
+def test_loop_only_dead_node_reported_in_mixed_set():
+    """Only the failing loader must produce an event; the healthy one must not."""
+    nodes = [
+        FakeNode("loader-alive", FakeRemoterOK()),
+        FakeNode("loader-dead", FakeRemoterFail()),
+    ]
+    loader_set = FakeLoaderSet(nodes=nodes)
+    published = _run_loop(loader_set, iterations=LOADER_HEALTH_CHECK_RETRIES + 1)
+
+    assert len(published) == 1
+    assert published[0].node == "loader-dead"
+
+
+def test_loop_stop_event_mid_sweep_skips_remaining_nodes():
+    """After the stop event is set during node processing, remaining nodes in
+    the same sweep must not be checked."""
+
+    checked_names = []
+
+    class StopAfterFirstRemoter:
+        def run(self, cmd, **kwargs):
+            checked_names.append("first")
+            # Flip the stop event so the second node should be skipped
+            loader_set._loader_health_check_stop_event.set()
+            return Result(stdout="", stderr="", exited=0)
+
+    class NeverCalledRemoter:
+        def run(self, cmd, **kwargs):
+            checked_names.append("second")
+            return Result(stdout="", stderr="", exited=0)
+
+    nodes = [
+        FakeNode("first", StopAfterFirstRemoter()),
+        FakeNode("second", NeverCalledRemoter()),
+    ]
+    loader_set = FakeLoaderSet(nodes=nodes)
+    _run_loop(loader_set, iterations=1)
+
+    # Only the first node's remoter should have been reached
+    assert checked_names == ["first"]


### PR DESCRIPTION
Add a background SSH health-check thread to BaseLoaderSet that periodically pings every loader node. After LOADER_HEALTH_CHECK_RETRIES (3) consecutive failures a LoaderNodeDownEvent with CRITICAL severity is published, which triggers EventsAnalyzer.kill_test via SIGUSR2.

Fixes: SCT-288

Previously, when a loader node died the test continued silently doing nothing until the full stress timeout (potentially hours) expired.

Key design decisions:
- Check stop event inside per-node sweep so teardown is responsive
- join() timeout uses LOADER_HEALTH_CHECK_TIMEOUT (SSH bound), not the sleep interval; thread ref kept intact if join times out to prevent a second thread spawning alongside a stuck one
- Health check stopped before loader remoter teardown to avoid false CRITICAL events during intentional shutdown
- Health check started after all setUp futures complete to avoid leaking a background thread if later setup work fails

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
