### PR TITLE
docs(sizing): constraint-based instance sizing plan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ data_dir/ssl_conf/
 
 # Internal private repo
 scylla-qa-internal/
+
+# AI agent working directory
+.sisyphus/

--- a/.sisyphus/plans/constraint-based-sizing.md
+++ b/.sisyphus/plans/constraint-based-sizing.md
@@ -1,0 +1,1 @@
+../../../docs/plans/constraint-based-sizing.md

--- a/.sisyphus/plans/constraint-based-sizing.md
+++ b/.sisyphus/plans/constraint-based-sizing.md
@@ -1,1 +1,0 @@
-../../../docs/plans/constraint-based-sizing.md

--- a/docs/cross-cloud-sizing.md
+++ b/docs/cross-cloud-sizing.md
@@ -10,7 +10,7 @@ SCT uses constraint-based instance selection to automatically resolve hardware r
 # Specify hardware requirements — resolved per cloud at runtime
 db_instance_type:
   vcpu: 8
-  memory: ">16gb"
+  memory: 32
 
 loader_instance_type:
   vcpu: 4
@@ -29,14 +29,20 @@ The same config with `--backend gce` resolves to:
 - **loader**: `e2-standard-4` (4 vCPU, 16 GB)
 - **monitor**: `n2-highmem-4` (4 vCPU, 32 GB)
 
-### Via environment variable
+### Via environment variable (dot-notation)
+
+SCT's existing dot-notation for nested config values works out of the box:
 
 ```bash
-# Flat string format for env vars
-export SCT_DB_INSTANCE_TYPE='vcpu=16,memory=>32gb'
-export SCT_LOADER_INSTANCE_TYPE='vcpu=4'
-export SCT_MONITOR_INSTANCE_TYPE='vcpu=2'
+export SCT_DB_INSTANCE_TYPE.vcpu=16
+export SCT_DB_INSTANCE_TYPE.memory=32
+export SCT_DB_INSTANCE_TYPE.arch=arm64
+
+export SCT_LOADER_INSTANCE_TYPE.vcpu=4
+export SCT_MONITOR_INSTANCE_TYPE.vcpu=2
 ```
+
+This builds the equivalent dict `{vcpu: 16, memory: 32, arch: "arm64"}` using the same mechanism as other nested SCT config parameters (e.g. `append_scylla_yaml`).
 
 ### Literal instance type (backward compatible)
 
@@ -52,38 +58,45 @@ db_instance_type: 'i4i.2xlarge'
 
 ```yaml
 db_instance_type:
-  vcpu: 8              # exact match
-  memory: ">16gb"      # minimum 16 GB
-  disk: "500gb-2tb"    # range: 500 GB to 2 TB local disk
-  arch: "arm64"        # optional: force architecture
+  vcpu: 8              # exact match (required)
+  memory: 32           # minimum 32 GB (plain int = minimum, unit always GB)
+  disk: 500            # minimum 500 GB local disk (plain int = minimum, unit always GB)
+  arch: arm64          # optional: force architecture (accepts: arm64, arm, x86_64, x86)
 ```
 
-### Flat string format (for env vars)
+### Advanced operators (optional)
 
-```bash
-SCT_DB_INSTANCE_TYPE='vcpu=8,memory=>16gb,disk=500gb-2tb,arch=arm64'
+For power users who need more precise control:
+
+```yaml
+db_instance_type:
+  vcpu: "8-16"         # range: 8 to 16 vCPUs
+  memory: ">64"        # more than 64 GB
+  disk: "500-2048"     # range: 500 GB to 2 TB local disk
 ```
-
-Both formats are equivalent and produce identical results.
 
 ## Constraint Reference
 
-| Field | Description | Operators | Units | Default if omitted |
-|-------|-------------|-----------|-------|--------------------|
-| `vcpu` | Number of virtual CPUs | exact, `>`, `<`, `>=`, range | plain int | No filter |
-| `memory` | RAM size | exact, `>`, `<`, `>=`, range | `gb`, `tb` | No filter |
-| `disk` | Local disk size (per disk) | exact, `>`, `<`, `>=`, range | `gb`, `tb` | db role: must have local disk |
-| `arch` | CPU architecture | exact only | `arm64`, `x86_64` | aws=`arm64`, others=`x86_64` |
+| Field | Description | Operators | Units | Required? |
+|-------|-------------|-----------|-------|-----------|
+| `vcpu` | Number of virtual CPUs | exact, range (`"8-16"`) | plain int | **Yes** |
+| `memory` | RAM size (minimum) | plain int (min), `>`, `<`, `>=`, range | GB (always) | No |
+| `disk` | Local disk size per disk (minimum) | plain int (min), `>`, `<`, `>=`, range | GB (always) | No (db role: must have local disk) |
+| `arch` | CPU architecture | exact only | `arm64`/`arm`, `x86_64`/`x86` | No (aws=`arm64`, others=`x86_64`) |
+
+**Plain integers**: For `memory` and `disk`, a plain integer always means "minimum GB". `memory: 32` is equivalent to `memory: ">=32"`.
+
+**Architecture shorthands**: `arm` is shorthand for `arm64`, `x86` is shorthand for `x86_64`.
 
 ### Operator examples
 
 | Syntax | Meaning |
 |--------|---------|
 | `vcpu: 16` | Exactly 16 vCPUs |
-| `memory: ">32gb"` | More than 32 GB |
-| `memory: ">=32gb"` | 32 GB or more |
-| `memory: "<64gb"` | Less than 64 GB |
-| `disk: "500gb-2tb"` | Between 500 GB and 2 TB |
+| `vcpu: "8-16"` | Between 8 and 16 vCPUs |
+| `memory: 32` | At least 32 GB (plain int = minimum) |
+| `memory: ">64"` | More than 64 GB |
+| `disk: "500-2048"` | Between 500 GB and 2 TB |
 
 ## Selection Algorithm
 
@@ -100,14 +113,14 @@ When you specify constraints, the system:
 
 | Role | AWS | GCE | Azure | OCI |
 |------|-----|-----|-------|-----|
-| db | i8g (ARM), i4i (x86 fallback) | z3-highmem | Standard_L*s_v4 | DenseIO.E5.Flex |
+| db | i8g (ARM), i7i, i4i (x86 fallback) | z3-highmem | Standard_L*s_v4 | DenseIO.E5.Flex |
 | loader | c6i | e2-standard, e2-highcpu | Standard_F*s_v2 | VM.Standard3.Flex |
 | monitor | t3, m6i | n2-highmem | Standard_D*_v4 | VM.Standard.E4.Flex |
 
 ### Implicit constraints
 
 - **db role**: Automatically requires `local_disk_count > 0` (NVMe/local SSD) unless explicitly overridden
-- **AWS db**: Defaults to ARM (`i8g`) architecture; use `arch: "x86_64"` to get `i4i` family
+- **AWS db**: Defaults to ARM (`i8g`) architecture; use `arch: x86_64` to get `i7i`/`i4i` family
 
 ## Examples
 
@@ -116,7 +129,7 @@ When you specify constraints, the system:
 ```yaml
 db_instance_type:
   vcpu: 16
-  memory: ">64gb"
+  memory: 64
 
 loader_instance_type:
   vcpu: 16
@@ -132,10 +145,21 @@ Resolves on AWS to: `i8g.4xlarge` / `c6i.4xlarge` / `m6i.xlarge`
 ```yaml
 db_instance_type:
   vcpu: 8
-  arch: "x86_64"
+  arch: x86_64
 ```
 
-Resolves to `i4i.2xlarge` instead of the default `i8g.2xlarge`.
+Resolves to `i7i.2xlarge` instead of the default `i8g.2xlarge`.
+
+### Flexible vCPU for cross-cloud compatibility
+
+```yaml
+# OCI DenseIO starts at 16 vCPU; use range to allow flexibility
+db_instance_type:
+  vcpu: "8-16"
+  memory: 32
+```
+
+Resolves to 8-vCPU instances on AWS/GCE/Azure, 16-vCPU on OCI (smallest available).
 
 ### Minimal CI test
 
@@ -156,7 +180,7 @@ monitor_instance_type:
 # test-cases/longevity/longevity-100gb-4h.yaml
 db_instance_type:
   vcpu: 8
-  memory: ">32gb"
+  memory: 32
 
 loader_instance_type:
   vcpu: 8
@@ -172,8 +196,9 @@ n_monitor_nodes: 1
 ### Environment variable override
 
 ```bash
-# Override just the DB instance for a quick test with bigger nodes
-export SCT_DB_INSTANCE_TYPE='vcpu=16,memory=>64gb'
+# Override just the DB vCPU count for a quick test with bigger nodes
+export SCT_DB_INSTANCE_TYPE.vcpu=16
+export SCT_DB_INSTANCE_TYPE.memory=64
 hydra run-test longevity_test.LongevityTest.test_custom_time --backend aws --config test-cases/longevity/longevity-100gb-4h.yaml
 ```
 
@@ -217,7 +242,7 @@ Show how constraints resolve per cloud:
 ```bash
 $ uv run sct.py translate-size --config test-cases/longevity/longevity-100gb-4h.yaml
 
-Constraint: db_instance_type = {vcpu: 8, memory: ">32gb"}
+Constraint: db_instance_type = {vcpu: 8, memory: 32}
 
   AWS:   i8g.2xlarge    (8 vCPU, 64 GB, 1875 GB NVMe, arm64, $0.62/hr)
   GCE:   z3-highmem-8   (8 vCPU, 64 GB, 2x375 GB SSD, x86_64)
@@ -250,7 +275,7 @@ Instance specs and pricing live in `data/instance_catalog/`:
 
 ```
 data/instance_catalog/
-├── aws.yaml       # i8g, i4i, c6i, m6i, t3
+├── aws.yaml       # i8g, i7i, i4i, c6i, m6i, t3
 ├── gce.yaml       # z3-highmem, e2-standard, e2-highcpu, n2-highmem
 ├── azure.yaml     # Standard_L, Standard_F, Standard_D
 └── oci.yaml       # DenseIO.E5, VM.Standard3, VM.Standard.E4
@@ -275,7 +300,7 @@ azure_instance_type_db: 'Standard_L16s_v4'
 ```yaml
 db_instance_type:
   vcpu: 8
-  memory: ">16gb"
+  memory: 32
 ```
 
 ### How to migrate
@@ -306,8 +331,8 @@ db_instance_type:
 ```yaml
 db_instance_type:
   vcpu: 8
-  arch: "x86_64"
-# Resolves to i4i.2xlarge (same as before)
+  arch: x86
+# Resolves to i7i.2xlarge
 ```
 
 **Loader nodes** — compute-optimized, no local disk needed:
@@ -344,6 +369,8 @@ All 5 roles support constraint syntax:
 | `gce` | Full resolution from catalog |
 | `azure` | Full resolution from catalog |
 | `oci` | Full resolution from catalog |
-| `docker` | Silently skipped (no instance types) |
-| `baremetal` | Silently skipped (pre-existing cluster) |
-| `k8s-*` | Silently skipped (pod resources managed separately) |
+| `docker` | Skipped with info log (no instance types) |
+| `baremetal` | Skipped with info log (pre-existing cluster) |
+| `k8s-*` | Skipped with info log (pod resources managed separately) |
+
+> **Note**: k8s backends (EKS/GKE) use the same `*_instance_type` parameters for worker node pools. Constraint resolution should work for these out of the box once tested — postponed to a follow-up.

