### PR TITLE
fix(cicd): fix billing_project in performance tests

### DIFF
--- a/vars/perfRegressionParallelPipeline.groovy
+++ b/vars/perfRegressionParallelPipeline.groovy
@@ -15,6 +15,7 @@ def call(Map pipelineParams) {
             AWS_ACCESS_KEY_ID     = credentials('qa-aws-secret-key-id')
             AWS_SECRET_ACCESS_KEY = credentials('qa-aws-secret-access-key')
             SCT_GCE_PROJECT = "${params.gce_project}"
+            SCT_BILLING_PROJECT = "${params.billing_project}"
         }
         parameters {
             // Cloud Provider Configuration


### PR DESCRIPTION
This pipeline did not set the env variable `SCT_BILLING_PROJECT`, but later wants to use it.

Fixes: SCT-293

### Testing
Tests are running a performance test with 3 subtests, and all 3 subtests are checked for resource tags
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] Before: https://jenkins.scylladb.com/job/scylla-staging/job/cezar/job/cezar-custom-perf-regression/5/
    `billing_project` is set, resources are **not** tagged
<details><summary>./sct.py list-resources</summary>
<p>

```
➜ ./sct.py list-resources -b aws --test-id 2b2ba276-12d8-4e44-8370-e1ee928b432a
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ Name                                                        ┃ Region-AZ  ┃ State   ┃ TestId                               ┃ RunByUser   ┃ billing_project    ┃ LaunchTime               ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ sct-runner-1.17-instance-2b2ba276                           │ us-east-1a │ running │ 2b2ba276-12d8-4e44-8370-e1ee928b432a │ cezar.moise │ no_billing_project │ Tue May  5 15:09:05 2026 │
│ perf-throughput-disk-and-cache-ubun-db-node-2b2ba276-1      │ us-east-1a │ running │ 2b2ba276-12d8-4e44-8370-e1ee928b432a │ cezar.moise │ no_billing_project │ Tue May  5 15:11:20 2026 │
│ perf-throughput-disk-and-cache-ubun-db-node-2b2ba276-2      │ us-east-1a │ running │ 2b2ba276-12d8-4e44-8370-e1ee928b432a │ cezar.moise │ no_billing_project │ Tue May  5 15:11:20 2026 │
│ perf-throughput-disk-and-cache-ubun-db-node-2b2ba276-3      │ us-east-1a │ running │ 2b2ba276-12d8-4e44-8370-e1ee928b432a │ cezar.moise │ no_billing_project │ Tue May  5 15:11:20 2026 │
│ perf-throughput-disk-and-cache-ubun-monitor-node-2b2ba276-1 │ us-east-1a │ running │ 2b2ba276-12d8-4e44-8370-e1ee928b432a │ cezar.moise │ no_billing_project │ Tue May  5 15:11:23 2026 │
│ perf-throughput-disk-and-cache-ubun-loader-node-2b2ba276-4  │ us-east-1a │ running │ 2b2ba276-12d8-4e44-8370-e1ee928b432a │ cezar.moise │ no_billing_project │ Tue May  5 15:11:26 2026 │
│ perf-throughput-disk-and-cache-ubun-loader-node-2b2ba276-3  │ us-east-1a │ running │ 2b2ba276-12d8-4e44-8370-e1ee928b432a │ cezar.moise │ no_billing_project │ Tue May  5 15:11:26 2026 │
│ perf-throughput-disk-and-cache-ubun-loader-node-2b2ba276-1  │ us-east-1a │ running │ 2b2ba276-12d8-4e44-8370-e1ee928b432a │ cezar.moise │ no_billing_project │ Tue May  5 15:11:26 2026 │
│ perf-throughput-disk-and-cache-ubun-loader-node-2b2ba276-2  │ us-east-1a │ running │ 2b2ba276-12d8-4e44-8370-e1ee928b432a │ cezar.moise │ no_billing_project │ Tue May  5 15:11:26 2026 │
└─────────────────────────────────────────────────────────────┴────────────┴─────────┴──────────────────────────────────────┴─────────────┴────────────────────┴──────────────────────────┘
```

