### PR TITLE
improvement(events): raise GCE host migration to critical in upgrade

### DIFF
--- a/sdcm/sct_events/gce_events.py
+++ b/sdcm/sct_events/gce_events.py
@@ -3,7 +3,7 @@ from typing import Dict
 from dateutil import parser
 
 from sdcm.sct_events import Severity
-from sdcm.sct_events.base import SctEvent, EventPeriod
+from sdcm.sct_events.base import SctEvent, EventPeriod, add_severity_limit_rules
 
 
 class GceInstanceEvent(SctEvent):
@@ -11,6 +11,7 @@ class GceInstanceEvent(SctEvent):
         self.date = str(parser.parse(gce_log_entry["timestamp"]).astimezone())
         self.node = gce_log_entry["protoPayload"]["resourceName"].split("/")[-1]
         self.method = gce_log_entry["protoPayload"]["methodName"]
+        self.type = self.method.rsplit(".", 1)[-1]
         self.message = gce_log_entry["protoPayload"]["status"]["message"]
         self.period_type = EventPeriod.INFORMATIONAL.value
         super().__init__(severity=severity)
@@ -18,3 +19,7 @@ class GceInstanceEvent(SctEvent):
     @property
     def msgfmt(self):
         return super().msgfmt + ": {0.method} on node {0.node} at {0.date}: {0.message}"
+
+
+# lift cap to CRITICAL for migrateOnHostMaintenance, so critical_host_maintenance_migration() can escalate
+add_severity_limit_rules(["GceInstanceEvent.migrateOnHostMaintenance=CRITICAL"])

--- a/sdcm/sct_events/group_common_events.py
+++ b/sdcm/sct_events/group_common_events.py
@@ -19,6 +19,7 @@ from sdcm.cluster import TestConfig
 from sdcm.sct_events import Severity
 from sdcm.sct_events.database import DatabaseLogEvent
 from sdcm.sct_events.filters import DbEventsFilter, EventsSeverityChangerFilter, EventsFilter
+from sdcm.sct_events.gce_events import GceInstanceEvent
 from sdcm.sct_events.loaders import YcsbStressEvent
 from sdcm.sct_events.monitors import PrometheusAlertManagerEvent
 from sdcm.utils.issues import SkipPerIssues
@@ -553,6 +554,18 @@ def ignore_take_snapshot_failing():
                 extra_time_to_expiration=60,
             )
         )
+        yield
+
+
+@contextmanager
+def critical_host_maintenance_migration(extra_time_to_expiration: int = 360):
+    """Escalate GCE host-maintenance migration events to CRITICAL for the duration of the block."""
+    with EventsSeverityChangerFilter(
+        new_severity=Severity.CRITICAL,
+        event_class=GceInstanceEvent,
+        regex=r".*migrateOnHostMaintenance.*",
+        extra_time_to_expiration=extra_time_to_expiration,
+    ):
         yield
 
 

--- a/unit_tests/unit/test_sct_events_filters.py
+++ b/unit_tests/unit/test_sct_events_filters.py
@@ -15,8 +15,10 @@ import re
 import pickle
 
 from sdcm.sct_events import Severity
+from sdcm.sct_events.base import max_severity
 from sdcm.sct_events.filters import DbEventsFilter, EventsFilter, EventsSeverityChangerFilter
 from sdcm.sct_events.database import DatabaseLogEvent
+from sdcm.sct_events.gce_events import GceInstanceEvent
 
 
 def test_db_events_filter_just_type():
@@ -151,3 +153,38 @@ def test_events_severity_changer_filter():
     assert event.severity == Severity.ERROR
     db_events_filter.eval_filter(event)
     assert event.severity == Severity.NORMAL
+
+
+def _make_gce_instance_event(method: str, severity: Severity = Severity.WARNING) -> GceInstanceEvent:
+    log_entry = {
+        "timestamp": "2026-05-04T12:34:56.000Z",
+        "protoPayload": {
+            "resourceName": "projects/proj/zones/us-east1-b/instances/test-node",
+            "methodName": f"compute.instances.{method}",
+            "status": {"message": f"synthetic {method} event"},
+        },
+    }
+    return GceInstanceEvent(log_entry, severity=severity)
+
+
+def test_critical_host_maintenance_migration_escalates_migrate_on_host_maintenance():
+    severity_filter = EventsSeverityChangerFilter(
+        new_severity=Severity.CRITICAL,
+        event_class=GceInstanceEvent,
+        regex=r".*migrateOnHostMaintenance.*",
+    )
+    event = _make_gce_instance_event(method="migrateOnHostMaintenance", severity=Severity.WARNING)
+    severity_filter.eval_filter(event)
+    assert event.severity == Severity.CRITICAL
+
+
+def test_critical_host_maintenance_migration_outside_context_keeps_warning():
+    event = _make_gce_instance_event(method="migrateOnHostMaintenance", severity=Severity.WARNING)
+    assert event.severity == Severity.WARNING
+
+
+def test_gce_instance_event_severity_cap_per_method():
+    migrate_event = _make_gce_instance_event(method="migrateOnHostMaintenance", severity=Severity.WARNING)
+    restart_event = _make_gce_instance_event(method="automaticRestart", severity=Severity.ERROR)
+    assert max_severity(migrate_event) == Severity.CRITICAL
+    assert max_severity(restart_event) == Severity.ERROR

