### PR TITLE
ci(artifacts): add Ubuntu 26.04 artifact test configs and pipelines

### DIFF
--- a/configurations/arm/gce-ubuntu2604.yaml
+++ b/configurations/arm/gce-ubuntu2604.yaml
@@ -1,0 +1,6 @@
+gce_image_db: 'https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/family/ubuntu-2604-lts-arm64'
+gce_instance_type_db: 't2a-standard-2'
+gce_n_local_ssd_disk_db: 0
+gce_pd_standard_disk_size_db: 50
+
+user_credentials_path: '~/.ssh/scylla_test_id_ed25519'

--- a/jenkins-pipelines/oss/artifacts-offline-install/artifacts-ubuntu2604-arm.jenkinsfile
+++ b/jenkins-pipelines/oss/artifacts-offline-install/artifacts-ubuntu2604-arm.jenkinsfile
@@ -1,0 +1,14 @@
+#! groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+artifactsPipeline(
+    test_config: '''["test-cases/artifacts/ubuntu2604.yaml", "configurations/arm/gce-ubuntu2604.yaml"]''',
+    backend: 'gce',
+    gce_datacenter: 'us-central1',
+    provision_type: 'spot',
+
+    timeout: [time: 35, unit: 'MINUTES'],
+    post_behavior_db_nodes: 'destroy'
+)

--- a/jenkins-pipelines/oss/artifacts-offline-install/artifacts-ubuntu2604-nonroot.jenkinsfile
+++ b/jenkins-pipelines/oss/artifacts-offline-install/artifacts-ubuntu2604-nonroot.jenkinsfile
@@ -1,0 +1,15 @@
+#! groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+artifactsPipeline(
+    test_config: 'test-cases/artifacts/ubuntu2604.yaml',
+    backend: 'gce',
+    nonroot_offline_install: true,
+    provision_type: 'spot',
+    manager_version: '',
+
+    timeout: [time: 30, unit: 'MINUTES'],
+    post_behavior_db_nodes: 'destroy'
+)

--- a/jenkins-pipelines/oss/artifacts-offline-install/artifacts-ubuntu2604.jenkinsfile
+++ b/jenkins-pipelines/oss/artifacts-offline-install/artifacts-ubuntu2604.jenkinsfile
@@ -1,0 +1,13 @@
+#! groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+artifactsPipeline(
+    test_config: 'test-cases/artifacts/ubuntu2604.yaml',
+    backend: 'gce',
+    provision_type: 'spot',
+
+    timeout: [time: 35, unit: 'MINUTES'],
+    post_behavior_db_nodes: 'destroy'
+)

--- a/jenkins-pipelines/oss/artifacts/artifacts-ubuntu2604-arm.jenkinsfile
+++ b/jenkins-pipelines/oss/artifacts/artifacts-ubuntu2604-arm.jenkinsfile
@@ -1,0 +1,14 @@
+#! groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+artifactsPipeline(
+    test_config: '''["test-cases/artifacts/ubuntu2604.yaml", "configurations/arm/gce-ubuntu2604.yaml"]''',
+    backend: 'gce',
+    gce_datacenter: 'us-central1',
+    provision_type: 'spot',
+
+    timeout: [time: 35, unit: 'MINUTES'],
+    post_behavior_db_nodes: 'destroy'
+)

--- a/jenkins-pipelines/oss/artifacts/artifacts-ubuntu2604.jenkinsfile
+++ b/jenkins-pipelines/oss/artifacts/artifacts-ubuntu2604.jenkinsfile
@@ -1,0 +1,13 @@
+#! groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+artifactsPipeline(
+    test_config: 'test-cases/artifacts/ubuntu2604.yaml',
+    backend: 'gce',
+    provision_type: 'spot',
+
+    timeout: [time: 35, unit: 'MINUTES'],
+    post_behavior_db_nodes: 'destroy'
+)