```
❯ ./sct.py list-resources -b aws --test-id 7b950270-7010-470c-8578-8c01b8afb847
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ Name                                                        ┃ Region-AZ  ┃ State   ┃ TestId                               ┃ RunByUser   ┃ billing_project    ┃ LaunchTime               ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ sct-runner-1.17-instance-7b950270                           │ us-east-1a │ running │ 7b950270-7010-470c-8578-8c01b8afb847 │ cezar.moise │ no_billing_project │ Tue May  5 15:09:08 2026 │
│ perf-throughput-disk-and-cache-ubun-db-node-7b950270-1      │ us-east-1a │ running │ 7b950270-7010-470c-8578-8c01b8afb847 │ cezar.moise │ no_billing_project │ Tue May  5 15:10:57 2026 │
│ perf-throughput-disk-and-cache-ubun-db-node-7b950270-2      │ us-east-1a │ running │ 7b950270-7010-470c-8578-8c01b8afb847 │ cezar.moise │ no_billing_project │ Tue May  5 15:10:57 2026 │
│ perf-throughput-disk-and-cache-ubun-db-node-7b950270-3      │ us-east-1a │ running │ 7b950270-7010-470c-8578-8c01b8afb847 │ cezar.moise │ no_billing_project │ Tue May  5 15:10:57 2026 │
│ perf-throughput-disk-and-cache-ubun-monitor-node-7b950270-1 │ us-east-1a │ running │ 7b950270-7010-470c-8578-8c01b8afb847 │ cezar.moise │ no_billing_project │ Tue May  5 15:11:01 2026 │
│ perf-throughput-disk-and-cache-ubun-loader-node-7b950270-4  │ us-east-1a │ running │ 7b950270-7010-470c-8578-8c01b8afb847 │ cezar.moise │ no_billing_project │ Tue May  5 15:11:03 2026 │
│ perf-throughput-disk-and-cache-ubun-loader-node-7b950270-3  │ us-east-1a │ running │ 7b950270-7010-470c-8578-8c01b8afb847 │ cezar.moise │ no_billing_project │ Tue May  5 15:11:03 2026 │
│ perf-throughput-disk-and-cache-ubun-loader-node-7b950270-2  │ us-east-1a │ running │ 7b950270-7010-470c-8578-8c01b8afb847 │ cezar.moise │ no_billing_project │ Tue May  5 15:11:03 2026 │
│ perf-throughput-disk-and-cache-ubun-loader-node-7b950270-1  │ us-east-1a │ running │ 7b950270-7010-470c-8578-8c01b8afb847 │ cezar.moise │ no_billing_project │ Tue May  5 15:11:03 2026 │
└─────────────────────────────────────────────────────────────┴────────────┴─────────┴──────────────────────────────────────┴─────────────┴────────────────────┴──────────────────────────┘
```

```
❯ ./sct.py list-resources -b aws --test-id  bb8fc3b3-6ad0-4287-9843-6086d0c58edd
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ Name                                                        ┃ Region-AZ  ┃ State   ┃ TestId                               ┃ RunByUser   ┃ billing_project    ┃ LaunchTime               ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ sct-runner-1.17-instance-bb8fc3b3                           │ us-east-1a │ running │ bb8fc3b3-6ad0-4287-9843-6086d0c58edd │ cezar.moise │ no_billing_project │ Tue May  5 15:10:29 2026 │
│ perf-throughput-disk-and-cache-ubun-db-node-bb8fc3b3-1      │ us-east-1a │ running │ bb8fc3b3-6ad0-4287-9843-6086d0c58edd │ cezar.moise │ no_billing_project │ Tue May  5 15:12:42 2026 │
│ perf-throughput-disk-and-cache-ubun-db-node-bb8fc3b3-3      │ us-east-1a │ running │ bb8fc3b3-6ad0-4287-9843-6086d0c58edd │ cezar.moise │ no_billing_project │ Tue May  5 15:12:42 2026 │
│ perf-throughput-disk-and-cache-ubun-db-node-bb8fc3b3-2      │ us-east-1a │ running │ bb8fc3b3-6ad0-4287-9843-6086d0c58edd │ cezar.moise │ no_billing_project │ Tue May  5 15:12:42 2026 │
│ perf-throughput-disk-and-cache-ubun-monitor-node-bb8fc3b3-1 │ us-east-1a │ running │ bb8fc3b3-6ad0-4287-9843-6086d0c58edd │ cezar.moise │ no_billing_project │ Tue May  5 15:12:46 2026 │
│ perf-throughput-disk-and-cache-ubun-loader-node-bb8fc3b3-4  │ us-east-1a │ running │ bb8fc3b3-6ad0-4287-9843-6086d0c58edd │ cezar.moise │ no_billing_project │ Tue May  5 15:12:48 2026 │
│ perf-throughput-disk-and-cache-ubun-loader-node-bb8fc3b3-1  │ us-east-1a │ running │ bb8fc3b3-6ad0-4287-9843-6086d0c58edd │ cezar.moise │ no_billing_project │ Tue May  5 15:12:48 2026 │
│ perf-throughput-disk-and-cache-ubun-loader-node-bb8fc3b3-2  │ us-east-1a │ running │ bb8fc3b3-6ad0-4287-9843-6086d0c58edd │ cezar.moise │ no_billing_project │ Tue May  5 15:12:48 2026 │
│ perf-throughput-disk-and-cache-ubun-loader-node-bb8fc3b3-3  │ us-east-1a │ running │ bb8fc3b3-6ad0-4287-9843-6086d0c58edd │ cezar.moise │ no_billing_project │ Tue May  5 15:12:48 2026 │
└─────────────────────────────────────────────────────────────┴────────────┴─────────┴──────────────────────────────────────┴─────────────┴────────────────────┴──────────────────────────┘
```

