### PR TITLE
fix(gce): use gce_datacenter instead of region in artifacts pipeline

### DIFF
--- a/jenkins-pipelines/oss/artifacts/artifacts-gce-image.jenkinsfile
+++ b/jenkins-pipelines/oss/artifacts/artifacts-gce-image.jenkinsfile
@@ -9,7 +9,7 @@ artifactsPipeline(
     test_config: 'test-cases/artifacts/gce-image.yaml',
     backend: 'gce',
     provision_type: 'spot',
-    region: 'us-central1',
+    gce_datacenter: 'us-central1',
 
     timeout: [time: 45, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy',


### PR DESCRIPTION
## Summary
- Fix `artifacts-gce-image.jenkinsfile` to use `gce_datacenter` instead of invalid `region` parameter for GCE backend configuration