### PR TITLE
fix(gce): properly configure PD disks if specified

### DIFF
--- a/sdcm/sct_provision/gce/gce_region_definition_builder.py
+++ b/sdcm/sct_provision/gce/gce_region_definition_builder.py
@@ -27,6 +27,7 @@ db_map = ConfigParamsMap(
     root_disk_size="root_disk_size_db",
     local_ssd_count="gce_n_local_ssd_disk_db",
     root_disk_type="gce_root_disk_type_db",
+    pd_standard_disk_size="gce_pd_standard_disk_size_db",
 )
 
 loader_map = ConfigParamsMap(

--- a/sdcm/sct_provision/region_definition_builder.py
+++ b/sdcm/sct_provision/region_definition_builder.py
@@ -58,6 +58,7 @@ class ConfigParamsMap:
     root_disk_size: str
     local_ssd_count: str | None = None  # Maps to gce_n_local_ssd_disk_* parameters
     root_disk_type: str | None = None  # Maps to gce_root_disk_type_* parameters
+    pd_standard_disk_size: str | None = None  # Maps to gce_pd_standard_disk_size_* parameters
 
 
 class DefinitionBuilder(abc.ABC):
@@ -125,9 +126,12 @@ class DefinitionBuilder(abc.ABC):
         mapper = self.SCT_PARAM_MAPPER[node_type]
         use_public_ip = ssh_connection_ip_type(self.params) == "public" or node_type == "monitor"
         local_ssd_count = self.params.get(mapper.local_ssd_count) if mapper.local_ssd_count else 0
+        pd_standard_disk_size = self.params.get(mapper.pd_standard_disk_size) if mapper.pd_standard_disk_size else 0
         data_disks = []
         if local_ssd_count:
             data_disks.append(DataDisk(type="local-ssd", size=375, count=local_ssd_count))
+        if pd_standard_disk_size:
+            data_disks.append(DataDisk(type="pd-standard", size=pd_standard_disk_size, count=1))
         return InstanceDefinition(
             name=name,
             image_id=self.params.get(mapper.image_id),


### PR DESCRIPTION
With the merge of the switch of the GCE cluster creation into using the new approach (https://github.com/scylladb/scylla-cluster-tests/pull/13105) the setup of PD disks got broken.

So, fix it by properly passing through the `gce_pd_standard_disk_size_db` SCT config option value.

Closes: #SCT-334

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
