### PR TITLE
fix(jenkins-pipeline): add missing SCT_BILLING_PROJECT to perfRegressionParallelPipeline

### DIFF
--- a/vars/perfRegressionParallelPipeline.groovy
+++ b/vars/perfRegressionParallelPipeline.groovy
@@ -15,6 +15,7 @@ def call(Map pipelineParams) {
             AWS_ACCESS_KEY_ID     = credentials('qa-aws-secret-key-id')
             AWS_SECRET_ACCESS_KEY = credentials('qa-aws-secret-access-key')
             SCT_GCE_PROJECT = "${params.gce_project}"
+            SCT_BILLING_PROJECT = "${params.billing_project}"
         }
         parameters {
             // Cloud Provider Configuration


### PR DESCRIPTION
## Summary
- `perfRegressionParallelPipeline.groovy` declared a `billing_project` parameter but never mapped it to `SCT_BILLING_PROJECT` in the environment block, causing billing project selection to be silently ignored for perf regression jobs.
- All other pipelines (longevity, rolling upgrade, manager, etc.) correctly set this env var.