### PR TITLE
ci(gce-trigger): drop hardcoded availability_zone=a from tier1-gce-custom-time-trigger

### DIFF
--- a/jenkins-pipelines/oss/sct_triggers/tier1-gce-custom-time-trigger.xml
+++ b/jenkins-pipelines/oss/sct_triggers/tier1-gce-custom-time-trigger.xml
@@ -38,7 +38,6 @@
             <hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
               <properties>gce_image_db=$gce_image_db
 scylla_version=$scylla_version
-availability_zone=a
 provision_type=on_demand
 post_behavior_db_nodes=destroy
 post_behavior_monitor_nodes=destroy


### PR DESCRIPTION
## Summary
- Remove hardcoded `availability_zone=a` from the tier1-gce-custom-time-trigger job
- Allows GCE to auto-select availability zone, improving flexibility and avoiding zone-a capacity constraints (the default region we use, doesn't have zone a !!!)