### PR TITLE
fix(apt-install): add Acquire::http::Timeout and Acquire::Retries to apt-get calls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -311,6 +311,7 @@ Modular, task-specific guidance for AI agents lives in the `skills/` directory. 
 | writing-integration-tests | Guides writing integration tests that interact with real external services. Use when creating tests requiring Docker, AWS, GCE, Azure, OCI, or Kubernetes backends. | `skills/writing-integration-tests/SKILL.md` |
 | commit-summary | Generate weekly commit summary reports for the SCT repository | `skills/commit-summary/SKILL.md` |
 | writing-nemesis | Guides writing new nemesis (chaos disruptions). Use when creating NemesisBaseClass subclasses or implementing disruption logic. | `skills/writing-nemesis/SKILL.md` |
+| package-installation | Guides writing remote package installation commands (apt-get, yum, dnf, zypper) in SCT. Use when adding install/update calls via remoter to ensure timeouts, retries, and non-interactive flags. | `skills/package-installation/SKILL.md` |
 
 When creating a new skill, follow the process in `skills/designing-skills/workflows/create-a-skill.md`.
 

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -96,6 +96,7 @@ from sdcm.remote.remote_long_running import run_long_running_cmd
 from sdcm.remote.remote_file import remote_file, yaml_file_to_dict, dict_to_yaml_file
 from sdcm import wait, mgmt
 from sdcm.sct_config import SCTConfiguration
+from sdcm.utils.apt import apt_cmd
 from sdcm.sct_events.continuous_event import ContinuousEventsRegistry
 from sdcm.sct_events.system import AwsKmsEvent
 from sdcm.snitch_configuration import SnitchConfig
@@ -2360,7 +2361,7 @@ class BaseNode(AutoSshContainerMixin):
 
         if self.distro.is_debian_like:
             self.fetch_apt_keys()
-            self.remoter.sudo("apt-get update", ignore_status=True)
+            self.remoter.sudo(apt_cmd("update"), ignore_status=True)
 
     def fetch_apt_keys(self):
         """
@@ -2453,10 +2454,7 @@ class BaseNode(AutoSshContainerMixin):
             pkg_cmd = "zypper"
             package_name = f"{package_name}-{package_version}" if package_version else package_name
         else:
-            pkg_cmd = (
-                "DEBIAN_FRONTEND=noninteractive apt-get "
-                '-o DPkg::Lock::Timeout=120 -o Dpkg::Options::="--force-confold" -o Dpkg::Options::="--force-confdef"'
-            )
+            pkg_cmd = apt_cmd()
             version_prefix = f"={package_version}*" if package_version else ""
             if version_prefix:
                 # get versioned dependencies as apt always get's the latest version which are not compatible
@@ -2536,12 +2534,8 @@ class BaseNode(AutoSshContainerMixin):
         elif self.distro.is_sles:
             self.remoter.sudo("zypper update scylla-manager-agent -y")
         else:
-            self.remoter.sudo("apt-get update", ignore_status=True)
-            self.remoter.sudo(
-                "DEBIAN_FRONTEND=noninteractive apt-get install -o Dpkg::Lock::Timeout=300 "
-                "-o Dpkg::Options::='--force-confold' -o Dpkg::Options::='--force-confdef' "
-                "-y scylla-manager-agent"
-            )
+            self.remoter.sudo(apt_cmd("update"), ignore_status=True)
+            self.remoter.sudo(apt_cmd("install -y scylla-manager-agent", options={"DPkg::Lock::Timeout": "300"}))
         self.remoter.sudo("scyllamgr_agent_setup -y")
         if start_agent_after_upgrade:
             if self.is_docker():
@@ -2595,7 +2589,7 @@ class BaseNode(AutoSshContainerMixin):
             else:
                 self.remoter.sudo("apt-get clean all")
                 self.remoter.sudo("rm -rf /var/cache/apt/")
-                self.remoter.sudo("apt-get update", retry=3)
+                self.remoter.sudo(apt_cmd("update"), retry=3)
         except Exception as ex:  # noqa: BLE001
             self.log.error("Failed to update repo cache: %s", ex)
 
@@ -2940,7 +2934,7 @@ class BaseNode(AutoSshContainerMixin):
         if self.distro.is_rhel_like:
             remoter.run("sudo yum makecache", ignore_status=True)
             return
-        remoter.run("sudo apt-get update", ignore_status=True)
+        remoter.run(f"sudo {apt_cmd('update')}", ignore_status=True)
 
     @retrying(n=3, sleep_time=10, allowed_exceptions=(_ScyllaSetupDnsRetryError,))
     def _run_scylla_setup_with_dns_retry(self, setup_cmd):
@@ -3013,13 +3007,8 @@ class BaseNode(AutoSshContainerMixin):
         elif self.distro.is_sles:
             self.remoter.sudo("zypper update scylla-manager-server scylla-manager-client -y")
         else:
-            self.remoter.sudo("apt-get update", ignore_status=True)
-            self.remoter.sudo(
-                "DEBIAN_FRONTEND=noninteractive apt-get install "
-                '-o Dpkg::Options::="--force-confold" '
-                '-o Dpkg::Options::="--force-confdef" '
-                "scylla-manager-server scylla-manager-client -y "
-            )
+            self.remoter.sudo(apt_cmd("update"), ignore_status=True)
+            self.remoter.sudo(apt_cmd("install -y scylla-manager-server scylla-manager-client"))
         time.sleep(3)
         if start_manager_after_upgrade:
             if self.is_docker():
@@ -7012,8 +7001,8 @@ class BaseMonitorSet:
             prereqs_script = dedent(f"""
                 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
                 sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-                sudo apt-get update
