### PR TITLE
feat(nemesis): Add type hint to the tester object

### DIFF
--- a/sdcm/nemesis/__init__.py
+++ b/sdcm/nemesis/__init__.py
@@ -208,6 +208,7 @@ from sdcm.utils.topology_ops import FailedDecommissionOperationMonitoring
 if TYPE_CHECKING:
     from sdcm.audit import AuditStore
     from sdcm.mgmt.cli import BackupTask
+    from sdcm.tester import ClusterTester
 
 LOGGER = logging.getLogger(__name__)
 DISRUPT_POOL_PROPERTY_NAME = "target_pool"
@@ -276,7 +277,7 @@ class NemesisRunner:
         self, tester_obj, termination_event, *args, nemesis_selector: Optional[str] = None, nemesis_seed=None, **kwargs
     ):
         # *args -  compatible with CategoricalMonkey
-        self.tester = tester_obj  # ClusterTester object
+        self.tester: "ClusterTester" = tester_obj
         self.nemesis_registry = NemesisRegistry(base_class=NemesisBaseClass, flag_class=NemesisFlags)
         self.cluster: Union[BaseCluster, BaseScyllaCluster] = tester_obj.db_cluster
         self.loaders = tester_obj.loaders


### PR DESCRIPTION
Adds a `ClusterTester` type hint for the nemesis `tester` object to improve readability and editor/type-checking support. No behavior change.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
