### PR TITLE
docs(skills): add running-staging-jobs skill for PR validation workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -311,6 +311,7 @@ Modular, task-specific guidance for AI agents lives in the `skills/` directory. 
 | writing-integration-tests | Guides writing integration tests that interact with real external services. Use when creating tests requiring Docker, AWS, GCE, Azure, OCI, or Kubernetes backends. | `skills/writing-integration-tests/SKILL.md` |
 | commit-summary | Generate weekly commit summary reports for the SCT repository | `skills/commit-summary/SKILL.md` |
 | writing-nemesis | Guides writing new nemesis (chaos disruptions). Use when creating NemesisBaseClass subclasses or implementing disruption logic. | `skills/writing-nemesis/SKILL.md` |
+| running-staging-jobs | Guides running staging Jenkins jobs for PRs, tracking results, diagnosing failures, and updating PR descriptions. | `skills/running-staging-jobs/SKILL.md` |
 
 When creating a new skill, follow the process in `skills/designing-skills/workflows/create-a-skill.md`.
 

--- a/skills/running-staging-jobs/SKILL.md
+++ b/skills/running-staging-jobs/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: running-staging-jobs
+description: >-
+  Guides running staging Jenkins jobs for SCT pull requests, tracking build results,
+  diagnosing failures from console logs, and updating PR descriptions with run status.
+  Use when triggering staging tests for a PR, monitoring Jenkins build progress,
+  analyzing build failures from console output, retrying failed builds with corrected
+  parameters, or updating a PR with staging run results. Covers staging_trigger.py CLI,
+  jenkins CLI for build-info and console-log, unified_package URL construction, and
+  PR description formatting with emoji status indicators.
+---
+
+# Running Staging Jobs
+
+Trigger, track, diagnose, and report staging Jenkins job results for SCT pull requests.
+
+## Essential Principles
+
+### Jobs Must Be Generated Before Triggering
+
+Staging jobs are per-PR Jenkins copies. They don't exist until `staging_trigger.py generate --pr <N>` creates them. The generate step copies pipeline definitions and configures SCM to point at the PR branch. Without this, trigger commands will 404.
+
+### Use Short Job Paths with staging_trigger.py
+
+The `staging_trigger.py` CLI internally prepends `scylla-staging/<user>/` to job paths. Always pass the **short path** (e.g., `oss/artifacts/artifacts-ubuntu2604-arm-test`), never the full Jenkins path. Using full paths causes double-prefixing and 404 errors.
+
+### Track Builds with jenkins CLI, Not the Trigger Output
+
+The trigger script outputs a build number but doesn't wait for completion. Use `/home/fruch/.local/bin/jenkins build-info --job <full-path> --build <N>` to poll status and `console-log` to download failure logs. The full path IS required for the jenkins CLI (e.g., `scylla-staging/fruch/oss/artifacts/...`).
+
+### Unified Package URLs Are Ephemeral
+
+S3 paths under `unstable/scylla/master/relocatable/latest/` change with every nightly build. Always verify the URL exists before triggering offline jobs. The build hash in the filename changes daily. Use `aws s3 ls` to get the current filename.
+
+### PR Description Is the Single Source of Truth
+
+All staging run results must be documented in the PR body with emoji status (✅ ❌ 🕐) and direct Jenkins links. Previous failures should be listed with root cause to document the debugging journey.
+
+## When to Use
+
+- Triggering staging Jenkins jobs for a new or updated PR
+- Monitoring in-progress Jenkins builds for pass/fail
+- Diagnosing build failures from Jenkins console logs
+- Retrying failed builds with corrected parameters or after code fixes
+- Updating PR descriptions with staging run results
+- Constructing unified_package URLs for offline artifact tests
+
+## When NOT to Use
+
+- Creating Jenkins pipeline files (use writing-plans or direct editing)
+- Modifying test-case YAML configurations (edit directly)
+- Running local tests with `uv run sct.py` (not staging)
+- Creating the PR itself (use git/gh commands directly)
+
+## Workflow
+
+The full process is in [run-and-track.md](workflows/run-and-track.md).
+
+## Quick Reference
+
+### staging_trigger.py Commands
+
+```bash
+# Generate staging jobs for a PR (required first step)
+python3 ./staging_trigger.py generate --pr <PR_NUMBER>
+
+# Trigger with scylla_version (online tests)
+python3 ./staging_trigger.py trigger --pr <N> --set scylla_version=master:latest <short-job-path>
+
+# Trigger with unified_package (offline tests)
+python3 ./staging_trigger.py trigger --pr <N> --set unified_package=<S3_URL> <short-job-path>
+```
+
+### jenkins CLI Commands
+
+```bash
+# Check build status (result/building/duration)
+/home/fruch/.local/bin/jenkins build-info --job <full-job-path> --build <N>
+
+# Download console log for failure analysis
+/home/fruch/.local/bin/jenkins console-log --job <full-job-path> --build <N> --dest /tmp/opencode
+```
+
+### S3 Unified Package Lookup
+
+```bash
+# x86_64
+aws s3 ls s3://downloads.scylladb.com/unstable/scylla/master/relocatable/latest/ | grep "x86_64.tar.gz$" | grep unified
+
+# aarch64
+aws s3 ls s3://downloads.scylladb.com/unstable/scylla/master/relocatable/latest/ | grep "aarch64.tar.gz$" | grep unified
+```
+
+URL format: `https://s3.amazonaws.com/downloads.scylladb.com/unstable/scylla/master/relocatable/latest/scylla-unified-<version>.tar.gz`
+
+### PR Description Format
+
+```markdown
+## Staging Runs ✅
+
+### Online (scylla_version=master:latest)
+- ✅ [x86 online #N](https://jenkins.scylladb.com/job/scylla-staging/job/<user>/job/...)
+- ❌ [ARM online #N](https://jenkins.scylladb.com/job/...) — <failure reason>
+
+### Offline (unified_package)
+- ✅ [x86 offline #N](https://jenkins.scylladb.com/job/...)
+- 🕐 [ARM offline #N](https://jenkins.scylladb.com/job/...) — running
+
+### Previous Failures (resolved)
+- ❌ ARM #4: `NodeSetupFailed: Failed to find disks!` — fixed by adding pd-standard data disk
+```
+
+### Common Failure Patterns
+
+| Error | Root Cause | Fix |
+|-------|-----------|-----|
+| `NodeSetupFailed: Failed to find disks!` | No data disk attached (local SSD or PD) | Add `gce_pd_standard_disk_size_db` or fix provisioner |
+| `curl: (22) The requested URL returned error: 404` | Stale unified_package URL | Re-lookup current S3 filename |
+| No `scylla_version` provided | Missing trigger parameter | Add `--set scylla_version=master:latest` |
+| Job 404 on trigger | Full path used instead of short path | Use short path without `scylla-staging/<user>/` prefix |
+
+## Success Criteria
+
+- [ ] All staging jobs generated for the PR
+- [ ] All jobs triggered with correct parameters
+- [ ] All builds reach terminal state (SUCCESS/FAILURE)
+- [ ] Failures diagnosed with root cause from console logs
+- [ ] Fixes applied, committed, pushed, and retried
+- [ ] PR description updated with final ✅/❌ status and links
+- [ ] Previous failures documented with root cause explanation