--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -52,6 +52,7 @@ from sdcm.sct_events.database import (
 )
 from sdcm.sct_events.filters import DbEventsFilter
 from sdcm.sct_events.group_common_events import (
+    critical_host_maintenance_migration,
     decorate_with_context,
     ignore_abort_requested_errors,
     ignore_upgrade_schema_errors,
@@ -828,12 +829,13 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
         with ignore_upgrade_schema_errors():
             step = "Step5 - Upgrade rest of the Nodes "
             self.actions_log.info(step)
-            for i in indexes[1:]:
-                self.db_cluster.node_to_upgrade = self.db_cluster.nodes[i]
-                self.upgrade_node(self.db_cluster.node_to_upgrade)
-                self.db_cluster.node_to_upgrade.check_node_health()
-                self.fill_and_verify_db_data("after upgraded %s" % self.db_cluster.node_to_upgrade.name)
-                self.search_for_idx_token_error_after_upgrade(node=self.db_cluster.node_to_upgrade, step=step)
+            with critical_host_maintenance_migration():
+                for i in indexes[1:]:
+                    self.db_cluster.node_to_upgrade = self.db_cluster.nodes[i]
+                    self.upgrade_node(self.db_cluster.node_to_upgrade)
+                    self.db_cluster.node_to_upgrade.check_node_health()
+                    self.fill_and_verify_db_data("after upgraded %s" % self.db_cluster.node_to_upgrade.name)
+                    self.search_for_idx_token_error_after_upgrade(node=self.db_cluster.node_to_upgrade, step=step)
         self.actions_log.info("Step5.1 - run raft topology upgrade procedure")
         self.run_raft_topology_upgrade_procedure()
         InfoEvent(message="Step5.2 - check limited voters feature").publish()
@@ -1098,8 +1100,9 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
 
         # Upgrade all nodes
         self.actions_log.info("Upgrade nodes")
-        for node_to_upgrade in nodes_to_upgrade:
-            self._start_and_wait_for_node_upgrade(node_to_upgrade, step=next(step))
+        with critical_host_maintenance_migration():
+            for node_to_upgrade in nodes_to_upgrade:
+                self._start_and_wait_for_node_upgrade(node_to_upgrade, step=next(step))
         self.actions_log.info("All nodes were upgraded successfully")
 
         self.actions_log.info("Run raft topology upgrade procedure")


### PR DESCRIPTION
Add critical_host_maintenance_migration() context manager that escalates GceInstanceEvent for migrateOnHostMaintenance from WARNING to CRITICAL, during the rolling-upgrade per-node loops.
Additionally, lift the per-method severity cap at gce_events module import, so the escalation reaches subscribers across forked processes (default severity outside the wrapped phase is unchanged).

Fixes: SCT-283

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :green_circle: [rolling-upgrade-alternator test (like in original issue), normal/happy path](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/upgrades/job/rolling-upgrade-alternator-test/2/)
- [x] :green_circle: locally synthetically triggered the condition like in original issue - issued `GceInstanceEvent.migrateOnHostMaintenance` event during rolling-upgrade - this was logged as CRITICAL even causing the test interruptioon:
```
                try:
                    if event_class in LOADERS_EVENTS:
                        raise TestFailure(f"Stress command failed: {event}")
>                   raise TestFailure(f"Got critical event: {event}")
E                   sdcm.sct_events.events_analyzer.TestFailure: Got critical event: (GceInstanceEvent Severity.CRITICAL) period_type=one-time event_id=0e0a1b2b-bace-4484-82b0-d0a112e4f384: compute.instances.migrateOnHostMaintenance on node rolling-upgrade-dmitriy-db-node-eed17010-0-1 at 2026-05-06 14:00:00+02:00: synthetic SCT-283 injection
```

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