--- a/docs/cross-cloud-sizing.md
+++ b/docs/cross-cloud-sizing.md
@@ -1,0 +1,349 @@
+# Cross-Cloud Instance Sizing
+
+SCT uses constraint-based instance selection to automatically resolve hardware requirements to cloud-specific instance types. Instead of memorizing instance type names across providers, you describe what you need and the system picks the best match.
+
+## Quick Start
+
+### In a test config YAML
+
+```yaml
+# Specify hardware requirements — resolved per cloud at runtime
+db_instance_type:
+  vcpu: 8
+  memory: ">16gb"
+
+loader_instance_type:
+  vcpu: 4
+
+monitor_instance_type:
+  vcpu: 2
+```
+
+When you run this config with `--backend aws`, it resolves to:
+- **db**: `i8g.2xlarge` (ARM, 8 vCPU, 64 GB, NVMe)
+- **loader**: `c6i.xlarge` (4 vCPU, 8 GB)
+- **monitor**: `t3.large` (2 vCPU, 8 GB)
+
+The same config with `--backend gce` resolves to:
+- **db**: `z3-highmem-8` (8 vCPU, 64 GB, local SSD)
+- **loader**: `e2-standard-4` (4 vCPU, 16 GB)
+- **monitor**: `n2-highmem-4` (4 vCPU, 32 GB)
+
+### Via environment variable
+
+```bash
+# Flat string format for env vars
+export SCT_DB_INSTANCE_TYPE='vcpu=16,memory=>32gb'
+export SCT_LOADER_INSTANCE_TYPE='vcpu=4'
+export SCT_MONITOR_INSTANCE_TYPE='vcpu=2'
+```
+
+### Literal instance type (backward compatible)
+
+If you already know the exact instance type you want, use it directly — no resolution happens:
+
+```yaml
+db_instance_type: 'i4i.2xlarge'
+```
+
+## Constraint Syntax
+
+### YAML dict format (in config files)
+
+```yaml
+db_instance_type:
+  vcpu: 8              # exact match
+  memory: ">16gb"      # minimum 16 GB
+  disk: "500gb-2tb"    # range: 500 GB to 2 TB local disk
+  arch: "arm64"        # optional: force architecture
+```
+
+### Flat string format (for env vars)
+
+```bash
+SCT_DB_INSTANCE_TYPE='vcpu=8,memory=>16gb,disk=500gb-2tb,arch=arm64'
+```
+
+Both formats are equivalent and produce identical results.
+
+## Constraint Reference
+
+| Field | Description | Operators | Units | Default if omitted |
+|-------|-------------|-----------|-------|--------------------|
+| `vcpu` | Number of virtual CPUs | exact, `>`, `<`, `>=`, range | plain int | No filter |
+| `memory` | RAM size | exact, `>`, `<`, `>=`, range | `gb`, `tb` | No filter |
+| `disk` | Local disk size (per disk) | exact, `>`, `<`, `>=`, range | `gb`, `tb` | db role: must have local disk |
+| `arch` | CPU architecture | exact only | `arm64`, `x86_64` | aws=`arm64`, others=`x86_64` |
+
+### Operator examples
+
+| Syntax | Meaning |
+|--------|---------|
+| `vcpu: 16` | Exactly 16 vCPUs |
+| `memory: ">32gb"` | More than 32 GB |
+| `memory: ">=32gb"` | 32 GB or more |
+| `memory: "<64gb"` | Less than 64 GB |
+| `disk: "500gb-2tb"` | Between 500 GB and 2 TB |
+
+## Selection Algorithm
+
+When you specify constraints, the system:
+
+1. **Filters by cloud** — only considers instances for the active backend
+2. **Filters by architecture** — uses `arch` constraint if specified, otherwise cloud default (aws=arm64, others=x86_64)
+3. **Filters by preferred family** — each role has preferred instance families per cloud (see below)
+4. **Applies constraints** — removes instances that don't satisfy vcpu/memory/disk requirements
+5. **Sorts by**: family preference order → price (cheapest first) → vCPU count (ascending)
+6. **Returns first match** — deterministic, always the same result for the same input
+
+### Preferred Families
+
+| Role | AWS | GCE | Azure | OCI |
+|------|-----|-----|-------|-----|
+| db | i8g (ARM), i4i (x86 fallback) | z3-highmem | Standard_L*s_v4 | DenseIO.E5.Flex |
+| loader | c6i | e2-standard, e2-highcpu | Standard_F*s_v2 | VM.Standard3.Flex |
+| monitor | t3, m6i | n2-highmem | Standard_D*_v4 | VM.Standard.E4.Flex |
+
+### Implicit constraints
+
+- **db role**: Automatically requires `local_disk_count > 0` (NVMe/local SSD) unless explicitly overridden
+- **AWS db**: Defaults to ARM (`i8g`) architecture; use `arch: "x86_64"` to get `i4i` family
+
+## Examples
+
+### Performance test — large DB nodes
+
+```yaml
+db_instance_type:
+  vcpu: 16
+  memory: ">64gb"
+
+loader_instance_type:
+  vcpu: 16
+
+monitor_instance_type:
+  vcpu: 4
+```
+
+Resolves on AWS to: `i8g.4xlarge` / `c6i.4xlarge` / `m6i.xlarge`
+
+### Force x86 architecture on AWS
+
+```yaml
+db_instance_type:
+  vcpu: 8
+  arch: "x86_64"
+```
+
+Resolves to `i4i.2xlarge` instead of the default `i8g.2xlarge`.
+
+### Minimal CI test
+
+```yaml
+db_instance_type:
+  vcpu: 2
+
+loader_instance_type:
+  vcpu: 2
+
+monitor_instance_type:
+  vcpu: 2
+```
+
+### Multi-role config (full example)
+
+```yaml
+# test-cases/longevity/longevity-100gb-4h.yaml
+db_instance_type:
+  vcpu: 8
+  memory: ">32gb"
+
+loader_instance_type:
+  vcpu: 8
+
+monitor_instance_type:
+  vcpu: 2
+
+n_db_nodes: 4
+n_loaders: 2
+n_monitor_nodes: 1
+```
+
+### Environment variable override
+
+```bash
+# Override just the DB instance for a quick test with bigger nodes
+export SCT_DB_INSTANCE_TYPE='vcpu=16,memory=>64gb'
+hydra run-test longevity_test.LongevityTest.test_custom_time --backend aws --config test-cases/longevity/longevity-100gb-4h.yaml
+```
+
+## Error Handling
+
+If no instance matches your constraints, you get a clear error:
+
+```
+NoMatchingInstanceError: No instance found for role='db', cloud='aws' satisfying:
+  - vcpu: 1024  (no instance has >= 1024 vCPUs)
+  Candidates considered: i8g family (max 64 vCPUs)
+  Suggestion: reduce vcpu constraint or check available families
+```
+
+## CLI Tools
+
+### show-prices
+
+Display available instances with pricing for a role:
+
+```bash
+$ uv run sct.py show-prices --cloud aws --role db
+
+AWS DB Instances (preferred family: i8g)
+┌──────────────────┬──────┬───────────┬──────────┬──────────┬─────────────┐
+│ Instance Type    │ vCPU │ Memory GB │ Disk GB  │ Arch     │ $/hour      │
+├──────────────────┼──────┼───────────┼──────────┼──────────┼─────────────┤
+│ i8g.large        │    2 │        16 │      468 │ arm64    │ $0.15       │
+│ i8g.xlarge       │    4 │        32 │      937 │ arm64    │ $0.31       │
+│ i8g.2xlarge      │    8 │        64 │    1,875 │ arm64    │ $0.62       │
+│ i8g.4xlarge      │   16 │       128 │    3,750 │ arm64    │ $1.24       │
+│ i8g.8xlarge      │   32 │       256 │    7,500 │ arm64    │ $2.48       │
+│ i8g.16xlarge     │   64 │       512 │   15,000 │ arm64    │ $4.96       │
+└──────────────────┴──────┴───────────┴──────────┴──────────┴─────────────┘
+```
+
+### translate-size
+
+Show how constraints resolve per cloud:
+
+```bash
+$ uv run sct.py translate-size --config test-cases/longevity/longevity-100gb-4h.yaml
+
+Constraint: db_instance_type = {vcpu: 8, memory: ">32gb"}
+
+  AWS:   i8g.2xlarge    (8 vCPU, 64 GB, 1875 GB NVMe, arm64, $0.62/hr)
+  GCE:   z3-highmem-8   (8 vCPU, 64 GB, 2x375 GB SSD, x86_64)
+  Azure: Standard_L8s_v4 (8 vCPU, 64 GB, 1x1788 GB NVMe, x86_64)
+  OCI:   DenseIO.E5.Flex:4:64 (4 oCPU/8 vCPU, 64 GB, local NVMe)
+
+Constraint: loader_instance_type = {vcpu: 8}
+
+  AWS:   c6i.2xlarge    (8 vCPU, 16 GB, x86_64, $0.34/hr)
+  GCE:   e2-standard-8  (8 vCPU, 32 GB, x86_64)
+  Azure: Standard_F8s_v2 (8 vCPU, 16 GB, x86_64)
+  OCI:   VM.Standard3.Flex:4:32 (4 oCPU/8 vCPU, 32 GB)
+```
+
+### update-catalog
+
+Refresh the instance catalog from live cloud APIs:
+
+```bash
+# Update all clouds
+uv run sct.py update-catalog
+
+# Update specific cloud
+uv run sct.py update-catalog --cloud aws
+```
+
+## Catalog Management
+
+Instance specs and pricing live in `data/instance_catalog/`:
+
+```
+data/instance_catalog/
+├── aws.yaml       # i8g, i4i, c6i, m6i, t3
+├── gce.yaml       # z3-highmem, e2-standard, e2-highcpu, n2-highmem
+├── azure.yaml     # Standard_L, Standard_F, Standard_D
+└── oci.yaml       # DenseIO.E5, VM.Standard3, VM.Standard.E4
+```
+
+Catalog files are generated by `sct.py update-catalog` (queries cloud pricing APIs) and can also be manually edited for new families.
+
+## Migration Guide
+
+### Migrating existing test configs
+
+If your config currently uses cloud-specific instance types:
+
+**Before** (cloud-specific, one backend only):
+```yaml
+instance_type_db: 'i4i.2xlarge'
+gce_instance_type_db: 'z3-highmem-16'
+azure_instance_type_db: 'Standard_L16s_v4'
+```
+
+**After** (single line, works on all backends):
+```yaml
+db_instance_type:
+  vcpu: 8
+  memory: ">16gb"
+```
+
+### How to migrate
+
+1. Look at the instance type you're currently using and note its vCPU/memory specs
+2. Use `show-prices` to see what's available:
+   ```bash
+   uv run sct.py show-prices --cloud aws --role db
+   ```
+3. Write constraints that match your hardware needs
+4. Verify resolution with `translate-size`:
+   ```bash
+   uv run sct.py translate-size --config your-test.yaml
+   ```
+5. Confirm the resolved types match what you had before (or better)
+
+### Common migration patterns
+
+**DB nodes** — typically need local NVMe storage. Just specify vCPU count:
+```yaml
+# Was: instance_type_db: 'i4i.2xlarge' (8 vCPU, 64 GB, NVMe)
+# Now: system picks i8g.2xlarge (ARM, cheaper, same specs)
+db_instance_type:
+  vcpu: 8
+```
+
+**DB nodes — force x86** (if your workload requires it):
+```yaml
+db_instance_type:
+  vcpu: 8
+  arch: "x86_64"
+# Resolves to i4i.2xlarge (same as before)
+```
+
+**Loader nodes** — compute-optimized, no local disk needed:
+```yaml
+# Was: instance_type_loader: 'c6i.2xlarge' (8 vCPU)
+loader_instance_type:
+  vcpu: 8
+```
+
+**Monitor nodes** — minimal resources:
+```yaml
+# Was: instance_type_monitor: 't3.large' (2 vCPU)
+monitor_instance_type:
+  vcpu: 2
+```
+
+## Supported Parameters
+
+All 5 roles support constraint syntax:
+
+| Parameter | Role | Description |
+|-----------|------|-------------|
+| `db_instance_type` | db | Database nodes |
+| `oracle_instance_type` | db_oracle | Oracle comparison nodes |
+| `zero_token_instance_type` | zero_token | Zero-token nodes |
+| `loader_instance_type` | loader | Stress tool nodes |
+| `monitor_instance_type` | monitor | Monitoring stack |
+
+## Backends
+
+| Backend | Constraint resolution |
+|---------|----------------------|
+| `aws` | Full resolution from catalog |
+| `gce` | Full resolution from catalog |
+| `azure` | Full resolution from catalog |
+| `oci` | Full resolution from catalog |
+| `docker` | Silently skipped (no instance types) |
+| `baremetal` | Silently skipped (pre-existing cluster) |
+| `k8s-*` | Silently skipped (pod resources managed separately) |

--- a/docs/cross-cloud-sizing.md
+++ b/docs/cross-cloud-sizing.md
@@ -1,376 +1,152 @@
 # Cross-Cloud Instance Sizing
 
-SCT uses constraint-based instance selection to automatically resolve hardware requirements to cloud-specific instance types. Instead of memorizing instance type names across providers, you describe what you need and the system picks the best match.
+SCT uses a constraint-based system to specify hardware requirements. Instead of hardcoding per-cloud instance types, you define hardware constraints that the system resolves to concrete instance types for AWS, GCE, Azure, or OCI.
 