</p>
</details> 

- [x] After: https://jenkins.scylladb.com/job/scylla-staging/job/cezar/job/cezar-custom-perf-regression/6/
  `billing_project` is set, resources are tagged
<details><summary>./sct.py list-resources</summary>
<p>

```
❯ ./sct.py list-resources -b aws --test-id  177b45f6-a3cb-44c6-bd62-647a164061dc
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ Name                                                        ┃ Region-AZ  ┃ State   ┃ TestId                               ┃ RunByUser   ┃ billing_project  ┃ LaunchTime               ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ sct-runner-1.17-instance-177b45f6                           │ us-east-1a │ running │ 177b45f6-a3cb-44c6-bd62-647a164061dc │ cezar.moise │ Trie-based index │ Tue May  5 15:33:34 2026 │
│ perf-throughput-disk-and-cache-ubun-db-node-177b45f6-2      │ us-east-1a │ running │ 177b45f6-a3cb-44c6-bd62-647a164061dc │ cezar.moise │ Trie-based index │ Tue May  5 15:35:59 2026 │
│ perf-throughput-disk-and-cache-ubun-db-node-177b45f6-1      │ us-east-1a │ running │ 177b45f6-a3cb-44c6-bd62-647a164061dc │ cezar.moise │ Trie-based index │ Tue May  5 15:35:59 2026 │
│ perf-throughput-disk-and-cache-ubun-db-node-177b45f6-3      │ us-east-1a │ running │ 177b45f6-a3cb-44c6-bd62-647a164061dc │ cezar.moise │ Trie-based index │ Tue May  5 15:35:59 2026 │
│ perf-throughput-disk-and-cache-ubun-monitor-node-177b45f6-1 │ us-east-1a │ running │ 177b45f6-a3cb-44c6-bd62-647a164061dc │ cezar.moise │ Trie-based index │ Tue May  5 15:36:02 2026 │
│ perf-throughput-disk-and-cache-ubun-loader-node-177b45f6-1  │ us-east-1a │ running │ 177b45f6-a3cb-44c6-bd62-647a164061dc │ cezar.moise │ Trie-based index │ Tue May  5 15:36:05 2026 │
│ perf-throughput-disk-and-cache-ubun-loader-node-177b45f6-2  │ us-east-1a │ running │ 177b45f6-a3cb-44c6-bd62-647a164061dc │ cezar.moise │ Trie-based index │ Tue May  5 15:36:05 2026 │
│ perf-throughput-disk-and-cache-ubun-loader-node-177b45f6-3  │ us-east-1a │ running │ 177b45f6-a3cb-44c6-bd62-647a164061dc │ cezar.moise │ Trie-based index │ Tue May  5 15:36:05 2026 │
│ perf-throughput-disk-and-cache-ubun-loader-node-177b45f6-4  │ us-east-1a │ running │ 177b45f6-a3cb-44c6-bd62-647a164061dc │ cezar.moise │ Trie-based index │ Tue May  5 15:36:05 2026 │
└─────────────────────────────────────────────────────────────┴────────────┴─────────┴──────────────────────────────────────┴─────────────┴──────────────────┴──────────────────────────┘
```