-                sudo apt-get install -y docker.io
+                sudo {apt_cmd("update")}
+                sudo {apt_cmd("install -y docker.io")}
                 python3 -m pip install pyyaml {pip_break_system_packages}
                 python3 -m pip install -I -U psutil {pip_break_system_packages}
                 systemctl start docker

--- a/sdcm/utils/apt.py
+++ b/sdcm/utils/apt.py
@@ -1,0 +1,49 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2025 ScyllaDB
+
+from typing import Optional
+
+
+APT_DEFAULTS = {
+    "Acquire::http::Timeout": "60",
+    "Acquire::Retries": "3",
+    "DPkg::Lock::Timeout": "120",
+    "Dpkg::Options::": '"--force-confold"',
+}
+
+APT_CONFDEF = '-o Dpkg::Options::="--force-confdef"'
+
+
+def apt_cmd(subcommand: str = "", options: Optional[dict[str, str]] = None) -> str:
+    """Build an apt-get command string with safe defaults for non-interactive use.
+
+    Args:
+        subcommand: The apt-get subcommand with arguments (e.g. "update", "install -y nginx").
+            If empty, returns the apt-get prefix with options (useful as a command prefix).
+        options: Override or extend default apt options. Keys are apt option names, values are their values.
+
+    Returns:
+        Complete apt-get command string ready for remoter.sudo().
+    """
+    merged = dict(APT_DEFAULTS)
+    if options:
+        merged.update(options)
+
+    parts = ["apt-get"]
+    for key, value in merged.items():
+        parts.append(f"-o {key}={value}")
+    parts.append(APT_CONFDEF)
+    if subcommand:
+        parts.append(subcommand)
+
+    return " ".join(parts)