-## Quick Start
-
-### In a test config YAML
-
-```yaml
-# Specify hardware requirements — resolved per cloud at runtime
-db_instance_type:
-  vcpu: 8
-  memory: 32
-
-loader_instance_type:
-  vcpu: 4
-
-monitor_instance_type:
-  vcpu: 2
-```
-
-When you run this config with `--backend aws`, it resolves to:
-- **db**: `i8g.2xlarge` (ARM, 8 vCPU, 64 GB, NVMe)
-- **loader**: `c6i.xlarge` (4 vCPU, 8 GB)
-- **monitor**: `t3.large` (2 vCPU, 8 GB)
-
-The same config with `--backend gce` resolves to:
-- **db**: `z3-highmem-8` (8 vCPU, 64 GB, local SSD)
-- **loader**: `e2-standard-4` (4 vCPU, 16 GB)
-- **monitor**: `n2-highmem-4` (4 vCPU, 32 GB)
-
-### Via environment variable (dot-notation)
-
-SCT's existing dot-notation for nested config values works out of the box:
-
-```bash
-export SCT_DB_INSTANCE_TYPE.vcpu=16
-export SCT_DB_INSTANCE_TYPE.memory=32
-export SCT_DB_INSTANCE_TYPE.arch=arm64
-
-export SCT_LOADER_INSTANCE_TYPE.vcpu=4
-export SCT_MONITOR_INSTANCE_TYPE.vcpu=2
-```
-
-This builds the equivalent dict `{vcpu: 16, memory: 32, arch: "arm64"}` using the same mechanism as other nested SCT config parameters (e.g. `append_scylla_yaml`).
-
-### Literal instance type (backward compatible)
-
-If you already know the exact instance type you want, use it directly — no resolution happens:
-
-```yaml
-db_instance_type: 'i4i.2xlarge'
-```
+Literal instance type strings (like `i4i.4xlarge`) still work and bypass the resolution system for backward compatibility.
 
 ## Constraint Syntax
 
-### YAML dict format (in config files)
+You can specify constraints in YAML configuration files or via environment variables.
+
+### YAML format
+Constraints are defined as a dictionary under the role's instance type parameter.
 
 ```yaml
-db_instance_type:
-  vcpu: 8              # exact match (required)
-  memory: 32           # minimum 32 GB (plain int = minimum, unit always GB)
-  disk: 500            # minimum 500 GB local disk (plain int = minimum, unit always GB)
-  arch: arm64          # optional: force architecture (accepts: arm64, arm, x86_64, x86)
+instance_type_db:
+  vcpu: 8
+  memory: 32
+  arch: arm64
 ```
 
-### Advanced operators (optional)
+### Environment variables
+Use dot notation to set specific constraint fields.
 
-For power users who need more precise control:
-
-```yaml
-db_instance_type:
-  vcpu: "8-16"         # range: 8 to 16 vCPUs
-  memory: ">64"        # more than 64 GB
-  disk: "500-2048"     # range: 500 GB to 2 TB local disk
+```bash
+export SCT_INSTANCE_TYPE_DB.VCPU=8
+export SCT_INSTANCE_TYPE_DB.MEMORY=32
 ```
 
-## Constraint Reference
+### Constraint Fields
 
-| Field | Description | Operators | Units | Required? |
-|-------|-------------|-----------|-------|-----------|
-| `vcpu` | Number of virtual CPUs | exact, range (`"8-16"`) | plain int | **Yes** |
-| `memory` | RAM size (minimum) | plain int (min), `>`, `<`, `>=`, range | GB (always) | No |
-| `disk` | Local disk size per disk (minimum) | plain int (min), `>`, `<`, `>=`, range | GB (always) | No (db role: must have local disk) |
-| `arch` | CPU architecture | exact only | `arm64`/`arm`, `x86_64`/`x86` | No (aws=`arm64`, others=`x86_64`) |
+| Field | Aliases | Type | Required | Default | Description |
+|-------|---------|------|----------|---------|-------------|
+| vcpu | vcpus | int or range | YES | - | Number of virtual CPUs |
+| memory | memory_gb | int, float, or string | no | any | RAM in GB |
+| disk | local_disk_gb | int, float, or string | no | auto for db roles | Local disk in GB |
+| arch | - | string | no | per-cloud default | x86_64 or arm64 |
 
-**Plain integers**: For `memory` and `disk`, a plain integer always means "minimum GB". `memory: 32` is equivalent to `memory: ">=32"`.
-
-**Architecture shorthands**: `arm` is shorthand for `arm64`, `x86` is shorthand for `x86_64`.
-
-### Operator examples
-
-| Syntax | Meaning |
-|--------|---------|
-| `vcpu: 16` | Exactly 16 vCPUs |
-| `vcpu: "8-16"` | Between 8 and 16 vCPUs |
-| `memory: 32` | At least 32 GB (plain int = minimum) |
-| `memory: ">64"` | More than 64 GB |
-| `disk: "500-2048"` | Between 500 GB and 2 TB |
+### Operators and Units
+- **Implicit Minimum**: A plain integer (e.g., `vcpu: 8`) means `vcpu >= 8`.
+- **Comparison Prefixes**: Use `>`, `>=`, `<`, `<=`.
+- **Ranges**: Use a string like `"8-16"`.
+- **Units**: Memory and disk default to GB. You can specify `gb` or `tb`.
+- **Architecture Aliases**: `x86` maps to `x86_64`, and `arm` maps to `arm64`.
+- **Default Architecture**: AWS defaults to `arm64`. Other clouds default to `x86_64`.
 
 ## Selection Algorithm
 
-When you specify constraints, the system:
+The resolver follows these steps to select the best instance:
 
-1. **Filters by cloud** — only considers instances for the active backend
-2. **Filters by architecture** — uses `arch` constraint if specified, otherwise cloud default (aws=arm64, others=x86_64)
-3. **Filters by preferred family** — each role has preferred instance families per cloud (see below)
-4. **Applies constraints** — removes instances that don't satisfy vcpu/memory/disk requirements
-5. **Sorts by**: family preference order → price (cheapest first) → vCPU count (ascending)
-6. **Returns first match** — deterministic, always the same result for the same input
+1. **Filter**: Identify all instance types in the cloud catalog that satisfy every constraint.
+2. **Implicit Local Storage**: For roles named `db`, `db_oracle`, or `zero_token`, the system requires local storage (`local_disk_count > 0`) unless a `disk` constraint is explicitly provided.
+3. **Sort**:
+   - Primary: Preferred family order (defined in the cloud catalog).
+   - Secondary: Hourly price (ascending).
+   - Tertiary: vCPU count (ascending).
+4. **Select**: Return the first match from the sorted list.
 
-### Preferred Families
-
-| Role | AWS | GCE | Azure | OCI |
-|------|-----|-----|-------|-----|
-| db | i8g (ARM), i7i, i4i (x86 fallback) | z3-highmem | Standard_L*s_v4 | DenseIO.E5.Flex |
-| loader | c6i | e2-standard, e2-highcpu | Standard_F*s_v2 | VM.Standard3.Flex |
-| monitor | t3, m6i | n2-highmem | Standard_D*_v4 | VM.Standard.E4.Flex |
-
-### Implicit constraints
-
-- **db role**: Automatically requires `local_disk_count > 0` (NVMe/local SSD) unless explicitly overridden
-- **AWS db**: Defaults to ARM (`i8g`) architecture; use `arch: x86_64` to get `i7i`/`i4i` family
+If no instance matches the criteria, the system raises a `NoMatchingInstanceError` showing the constraints and the search scope.
 
 ## Examples
 
-### Performance test — large DB nodes
-
+### Minimal (vCPU only)
 ```yaml
-db_instance_type:
-  vcpu: 16
-  memory: 64
+instance_type_db:
+  vcpu: 8
+```
+On AWS, this resolves to an `i8g` instance because `arm64` is the default architecture and `i8g` is a preferred family for the `db` role.
 
-loader_instance_type:
+### Multi-role Configuration
+```yaml
+instance_type_db:
   vcpu: 16
-
-monitor_instance_type:
+  memory: ">60"
+instance_type_loader:
+  vcpu: 8
+instance_type_monitor:
   vcpu: 4
 ```
 
-Resolves on AWS to: `i8g.4xlarge` / `c6i.4xlarge` / `m6i.xlarge`
-
-### Force x86 architecture on AWS
-
+### Architecture Override
 ```yaml
-db_instance_type:
+instance_type_db:
   vcpu: 8
   arch: x86_64
 ```
+This forces the use of x86 instances, such as `i4i` on AWS, instead of the `arm64` default.
 
-Resolves to `i7i.2xlarge` instead of the default `i8g.2xlarge`.
-
-### Flexible vCPU for cross-cloud compatibility
-
+### Literal Passthrough
 ```yaml
-# OCI DenseIO starts at 16 vCPU; use range to allow flexibility
-db_instance_type:
-  vcpu: "8-16"
-  memory: 32
+instance_type_db: 'i4i.4xlarge'
 ```
-
-Resolves to 8-vCPU instances on AWS/GCE/Azure, 16-vCPU on OCI (smallest available).
-
-### Minimal CI test
-
-```yaml
-db_instance_type:
-  vcpu: 2
-
-loader_instance_type:
-  vcpu: 2
-
-monitor_instance_type:
-  vcpu: 2
-```
-
-### Multi-role config (full example)
-
-```yaml
-# test-cases/longevity/longevity-100gb-4h.yaml
-db_instance_type:
-  vcpu: 8
-  memory: 32
-
-loader_instance_type:
-  vcpu: 8
-
-monitor_instance_type:
-  vcpu: 2
-
-n_db_nodes: 4
-n_loaders: 2
-n_monitor_nodes: 1
-```
-
-### Environment variable override
-
-```bash
-# Override just the DB vCPU count for a quick test with bigger nodes
-export SCT_DB_INSTANCE_TYPE.vcpu=16
-export SCT_DB_INSTANCE_TYPE.memory=64
-hydra run-test longevity_test.LongevityTest.test_custom_time --backend aws --config test-cases/longevity/longevity-100gb-4h.yaml
-```
-
-## Error Handling
-
-If no instance matches your constraints, you get a clear error:
-
-```
-NoMatchingInstanceError: No instance found for role='db', cloud='aws' satisfying:
-  - vcpu: 1024  (no instance has >= 1024 vCPUs)
-  Candidates considered: i8g family (max 64 vCPUs)
-  Suggestion: reduce vcpu constraint or check available families
-```
+The system treats literal strings as-is and skips resolution.
 
 ## CLI Tools
 
-### show-prices
+All sizing commands live under the `sizing` subcommand group.
 
-Display available instances with pricing for a role:
-
+### sizing catalog
+Browse the instance catalog with pricing for a cloud provider.
 ```bash
-$ uv run sct.py show-prices --cloud aws --role db
-
-AWS DB Instances (preferred family: i8g)
-┌──────────────────┬──────┬───────────┬──────────┬──────────┬─────────────┐
-│ Instance Type    │ vCPU │ Memory GB │ Disk GB  │ Arch     │ $/hour      │
-├──────────────────┼──────┼───────────┼──────────┼──────────┼─────────────┤
-│ i8g.large        │    2 │        16 │      468 │ arm64    │ $0.15       │
-│ i8g.xlarge       │    4 │        32 │      937 │ arm64    │ $0.31       │
-│ i8g.2xlarge      │    8 │        64 │    1,875 │ arm64    │ $0.62       │
-│ i8g.4xlarge      │   16 │       128 │    3,750 │ arm64    │ $1.24       │
-│ i8g.8xlarge      │   32 │       256 │    7,500 │ arm64    │ $2.48       │
-│ i8g.16xlarge     │   64 │       512 │   15,000 │ arm64    │ $4.96       │
-└──────────────────┴──────┴───────────┴──────────┴──────────┴─────────────┘
+uv run sct.py sizing catalog --cloud aws --role db
+uv run sct.py sizing catalog --cloud oci --family DenseIO.E5
 ```
 
-### translate-size
-
-Show how constraints resolve per cloud:
-
+### sizing update-catalog
+Fetch the latest instance data from cloud provider APIs to refresh local catalogs.
 ```bash
