### PR TITLE
fix(apt-keys): add fallback keyservers and HTTPS fallback to fetch_apt_keys

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2372,16 +2372,56 @@ class BaseNode(AutoSshContainerMixin):
         keys to be stored in /etc/apt/keyrings rather than the legacy /etc/apt/trusted.gpg.
         The temporary keyring avoids polluting the system keyring and ensures the correct
         format for APT to use.
+
+        Tries multiple HKP keyservers in order, and falls back to HTTPS if all HKP attempts fail.
         """
         self.remoter.sudo("mkdir -m 0755 -p /etc/apt/keyrings")
         temp_keyring = f"/tmp/temp-{uuid.uuid4()}.gpg"
         try:
             # Import all keys into a temporary keyring
             for apt_key in self.parent_cluster.params.get("scylla_apt_keys"):
-                self.remoter.sudo(
-                    f"gpg --homedir /tmp --no-default-keyring --keyring {temp_keyring} --keyserver hkp://keyserver.ubuntu.com:80 --keyserver-options timeout=10 --recv-keys {apt_key}",
-                    retry=3,
-                )
+                # List of HKP keyservers to try in order
+                hkp_keyservers = [
+                    "hkp://keyserver.ubuntu.com:80",
+                    "hkp://keys.openpgp.org",
+                    "hkp://pgp.mit.edu",
+                ]
+
+                key_fetched = False
+
+                # Try each HKP keyserver
+                for keyserver in hkp_keyservers:
+                    result = self.remoter.sudo(
+                        f"gpg --homedir /tmp --no-default-keyring --keyring {temp_keyring} --keyserver {keyserver} --keyserver-options timeout=10 --recv-keys {apt_key}",
+                        retry=1,
+                        ignore_status=True,
+                    )
+                    if result.ok:
+                        LOGGER.debug("Fetched GPG key %s from %s", apt_key, keyserver)
+                        key_fetched = True
+                        break
+
+                # If all HKP keyservers failed, try HTTPS fallback
+                if not key_fetched:
+                    https_url = f"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x{apt_key}&options=mr"
+                    result = self.remoter.sudo(
+                        shell_script_cmd(
+                            f"curl --retry 3 --retry-max-time 60 --connect-timeout 10 -fsSL '{https_url}' | gpg --homedir /tmp --no-default-keyring --keyring {temp_keyring} --import"
+                        ),
+                        retry=1,
+                        ignore_status=True,
+                    )
+                    if result.ok:
+                        LOGGER.debug("Fetched GPG key %s from HTTPS fallback", apt_key)
+                        key_fetched = True
+
+                # If all sources failed, raise an error
+                if not key_fetched:
+                    raise NodeSetupFailed(
+                        node=self,
+                        error_msg=f"Failed to fetch GPG key {apt_key} from all keyservers and HTTPS fallback",
+                    )
+
             # Export all keys at once to the keyring file
             self.remoter.sudo(
                 shell_script_cmd(

--- a/unit_tests/unit/test_fetch_apt_keys.py
+++ b/unit_tests/unit/test_fetch_apt_keys.py
@@ -1,0 +1,161 @@
+from unittest import mock
+
+import pytest
+from invoke.runners import Result
+
+from sdcm.cluster import BaseNode, NodeSetupFailed
+from sdcm.remote import shell_script_cmd
+
+
+APT_KEY = "AABBCCDD11223344"
+HKP_KEYSERVERS = [
+    "hkp://keyserver.ubuntu.com:80",
+    "hkp://keys.openpgp.org",
+    "hkp://pgp.mit.edu",
+]
+
+
+@pytest.fixture()
+def node():
+    n = mock.MagicMock()
+    n.parent_cluster.params.get.return_value = [APT_KEY]
+    return n
+
+
+def _make_result(ok):
+    r = mock.MagicMock(spec=Result)
+    r.ok = ok
+    return r
+
+
+def _gpg_recv_call(temp_keyring, keyserver, apt_key):
+    return mock.call(
+        f"gpg --homedir /tmp --no-default-keyring --keyring {temp_keyring} --keyserver {keyserver} --keyserver-options timeout=10 --recv-keys {apt_key}",
+        retry=1,
+        ignore_status=True,
+    )
+
+
+def _https_fallback_call(temp_keyring, apt_key):
+    https_url = f"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x{apt_key}&options=mr"
+    return mock.call(
+        shell_script_cmd(
+            f"curl --retry 3 --retry-max-time 60 --connect-timeout 10 -fsSL '{https_url}' | gpg --homedir /tmp --no-default-keyring --keyring {temp_keyring} --import"
+        ),
+        retry=1,
+        ignore_status=True,
+    )
+
+
+def _export_call(temp_keyring):
+    return mock.call(
+        shell_script_cmd(
+            f"gpg --homedir /tmp --no-default-keyring --keyring {temp_keyring} --export --armor | gpg --dearmor > /etc/apt/keyrings/scylladb.gpg"
+        ),
+        retry=3,
+    )
+
+
+def test_fetch_apt_keys_first_keyserver_succeeds(node):
+    node.remoter.sudo.side_effect = [
+        None,  # mkdir
+        _make_result(True),  # first keyserver succeeds
+        None,  # export
+        None,  # cleanup
+    ]
+
+    with mock.patch("sdcm.cluster.uuid.uuid4", return_value="test-uuid"):
+        BaseNode.fetch_apt_keys(node)
+
+    temp_keyring = "/tmp/temp-test-uuid.gpg"
+    node.remoter.sudo.assert_has_calls(
+        [
+            mock.call("mkdir -m 0755 -p /etc/apt/keyrings"),
+            _gpg_recv_call(temp_keyring, HKP_KEYSERVERS[0], APT_KEY),
+            _export_call(temp_keyring),
+            mock.call(f"rm -f {temp_keyring}", ignore_status=True),
+        ]
+    )
+    assert node.remoter.sudo.call_count == 4
+
+
+def test_fetch_apt_keys_first_fails_second_succeeds(node):
+    node.remoter.sudo.side_effect = [
+        None,  # mkdir
+        _make_result(False),  # first keyserver fails
+        _make_result(True),  # second keyserver succeeds
+        None,  # export
+        None,  # cleanup
+    ]
+
+    with mock.patch("sdcm.cluster.uuid.uuid4", return_value="test-uuid"):
+        BaseNode.fetch_apt_keys(node)
+
+    temp_keyring = "/tmp/temp-test-uuid.gpg"
+    node.remoter.sudo.assert_has_calls(
+        [
+            mock.call("mkdir -m 0755 -p /etc/apt/keyrings"),
+            _gpg_recv_call(temp_keyring, HKP_KEYSERVERS[0], APT_KEY),
+            _gpg_recv_call(temp_keyring, HKP_KEYSERVERS[1], APT_KEY),
+            _export_call(temp_keyring),
+            mock.call(f"rm -f {temp_keyring}", ignore_status=True),
+        ]
+    )
+    assert node.remoter.sudo.call_count == 5
+
+
+def test_fetch_apt_keys_all_hkp_fail_https_succeeds(node):
+    node.remoter.sudo.side_effect = [
+        None,  # mkdir
+        _make_result(False),  # first keyserver fails
+        _make_result(False),  # second keyserver fails
+        _make_result(False),  # third keyserver fails
+        _make_result(True),  # HTTPS fallback succeeds
+        None,  # export
+        None,  # cleanup
+    ]
+
+    with mock.patch("sdcm.cluster.uuid.uuid4", return_value="test-uuid"):
+        BaseNode.fetch_apt_keys(node)
+
+    temp_keyring = "/tmp/temp-test-uuid.gpg"
+    node.remoter.sudo.assert_has_calls(
+        [
+            mock.call("mkdir -m 0755 -p /etc/apt/keyrings"),
+            _gpg_recv_call(temp_keyring, HKP_KEYSERVERS[0], APT_KEY),
+            _gpg_recv_call(temp_keyring, HKP_KEYSERVERS[1], APT_KEY),
+            _gpg_recv_call(temp_keyring, HKP_KEYSERVERS[2], APT_KEY),
+            _https_fallback_call(temp_keyring, APT_KEY),
+            _export_call(temp_keyring),
+            mock.call(f"rm -f {temp_keyring}", ignore_status=True),
+        ]
+    )
+    assert node.remoter.sudo.call_count == 7
+
+
+def test_fetch_apt_keys_all_sources_fail_raises_exception(node):
+    node.remoter.sudo.side_effect = [
+        None,  # mkdir
+        _make_result(False),  # first keyserver fails
+        _make_result(False),  # second keyserver fails
+        _make_result(False),  # third keyserver fails
+        _make_result(False),  # HTTPS fallback fails
+        None,  # cleanup
+    ]
+
+    with mock.patch("sdcm.cluster.uuid.uuid4", return_value="test-uuid"):
+        with pytest.raises(NodeSetupFailed):
+            BaseNode.fetch_apt_keys(node)
+
+    temp_keyring = "/tmp/temp-test-uuid.gpg"
+    node.remoter.sudo.assert_has_calls(
+        [
+            mock.call("mkdir -m 0755 -p /etc/apt/keyrings"),
+            _gpg_recv_call(temp_keyring, HKP_KEYSERVERS[0], APT_KEY),
+            _gpg_recv_call(temp_keyring, HKP_KEYSERVERS[1], APT_KEY),
+            _gpg_recv_call(temp_keyring, HKP_KEYSERVERS[2], APT_KEY),
+            _https_fallback_call(temp_keyring, APT_KEY),
+            mock.call(f"rm -f {temp_keyring}", ignore_status=True),
+        ]
+    )
+    assert node.remoter.sudo.call_count == 6


### PR DESCRIPTION
## Summary

Fixes SCT-320. \`fetch_apt_keys()\` was using a single HKP keyserver (\`hkp://keyserver.ubuntu.com:80\`) with no fallback, causing transient failures when that keyserver was unreachable.

## Changes

- **\`sdcm/cluster.py\`** — \`fetch_apt_keys()\` now tries 3 HKP keyservers in order:
  1. \`hkp://keyserver.ubuntu.com:80\`
  2. \`hkp://keys.openpgp.org\`
  3. \`hkp://pgp.mit.edu\`

  If all HKP attempts fail, falls back to HTTPS (\`https://keyserver.ubuntu.com/pks/lookup?...\`). Raises \`NodeSetupFailed\` only if every source fails.

- **\`unit_tests/unit/test_fetch_apt_keys.py\`** — 4 new pytest tests covering:
  - First keyserver succeeds
  - First fails, second succeeds
  - All HKP fail, HTTPS fallback succeeds
  - All sources fail → \`NodeSetupFailed\` raised

## Testing

\`\`\`
uv run sct.py unit-tests -t test_fetch_apt_keys.py
\`\`\`

All 4 tests pass. Pre-commit checks clean.