### PR TITLE
fix(unit-test): reset TestConfig state in test_decode_backtrace fixture teardown

### DIFF
--- a/unit_tests/unit/test_decode_backtrace.py
+++ b/unit_tests/unit/test_decode_backtrace.py
@@ -40,6 +40,8 @@ def test_config_fixture():
     config.BACKTRACE_DECODING = True
     config.DECODING_QUEUE = Queue()
     yield config
+    TestConfig.BACKTRACE_DECODING = False
+    TestConfig.DECODING_QUEUE = None
 
 
 @pytest.fixture(name="dummy_node")


### PR DESCRIPTION
## Summary

- Fix test pollution: `test_config_fixture` in `test_decode_backtrace.py` sets `TestConfig.BACKTRACE_DECODING=True` and `DECODING_QUEUE=Queue()` on the class without resetting in teardown
- This causes `test_tester_subclass[TeardownFailsTest]` to fail when run after decode backtrace tests, because the tester teardown enters the "closing decoding queue" path and generates an unexpected ERROR event

## Root Cause

The fixture modifies class-level state on `TestConfig` (a singleton-like class with class variables) but only yields without cleanup. Subsequent tests that run tester teardown see `BACKTRACE_DECODING=True`, try to `close()` the stale queue, fail inside a `silence()` block, and produce an extra ERROR event that breaks assertions.

## Fix

Reset `TestConfig.BACKTRACE_DECODING` and `TestConfig.DECODING_QUEUE` to their defaults after the fixture yields.

[SCT-275]

[SCT-275]: https://scylladb.atlassian.net/browse/SCT-275?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