-$ uv run sct.py translate-size --config test-cases/longevity/longevity-100gb-4h.yaml
-
-Constraint: db_instance_type = {vcpu: 8, memory: 32}
-
-  AWS:   i8g.2xlarge    (8 vCPU, 64 GB, 1875 GB NVMe, arm64, $0.62/hr)
-  GCE:   z3-highmem-8   (8 vCPU, 64 GB, 2x375 GB SSD, x86_64)
-  Azure: Standard_L8s_v4 (8 vCPU, 64 GB, 1x1788 GB NVMe, x86_64)
-  OCI:   DenseIO.E5.Flex:4:64 (4 oCPU/8 vCPU, 64 GB, local NVMe)
-
-Constraint: loader_instance_type = {vcpu: 8}
-
-  AWS:   c6i.2xlarge    (8 vCPU, 16 GB, x86_64, $0.34/hr)
-  GCE:   e2-standard-8  (8 vCPU, 32 GB, x86_64)
-  Azure: Standard_F8s_v2 (8 vCPU, 16 GB, x86_64)
-  OCI:   VM.Standard3.Flex:4:32 (4 oCPU/8 vCPU, 32 GB)
+uv run sct.py sizing update-catalog --cloud aws
+uv run sct.py sizing update-catalog --cloud all
 ```
 
-### update-catalog
-
-Refresh the instance catalog from live cloud APIs:
-
+### sizing resolve
+Resolve hardware constraints to instance types across all clouds.
 ```bash
-# Update all clouds
-uv run sct.py update-catalog
+uv run sct.py sizing resolve --vcpu 8 --role db
+uv run sct.py sizing resolve --vcpu 8-16 --memory ">60" --role db
+uv run sct.py sizing resolve --vcpu 4 --arch x86_64 --role loader
+```
 
-# Update specific cloud
-uv run sct.py update-catalog --cloud aws
+### sizing preview
+Preview how a config file resolves instance types across all clouds.
+```bash
+uv run sct.py sizing preview test-cases/my-test.yaml
 ```
 
 ## Catalog Management
 
-Instance specs and pricing live in `data/instance_catalog/`:
+Catalog files are stored in `data/instance_catalog/{aws,gce,azure,oci}.yaml`.
 
-```
-data/instance_catalog/
-├── aws.yaml       # i8g, i7i, i4i, c6i, m6i, t3
-├── gce.yaml       # z3-highmem, e2-standard, e2-highcpu, n2-highmem
-├── azure.yaml     # Standard_L, Standard_F, Standard_D
-└── oci.yaml       # DenseIO.E5, VM.Standard3, VM.Standard.E4
-```
+Each entry in the catalog includes:
+- Instance name and family
+- Hardware specs: vCPUs, memory (GB), architecture
+- Storage: Local disk count and total local disk size (GB)
+- Price: Hourly cost
 
-Catalog files are generated by `sct.py update-catalog` (queries cloud pricing APIs) and can also be manually edited for new families.
-
-## Migration Guide
-
-### Migrating existing test configs
-
-If your config currently uses cloud-specific instance types:
-
-**Before** (cloud-specific, one backend only):
-```yaml
-instance_type_db: 'i4i.2xlarge'
-gce_instance_type_db: 'z3-highmem-16'
-azure_instance_type_db: 'Standard_L16s_v4'
-```
-
-**After** (single line, works on all backends):
-```yaml
-db_instance_type:
-  vcpu: 8
-  memory: 32
-```
-
-### How to migrate
-
-1. Look at the instance type you're currently using and note its vCPU/memory specs
-2. Use `show-prices` to see what's available:
-   ```bash
-   uv run sct.py show-prices --cloud aws --role db
-   ```
-3. Write constraints that match your hardware needs
-4. Verify resolution with `translate-size`:
-   ```bash
-   uv run sct.py translate-size --config your-test.yaml
-   ```
-5. Confirm the resolved types match what you had before (or better)
-
-### Common migration patterns
-
-**DB nodes** — typically need local NVMe storage. Just specify vCPU count:
-```yaml
-# Was: instance_type_db: 'i4i.2xlarge' (8 vCPU, 64 GB, NVMe)
-# Now: system picks i8g.2xlarge (ARM, cheaper, same specs)
-db_instance_type:
-  vcpu: 8
-```
-
-**DB nodes — force x86** (if your workload requires it):
-```yaml
-db_instance_type:
-  vcpu: 8
-  arch: x86
-# Resolves to i7i.2xlarge
-```
-
-**Loader nodes** — compute-optimized, no local disk needed:
-```yaml
-# Was: instance_type_loader: 'c6i.2xlarge' (8 vCPU)
-loader_instance_type:
-  vcpu: 8
-```
-
-**Monitor nodes** — minimal resources:
-```yaml
-# Was: instance_type_monitor: 't3.large' (2 vCPU)
-monitor_instance_type:
-  vcpu: 2
-```
-
-## Supported Parameters
-
-All 5 roles support constraint syntax:
-
-| Parameter | Role | Description |
-|-----------|------|-------------|
-| `db_instance_type` | db | Database nodes |
-| `oracle_instance_type` | db_oracle | Oracle comparison nodes |
-| `zero_token_instance_type` | zero_token | Zero-token nodes |
-| `loader_instance_type` | loader | Stress tool nodes |
-| `monitor_instance_type` | monitor | Monitoring stack |
+The catalog also defines `preferred_families` for different roles and `cloud_defaults` for settings like architecture. You can update these by running `update-catalog` or by editing the YAML files.
 
 ## Backends
 
-| Backend | Constraint resolution |
-|---------|----------------------|
-| `aws` | Full resolution from catalog |
-| `gce` | Full resolution from catalog |
-| `azure` | Full resolution from catalog |
-| `oci` | Full resolution from catalog |
-| `docker` | Skipped with info log (no instance types) |
-| `baremetal` | Skipped with info log (pre-existing cluster) |
-| `k8s-*` | Skipped with info log (pod resources managed separately) |
+- **AWS, GCE, Azure, OCI**: Support full constraint resolution.
+- **Docker, baremetal, k8s-local-kind**: Skip resolution. The system logs a message and uses the provided values directly.
+- **Kubernetes**: `k8s-eks` uses the AWS resolver, and `k8s-gke` uses the GCE resolver.
 
-> **Note**: k8s backends (EKS/GKE) use the same `*_instance_type` parameters for worker node pools. Constraint resolution should work for these out of the box once tested — postponed to a follow-up.
+## Implementation Details
+
+The resolution process is integrated into the `SCTConfiguration` lifecycle:
+
+1. `_resolve_instance_sizes()` executes during `SCTConfiguration.__init__` after environment variables are merged.
+2. The system checks the `cluster_backend` to select the appropriate cloud catalog.
+3. For each role-based instance parameter (e.g., `instance_type_db`, `gce_instance_type_db`), the system checks the value type.
+4. If the value is a dictionary, the resolver finds the best matching instance string.
+5. If the value is a string, it is used as a literal.

--- a/docs/plans/constraint-based-sizing.md
+++ b/docs/plans/constraint-based-sizing.md
@@ -28,10 +28,10 @@ Replace the T-shirt sizing system (roydahan/pehala review feedback on PR #14490)
 ### Interview Summary
 **Key Discussions**:
 - T-shirt sizes removed entirely; constraint-based only
-- YAML dict syntax in configs, flat string for env vars (`SCT_DB_INSTANCE_TYPE='vcpu=16,memory=>20gb'`)
+- YAML dict syntax in configs, dot-notation for env vars (`SCT_DB_INSTANCE_TYPE.vcpu=16`)
 - Catalog: generated from live cloud APIs + manual curations, current families only
 - Selection: preferred family per role (price-based), with CLI price display
-- Constraints: exact (`vcpu: 16`), ranges (`memory: "10gb-30gb"`), comparisons (`memory: ">20gb"`), arch (`arch: "arm64"` or `arch: "x86_64"` — optional, overrides cloud default)
+- Constraints: exact (`vcpu: 16`), ranges (`vcpu: "8-16"`, `memory: "10gb-30gb"`), comparisons (`memory: ">20gb"`), plain int for memory/disk means minimum GB, arch (`arch: "arm64"` or `arch: "x86"` — optional, overrides cloud default)
 
 **Research Findings**:
 - Existing `InstanceSpec` already has vcpus, memory_gb, local_ssd_count
@@ -68,8 +68,8 @@ Enable cloud-agnostic instance selection via hardware constraints (vcpu, memory,
 
 ### Definition of Done
 - [ ] `{vcpu: 8, memory: ">16gb"}` on AWS resolves to `i8g.2xlarge` (ARM preferred) and all downstream works
-- [ ] `SCT_DB_INSTANCE_TYPE='vcpu=16,memory=>20gb'` env var parses correctly
-- [ ] `SCT_DB_INSTANCE_TYPE='vcpu=8,arch=x86_64'` forces x86 on AWS (overrides arm64 default)
+- [ ] `SCT_DB_INSTANCE_TYPE.vcpu=16` and `SCT_DB_INSTANCE_TYPE.memory=32` env vars parse correctly via dot-notation
+- [ ] `SCT_DB_INSTANCE_TYPE.vcpu=8` with `SCT_DB_INSTANCE_TYPE.arch=x86` forces x86 on AWS (overrides arm64 default)
 - [ ] `instance_type_db: 'i4i.large'` still works (literal passthrough)
 - [ ] `sct.py show-prices --cloud aws --role db` shows pricing table
 - [ ] 100% unit test coverage on matcher logic
@@ -78,9 +78,12 @@ Enable cloud-agnostic instance selection via hardware constraints (vcpu, memory,
 ### Must Have
 - Backward compatibility: literal instance type strings still work as passthrough
 - All 5 roles supported: db, db_oracle, zero_token, loader, monitor
-- Constraint types: exact value, min (>), max (<), range (min-max), arch selector (arm64|x86_64)
+- vcpu is mandatory in constraint dicts
+- Constraint types: exact value, min (> or plain int), max (<), range (min-max), arch selector (arm64|arm|x86_64|x86)
+- vcpu supports range syntax (`"8-16"`)
+- Plain int for memory/disk means minimum GB
 - Deterministic selection (same input → same output)
-- Docker/baremetal backends silently skip resolution
+- Docker/baremetal backends skip resolution with info log
 - Clear error messages when no instance matches
 
 ### Must NOT Have (Guardrails)
@@ -236,17 +239,20 @@ Wave FINAL (4 parallel reviews):
 
   **What to do**:
   - Create constraint parsing in `sdcm/utils/instance_matcher.py`
-  - Parse dict format: `{"vcpu": 16, "memory": ">20gb", "disk": "500gb-2tb", "arch": "arm64"}`
-  - Parse flat string format: `"vcpu=16,memory=>20gb,disk=500gb-2tb,arch=arm64"`
-  - Supported operators: exact (`16`), gt (`>16`), lt (`<16`), gte (`>=16`), range (`10-30`)
-  - Supported units: gb, tb (for memory/disk); plain int for vcpu
-  - Special fields: `arch` accepts "arm64" or "x86_64" (optional — if omitted, uses cloud default)
+  - Parse dict format: `{"vcpu": 16, "memory": 32, "disk": 500, "arch": "arm64"}`
+  - Plain int for memory/disk means minimum GB (e.g. `memory: 32` → `memory >= 32 GB`)
+  - vcpu is **mandatory** — raise ValueError if missing
+  - vcpu supports exact int (`8`) or range string (`"8-16"`)
+  - Supported operators for memory/disk: exact (`32`), gt (`">32"`), lt (`"<32"`), gte (`">=32"`), range (`"500-2048"`)
+  - Arch accepts `arm64`, `arm` (→arm64), `x86_64`, `x86` (→x86_64) — optional, uses cloud default if omitted
   - Output: list of `Constraint(field, operator, value)` objects
-  - Handle edge cases: whitespace, case-insensitive units, missing fields (optional)
+  - Handle edge cases: whitespace, missing fields (except vcpu)
+  - **No flat string parser** — env vars use SCT's native dot-notation (`SCT_DB_INSTANCE_TYPE.vcpu=8`)
 
   **Must NOT do**:
   - No matching against catalog — just parsing
   - No sct_config integration
+  - No flat string parser — dot-notation handles env vars natively
 
   **Recommended Agent Profile**:
   - **Category**: `deep`
@@ -271,33 +277,41 @@ Wave FINAL (4 parallel reviews):
   Scenario: Parse YAML dict constraints
     Tool: Bash (python)
     Steps:
-      1. parse_constraints({"vcpu": 16, "memory": ">20gb"})
+      1. parse_constraints({"vcpu": 16, "memory": 32})
       2. Assert 2 constraints returned
       3. Assert vcpu constraint: field="vcpus", op="eq", value=16
-      4. Assert memory constraint: field="memory_gb", op="gt", value=20.0
-    Expected Result: Correct Constraint objects
+      4. Assert memory constraint: field="memory_gb", op="gte", value=32
+    Expected Result: Correct Constraint objects, plain int = minimum
     Evidence: .sisyphus/evidence/task-2-parse-dict.txt
 
-  Scenario: Parse flat string (env var format)
+  Scenario: Parse vcpu range
     Tool: Bash (python)
     Steps:
-      1. parse_constraints("vcpu=16,memory=>20gb,disk=500gb-2tb")
-      2. Assert 3 constraints
-      3. Assert disk constraint: field="local_disk_gb", op="range", value=(500, 2048)
-    Expected Result: String parsed identically to dict
-    Evidence: .sisyphus/evidence/task-2-parse-string.txt
+      1. parse_constraints({"vcpu": "8-16", "memory": 32})
+      2. Assert vcpu constraint: field="vcpus", op="range", value=(8, 16)
+    Expected Result: Range parsed correctly
+    Evidence: .sisyphus/evidence/task-2-parse-range.txt
 
-  Scenario: Invalid constraint raises ValueError
+  Scenario: Missing vcpu raises ValueError
     Tool: Bash (python)
     Steps:
-      1. parse_constraints({"vcpu": "abc"}) → expect ValueError
-      2. parse_constraints("invalid_format") → expect ValueError
+      1. parse_constraints({"memory": 32}) → expect ValueError("vcpu is mandatory")
     Expected Result: Clear error message
-    Evidence: .sisyphus/evidence/task-2-parse-error.txt
+    Evidence: .sisyphus/evidence/task-2-missing-vcpu.txt
+
+  Scenario: Arch shorthands normalized
+    Tool: Bash (python)
+    Steps:
+      1. parse_constraints({"vcpu": 8, "arch": "arm"})
+      2. Assert arch constraint value == "arm64"
+      3. parse_constraints({"vcpu": 8, "arch": "x86"})
+      4. Assert arch constraint value == "x86_64"
+    Expected Result: Shorthands expanded
+    Evidence: .sisyphus/evidence/task-2-arch-shorthands.txt
   ```
 
   **Commit**: YES