--- a/skills/running-staging-jobs/workflows/run-and-track.md
+++ b/skills/running-staging-jobs/workflows/run-and-track.md
@@ -1,0 +1,100 @@
+# Run and Track Staging Jobs
+
+Step-by-step process for running staging Jenkins jobs and tracking results for an SCT PR.
+
+## Phase 1: Generate Staging Jobs
+
+**Entry**: PR exists on GitHub with branch pushed to remote.
+
+1. Run `python3 ./staging_trigger.py generate --pr <PR_NUMBER>`
+2. Verify output lists the expected job paths
+3. Note the job short paths for triggering
+
+**Exit**: Staging jobs exist on Jenkins for this PR.
+
+## Phase 2: Determine Trigger Parameters
+
+**Entry**: Know which test types to run (online vs offline, x86 vs ARM).
+
+1. **Online tests**: Use `--set scylla_version=master:latest`
+2. **Offline tests**: Look up current unified package from S3:
+   ```bash
+   aws s3 ls s3://downloads.scylladb.com/unstable/scylla/master/relocatable/latest/ | grep unified
+   ```
+3. Construct the full S3 URL: `https://s3.amazonaws.com/downloads.scylladb.com/unstable/scylla/master/relocatable/latest/<filename>`
+4. Verify the URL returns 200 (not 404) before triggering
+
+**Exit**: Have the correct `--set` parameter for each job.
+
+## Phase 3: Trigger Jobs
+
+**Entry**: Jobs generated, parameters determined.
+
+1. Trigger each job with `staging_trigger.py trigger`:
+   ```bash
+   python3 ./staging_trigger.py trigger --pr <N> --set <key>=<value> <short-job-path>
+   ```
+2. Record the build number from output (e.g., `#5`)
+3. Note the full Jenkins URL for PR tracking
+
+**Exit**: All jobs queued/running with known build numbers.
+
+## Phase 4: Monitor Progress
+
+**Entry**: Jobs triggered, build numbers known.
+
+1. Poll build status periodically:
+   ```bash
+   /home/fruch/.local/bin/jenkins build-info --job <full-path> --build <N>
+   ```
+2. Parse JSON output: check `result` (null=running, SUCCESS, FAILURE) and `building` (true/false)
+3. Artifact tests typically complete in 15-25 minutes
+4. Batch-check all jobs in a loop for efficiency
+
+**Exit**: All builds reach terminal state.
+
+## Phase 5: Diagnose Failures
+
+**Entry**: One or more builds show `result=FAILURE`.
+
+1. Download console log:
+   ```bash
+   /home/fruch/.local/bin/jenkins console-log --job <full-path> --build <N> --dest /tmp/opencode
+   ```
+2. Search for error patterns:
+   ```bash
+   grep -n "ERROR\|Failed\|Exception\|assert" /tmp/opencode/<logfile> | grep -vi "Argus\|send-email\|CORRUPTED"
+   ```
+3. Identify root cause category:
+   - **Infrastructure** (disk, network, image not found) → fix config/provisioner
+   - **Stale parameter** (404 on URL, wrong version) → update trigger parameter
+   - **Test bug** (assertion failure in test logic) → fix test code
+   - **Scylla bug** (crash, timeout in Scylla) → report upstream
+4. Document the failure reason for PR description
+
+**Exit**: Root cause identified for each failure.
+
+## Phase 6: Fix and Retry
+
+**Entry**: Root cause known, fix implemented.
+
+1. Apply fix (code change, config change, or parameter correction)
+2. If code/config changed: commit, push, then retrigger
+3. If parameter-only: retrigger with corrected `--set` value
+4. Retrigger failed jobs only (don't re-run passing jobs)
+5. Return to Phase 4 to monitor
+
+**Exit**: All retried builds pass (or new failure identified → repeat Phase 5).
+
+## Phase 7: Update PR Description
+
+**Entry**: All builds passing.
+
+1. Edit PR body with `gh pr edit <N> --body "..."`
+2. Include sections:
+   - **Staging Runs**: Final passing builds with ✅ and links
+   - **Previous Failures**: Document what failed and why (for reviewer context)
+3. Use emoji conventions: ✅ pass, ❌ fail, 🕐 running
+4. Group by test type (online/offline) and architecture (x86/ARM)
+
+**Exit**: PR description reflects all staging results with links and status.


### PR DESCRIPTION
## Summary
- Adds a new skill `running-staging-jobs` that documents the end-to-end workflow for validating PRs with staging Jenkins jobs
- Covers: triggering jobs, monitoring builds, diagnosing failures, retrying, and updating PR descriptions

## Files
- `skills/running-staging-jobs/SKILL.md` — Main skill with principles, quick reference, common failure patterns
- `skills/running-staging-jobs/workflows/run-and-track.md` — 7-phase workflow (generate → trigger → monitor → diagnose → fix → retry → update PR)
- `AGENTS.md` — Registered skill in the skills table