```
❯ ./sct.py list-resources -b aws --test-id 177b45f6-a3cb-44c6-bd62-647a164061dc
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ Name                                                        ┃ Region-AZ  ┃ State   ┃ TestId                               ┃ RunByUser   ┃ billing_project  ┃ LaunchTime               ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ sct-runner-1.17-instance-177b45f6                           │ us-east-1a │ running │ 177b45f6-a3cb-44c6-bd62-647a164061dc │ cezar.moise │ Trie-based index │ Tue May  5 15:33:34 2026 │
│ perf-throughput-disk-and-cache-ubun-db-node-177b45f6-2      │ us-east-1a │ running │ 177b45f6-a3cb-44c6-bd62-647a164061dc │ cezar.moise │ Trie-based index │ Tue May  5 15:35:59 2026 │
│ perf-throughput-disk-and-cache-ubun-db-node-177b45f6-1      │ us-east-1a │ running │ 177b45f6-a3cb-44c6-bd62-647a164061dc │ cezar.moise │ Trie-based index │ Tue May  5 15:35:59 2026 │
│ perf-throughput-disk-and-cache-ubun-db-node-177b45f6-3      │ us-east-1a │ running │ 177b45f6-a3cb-44c6-bd62-647a164061dc │ cezar.moise │ Trie-based index │ Tue May  5 15:35:59 2026 │
│ perf-throughput-disk-and-cache-ubun-monitor-node-177b45f6-1 │ us-east-1a │ running │ 177b45f6-a3cb-44c6-bd62-647a164061dc │ cezar.moise │ Trie-based index │ Tue May  5 15:36:02 2026 │
│ perf-throughput-disk-and-cache-ubun-loader-node-177b45f6-1  │ us-east-1a │ running │ 177b45f6-a3cb-44c6-bd62-647a164061dc │ cezar.moise │ Trie-based index │ Tue May  5 15:36:05 2026 │
│ perf-throughput-disk-and-cache-ubun-loader-node-177b45f6-2  │ us-east-1a │ running │ 177b45f6-a3cb-44c6-bd62-647a164061dc │ cezar.moise │ Trie-based index │ Tue May  5 15:36:05 2026 │
│ perf-throughput-disk-and-cache-ubun-loader-node-177b45f6-3  │ us-east-1a │ running │ 177b45f6-a3cb-44c6-bd62-647a164061dc │ cezar.moise │ Trie-based index │ Tue May  5 15:36:05 2026 │
│ perf-throughput-disk-and-cache-ubun-loader-node-177b45f6-4  │ us-east-1a │ running │ 177b45f6-a3cb-44c6-bd62-647a164061dc │ cezar.moise │ Trie-based index │ Tue May  5 15:36:05 2026 │
└─────────────────────────────────────────────────────────────┴────────────┴─────────┴──────────────────────────────────────┴─────────────┴──────────────────┴──────────────────────────┘
```

```
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ Name                                                        ┃ Region-AZ  ┃ State   ┃ TestId                               ┃ RunByUser   ┃ billing_project  ┃ LaunchTime               ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ sct-runner-1.17-instance-f3d357b0                           │ us-east-1a │ running │ f3d357b0-7826-4434-9688-f649a49c8f9d │ cezar.moise │ Trie-based index │ Tue May  5 15:34:35 2026 │
│ perf-throughput-disk-and-cache-ubun-db-node-f3d357b0-3      │ us-east-1a │ running │ f3d357b0-7826-4434-9688-f649a49c8f9d │ cezar.moise │ Trie-based index │ Tue May  5 15:36:19 2026 │
│ perf-throughput-disk-and-cache-ubun-db-node-f3d357b0-1      │ us-east-1a │ running │ f3d357b0-7826-4434-9688-f649a49c8f9d │ cezar.moise │ Trie-based index │ Tue May  5 15:36:19 2026 │
│ perf-throughput-disk-and-cache-ubun-db-node-f3d357b0-2      │ us-east-1a │ running │ f3d357b0-7826-4434-9688-f649a49c8f9d │ cezar.moise │ Trie-based index │ Tue May  5 15:36:19 2026 │
│ perf-throughput-disk-and-cache-ubun-monitor-node-f3d357b0-1 │ us-east-1a │ running │ f3d357b0-7826-4434-9688-f649a49c8f9d │ cezar.moise │ Trie-based index │ Tue May  5 15:36:22 2026 │
│ perf-throughput-disk-and-cache-ubun-loader-node-f3d357b0-1  │ us-east-1a │ running │ f3d357b0-7826-4434-9688-f649a49c8f9d │ cezar.moise │ Trie-based index │ Tue May  5 15:36:25 2026 │
│ perf-throughput-disk-and-cache-ubun-loader-node-f3d357b0-2  │ us-east-1a │ running │ f3d357b0-7826-4434-9688-f649a49c8f9d │ cezar.moise │ Trie-based index │ Tue May  5 15:36:25 2026 │
│ perf-throughput-disk-and-cache-ubun-loader-node-f3d357b0-3  │ us-east-1a │ running │ f3d357b0-7826-4434-9688-f649a49c8f9d │ cezar.moise │ Trie-based index │ Tue May  5 15:36:25 2026 │
│ perf-throughput-disk-and-cache-ubun-loader-node-f3d357b0-4  │ us-east-1a │ running │ f3d357b0-7826-4434-9688-f649a49c8f9d │ cezar.moise │ Trie-based index │ Tue May  5 15:36:25 2026 │
└─────────────────────────────────────────────────────────────┴────────────┴─────────┴──────────────────────────────────────┴─────────────┴──────────────────┴──────────────────────────┘
```

</p>
</details> 

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