-  - Message: `feature(sizing): add constraint parser with range/comparison support`
+  - Message: `feature(sizing): add constraint parser with range and arch shorthand support`
   - Files: `sdcm/utils/instance_matcher.py`, `unit_tests/unit/test_instance_matcher.py`
 
 - [ ] 3. Catalog file format and loader
@@ -306,7 +320,7 @@ Wave FINAL (4 parallel reviews):
   - Create `data/instance_catalog/` directory
   - Create initial curated catalog files: `aws.yaml`, `gce.yaml`, `azure.yaml`, `oci.yaml`
   - Populate with current families we use (from existing SIZING dict data):
-    - AWS: i8g, i4i, c6i, m6i, t3
+    - AWS: i8g, i7i, i4i, c6i, m6i, t3
     - GCE: z3-highmem, e2-standard, e2-highcpu, n2-highmem
     - Azure: Standard_L*s_v4, Standard_F*s_v2, Standard_D*_v4
     - OCI: DenseIO.E5.Flex, VM.Standard3.Flex, VM.Standard.E4.Flex
@@ -331,7 +345,7 @@ Wave FINAL (4 parallel reviews):
   - `sdcm/utils/cloud_sizes.py:80-220` — existing SIZING dict with all instance types and specs
 
   **Acceptance Criteria**:
-  - [ ] `data/instance_catalog/aws.yaml` has all i8g/i4i/c6i/m6i/t3 entries
+  - [ ] `data/instance_catalog/aws.yaml` has all i8g/i7i/i4i/c6i/m6i/t3 entries
   - [ ] YAML files are valid and loadable by Task 1's InstanceCatalog
 
   **QA Scenarios**:
@@ -356,7 +370,7 @@ Wave FINAL (4 parallel reviews):
   - Define preferred family ordering per role per cloud in catalog files or separate config
   - Structure: `{role: {cloud: [family1, family2, ...]}}` — ordered by preference (first = best)
   - Defaults:
-    - db/aws: ["i8g", "i4i"] (ARM preferred, x86 fallback)
+    - db/aws: ["i8g", "i7i", "i4i"] (ARM preferred, x86 fallback via i7i then i4i)
     - db/gce: ["z3-highmem"]
     - db/azure: ["Standard_L"]
     - db/oci: ["DenseIO.E5"]
@@ -476,7 +490,7 @@ Wave FINAL (4 parallel reviews):
   - Create `sdcm/utils/catalog_generator.py` with `generate_aws_catalog(families, region) -> list[InstanceTypeInfo]`
   - Use `boto3` `describe_instance_types` to get vcpu/memory/disk specs
   - Use AWS Pricing API (`get_products`) to get on-demand hourly pricing
-  - Filter to specified families only (i8g, i4i, c6i, m6i, t3)
+  - Filter to specified families only (i8g, i7i, i4i, c6i, m6i, t3)
   - Output: write `data/instance_catalog/aws.yaml`
   - CLI entry: `sct.py update-catalog --cloud aws`
 
@@ -603,9 +617,9 @@ Wave FINAL (4 parallel reviews):
   **What to do**:
   - Modify `_resolve_instance_sizes()` to detect constraint syntax:
     - If value is a `dict` → parse as constraints, call `select_instance()`
-    - If value is a `str` matching flat constraint format (`vcpu=...`) → parse + select
     - If value is a `str` that looks like an instance type (contains `.` or `-`) → passthrough (backward compat)
-    - If backend is docker/baremetal → skip resolution entirely
+    - If backend is docker/baremetal → skip resolution with info log
+    - Env var dot-notation (`SCT_DB_INSTANCE_TYPE.vcpu=8`) already builds dicts natively — no custom parsing needed
   - Load `InstanceCatalog` at config init (from `data/instance_catalog/`)
   - Resolved instance type flows into existing params (`instance_type_db`, `gce_instance_type_db`, etc.)
   - All 5 roles: db, db_oracle, zero_token, loader, monitor