--- a/sdcm/utils/distro.py
+++ b/sdcm/utils/distro.py
@@ -38,7 +38,7 @@ KNOWN_OS = (
     ("AMAZON", "amzn", ["2023"], DistroBase.RHEL),
     ("ROCKY", "rocky", ["8", "9", "10"], DistroBase.RHEL),
     ("DEBIAN", "debian", ["11", "12", "13"], DistroBase.DEBIAN),
-    ("UBUNTU", "ubuntu", ["20.04", "21.04", "21.10", "22.04", "24.04"], DistroBase.DEBIAN),
+    ("UBUNTU", "ubuntu", ["20.04", "21.04", "21.10", "22.04", "24.04", "26.04"], DistroBase.DEBIAN),
     ("SLES", "sles", ["15"], DistroBase.UNKNOWN),
     ("FEDORA", "fedora", ["34", "35", "36"], DistroBase.RHEL),
     ("MINT", "linuxmint", ["20", "21", "22"], DistroBase.DEBIAN),

--- a/test-cases/artifacts/ubuntu2604.yaml
+++ b/test-cases/artifacts/ubuntu2604.yaml
@@ -1,0 +1,20 @@
+backtrace_decoding: false
+cluster_backend: 'gce'
+gce_image_db: 'https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/family/ubuntu-2604-lts-amd64'
+gce_instance_type_db: 'n2-standard-2'
+gce_root_disk_type_db: 'pd-ssd'
+root_disk_size_db: 50
+gce_n_local_ssd_disk_db: 1
+instance_provision: "spot"
+instance_provision_fallback_on_demand: true
+n_db_nodes: 1
+n_loaders: 0
+n_monitor_nodes: 0
+nemesis_class_name: 'NoOpMonkey'
+scylla_linux_distro: 'ubuntu-resolute'
+test_duration: 60
+user_prefix: 'artifacts-ubuntu2604'
+use_preinstalled_scylla: false
+aws_fallback_to_next_availability_zone: true
+
+user_credentials_path: '~/.ssh/scylla_test_id_ed25519'

--- a/unit_tests/unit/test_utils_distro.py
+++ b/unit_tests/unit/test_utils_distro.py
@@ -188,6 +188,20 @@ PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-poli
 VERSION_CODENAME=jammy
 UBUNTU_CODENAME=jammy
     """,
+    "Ubuntu 26.04": """\
+NAME="Ubuntu"
+VERSION="26.04 LTS (Resolute Raccoon)"
+ID=ubuntu
+ID_LIKE=debian
+PRETTY_NAME="Ubuntu 26.04 LTS"
+VERSION_ID="26.04"
+HOME_URL="https://www.ubuntu.com/"
+SUPPORT_URL="https://help.ubuntu.com/"
+BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
+PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
+VERSION_CODENAME=resolute
+UBUNTU_CODENAME=resolute
+""",
     "Amazon Linux 2": """\
 NAME="Amazon Linux"
 VERSION="2"
@@ -332,6 +346,13 @@ class TestDistro:
         distro = Distro.from_os_release(DISTROS_OS_RELEASE["Ubuntu 22.04"])
         assert distro.is_ubuntu22
         assert distro.is_ubuntu
+
+    def test_ubuntu26(self):
+        assert Distro.UBUNTU26.is_ubuntu26
+        distro = Distro.from_os_release(DISTROS_OS_RELEASE["Ubuntu 26.04"])
+        assert distro.is_ubuntu26
+        assert distro.is_ubuntu
+        assert distro.is_debian_like
 
     def test_amazon2023(self):
         assert Distro.AMAZON2023.is_amazon2023


### PR DESCRIPTION
## Summary
- Add full artifact test coverage for Ubuntu 26.04 on GCE (x86_64 + ARM)
- First GCE ARM artifact tests in the repo (t2a-standard-2, us-central1)
- Extends `sdcm/utils/distro.py` for Ubuntu 26.04 recognition
- Fixes GCE provisioner to wire `gce_pd_standard_disk_size_db` into instance data_disks

## Changes
- `sdcm/utils/distro.py`: Add `"26.04"` to Ubuntu versions
- `sdcm/sct_provision/region_definition_builder.py`: Add `pd_standard_disk_size` to `ConfigParamsMap` and create pd-standard DataDisk when configured
- `sdcm/sct_provision/gce/gce_region_definition_builder.py`: Map `gce_pd_standard_disk_size_db` in db_map
- `test-cases/artifacts/ubuntu2604.yaml`: Base GCE x86 config
- `configurations/arm/gce-ubuntu2604.yaml`: ARM overlay (t2a-standard-2, pd-standard 50GB)
- 5 Jenkins pipelines (online/offline/nonroot x86, online/offline ARM)
- `unit_tests/test_distro_ubuntu2604.py`: Distro detection tests

## Staging Runs ✅

### Online (scylla_version=master:latest)
- ✅ [x86 online #4](https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/oss/job/artifacts/job/artifacts-ubuntu2604-test/4/)
- ✅ [ARM online #6](https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/oss/job/artifacts/job/artifacts-ubuntu2604-arm-test/6/)

### Offline (unified_package)
- ✅ [x86 offline #5](https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/oss/job/artifacts-offline-install/job/artifacts-ubuntu2604-test/5/)
- ✅ [x86 nonroot offline #5](https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/oss/job/artifacts-offline-install/job/artifacts-ubuntu2604-nonroot-test/5/)
- ✅ [ARM offline #8](https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/oss/job/artifacts-offline-install/job/artifacts-ubuntu2604-arm-test/8/)

### Previous Failures (resolved)
- ❌ ARM `#4`,`#5`: `NodeSetupFailed: Failed to find disks!` — t2a has no local SSD; needed pd-standard data disk + provisioner fix
- ❌ ARM offline `#7`: 404 on unified_package URL (stale build hash)