### PR TITLE
fix(cql): use AsyncioConnection to prevent [Errno 9] Bad file descriptor

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -47,6 +47,7 @@ import packaging.version
 
 import yaml
 import requests
+from cassandra.io.asyncioreactor import AsyncioConnection
 from paramiko import SSHException
 from tenacity import RetryError
 from invoke.exceptions import UnexpectedExit, Failure
@@ -4582,6 +4583,7 @@ class BaseCluster:
         kwargs = dict(contact_points=node_ips, port=port, ssl_context=ssl_context)
         cluster_driver = ClusterDriver(
             auth_provider=auth_provider,
+            connection_class=AsyncioConnection,
             compression=compression,
             protocol_version=protocol_version,
             load_balancing_policy=load_balancing_policy,


### PR DESCRIPTION
SCT creates many short-lived ClusterDriver instances during setUp. The default libev reactor is shared across all Cluster objects in the process, causing stale file descriptor watchers to accumulate across shutdown/reconnect cycles. When the OS reuses a closed FD, the stale watcher fires on the wrong socket producing NoHostAvailable: ConnectionShutdown('[Errno 9] Bad file descriptor').

Switching to AsyncioConnection gives each Cluster its own isolated event loop, eliminating the shared state. Workaround for scylladb/python-driver#614.

This issue prevented reliable spin-up of 12-node GCP clusters https://argus.scylladb.com/tests/scylla-cluster-tests/ffb076b5-dd08-4efd-ba4b-db2594aeb7af; this workaround fixes that.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] Test is running

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