--- a/docs/plans/constraint-based-sizing.md
+++ b/docs/plans/constraint-based-sizing.md
@@ -1,0 +1,877 @@
+# Constraint-Based Instance Sizing
+
+## TL;DR
+
+> **Quick Summary**: Replace T-shirt sizing (`db_instance_type: '2xlarge'`) with constraint-based selection (`db_instance_type: {vcpu: 16, memory: ">20gb"}`). An instance catalog per cloud (populated from APIs + curated) is matched against user constraints, selecting the best instance from preferred families by price.
+>
+> **Deliverables**:
+> - Instance catalog module with per-cloud type specs (vcpu/mem/disk/price)
+> - Catalog generation script querying AWS/GCE/Azure/OCI pricing APIs
+> - Constraint parser supporting exact, range, and comparison operators
+> - Matcher selecting best instance per role/cloud from catalog
+> - Updated `sct_config.py` wiring (backward-compat: literal strings still passthrough)
+> - CLI: `sct.py show-prices`, updated `show-sizes`/`translate-size`
+> - Migration of existing test configs
+> - User-facing documentation
+>
+> **Estimated Effort**: Large
+> **Parallel Execution**: YES — 4 waves
+> **Critical Path**: Task 1 → Task 3 → Task 6 → Task 9 → Task 11 → Final
+
+---
+
+## Context
+
+### Original Request
+Replace the T-shirt sizing system (roydahan/pehala review feedback on PR #14490) with a constraint-based selector where users specify requirements (vcpu, memory, disk) and the system resolves to the best matching instance type per cloud provider.
+
+### Interview Summary
+**Key Discussions**:
+- T-shirt sizes removed entirely; constraint-based only
+- YAML dict syntax in configs, flat string for env vars (`SCT_DB_INSTANCE_TYPE='vcpu=16,memory=>20gb'`)
+- Catalog: generated from live cloud APIs + manual curations, current families only
+- Selection: preferred family per role (price-based), with CLI price display
+- Constraints: exact (`vcpu: 16`), ranges (`memory: "10gb-30gb"`), comparisons (`memory: ">20gb"`), arch (`arch: "arm64"` or `arch: "x86_64"` — optional, overrides cloud default)
+
+**Research Findings**:
+- Existing `InstanceSpec` already has vcpus, memory_gb, local_ssd_count
+- `_resolve_instance_sizes()` in sct_config.py handles resolution at config-load time
+- PR #14490 has 3 commits implementing T-shirt system (to be replaced)
+- AWS Pricing API accessible from us-east-1; GCE uses `gcloud compute machine-types list`; Azure has Retail Prices REST API
+
+### Metis Review
+**Identified Gaps** (addressed):
+- Backward compat for literal strings: added as passthrough detection
+- Docker/baremetal backends: silently skip constraint resolution
+- No-match error handling: explicit error message naming unsatisfied constraint
+- Multi-role (oracle/zero_token): all roles get constraint syntax
+- Determinism: same constraints + catalog → always same instance (no randomness)
+- Local disk as implicit constraint for db role: YES, db role implies `local_disk: true`
+- Tie-breaking: preferred family first, then cheapest within family
+
+---
+
+## Work Objectives
+
+### Core Objective
+Enable cloud-agnostic instance selection via hardware constraints (vcpu, memory, disk) instead of arbitrary T-shirt size names, with automated catalog generation and price-based selection.
+
+### Concrete Deliverables
+- `sdcm/utils/instance_catalog.py` — catalog data model + loader
+- `sdcm/utils/instance_matcher.py` — constraint parser + matching engine
+- `sdcm/utils/catalog_generator.py` — script to populate catalog from cloud APIs
+- `data/instance_catalog/` — generated + curated catalog files (YAML per cloud)
+- Updated `sdcm/sct_config.py` — wiring constraint resolution
+- Updated `sct.py` — CLI commands
+- Updated test configs — migrated from T-shirt to constraints
+- `docs/cross-cloud-sizing.md` — updated user guide
+
+### Definition of Done
+- [ ] `{vcpu: 8, memory: ">16gb"}` on AWS resolves to `i8g.2xlarge` (ARM preferred) and all downstream works
+- [ ] `SCT_DB_INSTANCE_TYPE='vcpu=16,memory=>20gb'` env var parses correctly
+- [ ] `SCT_DB_INSTANCE_TYPE='vcpu=8,arch=x86_64'` forces x86 on AWS (overrides arm64 default)
+- [ ] `instance_type_db: 'i4i.large'` still works (literal passthrough)
+- [ ] `sct.py show-prices --cloud aws --role db` shows pricing table
+- [ ] 100% unit test coverage on matcher logic
+- [ ] Integration tests verify API-based catalog generation
+
+### Must Have
+- Backward compatibility: literal instance type strings still work as passthrough
+- All 5 roles supported: db, db_oracle, zero_token, loader, monitor
+- Constraint types: exact value, min (>), max (<), range (min-max), arch selector (arm64|x86_64)
+- Deterministic selection (same input → same output)
+- Docker/baremetal backends silently skip resolution
+- Clear error messages when no instance matches
+
+### Must NOT Have (Guardrails)
+- No spot/preemptible pricing — on-demand only
+- No cross-region auto-selection — region is fixed by other config
+- No GPU/accelerator constraints
+- No auto-detection of instance availability in region (future work)
+- No new cloud API dependencies in test runtime hot path — catalog loaded at startup only
+- No changes to downstream provisioning code — output is still a string instance type
+
+---
+
+## Verification Strategy
+
+> **ZERO HUMAN INTERVENTION** — ALL verification is agent-executed.
+
+### Test Decision
+- **Infrastructure exists**: YES (pytest + unit_tests/)
+- **Automated tests**: TDD
+- **Framework**: pytest (existing)
+- **Split**: Unit tests for parsing/matching logic, integration tests for API catalog generation
+
+### QA Policy
+Every task includes agent-executed QA scenarios.
+Evidence saved to `.sisyphus/evidence/task-{N}-{scenario-slug}.{ext}`.
+
+- **Library/Module**: Use Bash (python REPL) — import, call functions, compare output
+- **CLI**: Use interactive_bash (tmux) — run command, validate output
+- **API/Backend**: Use Bash (curl/python) — call cloud APIs, verify catalog generation
+
+---
+
+## Execution Strategy
+
+### Parallel Execution Waves
+
+```
+Wave 1 (Foundation — no dependencies):
+├── Task 1: Instance catalog data model [quick]
+├── Task 2: Constraint parser module [deep]
+├── Task 3: Catalog file format + loader [quick]
+├── Task 4: Preferred families config [quick]
+
+Wave 2 (Core logic — depends on Wave 1):
+├── Task 5: Matching engine (depends: 1, 2, 4) [deep]
+├── Task 6: Catalog generator — AWS (depends: 1, 3) [unspecified-high]
+├── Task 7: Catalog generator — GCE (depends: 1, 3) [unspecified-high]
+├── Task 8: Catalog generator — Azure + OCI (depends: 1, 3) [unspecified-high]
+
+Wave 3 (Integration — depends on Wave 2):
+├── Task 9: Wire into sct_config.py (depends: 5) [deep]
+├── Task 10: CLI commands (depends: 5, 6-8) [unspecified-high]
+├── Task 11: Migration of test configs (depends: 9) [quick]
+
+Wave 4 (Docs + cleanup):
+├── Task 12: User documentation (depends: 9, 10) [writing]
+├── Task 13: Remove old T-shirt sizing code (depends: 11) [quick]
+
+Wave FINAL (4 parallel reviews):
+├── F1: Plan compliance audit (oracle)
+├── F2: Code quality review (unspecified-high)
+├── F3: Real QA execution (unspecified-high)
+├── F4: Scope fidelity check (deep)
+→ Present results → Get explicit user okay
+```
+
+### Dependency Matrix
+
+| Task | Depends On | Blocks | Wave |
+|------|-----------|--------|------|
+| 1 | — | 5, 6, 7, 8 | 1 |
+| 2 | — | 5 | 1 |
+| 3 | — | 6, 7, 8 | 1 |
+| 4 | — | 5 | 1 |
+| 5 | 1, 2, 4 | 9, 10 | 2 |
+| 6 | 1, 3 | 10 | 2 |
+| 7 | 1, 3 | 10 | 2 |
+| 8 | 1, 3 | 10 | 2 |
+| 9 | 5 | 11 | 3 |
+| 10 | 5, 6-8 | 12 | 3 |
+| 11 | 9 | 12, 13 | 3 |
+| 12 | 9, 10 | — | 4 |
+| 13 | 11 | — | 4 |
+
+### Agent Dispatch Summary
+
+- **Wave 1**: 4 tasks — T1,T3,T4 → `quick`, T2 → `deep`
+- **Wave 2**: 4 tasks — T5 → `deep`, T6-T8 → `unspecified-high`
+- **Wave 3**: 3 tasks — T9 → `deep`, T10 → `unspecified-high`, T11 → `quick`
+- **Wave 4**: 2 tasks — T12 → `writing`, T13 → `quick`
+- **FINAL**: 4 tasks — F1 → `oracle`, F2-F3 → `unspecified-high`, F4 → `deep`
+
+---
+
+## TODOs
+
+- [ ] 1. Instance catalog data model
+
+  **What to do**:
+  - Create `sdcm/utils/instance_catalog.py`
+  - Define `@dataclass InstanceTypeInfo`: instance_type (str), cloud (str), family (str), vcpus (int), memory_gb (float), local_disk_gb (float), local_disk_count (int), arch (str: "x86_64"|"arm64"), price_per_hour (float|None)
+  - Define `InstanceCatalog` class: loads from YAML files, provides `query(cloud, **constraints) -> list[InstanceTypeInfo]`
+  - Define catalog file format: `data/instance_catalog/{cloud}.yaml` — list of instance type entries
+
+  **Must NOT do**:
+  - No cloud API calls in this task — just the data model and file loader
+  - No matching logic — that's Task 5
+
+  **Recommended Agent Profile**:
+  - **Category**: `quick`
+  - **Skills**: []
+
+  **Parallelization**:
+  - **Can Run In Parallel**: YES
+  - **Parallel Group**: Wave 1 (with Tasks 2, 3, 4)
+  - **Blocks**: Tasks 5, 6, 7, 8
+  - **Blocked By**: None
+
+  **References**:
+  - `sdcm/utils/cloud_sizes.py:42-70` — existing InstanceSpec dataclass to evolve from
+  - `defaults/` — YAML file loading patterns used in SCT
+
+  **Acceptance Criteria**:
+  - [ ] Test file: `unit_tests/unit/test_instance_catalog.py`
+  - [ ] `pytest unit_tests/unit/test_instance_catalog.py` → PASS
+
+  **QA Scenarios**:
+  ```
+  Scenario: Load catalog from YAML file
+    Tool: Bash (python)
+    Steps:
+      1. Create temp YAML with 3 instance entries
+      2. Load with InstanceCatalog.from_file(path)
+      3. Assert len(catalog.instances) == 3
+      4. Assert first entry has correct vcpus/memory
+    Expected Result: All fields correctly deserialized
+    Evidence: .sisyphus/evidence/task-1-load-catalog.txt
+
+  Scenario: Empty catalog file
+    Tool: Bash (python)
+    Steps:
+      1. Load empty YAML file
+      2. Assert catalog.instances == []
+    Expected Result: No error, empty list
+    Evidence: .sisyphus/evidence/task-1-empty-catalog.txt
+  ```
+
+  **Commit**: YES
+  - Message: `feature(sizing): add instance catalog data model`
+  - Files: `sdcm/utils/instance_catalog.py`, `unit_tests/unit/test_instance_catalog.py`
+
+- [ ] 2. Constraint parser module
+
+  **What to do**:
+  - Create constraint parsing in `sdcm/utils/instance_matcher.py`
+  - Parse dict format: `{"vcpu": 16, "memory": ">20gb", "disk": "500gb-2tb", "arch": "arm64"}`
+  - Parse flat string format: `"vcpu=16,memory=>20gb,disk=500gb-2tb,arch=arm64"`
+  - Supported operators: exact (`16`), gt (`>16`), lt (`<16`), gte (`>=16`), range (`10-30`)
+  - Supported units: gb, tb (for memory/disk); plain int for vcpu
+  - Special fields: `arch` accepts "arm64" or "x86_64" (optional — if omitted, uses cloud default)
+  - Output: list of `Constraint(field, operator, value)` objects
+  - Handle edge cases: whitespace, case-insensitive units, missing fields (optional)
+
+  **Must NOT do**:
+  - No matching against catalog — just parsing
+  - No sct_config integration
+
+  **Recommended Agent Profile**:
+  - **Category**: `deep`
+  - **Skills**: []
+
+  **Parallelization**:
+  - **Can Run In Parallel**: YES
+  - **Parallel Group**: Wave 1 (with Tasks 1, 3, 4)
+  - **Blocks**: Task 5
+  - **Blocked By**: None
+
+  **References**:
+  - No direct codebase reference — new module
+  - Python `re` module for parsing expressions
+
+  **Acceptance Criteria**:
+  - [ ] Test file: `unit_tests/unit/test_instance_matcher.py`
+  - [ ] `pytest unit_tests/unit/test_instance_matcher.py -k parse` → PASS (20+ parametrized cases)
+
+  **QA Scenarios**:
+  ```
+  Scenario: Parse YAML dict constraints
+    Tool: Bash (python)
+    Steps:
+      1. parse_constraints({"vcpu": 16, "memory": ">20gb"})
+      2. Assert 2 constraints returned
+      3. Assert vcpu constraint: field="vcpus", op="eq", value=16
+      4. Assert memory constraint: field="memory_gb", op="gt", value=20.0
+    Expected Result: Correct Constraint objects
+    Evidence: .sisyphus/evidence/task-2-parse-dict.txt
+
+  Scenario: Parse flat string (env var format)
+    Tool: Bash (python)
+    Steps:
+      1. parse_constraints("vcpu=16,memory=>20gb,disk=500gb-2tb")
+      2. Assert 3 constraints
+      3. Assert disk constraint: field="local_disk_gb", op="range", value=(500, 2048)
+    Expected Result: String parsed identically to dict
+    Evidence: .sisyphus/evidence/task-2-parse-string.txt
+
+  Scenario: Invalid constraint raises ValueError
+    Tool: Bash (python)
+    Steps:
+      1. parse_constraints({"vcpu": "abc"}) → expect ValueError
+      2. parse_constraints("invalid_format") → expect ValueError
+    Expected Result: Clear error message
+    Evidence: .sisyphus/evidence/task-2-parse-error.txt
+  ```
+
+  **Commit**: YES
+  - Message: `feature(sizing): add constraint parser with range/comparison support`
+  - Files: `sdcm/utils/instance_matcher.py`, `unit_tests/unit/test_instance_matcher.py`
+
+- [ ] 3. Catalog file format and loader
+
+  **What to do**:
+  - Create `data/instance_catalog/` directory
+  - Create initial curated catalog files: `aws.yaml`, `gce.yaml`, `azure.yaml`, `oci.yaml`
+  - Populate with current families we use (from existing SIZING dict data):
+    - AWS: i8g, i4i, c6i, m6i, t3
+    - GCE: z3-highmem, e2-standard, e2-highcpu, n2-highmem
+    - Azure: Standard_L*s_v4, Standard_F*s_v2, Standard_D*_v4
+    - OCI: DenseIO.E5.Flex, VM.Standard3.Flex, VM.Standard.E4.Flex
+  - Each entry: instance_type, family, vcpus, memory_gb, local_disk_gb, local_disk_count, arch, price_per_hour (null initially)
+  - Add `preferred_families` section per role in each file
+
+  **Must NOT do**:
+  - No API calls — manual curation from existing SIZING dict
+  - No pricing data yet (null/0) — filled by Task 6-8
+
+  **Recommended Agent Profile**:
+  - **Category**: `quick`
+  - **Skills**: []
+
+  **Parallelization**:
+  - **Can Run In Parallel**: YES
+  - **Parallel Group**: Wave 1 (with Tasks 1, 2, 4)
+  - **Blocks**: Tasks 6, 7, 8
+  - **Blocked By**: None
+
+  **References**:
+  - `sdcm/utils/cloud_sizes.py:80-220` — existing SIZING dict with all instance types and specs
+
+  **Acceptance Criteria**:
+  - [ ] `data/instance_catalog/aws.yaml` has all i8g/i4i/c6i/m6i/t3 entries
+  - [ ] YAML files are valid and loadable by Task 1's InstanceCatalog
+
+  **QA Scenarios**:
+  ```
+  Scenario: Catalog files are valid YAML
+    Tool: Bash (python)
+    Steps:
+      1. yaml.safe_load each file in data/instance_catalog/
+      2. Assert no parse errors
+      3. Assert each has "instances" key with list
+    Expected Result: All 4 files load cleanly
+    Evidence: .sisyphus/evidence/task-3-valid-yaml.txt
+  ```
+
+  **Commit**: YES
+  - Message: `feature(sizing): add curated instance catalog data files`
+  - Files: `data/instance_catalog/*.yaml`
+
+- [ ] 4. Preferred families configuration
+
+  **What to do**:
+  - Define preferred family ordering per role per cloud in catalog files or separate config
+  - Structure: `{role: {cloud: [family1, family2, ...]}}` — ordered by preference (first = best)
+  - Defaults:
+    - db/aws: ["i8g", "i4i"] (ARM preferred, x86 fallback)
+    - db/gce: ["z3-highmem"]
+    - db/azure: ["Standard_L"]
+    - db/oci: ["DenseIO.E5"]
+    - loader/aws: ["c6i"]
+    - loader/gce: ["e2-standard", "e2-highcpu"]
+    - monitor/aws: ["t3", "m6i"]
+  - Include arch preference per cloud (aws defaults to arm64, others x86_64)
+
+  **Must NOT do**:
+  - No matching logic — just the config data
+
+  **Recommended Agent Profile**:
+  - **Category**: `quick`
+  - **Skills**: []
+
+  **Parallelization**:
+  - **Can Run In Parallel**: YES
+  - **Parallel Group**: Wave 1 (with Tasks 1, 2, 3)
+  - **Blocks**: Task 5
+  - **Blocked By**: None
+
+  **References**:
+  - `sdcm/utils/cloud_sizes.py:80-90` — current family choices per role
+
+  **Acceptance Criteria**:
+  - [ ] Config loadable from file
+  - [ ] All current roles/clouds have family preferences defined
+
+  **QA Scenarios**:
+  ```
+  Scenario: Load preferred families
+    Tool: Bash (python)
+    Steps:
+      1. Load config
+      2. Assert db/aws first family is "i8g"
+      3. Assert loader/aws first family is "c6i"
+    Expected Result: Correct ordering
+    Evidence: .sisyphus/evidence/task-4-families.txt
+  ```
+
+  **Commit**: grouped with Task 3
+
+- [ ] 5. Matching engine
+
+  **What to do**:
+  - In `sdcm/utils/instance_matcher.py`, add `select_instance(catalog, role, cloud, constraints, arch=None) -> InstanceTypeInfo`
+  - Algorithm:
+    1. Filter catalog by cloud
+    2. Filter by arch: if `arch` constraint specified, use it; otherwise use cloud default (aws=arm64, others=x86_64)
+    3. Filter by preferred families for the role (ordered)
+    4. Apply constraint filters (vcpu, memory, disk)
+    5. Sort remaining by: family preference order → price → vcpu (ascending)
+    6. Return first match (deterministic)
+  - If no match: raise `NoMatchingInstanceError` with details of unsatisfied constraints
+  - For db role: implicitly add `local_disk_count > 0` unless user explicitly sets `local_disk: false`
+
+  **Must NOT do**:
+  - No sct_config wiring — standalone module
+  - No cloud API calls
+
+  **Recommended Agent Profile**:
+  - **Category**: `deep`
+  - **Skills**: []
+
+  **Parallelization**:
+  - **Can Run In Parallel**: NO
+  - **Parallel Group**: Wave 2
+  - **Blocks**: Tasks 9, 10
+  - **Blocked By**: Tasks 1, 2, 4
+
+  **References**:
+  - `sdcm/utils/cloud_sizes.py:240-280` — existing `resolve_size()` for comparison
+  - `sdcm/utils/instance_catalog.py` (Task 1) — data model
+  - `sdcm/utils/instance_matcher.py` (Task 2) — constraint parser
+
+  **Acceptance Criteria**:
+  - [ ] `pytest unit_tests/unit/test_instance_matcher.py -k select` → PASS (15+ cases)
+  - [ ] Deterministic: same input always same output
+  - [ ] NoMatchingInstanceError raised with descriptive message
+
+  **QA Scenarios**:
+  ```
+  Scenario: Select db instance on AWS with vcpu constraint
+    Tool: Bash (python)
+    Steps:
+      1. Load catalog with i8g.large(2vcpu), i8g.2xlarge(8vcpu), i8g.4xlarge(16vcpu)
+      2. select_instance(catalog, "db", "aws", {"vcpu": 8})
+      3. Assert result.instance_type == "i8g.2xlarge"
+    Expected Result: Exact match returned
+    Evidence: .sisyphus/evidence/task-5-select-exact.txt
+
+  Scenario: Range constraint selects smallest fitting
+    Tool: Bash (python)
+    Steps:
+      1. select_instance(catalog, "db", "aws", {"vcpu": ">4", "memory": "16gb-64gb"})
+      2. Assert result is i8g.2xlarge (8vcpu, 64gb) — smallest that fits
+    Expected Result: Smallest instance satisfying all constraints
+    Evidence: .sisyphus/evidence/task-5-select-range.txt
+
+  Scenario: No match raises clear error
+    Tool: Bash (python)
+    Steps:
+      1. select_instance(catalog, "db", "aws", {"vcpu": 1024})
+      2. Expect NoMatchingInstanceError
+      3. Assert error message contains "vcpu: 1024"
+    Expected Result: Descriptive error
+    Evidence: .sisyphus/evidence/task-5-no-match.txt
+  ```
+
+  **Commit**: YES
+  - Message: `feature(sizing): add instance matching engine with price-based selection`
+  - Files: `sdcm/utils/instance_matcher.py`, `unit_tests/unit/test_instance_matcher.py`
+
+- [ ] 6. Catalog generator — AWS
+
+  **What to do**:
+  - Create `sdcm/utils/catalog_generator.py` with `generate_aws_catalog(families, region) -> list[InstanceTypeInfo]`
+  - Use `boto3` `describe_instance_types` to get vcpu/memory/disk specs
+  - Use AWS Pricing API (`get_products`) to get on-demand hourly pricing
+  - Filter to specified families only (i8g, i4i, c6i, m6i, t3)
+  - Output: write `data/instance_catalog/aws.yaml`
+  - CLI entry: `sct.py update-catalog --cloud aws`
+
+  **Must NOT do**:
+  - No matching logic
+  - No GCE/Azure/OCI — separate tasks
+
+  **Recommended Agent Profile**:
+  - **Category**: `unspecified-high`
+  - **Skills**: []
+
+  **Parallelization**:
+  - **Can Run In Parallel**: YES
+  - **Parallel Group**: Wave 2 (with Tasks 5, 7, 8)
+  - **Blocks**: Task 10
+  - **Blocked By**: Tasks 1, 3
+
+  **References**:
+  - `sdcm/utils/aws_utils.py` — existing boto3 usage patterns
+  - AWS Pricing API: `us-east-1` region required
+
+  **Acceptance Criteria**:
+  - [ ] Integration test: `unit_tests/integration/test_catalog_generator.py::test_aws`
+  - [ ] Generated YAML matches expected format
+
+  **QA Scenarios**:
+  ```
+  Scenario: Generate AWS catalog for i8g family
+    Tool: Bash (python)
+    Preconditions: AWS credentials available
+    Steps:
+      1. generate_aws_catalog(["i8g"], region="us-east-1")
+      2. Assert result contains i8g.large, i8g.xlarge, etc.
+      3. Assert each has vcpus > 0, memory_gb > 0, price_per_hour > 0
+    Expected Result: Valid catalog entries with pricing
+    Evidence: .sisyphus/evidence/task-6-aws-catalog.txt
+  ```
+
+  **Commit**: YES
+  - Message: `feature(sizing): add AWS catalog generator with pricing`
+  - Files: `sdcm/utils/catalog_generator.py`, `unit_tests/integration/test_catalog_generator.py`
+
+- [ ] 7. Catalog generator — GCE
+
+  **What to do**:
+  - Add `generate_gce_catalog(families, project, zone) -> list[InstanceTypeInfo]`
+  - Use `gcloud compute machine-types list` or `google-cloud-compute` Python SDK
+  - Use GCE Billing API or `gcloud billing` for pricing
+  - Filter to: z3-highmem, e2-standard, e2-highcpu, n2-highmem
+  - Output: `data/instance_catalog/gce.yaml`
+
+  **Recommended Agent Profile**:
+  - **Category**: `unspecified-high`
+  - **Skills**: []
+
+  **Parallelization**:
+  - **Can Run In Parallel**: YES
+  - **Parallel Group**: Wave 2 (with Tasks 5, 6, 8)
+  - **Blocks**: Task 10
+  - **Blocked By**: Tasks 1, 3
+
+  **References**:
+  - `sdcm/utils/gce_utils.py` — existing GCE patterns
+
+  **Acceptance Criteria**:
+  - [ ] Integration test: `test_catalog_generator.py::test_gce`
+
+  **QA Scenarios**:
+  ```
+  Scenario: Generate GCE catalog for z3-highmem
+    Tool: Bash (python)
+    Preconditions: GCE credentials available
+    Steps:
+      1. generate_gce_catalog(["z3-highmem"], project="...", zone="us-east1-b")
+      2. Assert z3-highmem-4, z3-highmem-8, etc. present
+      3. Assert local_disk_count > 0 for z3 family
+    Expected Result: Valid entries with disk info
+    Evidence: .sisyphus/evidence/task-7-gce-catalog.txt
+  ```
+
+  **Commit**: grouped with Task 6
+
+- [ ] 8. Catalog generator — Azure + OCI
+
+  **What to do**:
+  - Add `generate_azure_catalog(families, region)` — Azure Retail Prices REST API (no SDK needed)
+  - Add `generate_oci_catalog(families, compartment)` — OCI SDK or REST
+  - Azure families: Standard_L, Standard_F, Standard_D
+  - OCI families: DenseIO.E5, VM.Standard3, VM.Standard.E4
+  - Output: `data/instance_catalog/azure.yaml`, `data/instance_catalog/oci.yaml`
+
+  **Recommended Agent Profile**:
+  - **Category**: `unspecified-high`
+  - **Skills**: []
+
+  **Parallelization**:
+  - **Can Run In Parallel**: YES
+  - **Parallel Group**: Wave 2 (with Tasks 5, 6, 7)
+  - **Blocks**: Task 10
+  - **Blocked By**: Tasks 1, 3
+
+  **References**:
+  - `sdcm/utils/azure_utils.py` — existing Azure patterns
+  - Azure Retail Prices: `https://prices.azure.com/api/retail/prices`
+
+  **Acceptance Criteria**:
+  - [ ] Integration test: `test_catalog_generator.py::test_azure`, `test_catalog_generator.py::test_oci`
+
+  **QA Scenarios**:
+  ```
+  Scenario: Generate Azure catalog
+    Tool: Bash (python)
+    Steps:
+      1. generate_azure_catalog(["Standard_L"], region="eastus")
+      2. Assert Standard_L4s_v4, Standard_L8s_v4, etc. present
+    Expected Result: Valid entries with pricing
+    Evidence: .sisyphus/evidence/task-8-azure-catalog.txt
+  ```
+
+  **Commit**: grouped with Task 6
+
+- [ ] 9. Wire into sct_config.py
+
+  **What to do**:
+  - Modify `_resolve_instance_sizes()` to detect constraint syntax:
+    - If value is a `dict` → parse as constraints, call `select_instance()`
+    - If value is a `str` matching flat constraint format (`vcpu=...`) → parse + select
+    - If value is a `str` that looks like an instance type (contains `.` or `-`) → passthrough (backward compat)
+    - If backend is docker/baremetal → skip resolution entirely
+  - Load `InstanceCatalog` at config init (from `data/instance_catalog/`)
+  - Resolved instance type flows into existing params (`instance_type_db`, `gce_instance_type_db`, etc.)
+  - All 5 roles: db, db_oracle, zero_token, loader, monitor
+
+  **Must NOT do**:
+  - No changes to downstream provisioning — output is still a string
+  - No changes to `verify_configuration()` beyond validating constraint syntax
+
+  **Recommended Agent Profile**:
+  - **Category**: `deep`
+  - **Skills**: []
+
+  **Parallelization**:
+  - **Can Run In Parallel**: NO
+  - **Parallel Group**: Wave 3
+  - **Blocks**: Tasks 11, 12
+  - **Blocked By**: Task 5
+
+  **References**:
+  - `sdcm/sct_config.py:3076-3151` — existing `_resolve_instance_sizes()` to replace
+  - `sdcm/sct_config.py:3090-3105` — `_primary_param_overrides` for zero_token naming
+
+  **Acceptance Criteria**:
+  - [ ] `pytest unit_tests/unit/test_config.py -k resolve_instance` → PASS
+  - [ ] Literal string `instance_type_db: 'i4i.large'` still works unchanged
+  - [ ] Dict `db_instance_type: {vcpu: 8}` resolves to correct type
+
+  **QA Scenarios**:
+  ```
+  Scenario: Constraint dict resolves to correct instance
+    Tool: Bash (python)
+    Steps:
+      1. Create config with db_instance_type: {vcpu: 8, memory: ">16gb"}
+      2. Load SCTConfiguration with backend=aws
+      3. Assert self["instance_type_db"] == "i8g.2xlarge"
+    Expected Result: Resolved to ARM 8-vcpu instance
+    Evidence: .sisyphus/evidence/task-9-constraint-resolve.txt
+
+  Scenario: Literal string passthrough
+    Tool: Bash (python)
+    Steps:
+      1. Create config with db_instance_type: "i4i.large"
+      2. Load SCTConfiguration with backend=aws
+      3. Assert self["instance_type_db"] == "i4i.large"
+    Expected Result: No catalog lookup, direct passthrough
+    Evidence: .sisyphus/evidence/task-9-passthrough.txt
+
+  Scenario: Docker backend skips resolution
+    Tool: Bash (python)
+    Steps:
+      1. Create config with db_instance_type: {vcpu: 8}, backend=docker
+      2. Load SCTConfiguration
+      3. Assert no error, instance_type_db unchanged
+    Expected Result: Silent skip
+    Evidence: .sisyphus/evidence/task-9-docker-skip.txt
+  ```
+
+  **Commit**: YES
+  - Message: `feature(sizing): wire constraint-based selector into sct_config`
+  - Files: `sdcm/sct_config.py`, `unit_tests/unit/test_config.py`
+
+- [ ] 10. CLI commands
+
+  **What to do**:
+  - Add `sct.py show-prices --cloud <cloud> --role <role> [--family <family>]` — tabular pricing display
+  - Add `sct.py update-catalog [--cloud <cloud>]` — runs catalog generator scripts
+  - Update `sct.py show-sizes` to show constraint-based entries
+  - Update `sct.py translate-size` to accept constraint format and show resolved types per cloud
+
+  **Recommended Agent Profile**:
+  - **Category**: `unspecified-high`
+  - **Skills**: []
+
+  **Parallelization**:
+  - **Can Run In Parallel**: YES (with Task 9 if no dependency conflicts)
+  - **Parallel Group**: Wave 3
+  - **Blocks**: Task 12
+  - **Blocked By**: Tasks 5, 6-8
+
+  **References**:
+  - `sct.py:2774-2900` — existing `show-sizes` and `translate-size` commands
+
+  **Acceptance Criteria**:
+  - [ ] `sct.py show-prices --cloud aws --role db` outputs table with price column
+  - [ ] `sct.py update-catalog --cloud aws` generates valid catalog file
+
+  **QA Scenarios**:
+  ```
+  Scenario: show-prices displays table
+    Tool: interactive_bash (tmux)
+    Steps:
+      1. Run: uv run sct.py show-prices --cloud aws --role db
+      2. Assert output contains "i8g" and "$" price column
+    Expected Result: Formatted table with pricing
+    Evidence: .sisyphus/evidence/task-10-show-prices.txt
+  ```
+
+  **Commit**: YES
+  - Message: `feature(sizing): add show-prices CLI and update show-sizes/translate-size`
+  - Files: `sct.py`
+
+- [ ] 11. Migrate test configs
+
+  **What to do**:
+  - Update longevity test configs (12 files in `test-cases/longevity/`) from T-shirt to constraint syntax
+  - Map: `db_instance_type: '2xlarge'` → `db_instance_type: {vcpu: 8, memory: ">16gb"}`
+  - Map: `loader_instance_type: 'small'` → `loader_instance_type: {vcpu: 4}`
+  - Map: `monitor_instance_type: 'small'` → `monitor_instance_type: {vcpu: 2}`
+  - Verify each migrated config resolves to same instance types as before
+
+  **Recommended Agent Profile**:
+  - **Category**: `quick`
+  - **Skills**: []
+
+  **Parallelization**:
+  - **Can Run In Parallel**: NO
+  - **Parallel Group**: Wave 3
+  - **Blocks**: Tasks 12, 13
+  - **Blocked By**: Task 9
+
+  **References**:
+  - `test-cases/longevity/` — 12 migrated config files
+
+  **Acceptance Criteria**:
+  - [ ] All configs resolve to same instance types as the old T-shirt mapping
+  - [ ] `sct.py translate-size --config <file> --backend aws` shows expected types
+
+  **QA Scenarios**:
+  ```
+  Scenario: Migrated config resolves identically
+    Tool: Bash
+    Steps:
+      1. For each migrated file, run translate-size and capture output
+      2. Compare against expected instance types from old SIZING dict
+    Expected Result: 1:1 match
+    Evidence: .sisyphus/evidence/task-11-migration-verify.txt
+  ```
+
+  **Commit**: YES
+  - Message: `refactor(sizing): migrate test configs from T-shirt to constraint syntax`
+  - Files: `test-cases/longevity/*.yaml`
+
+- [ ] 12. User documentation
+
+  **What to do**:
+  - Rewrite `docs/cross-cloud-sizing.md` for constraint-based system
+  - Sections: Overview, Syntax (YAML dict + env var), Constraint types, Selection algorithm, CLI tools, Examples, Migration guide
+  - Include mapping table: "old T-shirt → new constraints"
+  - Include **Demo & Quick Start** section:
+    - Minimal example: `db_instance_type: {vcpu: 8}` → what happens on each cloud
+    - Env var example: `export SCT_DB_INSTANCE_TYPE='vcpu=16,memory=>32gb'`
+    - Arch override example: `db_instance_type: {vcpu: 8, arch: "x86_64"}` forces i4i on AWS
+    - Multi-role example showing db + loader + monitor in one config file
+    - `sct.py show-prices --cloud aws --role db` output screenshot/example
+    - `sct.py translate-size --config my-test.yaml` showing per-cloud resolution
+    - Error case: what happens when no instance matches (error message example)
+  - Include **Constraint Reference** section:
+    - Table of all constraint fields: vcpu, memory, disk, arch
+    - Operators per field: exact, >, <, >=, range
+    - Units: gb, tb (auto-converted)
+    - Defaults when omitted (arch per cloud, local_disk for db role)
+  - Include **Selection Algorithm** section (user-facing explanation):
+    - How preferred families work
+    - How tie-breaking works (family order → price → vcpu ascending)
+    - How to inspect what was selected: `translate-size` output
+  - Include **Catalog Management** section:
+    - How to update catalog: `sct.py update-catalog`
+    - Where catalog files live: `data/instance_catalog/`
+    - How to add a new instance family manually
+
+  **Recommended Agent Profile**:
+  - **Category**: `writing`
+  - **Skills**: []
+
+  **Parallelization**:
+  - **Can Run In Parallel**: YES (with Task 13)
+  - **Parallel Group**: Wave 4
+  - **Blocks**: None
+  - **Blocked By**: Tasks 9, 10
+
+  **Acceptance Criteria**:
+  - [ ] Doc covers all constraint types with examples
+  - [ ] Migration table present
+
+  **Commit**: YES
+  - Message: `docs(sizing): update cross-cloud sizing guide for constraint-based selection`
+  - Files: `docs/cross-cloud-sizing.md`
+
+- [ ] 13. Remove old T-shirt sizing code
+
+  **What to do**:
+  - Remove `SIZING` dict from `sdcm/utils/cloud_sizes.py`
+  - Remove `resolve_size()`, `identify_size()`, `SizeMapping` — replaced by catalog + matcher
+  - Keep `get_cloud_params()` if still needed, or inline into new matcher
+  - Update imports across codebase
+  - Remove old `unit_tests/unit/test_cloud_sizes.py`
+
+  **Recommended Agent Profile**:
+  - **Category**: `quick`
+  - **Skills**: []
+
+  **Parallelization**:
+  - **Can Run In Parallel**: YES (with Task 12)
+  - **Parallel Group**: Wave 4
+  - **Blocks**: None
+  - **Blocked By**: Task 11
+
+  **Acceptance Criteria**:
+  - [ ] No references to `resolve_size` or `SIZING` remain
+  - [ ] All tests pass after removal
+
+  **Commit**: YES
+  - Message: `refactor(sizing): remove deprecated T-shirt sizing code`
+  - Files: `sdcm/utils/cloud_sizes.py` (gutted), `unit_tests/unit/test_cloud_sizes.py` (removed)
+
+---
+
+## Final Verification Wave
+
+- [ ] F1. **Plan Compliance Audit** — `oracle`
+  Read the plan end-to-end. For each "Must Have": verify implementation exists. For each "Must NOT Have": search codebase for forbidden patterns. Check evidence files exist.
+  Output: `Must Have [N/N] | Must NOT Have [N/N] | VERDICT`
+
+- [ ] F2. **Code Quality Review** — `unspecified-high`
+  Run ruff + pytest. Review all changed files for type safety, error handling, unused imports. Check no AI slop.
+  Output: `Build [PASS/FAIL] | Tests [N pass/N fail] | VERDICT`
+
+- [ ] F3. **Real QA** — `unspecified-high`
+  Execute every QA scenario from every task. Test cross-task integration. Save evidence.
+  Output: `Scenarios [N/N pass] | VERDICT`
+
+- [ ] F4. **Scope Fidelity Check** — `deep`
+  Verify 1:1 match between plan spec and actual implementation. Flag scope creep.
+  Output: `Tasks [N/N compliant] | VERDICT`
+
+---
+
+## Commit Strategy
+
+- **1**: `feature(sizing): add instance catalog data model` — instance_catalog.py
+- **2**: `feature(sizing): add constraint parser with range/comparison support` — instance_matcher.py (parser part)
+- **3**: `feature(sizing): add instance matching engine with price-based selection` — instance_matcher.py (matcher part)
+- **4**: `feature(sizing): add catalog generation scripts for AWS/GCE/Azure/OCI` — catalog_generator.py + data/
+- **5**: `feature(sizing): wire constraint-based selector into sct_config` — sct_config.py
+- **6**: `feature(sizing): add show-prices CLI and update show-sizes/translate-size` — sct.py
+- **7**: `refactor(sizing): migrate test configs from T-shirt to constraint syntax` — test-cases/
+- **8**: `docs(sizing): update cross-cloud sizing guide for constraint-based selection` — docs/
+- **9**: `refactor(sizing): remove deprecated T-shirt sizing code` — cloud_sizes.py cleanup
+
+---
+
+## Success Criteria
+
+### Verification Commands
+```bash
+python -m pytest unit_tests/unit/test_instance_catalog.py -v  # catalog model tests
+python -m pytest unit_tests/unit/test_instance_matcher.py -v  # parser + matcher tests
+python -m pytest unit_tests/unit/test_config.py -v  # integration with sct_config
+python -m pytest unit_tests/integration/test_catalog_generator.py -v  # API tests
+uv run sct.py show-prices --cloud aws --role db  # CLI works
+```
+
+### Final Checklist
+- [ ] All "Must Have" present
+- [ ] All "Must NOT Have" absent
+- [ ] All tests pass
+- [ ] Literal string backward compat verified
+- [ ] All 5 roles work with constraint syntax
+- [ ] Docker backend silently skips resolution

--- a/docs/plans/constraint-based-sizing.md
+++ b/docs/plans/constraint-based-sizing.md
@@ -1,5 +1,41 @@
 # Constraint-Based Instance Sizing
 
+## Implementation Status
+
+> **Status**: Implementation complete in PR #14576.
+>
+> All 32 review comments from PR #14517 are resolved in the implementation.
+>
+> ### Key Deviations from Original Plan
+>
+> | Plan | Actual Implementation |
+> |------|----------------------|
+> | CLI: `show-prices`, `translate-size`, `show-sizes` | CLI: `sizing catalog`, `sizing resolve`, `sizing preview` (grouped under `sizing` subcommand) |
+> | Config key: `db_instance_type` | Config key: `instance_type_db` (matches existing SCT naming) |
+> | Env var: `SCT_DB_INSTANCE_TYPE.vcpu=8` | Env var: `SCT_INSTANCE_TYPE_DB.VCPU=8` |
+> | 9 separate commits | 3 commits (core + config extraction + agnostic defaults) |
+> | `sdcm/utils/cloud_sizes.py` removal (Task 13) | Deferred — old code still present, not yet removed |
+> | CLI in `sct.py` | CLI extracted to `sct_sizing.py` (separate module) |
+> | Preferred families in catalog YAML files | Preferred families in `sizing_config.yaml` (separate config) |
+> | OCI pricing hardcoded | OCI pricing fetched live from Oracle API with lazy caching |
+> | GCE catalog: z3-highmem only | GCE catalog: z3-highmem + n2-highmem (with disk variants 1-24 SSDs) |
+> | DenseIO memory: 16 GB/OCPU | DenseIO memory: 12 GB/OCPU (corrected from Oracle docs) |
+> | Tier1 configs: all migrated uniformly | 3 configs had memory lowered for OCI compatibility; 7 with vcpu≤8 left with `# no OCI match` |
+>
+> ### Files Created (not in plan)
+>
+> - `sct_sizing.py` — extracted sizing CLI (plan had it in `sct.py`)
+> - `data/instance_catalog/sizing_config.yaml` — role constraints, preferred families, sort order
+> - `sdcm/utils/instance_catalog.py` — catalog model + loader (as planned)
+> - `sdcm/utils/instance_matcher.py` — constraint parser + matching engine (as planned)
+> - `sdcm/utils/catalog_generator.py` — catalog generators for all 4 clouds (as planned)
+>
+> ### Test Coverage
+>
+> - `unit_tests/unit/test_instance_matcher.py` — 40 test functions
+> - `unit_tests/unit/test_instance_catalog.py` — 14 test functions
+> - `unit_tests/integration/test_catalog_generator.py` — integration tests for API generation
+
 ## TL;DR
 
 > **Quick Summary**: Replace T-shirt sizing (`db_instance_type: '2xlarge'`) with constraint-based selection (`db_instance_type: {vcpu: 16, memory: ">20gb"}`). An instance catalog per cloud (populated from APIs + curated) is matched against user constraints, selecting the best instance from preferred families by price.


### PR DESCRIPTION
## Summary

Implementation plan and user-facing documentation for constraint-based instance sizing.

Replaces T-shirt sizing (`db_type: local_ssd`) with constraint dictionaries:
```yaml
db_instance_type:
  vcpu: 16
  memory: ">20gb"
  arch: arm64
```

The resolver picks the cheapest matching instance per cloud, using preferred families (i8g for AWS, z3 for GCE, v4 for Azure, DenseIO.E5 for OCI).

## Contents

- `docs/plans/constraint-based-sizing.md` — full implementation plan (4 waves, 13 tasks)
- `docs/cross-cloud-sizing.md` — user guide: constraint syntax, selection algorithm, CLI tools, migration

## Reference

- #14490 — prior T-shirt sizing PR (kept as reference, not superseded)