--- a/skills/package-installation/SKILL.md
+++ b/skills/package-installation/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: package-installation
+description: >-
+  Guides writing remote package installation commands (apt-get, yum, dnf, zypper)
+  in SCT code. Use when adding apt-get install/update, yum install, dnf install,
+  or zypper install calls via remoter.run/remoter.sudo. Ensures timeouts, retries,
+  and non-interactive flags are always present to prevent hangs in CI.
+---
+
+# Package Installation Commands in SCT
+
+Best practices for running package manager commands on remote nodes via `remoter.run()` / `remoter.sudo()`.
+
+## Why This Matters
+
+Remote package installation can hang indefinitely due to:
+- Network timeouts to package repositories
+- GPG keyserver unavailability
+- dpkg lock contention from unattended-upgrades
+- Interactive prompts when running non-interactively
+
+A single hung `apt-get` call can block an entire SCT test for hours/days.
+
+## Mandatory Options by Package Manager
+
+### apt-get (Debian/Ubuntu)
+
+Every `apt-get` call MUST include:
+
+```python
+# For apt-get update:
+self.remoter.sudo(
+    "apt-get -o Acquire::http::Timeout=60 -o Acquire::Retries=3 update",
+    ignore_status=True,
+)
+
+# For apt-get install:
+self.remoter.sudo(
+    "DEBIAN_FRONTEND=noninteractive apt-get install "
+    "-o DPkg::Lock::Timeout=120 "
+    "-o Acquire::http::Timeout=60 "
+    "-o Acquire::Retries=3 "
+    '-o Dpkg::Options::="--force-confold" '
+    '-o Dpkg::Options::="--force-confdef" '
+    "-y <package>",
+)
+```
+
+**Required options:**
+| Option | Purpose |
+|--------|---------|
+| `DEBIAN_FRONTEND=noninteractive` | Prevents interactive prompts (install only) |
+| `-o Acquire::http::Timeout=60` | 60s timeout for HTTP downloads — prevents indefinite hangs |
+| `-o Acquire::Retries=3` | Retry failed downloads 3 times |
+| `-o DPkg::Lock::Timeout=120` | Wait up to 120s for dpkg lock (install only) |
+| `-o Dpkg::Options::="--force-confold"` | Keep existing config files (install only) |
+| `-o Dpkg::Options::="--force-confdef"` | Use default for new config files (install only) |
+| `-y` | Assume yes to all prompts (install only) |
+
+### yum / dnf (RHEL/CentOS/Fedora)
+
+```python
+# yum/dnf have built-in timeouts (default 30s) but always use:
+self.remoter.sudo("yum install -y <package>", retry=3)
+
+# For long-running operations, add timeout to the remoter call:
+self.remoter.sudo("yum install -y <package>", retry=3, timeout=600)
+```
+
+**Required options:**
+| Option | Purpose |
+|--------|---------|
+| `-y` | Non-interactive |
+| `retry=3` on remoter call | Retry on SSH/command failures |
+| `timeout=600` on remoter call | Prevent indefinite hangs (for large packages) |
+
+### zypper (SLES)
+
+```python
+self.remoter.sudo("zypper install -y <package>", retry=3)
+```
+
+**Required options:**
+| Option | Purpose |
+|--------|---------|
+| `-y` | Non-interactive |
+| `retry=3` on remoter call | Retry on failures |
+
+## The `install_package()` Method
+
+Prefer using `BaseNode.install_package()` from `sdcm/cluster.py` which already handles:
+- Distro detection (apt vs yum vs zypper)
+- Proper timeout/retry options
+- `@retrying` decorator for transient failures
+- Version pinning
+
+```python
+# Preferred:
+self.install_package("scylla-manager-agent")
+
+# Only use raw remoter commands when install_package doesn't fit
+# (e.g., shell scripts, multi-command pipelines)
+```
+
+## Shell Script Blocks
+
+When apt-get commands are embedded in shell scripts (via `shell_script_cmd()` or heredocs), the same options apply:
+
+```python
+script = dedent("""
+    sudo apt-get -o Acquire::http::Timeout=60 -o Acquire::Retries=3 update
+    sudo apt-get -o Acquire::http::Timeout=60 -o Acquire::Retries=3 install -y docker.io
+""")
+```
+
+## GPG Key Fetching
+
+Use `BaseNode.fetch_apt_keys()` which handles:
+- Multiple HKP keyserver fallbacks
+- HTTPS fallback
+- Timeout on each attempt (`--keyserver-options timeout=10`)
+- Raises `NodeSetupFailed` if all sources fail
+
+Never write bare `apt-key adv --recv-keys` without timeout and fallback logic.
+
+## Anti-Patterns
+
+```python
+# BAD: No timeout, will hang forever on network issues
+self.remoter.sudo("apt-get update")
+self.remoter.sudo("apt-get install -y foo")
+
+# BAD: Missing DEBIAN_FRONTEND, may prompt
+self.remoter.sudo("apt-get install -y foo")
+
+# BAD: No Acquire timeout, download can hang
+self.remoter.sudo("DEBIAN_FRONTEND=noninteractive apt-get install -y foo")
+
+# BAD: ignore_status without retry — silently fails
+self.remoter.sudo("apt-get update", ignore_status=True)
+```
+
+## Checklist for Code Review
+
+When reviewing code that adds package installation:
+
+- [ ] `Acquire::http::Timeout=60` present on all apt-get calls?
+- [ ] `Acquire::Retries=3` present on all apt-get calls?
+- [ ] `DEBIAN_FRONTEND=noninteractive` on all apt-get install calls?
+- [ ] `-y` flag on all install commands (apt, yum, zypper)?
+- [ ] `DPkg::Lock::Timeout` on apt-get install calls?
+- [ ] `retry=N` on remoter call for yum/zypper?
+- [ ] No bare `apt-key adv` without timeout/fallback?
+- [ ] Prefer `install_package()` over raw commands?

--- a/unit_tests/unit/test_dns_readiness.py
+++ b/unit_tests/unit/test_dns_readiness.py
@@ -87,7 +87,7 @@ def setup_command_runner(existing_node):
                 if attempts["scylla_setup"] == 1 and first_error is not None:
                     raise _make_unexpected_exit(stderr=first_error)
                 return _fake_result()
-            if "sudo apt-get update" in cmd:
+            if "apt-get" in cmd and "update" in cmd:
                 attempts["apt_get"] += 1
                 return _fake_result()
             if "sudo yum makecache" in cmd:
@@ -237,7 +237,7 @@ def test_scylla_setup_raises_after_dns_retries_are_exhausted(mock_sleep, existin
             return _fake_result(stdout="--swap-directory")
         if "scylla_setup --nic" in cmd:
             raise _make_unexpected_exit(stderr="Temporary failure resolving 'archive.ubuntu.com'")
-        if "sudo apt-get update" in cmd:
+        if "apt-get" in cmd and "update" in cmd:
             return _fake_result()
         return _fake_result()
 


### PR DESCRIPTION
## Summary

- Add `-o Acquire::http::Timeout=60 -o Acquire::Retries=3` to all `apt-get update` and `apt-get install` calls in `sdcm/cluster.py`
- Prevents tests from hanging indefinitely (30+ hours observed) when package repos or keyservers are unreachable
- Adds `package-installation` skill documenting mandatory options for apt-get, yum, and zypper commands

## Root Cause

SCT test `longevity-twcs-48h-master` hung for 30+ hours during scylla-manager installation on the monitor node. The GPG keyserver returned "No data" and `apt-get` had no network timeout configured, causing an indefinite hang.

## Changes

| File | Change |
|------|--------|
| `sdcm/cluster.py` | Added `Acquire::http::Timeout=60` and `Acquire::Retries=3` to all apt-get calls |
| `skills/package-installation/SKILL.md` | New skill documenting package installer best practices |
| `AGENTS.md` | Registered new skill |

## Ref

SCT-290