### PR TITLE
fix(db-log-reader): decode multi-line OVERSIZED_ALLOCATION backtraces

### DIFF
--- a/sdcm/db_log_reader.py
+++ b/sdcm/db_log_reader.py
@@ -53,6 +53,7 @@ class DbLogReader(Process):
     ]
 
     BUILD_ID_REGEX = re.compile(r"build-id\s(.*?)\sstarting\s\.\.\.")
+    MULTI_ADDR_CONTINUATION_RE = re.compile(r"^\s+(at\s+)?0x[0-9a-f]", re.IGNORECASE)
 
     def __init__(
         self,
@@ -112,6 +113,10 @@ class DbLogReader(Process):
 
         return False
 
+    @staticmethod
+    def _is_multiaddress_continuation(line: str) -> bool:
+        return bool(DbLogReader.MULTI_ADDR_CONTINUATION_RE.match(line))
+
     def _read_and_publish_events(self) -> None:  # noqa: PLR0912
         """Search for all known patterns listed in `sdcm.sct_events.database.SYSTEM_ERROR_EVENTS'."""
 
@@ -170,6 +175,16 @@ class DbLogReader(Process):
                         for trace_line in splitted_line[1].split():
                             if trace_line.startswith("0x") or "scylladb/lib" in trace_line:
                                 one_line_backtrace.append(trace_line)
+
+                    elif self._is_multiaddress_continuation(line) and backtraces:
+                        # Handle multi-line backtraces where addresses are on continuation lines.
+                        # Example (OVERSIZED_ALLOCATION):
+                        #   seastar_memory - oversized allocation: 167936 bytes, please report:
+                        #    at 0x194b7ff 0x3526010 0x1d3b798 0x3661f77
+                        #       0x1da7f14 0x1de7b52 /opt/scylladb/libreloc/libc.so.6+0x72463
+                        for trace_line in line.split():
+                            if trace_line.startswith("0x") or "scylladb/lib" in trace_line:
+                                backtraces[-1]["backtrace"].append(trace_line)
 
                     elif (match := BACKTRACE_RE.search(line)) and backtraces:
                         data = match.groupdict()

--- a/unit_tests/test_data/system_multiline_oversized_allocation.log
+++ b/unit_tests/test_data/system_multiline_oversized_allocation.log
@@ -1,0 +1,7 @@
+2026-04-15T10:22:33.456+00:00 rolling-upgrade-ubuntu-db-node-edf1b37c-eastus-5  ! ERROR | scylla[1234]:  [shard 3] seastar_memory - oversized allocation: 167936 bytes, please report:
+ at 0x194b7ff 0x3526010 0x1d3b798 0x3661f77 0x1b7e4c3 0x18ddb68
+    0x1da7f14 0x1de7b52 0x1df17ce 0x1f5ef84 0x1f5e2ba 0x1f62d76
+    0x1f62888 0x18f4ffc 0x18f3418 0x6b463fe 0x6b030ca
+    /opt/scylladb/libreloc/libc.so.6+0x72463
+    /opt/scylladb/libreloc/libc.so.6+0xf55eb
+2026-04-15T10:22:34.000+00:00 rolling-upgrade-ubuntu-db-node-edf1b37c-eastus-5  ! INFO | scylla[1234]:  [shard 3] some other log line

--- a/unit_tests/unit/test_cluster.py
+++ b/unit_tests/unit/test_cluster.py
@@ -197,6 +197,20 @@ class TestBaseNode:
 
         print(events[-1])
 
+    def test_search_multiline_oversized_allocation_backtrace(self):
+        self.node.system_log = str(self.test_data_dir / "system_multiline_oversized_allocation.log")
+
+        self._read_and_publish_events()
+
+        events = self._events.published_events
+
+        oversized_events = [event for event in events if event["type"] == "OVERSIZED_ALLOCATION"]
+        assert len(oversized_events) == 1
+        assert oversized_events[0]["raw_backtrace"]
+        assert "0x194b7ff" in oversized_events[0]["raw_backtrace"]
+        assert "0x6b030ca" in oversized_events[0]["raw_backtrace"]
+        assert "libc.so.6+0x72463" in oversized_events[0]["raw_backtrace"]
+
     def test_gate_closed_ignored_exception_is_catched(self):
         self.node.system_log = str(self.test_data_dir / "gate_closed_ignored_exception.log")
 


### PR DESCRIPTION
## Summary
- Handle multi-line OVERSIZED_ALLOCATION backtraces where hex addresses appear on continuation lines (`at 0x...` or indented `0x...`) rather than inline with the error message
- Previously only the single-line format (`Please report: at 0x...`) was decoded; the multi-line format from newer Scylla versions was left undecoded

## Testing
- Added unit test with multi-line OVERSIZED_ALLOCATION log format
- All existing tests pass

Fixes: [SCT-335](https://scylladb.atlassian.net/browse/SCT-335)

[SCT-335]: https://scylladb.atlassian.net/browse/SCT-335?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