### PR TITLE
feature(monkey): Update AddRemoveDCNemesis

### DIFF
--- a/sdcm/nemesis/__init__.py
+++ b/sdcm/nemesis/__init__.py
@@ -75,7 +75,6 @@ from sdcm.mgmt.backup import run_manager_backup
 from sdcm.mgmt.argus_report import report_manager_backup_results_to_argus
 from sdcm.mgmt.helpers import get_dc_name_from_ks_statement, get_schema_create_statements_from_snapshot
 from sdcm.prometheus import nemesis_metrics_obj
-from sdcm.provision.scylla_yaml import SeedProvider
 from sdcm.provision.helpers.certificate import update_certificate, TLSAssets
 from sdcm.remote.libssh2_client.exceptions import UnexpectedExit as Libssh2UnexpectedExit
 from sdcm.sct_events import Severity
@@ -162,12 +161,6 @@ from sdcm.nemesis.utils.indexes import (
 )
 from sdcm.nemesis.utils.node_allocator import NemesisNodeAllocator, NemesisNodeAllocationError
 from sdcm.utils.node import build_node_api_command
-from sdcm.utils.replication_strategy_utils import (
-    temporary_replication_strategy_setter,
-    NetworkTopologyReplicationStrategy,
-    ReplicationStrategy,
-    SimpleReplicationStrategy,
-)
 from sdcm.utils.sstable.load_utils import SstableLoadUtils
 from sdcm.utils.sstable.sstable_utils import SstableUtils
 from sdcm.utils.tablets.common import wait_no_tablets_migration_running
@@ -176,7 +169,7 @@ from sdcm.utils.version_utils import MethodVersionNotFound, scylla_versions, Com
 from sdcm.utils.raft import Group0MembersNotConsistentWithTokenRingMembersException, TopologyOperations
 from sdcm.utils.raft.common import NodeBootstrapAbortManager, get_topology_coordinator_node
 from sdcm.utils.issues import SkipPerIssues
-from sdcm.wait import wait_for, wait_for_log_lines
+from sdcm.wait import wait_for
 from sdcm.exceptions import (
     KillNemesis,
     NoFilesFoundToDestroy,
@@ -4883,174 +4876,6 @@ class NemesisRunner:
             assert actual_cdc_settings == cdc_settings, (
                 f"CDC extension settings are differs. Current: {actual_cdc_settings} expected: {cdc_settings}"
             )
-
-    def _configure_new_dc(self, node: BaseNode):
-        """Configure node for new datacenter before Scylla starts."""
-        with node.remote_scylla_yaml() as scylla_yml:
-            scylla_yml.rpc_address = node.ip_address
-            scylla_yml.seed_provider = [
-                SeedProvider(
-                    class_name="org.apache.cassandra.locator.SimpleSeedProvider",
-                    parameters=[{"seeds": ",".join(self.tester.db_cluster.seed_nodes_addresses)}],
-                )
-            ]
-
-        endpoint_snitch = self.cluster.params.get("endpoint_snitch") or ""
-        if endpoint_snitch.endswith("GossipingPropertyFileSnitch"):
-            rackdc_value = {"dc": "add_remove_nemesis_dc"}
-        else:
-            rackdc_value = {"dc_suffix": "_nemesis_dc"}
-
-        with node.remote_cassandra_rackdc_properties() as properties_file:
-            properties_file.update(**rackdc_value)
-
-    def _add_new_node_in_new_dc(self, is_zero_node=False) -> BaseNode:
-        add_node_func_args = {
-            "count": 1,
-            "dc_idx": 0,
-            "enable_auto_bootstrap": True,
-            "disruption_name": self.current_disruption,
-            "after_config": self._configure_new_dc,
-            **({"is_zero_node": is_zero_node} if is_zero_node else {}),
-        }
-        new_node = skip_on_capacity_issues(db_cluster=self.tester.db_cluster)(self.cluster.add_nodes)(
-            **add_node_func_args
-        )[0]
-        # wait_for_init() will call node_setup(), which executes the callback after config_setup()
-        self.cluster.wait_for_init(node_list=[new_node], timeout=900, check_node_health=False)
-        new_node.wait_node_fully_start()
-        self.monitoring_set.reconfigure_scylla_monitoring()
-        return new_node
-
-    def _write_read_data_to_multi_dc_keyspace(self, dc_rf3: str, dc_rf1: str) -> None:
-        InfoEvent(message="Writing and reading data with new dc").publish()
-        write_cmd = (
-            f"cassandra-stress write no-warmup cl=ALL n=100000 -schema 'keyspace=keyspace_new_dc "
-            f"replication(strategy=NetworkTopologyStrategy,{dc_rf3}=3,{dc_rf1}=1) "
-            f"compression=LZ4Compressor compaction(strategy=SizeTieredCompactionStrategy)' "
-            f"-mode cql3 native compression=lz4 -rate threads=5 -pop seq=1..100000 -log interval=5"
-        )
-        write_thread = self.tester.run_stress_thread(stress_cmd=write_cmd, round_robin=True, stop_test_on_failure=False)
-        self.tester.verify_stress_thread(write_thread, error_handler=self._nemesis_stress_failure_handler)
-        with self.action_log_scope("Verify multi DC keyspace data"):
-            self._verify_multi_dc_keyspace_data(consistency_level="ALL")
-        # flush data to ensure it is seen in monitoring
-        for node in self.cluster.nodes:
-            with self.action_log_scope(f"Flush data in keyspace_new_dc on {node.name} node"):
-                node.run_nodetool("flush keyspace_new_dc")
-
-    def _verify_multi_dc_keyspace_data(self, consistency_level: str = "ALL"):
-        read_cmd = (
-            f"cassandra-stress read no-warmup cl={consistency_level} n=100000 -schema 'keyspace=keyspace_new_dc "
-            f"compression=LZ4Compressor' -mode cql3 native compression=lz4 -rate threads=5 "
-            f"-pop seq=1..100000 -log interval=5"
-        )
-        read_thread = self.tester.run_stress_thread(stress_cmd=read_cmd, round_robin=True, stop_test_on_failure=False)
-        self.tester.verify_stress_thread(read_thread, error_handler=self._nemesis_stress_failure_handler)
-
-    def _switch_to_network_replication_strategy(self, keyspaces: List[str]) -> None:
-        """Switches replication strategy to NetworkTopology for given keyspaces."""
-        node = self.cluster.data_nodes[0]
-        nodes_by_region = self.tester.db_cluster.nodes_by_region(nodes=self.tester.db_cluster.data_nodes)
-        region = list(nodes_by_region.keys())[0]
-        dc_name = self.tester.db_cluster.get_nodetool_info(nodes_by_region[region][0])["Data Center"]
-        for keyspace in keyspaces:
-            replication_strategy = ReplicationStrategy.get(node, keyspace)
-            if not isinstance(replication_strategy, SimpleReplicationStrategy):
-                # no need to switch as already is NetworkTopology
-                continue
-            self.log.info(f"Switching replication strategy to Network for '{keyspace}' keyspace")
-            if keyspace == "system_auth" and replication_strategy.replication_factors[0] != len(
-                nodes_by_region[region]
-            ):
-                self.log.warning(
-                    f"system_auth keyspace is not replicated on all nodes "
-                    f"({replication_strategy.replication_factors[0]}/{len(nodes_by_region[region])})."
-                )
-            with self.action_log_scope(f"Switching {keyspace} replication strategy to Network"):
-                network_replication = NetworkTopologyReplicationStrategy(
-                    **{dc_name: replication_strategy.replication_factors[0]}
-                )
-                network_replication.apply(node, keyspace)
-
-    def disrupt_add_remove_dc(self) -> None:
-        if self.cluster.test_config.MULTI_REGION:
-            raise UnsupportedNemesis(
-                "add_remove_dc skipped for multi-dc scenario (https://github.com/scylladb/scylla-cluster-tests/issues/5369)"
-            )
-        InfoEvent(message="Starting New DC Nemesis").publish()
-        node = self.cluster.data_nodes[0]
-        system_keyspaces = ["system_distributed", "system_traces"]
-        if not node.raft.is_consistent_topology_changes_enabled:  # auth-v2 is used when consistent topology is enabled
-            system_keyspaces.insert(0, "system_auth")
-        self._switch_to_network_replication_strategy(self.cluster.get_test_keyspaces() + system_keyspaces)
-        datacenters = list(self.tester.db_cluster.get_nodetool_status().keys())
-        initial_dc_name = datacenters[0]
-        self.tester.create_keyspace(
-            "keyspace_new_dc", replication_factor={initial_dc_name: min(3, len(self.cluster.data_nodes))}
-        )
-        node_added = False
-        with ExitStack() as context_manager:
-
-            def finalizer(exc_type, *_):
-                # in case of test end/killed, leave the cleanup alone
-                if exc_type is not KillNemesis:
-                    with self.cluster.cql_connection_patient(node) as session:
-                        session.execute("DROP KEYSPACE IF EXISTS keyspace_new_dc")
-                    if node_added:
-                        self.cluster.decommission(new_node)
-
-            context_manager.push(finalizer)
-
-            with temporary_replication_strategy_setter(node) as replication_strategy_setter:
-                with self.action_log_scope("Add new node in new DC"):
-                    new_node = self._add_new_node_in_new_dc()
-                node_added = True
-                status = self.tester.db_cluster.get_nodetool_status()
-                new_dc_list = [dc for dc in list(status.keys()) if dc.endswith("_nemesis_dc")]
-                assert new_dc_list, "new datacenter was not registered"
-                new_dc_name = new_dc_list[0]
-                for keyspace in system_keyspaces + ["keyspace_new_dc"]:
-                    strategy = ReplicationStrategy.get(node, keyspace)
-                    assert isinstance(strategy, NetworkTopologyReplicationStrategy), (
-                        "Should have been already switched to NetworkStrategy"
-                    )
-                    strategy.replication_factors_per_dc.update({new_dc_name: 1})
-                    replication_strategy_setter(**{keyspace: strategy})
-
-                for key, preserved_strategy in replication_strategy_setter.preserved.items():
-                    preserved_strategy.replication_factors_per_dc[new_dc_name] = 0
-
-                InfoEvent(message="execute rebuild on new datacenter").publish()
-                cmd = f"rebuild -- {initial_dc_name}"
-                with (
-                    wait_for_log_lines(
-                        node=new_node,
-                        start_line_patterns=["rebuild.*started with keyspaces=", "Rebuild starts"],
-                        end_line_patterns=["rebuild.*finished with keyspaces=", "Rebuild succeeded"],
-                        start_timeout=60,
-                        end_timeout=600,
-                    ),
-                    self.action_log_scope(f"Run rebuild on the new datacenter with cmd: {cmd}"),
-                ):
-                    new_node.run_nodetool(sub_cmd=cmd, long_running=True, retry=0)
-                InfoEvent(message="Running full cluster repair on each data node").publish()
-                cmd = "repair -pr"
-                for cluster_node in self.cluster.data_nodes:
-                    with self.action_log_scope(f"Run repair on {cluster_node.name} node with cmd: {cmd}"):
-                        cluster_node.run_nodetool(sub_cmd=cmd, publish_event=True)
-                with self.action_log_scope("Run write and then read data to multiDC keyspace"):
-                    self._write_read_data_to_multi_dc_keyspace(dc_rf3=initial_dc_name, dc_rf1=new_dc_name)
-
-            with self.action_log_scope(f"Decommission of the new node {new_node.name}"):
-                self.cluster.decommission(new_node)
-            node_added = False
-            self.node_allocator.unset_running_nemesis(new_node, self.current_disruption)
-
-            datacenters = list(self.tester.db_cluster.get_nodetool_status().keys())
-            assert not [dc for dc in datacenters if dc.endswith("_nemesis_dc")], "new datacenter was not unregistered"
-            with self.action_log_scope("Verify keyspace data after decommissioning"):
-                self._verify_multi_dc_keyspace_data(consistency_level="QUORUM")
 
     def get_cassandra_stress_write_cmds(self):
         write_cmds = self.tester.params.get("prepare_write_cmd")

--- a/sdcm/nemesis/monkey/__init__.py
+++ b/sdcm/nemesis/monkey/__init__.py
@@ -38,15 +38,6 @@ class ToggleLdapConfiguration(NemesisBaseClass):
         self.runner.disrupt_disable_enable_ldap_authorization()
 
 
-class AddRemoveDcNemesis(NemesisBaseClass):
-    disruptive = True
-    limited = True
-    topology_changes = True
-
-    def disrupt(self):
-        self.runner.disrupt_add_remove_dc()
-
-
 @target_data_nodes
 class GrowShrinkClusterNemesis(NemesisBaseClass):
     disruptive = True

--- a/sdcm/nemesis/monkey/add_remove_dc.py
+++ b/sdcm/nemesis/monkey/add_remove_dc.py
@@ -1,28 +1,127 @@
-from contextlib import ExitStack
-from typing import List
+from collections.abc import Iterator
+from contextlib import ExitStack, contextmanager
 
 from sdcm.cluster import BaseNode
 from sdcm.exceptions import KillNemesis, UnsupportedNemesis
 from sdcm.nemesis import NemesisBaseClass
 from sdcm.provision.scylla_yaml import SeedProvider
-from sdcm.sct_events.system import InfoEvent
-from sdcm.utils.decorators import skip_on_capacity_issues
+from sdcm.utils.decorators import retrying, skip_on_capacity_issues
+from sdcm.utils.features import is_tablets_feature_enabled
 from sdcm.utils.replication_strategy_utils import (
     NetworkTopologyReplicationStrategy,
     ReplicationStrategy,
-    SimpleReplicationStrategy,
     temporary_replication_strategy_setter,
 )
 from sdcm.wait import wait_for_log_lines
 
 
 class AddRemoveDcNemesis(NemesisBaseClass):
+    """
+    https://docs.scylladb.com/manual/stable/operating-scylla/procedures/cluster-management/add-dc-to-existing-dc.html
+    https://docs.scylladb.com/manual/stable/operating-scylla/procedures/cluster-management/decommissioning-data-center.html
+
+    1. Create and populate a new keyspace
+    2. Add some new nodes in a new datacenter
+    3. Ensure relevant keyspaces are using NetworkTopologyStrategy
+    4. Alter the keyspaces to add the new datacenter with the appropriate replication factor
+    5. Run rebuild on the new datacenter nodes, if vnodes
+    6. Run a full cluster repair
+    7. Run some writes and reads to verify the new datacenter is working
+    8. Alter the keyspaces to set replication factor to 0 for the new datacenter
+    9. Decommission the new datacenter nodes
+    10. Verify the keyspace is healthy after decommissioning the new datacenter
+    """
+
     disruptive = True
     limited = True
     topology_changes = True
 
-    def _configure_new_dc(self, node: BaseNode):
-        """Configure node for new datacenter before Scylla starts."""
+    def __init__(self, *args, **kwargs):
+        """Initialize new-datacenter state and keyspace defaults."""
+        super().__init__(*args, **kwargs)
+        self.new_nodes: list[BaseNode] = []
+        self.initial_dc_name: str = self.datacenters[0]
+        self.new_ks_name: str = "keyspace_new_dc"
+        self.new_ks_rf: int = len(self.runner.cluster.racks)
+
+    @property
+    def num_nodes_in_new_dc(self) -> int:
+        """Return new datacenter size based on supported RF change size."""
+        if self.runner.cluster.is_features_enabled_on_node(
+            node=self.runner.target_node, feature_list=["KEYSPACE_MULTI_RF_CHANGE"]
+        ):
+            return 2
+        return 1
+
+    @property
+    def system_keyspaces(self) -> list[str]:
+        """Return system keyspaces"""
+        system_keyspaces = ["system_distributed", "system_traces"]
+        if (
+            not self.runner.target_node.raft.is_consistent_topology_changes_enabled
+        ):  # auth-v2 is used when consistent topology is enabled
+            system_keyspaces.append("system_auth")
+        return system_keyspaces
+
+    @contextmanager
+    def temporary_system_keyspaces_network_topology_strategy(self) -> Iterator[None]:
+        """Temporarily switch system keyspaces to NetworkTopologyStrategy."""
+        with (
+            temporary_replication_strategy_setter(self.runner.target_node) as ntrs_setter,
+            self.runner.action_log_scope("Temporarily switch system keyspaces to NetworkTopologyStrategy"),
+        ):
+            for keyspace in self.system_keyspaces:
+                old_rs = ReplicationStrategy.get(self.runner.target_node, keyspace)
+                if not isinstance(old_rs, NetworkTopologyReplicationStrategy):
+                    new_rs = NetworkTopologyReplicationStrategy(**{self.initial_dc_name: old_rs.replication_factors[0]})
+                    ntrs_setter(**{keyspace: new_rs})
+            yield
+
+    @contextmanager
+    def temporary_new_dc_replication_factors(self) -> Iterator[None]:
+        """Temporarily update replication factors for the new datacenter."""
+        with (
+            temporary_replication_strategy_setter(self.runner.target_node) as new_dc_setter,
+            self.runner.action_log_scope("Temporarily update replication factors for new datacenter"),
+        ):
+            for keyspace in self.system_keyspaces + [self.new_ks_name]:
+                strategy = ReplicationStrategy.get(self.runner.target_node, keyspace)
+                strategy.replication_factors_per_dc.update({self.new_dc_name: self.num_nodes_in_new_dc})
+                new_dc_setter(**{keyspace: strategy})
+
+            # when context exits, set RF=0 for the new DC
+            for _, preserved_strategy in new_dc_setter.preserved.items():
+                preserved_strategy.replication_factors_per_dc[self.new_dc_name] = 0
+            yield
+
+    @property
+    def datacenters(self) -> list[str]:
+        """Return datacenter names currently reported by nodetool status."""
+        return list(self.runner.tester.db_cluster.get_nodetool_status().keys())
+
+    @property
+    def new_dc_name(self) -> str | None:
+        """Return the temporary nemesis datacenter name if it is registered."""
+        if has_suffix := [dc for dc in self.datacenters if dc.endswith("_nemesis_dc")]:
+            return has_suffix[0]
+        return None
+
+    @retrying(n=3, sleep_time=30, allowed_exceptions=(AssertionError,))
+    def assert_new_dc_registered(self) -> None:
+        """Assert that the temporary datacenter is visible in cluster status."""
+        assert self.new_dc_name, "new datacenter was not registered"
+
+    @retrying(n=3, sleep_time=30, allowed_exceptions=(AssertionError,))
+    def assert_new_dc_unregistered(self) -> None:
+        """Assert that the temporary datacenter is no longer visible in cluster status."""
+        assert not self.new_dc_name, "new datacenter was not unregistered"
+
+    def configure_new_dc(self, node: BaseNode) -> None:
+        """Configure node for new datacenter before Scylla starts.
+
+        Args:
+            node: New datacenter node to configure.
+        """
         with node.remote_scylla_yaml() as scylla_yml:
             scylla_yml.rpc_address = node.ip_address
             scylla_yml.seed_provider = [
@@ -41,31 +140,55 @@ class AddRemoveDcNemesis(NemesisBaseClass):
         with node.remote_cassandra_rackdc_properties() as properties_file:
             properties_file.update(**rackdc_value)
 
-    def _add_new_node_in_new_dc(self, is_zero_node=False) -> BaseNode:
+    def add_nodes_in_new_dc(self) -> None:
+        """Add and initialize temporary nodes configured to join a new datacenter."""
         add_node_func_args = {
-            "count": 2,
+            "count": self.num_nodes_in_new_dc,
             "dc_idx": 0,
             "rack": None,
             "enable_auto_bootstrap": True,
             "disruption_name": self.runner.current_disruption,
-            "after_config": self._configure_new_dc,
-            **({"is_zero_node": is_zero_node} if is_zero_node else {}),
+            "after_config": self.configure_new_dc,
         }
-        new_nodes = skip_on_capacity_issues(db_cluster=self.runner.tester.db_cluster)(self.runner.cluster.add_nodes)(
-            **add_node_func_args
-        )
+        with self.runner.action_log_scope("Add nodes in new DC"):
+            self.new_nodes = skip_on_capacity_issues(db_cluster=self.runner.tester.db_cluster)(
+                self.runner.cluster.add_nodes
+            )(**add_node_func_args)
         # wait_for_init() will call node_setup(), which executes the callback after config_setup()
-        self.runner.cluster.wait_for_init(node_list=new_nodes, timeout=900, check_node_health=False)
-        for new_node in new_nodes:
+        self.runner.cluster.wait_for_init(node_list=self.new_nodes, check_node_health=False)
+        for new_node in self.new_nodes:
             new_node.wait_node_fully_start()
         self.runner.monitoring_set.reconfigure_scylla_monitoring()
-        return new_nodes
 
-    def _create_new_keyspace(self, dc_rf3: str) -> None:
-        InfoEvent(message="Writing to new keyspace").publish()
+    def rebuild_node(self, new_node: BaseNode) -> None:
+        """Run nodetool rebuild on a node in the new datacenter.
+
+        Args:
+            new_node: New datacenter node to rebuild from the initial datacenter.
+        """
+        cmd = f"rebuild -- {self.initial_dc_name}"
+        with (
+            wait_for_log_lines(
+                node=new_node,
+                start_line_patterns=["rebuild.*started with keyspaces=", "Rebuild starts"],
+                end_line_patterns=["rebuild.*finished with keyspaces=", "Rebuild succeeded"],
+                start_timeout=60,
+                end_timeout=600,
+            ),
+            self.runner.action_log_scope(f"Run rebuild on {new_node.name} with cmd: {cmd}"),
+        ):
+            new_node.run_nodetool(sub_cmd=cmd, long_running=True, retry=0)
+
+    def rebuild_nodes_in_new_dc(self) -> None:
+        """Run nodetool rebuild on all new datacenter nodes."""
+        for new_node in self.new_nodes:
+            self.rebuild_node(new_node)
+
+    def create_new_dc_keyspace(self) -> None:
+        """Create and populate the keyspace used to validate add/remove DC flow."""
         write_cmd = (
-            f"cassandra-stress write no-warmup cl=ALL n=100000 -schema 'keyspace=keyspace_new_dc "
-            f"replication(strategy=NetworkTopologyStrategy,{dc_rf3}=3) "
+            f"cassandra-stress write no-warmup cl=ALL n=100000 -schema 'keyspace={self.new_ks_name} "
+            f"replication(strategy=NetworkTopologyStrategy,{self.initial_dc_name}={self.new_ks_rf}) "
             f"compression=LZ4Compressor compaction(strategy=SizeTieredCompactionStrategy)' "
             f"-mode cql3 native compression=lz4 -rate threads=5 -pop seq=1..100000 -log interval=5"
         )
@@ -75,139 +198,89 @@ class AddRemoveDcNemesis(NemesisBaseClass):
         self.runner.tester.verify_stress_thread(write_thread, error_handler=self.runner._nemesis_stress_failure_handler)
         # flush data to ensure it is seen in monitoring
         for node in self.runner.cluster.nodes:
-            with self.runner.action_log_scope(f"Flush data in keyspace_new_dc on {node.name} node"):
-                node.run_nodetool("flush keyspace_new_dc")
+            with self.runner.action_log_scope(f"Flush data in {self.new_ks_name} on {node.name} node"):
+                node.run_nodetool(f"flush {self.new_ks_name}")
 
-    def _write_read_data_to_multi_dc_keyspace(self, dc_rf3: str, dc_rf2: str) -> None:
-        InfoEvent(message="Writing and reading data with new dc").publish()
+    def write_to_multi_dc_keyspace(self) -> None:
+        """Write data to the validation keyspace after it is replicated to both datacenters."""
         write_cmd = (
-            f"cassandra-stress write no-warmup cl=ALL n=100000 -schema 'keyspace=keyspace_new_dc "
-            f"replication(strategy=NetworkTopologyStrategy,{dc_rf3}=3,{dc_rf2}=2) "
+            f"cassandra-stress write no-warmup cl=ALL n=100000 -schema 'keyspace={self.new_ks_name} "
+            f"replication(strategy=NetworkTopologyStrategy,{self.initial_dc_name}={self.new_ks_rf},{self.new_dc_name}={self.num_nodes_in_new_dc}) "
             f"compression=LZ4Compressor compaction(strategy=SizeTieredCompactionStrategy)' "
             f"-mode cql3 native compression=lz4 -rate threads=5 -pop seq=100001..200000 -log interval=5"
         )
         write_thread = self.runner.tester.run_stress_thread(
             stress_cmd=write_cmd, round_robin=True, stop_test_on_failure=False
         )
-        self.runner.tester.verify_stress_thread(write_thread, error_handler=self.runner._nemesis_stress_failure_handler)
-        with self.runner.action_log_scope("Verify multi DC keyspace data"):
-            self._verify_multi_dc_keyspace_data(consistency_level="ALL")
+        with self.runner.action_log_scope("Run write data to multiDC keyspace"):
+            self.runner.tester.verify_stress_thread(
+                write_thread, error_handler=self.runner._nemesis_stress_failure_handler
+            )
         # flush data to ensure it is seen in monitoring
         for node in self.runner.cluster.nodes:
-            with self.runner.action_log_scope(f"Flush data in keyspace_new_dc on {node.name} node"):
-                node.run_nodetool("flush keyspace_new_dc")
+            node.run_nodetool(f"flush {self.new_ks_name}")
 
-    def _verify_multi_dc_keyspace_data(self, consistency_level: str = "ALL"):
+    def verify_multi_dc_keyspace(self, consistency_level: str = "ALL") -> None:
+        """Read validation data from the multi-DC keyspace at the requested consistency level.
+
+        Args:
+            consistency_level: Consistency level to use for the cassandra-stress read.
+        """
         read_cmd = (
-            f"cassandra-stress read no-warmup cl={consistency_level} n=100000 -schema 'keyspace=keyspace_new_dc "
+            f"cassandra-stress read no-warmup cl={consistency_level} n=100000 -schema 'keyspace={self.new_ks_name} "
             f"compression=LZ4Compressor' -mode cql3 native compression=lz4 -rate threads=5 "
-            f"-pop seq=100001..200000 -log interval=5"
+            f"-pop seq=1..200000 -log interval=5"
         )
         read_thread = self.runner.tester.run_stress_thread(
             stress_cmd=read_cmd, round_robin=True, stop_test_on_failure=False
         )
-        self.runner.tester.verify_stress_thread(read_thread, error_handler=self.runner._nemesis_stress_failure_handler)
+        with self.runner.action_log_scope("Verify keyspace data"):
+            self.runner.tester.verify_stress_thread(
+                read_thread, error_handler=self.runner._nemesis_stress_failure_handler
+            )
 
-    def _switch_to_network_replication_strategy(self, keyspaces: List[str]) -> None:
-        """Switches replication strategy to NetworkTopology for given keyspaces."""
-        node = self.runner.cluster.data_nodes[0]
-        nodes_by_region = self.runner.tester.db_cluster.nodes_by_region(nodes=self.runner.tester.db_cluster.data_nodes)
-        region = list(nodes_by_region.keys())[0]
-        dc_name = self.runner.tester.db_cluster.get_nodetool_info(nodes_by_region[region][0])["Data Center"]
-        for keyspace in keyspaces:
-            replication_strategy = ReplicationStrategy.get(node, keyspace)
-            if not isinstance(replication_strategy, SimpleReplicationStrategy):
-                # no need to switch as already is NetworkTopology
-                continue
-            self.runner.log.info(f"Switching replication strategy to Network for '{keyspace}' keyspace")
-            if keyspace == "system_auth" and replication_strategy.replication_factors[0] != len(
-                nodes_by_region[region]
-            ):
-                self.runner.log.warning(
-                    f"system_auth keyspace is not replicated on all nodes "
-                    f"({replication_strategy.replication_factors[0]}/{len(nodes_by_region[region])})."
-                )
-            with self.runner.action_log_scope(f"Switching {keyspace} replication strategy to Network"):
-                network_replication = NetworkTopologyReplicationStrategy(
-                    **{dc_name: replication_strategy.replication_factors[0]}
-                )
-                network_replication.apply(node, keyspace)
+    def decommission_new_nodes(self) -> None:
+        """Decommission temporary datacenter nodes and clear local node tracking."""
+        with self.runner.action_log_scope(f"Decommission nodes in the new datacenter {self.new_dc_name}"):
+            self.runner.decommission_nodes(self.new_nodes)
+        self.new_nodes = []
+
+    def finalizer(self, exc_type, *_):
+        """Clean up the validation keyspace and temporary nodes on regular exits.
+
+        Args:
+            exc_type: Exception type received from the ExitStack callback, if any.
+            *_: Additional exception callback arguments ignored by this finalizer.
+        """
+        # in case of test end/killed, leave the cleanup alone
+        if exc_type is not KillNemesis:
+            with self.runner.cluster.cql_connection_patient(self.runner.target_node) as session:
+                session.execute(f"DROP KEYSPACE IF EXISTS {self.new_ks_name}")
+            if self.new_nodes:
+                self.decommission_new_nodes()
 
     def disrupt(self) -> None:
+        """Execute the add/remove datacenter nemesis workflow."""
         if self.runner.cluster.test_config.MULTI_REGION:
             raise UnsupportedNemesis(
-                "add_remove_dc skipped for multi-dc scenario (https://github.com/scylladb/scylla-cluster-tests/issues/5369)"
+                "Skipped for multi-dc scenario (https://github.com/scylladb/scylla-cluster-tests/issues/5369)"
             )
-        InfoEvent(message="Starting New DC Nemesis").publish()
-        node = self.runner.cluster.data_nodes[0]
-        system_keyspaces = ["system_distributed", "system_traces"]
-        if not node.raft.is_consistent_topology_changes_enabled:  # auth-v2 is used when consistent topology is enabled
-            system_keyspaces.insert(0, "system_auth")
-        self._switch_to_network_replication_strategy(self.runner.cluster.get_test_keyspaces() + system_keyspaces)
-        datacenters = list(self.runner.tester.db_cluster.get_nodetool_status().keys())
-        initial_dc_name = datacenters[0]
-        self._create_new_keyspace(dc_rf3=initial_dc_name)
-        node_added = False
+
         with ExitStack() as context_manager:
+            context_manager.push(self.finalizer)
+            self.create_new_dc_keyspace()
+            self.add_nodes_in_new_dc()
+            self.assert_new_dc_registered()
 
-            def finalizer(exc_type, *_):
-                # in case of test end/killed, leave the cleanup alone
-                if exc_type is not KillNemesis:
-                    with self.runner.cluster.cql_connection_patient(node) as session:
-                        session.execute("DROP KEYSPACE IF EXISTS keyspace_new_dc")
-                    if node_added:
-                        self.runner.decommission_nodes(new_nodes)
+            with self.temporary_system_keyspaces_network_topology_strategy():
+                with self.temporary_new_dc_replication_factors():
+                    if not is_tablets_feature_enabled(self.runner.target_node):
+                        self.rebuild_nodes_in_new_dc()
+                    self.runner.run_repair()
 
-            context_manager.push(finalizer)
+                    self.write_to_multi_dc_keyspace()
+                    self.verify_multi_dc_keyspace(consistency_level="ALL")
 
-            with temporary_replication_strategy_setter(node) as replication_strategy_setter:
-                with self.runner.action_log_scope("Add new node in new DC"):
-                    new_nodes = self._add_new_node_in_new_dc()
-                node_added = True
-                status = self.runner.tester.db_cluster.get_nodetool_status()
-                new_dc_list = [dc for dc in list(status.keys()) if dc.endswith("_nemesis_dc")]
-                assert new_dc_list, "new datacenter was not registered"
-                new_dc_name = new_dc_list[0]
-                for keyspace in system_keyspaces + ["keyspace_new_dc"]:
-                    strategy = ReplicationStrategy.get(node, keyspace)
-                    assert isinstance(strategy, NetworkTopologyReplicationStrategy), (
-                        "Should have been already switched to NetworkStrategy"
-                    )
-                    strategy.replication_factors_per_dc.update({new_dc_name: 2})
-                    replication_strategy_setter(**{keyspace: strategy})
-
-                for key, preserved_strategy in replication_strategy_setter.preserved.items():
-                    preserved_strategy.replication_factors_per_dc[new_dc_name] = 0
-
-                InfoEvent(message="execute rebuild on new datacenter").publish()
-                cmd = f"rebuild -- {initial_dc_name}"
-                for new_node in new_nodes:
-                    with (
-                        wait_for_log_lines(
-                            node=new_node,
-                            start_line_patterns=["rebuild.*started with keyspaces=", "Rebuild starts"],
-                            end_line_patterns=["rebuild.*finished with keyspaces=", "Rebuild succeeded"],
-                            start_timeout=60,
-                            end_timeout=600,
-                        ),
-                        self.runner.action_log_scope(f"Run rebuild on the new datacenter with cmd: {cmd}"),
-                    ):
-                        new_node.run_nodetool(sub_cmd=cmd, long_running=True, retry=0)
-                InfoEvent(message="Running full cluster repair on each data node").publish()
-                cmd = "repair -pr"
-                for cluster_node in self.runner.cluster.data_nodes:
-                    with self.runner.action_log_scope(f"Run repair on {cluster_node.name} node with cmd: {cmd}"):
-                        cluster_node.run_nodetool(sub_cmd=cmd, publish_event=True)
-                with self.runner.action_log_scope("Run write and then read data to multiDC keyspace"):
-                    self._write_read_data_to_multi_dc_keyspace(dc_rf3=initial_dc_name, dc_rf2=new_dc_name)
-
-            for new_node in new_nodes:
-                with self.runner.action_log_scope(f"Decommission of the new node {new_node.name}"):
-                    self.runner.cluster.decommission(new_node)
-                node_added = False
-                self.runner.node_allocator.unset_running_nemesis(new_node, self.runner.current_disruption)
-
-            datacenters = list(self.runner.tester.db_cluster.get_nodetool_status().keys())
-            assert not [dc for dc in datacenters if dc.endswith("_nemesis_dc")], "new datacenter was not unregistered"
-            with self.runner.action_log_scope("Verify keyspace data after decommissioning"):
-                self._verify_multi_dc_keyspace_data(consistency_level="QUORUM")
+                self.decommission_new_nodes()
+                self.assert_new_dc_unregistered()
+                self.verify_multi_dc_keyspace(consistency_level="QUORUM")

--- a/sdcm/nemesis/monkey/add_remove_dc.py
+++ b/sdcm/nemesis/monkey/add_remove_dc.py
@@ -1,0 +1,194 @@
+from contextlib import ExitStack
+from typing import List
+
+from sdcm.cluster import BaseNode
+from sdcm.exceptions import KillNemesis, UnsupportedNemesis
+from sdcm.nemesis import NemesisBaseClass
+from sdcm.provision.scylla_yaml import SeedProvider
+from sdcm.sct_events.system import InfoEvent
+from sdcm.utils.decorators import skip_on_capacity_issues
+from sdcm.utils.replication_strategy_utils import (
+    NetworkTopologyReplicationStrategy,
+    ReplicationStrategy,
+    SimpleReplicationStrategy,
+    temporary_replication_strategy_setter,
+)
+from sdcm.wait import wait_for_log_lines
+
+
+class AddRemoveDcNemesis(NemesisBaseClass):
+    disruptive = True
+    limited = True
+    topology_changes = True
+
+    def _configure_new_dc(self, node: BaseNode):
+        """Configure node for new datacenter before Scylla starts."""
+        with node.remote_scylla_yaml() as scylla_yml:
+            scylla_yml.rpc_address = node.ip_address
+            scylla_yml.seed_provider = [
+                SeedProvider(
+                    class_name="org.apache.cassandra.locator.SimpleSeedProvider",
+                    parameters=[{"seeds": ",".join(self.runner.tester.db_cluster.seed_nodes_addresses)}],
+                )
+            ]
+
+        endpoint_snitch = self.runner.cluster.params.get("endpoint_snitch") or ""
+        if endpoint_snitch.endswith("GossipingPropertyFileSnitch"):
+            rackdc_value = {"dc": "add_remove_nemesis_dc"}
+        else:
+            rackdc_value = {"dc_suffix": "_nemesis_dc"}
+
+        with node.remote_cassandra_rackdc_properties() as properties_file:
+            properties_file.update(**rackdc_value)
+
+    def _add_new_node_in_new_dc(self, is_zero_node=False) -> BaseNode:
+        add_node_func_args = {
+            "count": 1,
+            "dc_idx": 0,
+            "enable_auto_bootstrap": True,
+            "disruption_name": self.runner.current_disruption,
+            "after_config": self._configure_new_dc,
+            **({"is_zero_node": is_zero_node} if is_zero_node else {}),
+        }
+        new_node = skip_on_capacity_issues(db_cluster=self.runner.tester.db_cluster)(self.runner.cluster.add_nodes)(
+            **add_node_func_args
+        )[0]
+        # wait_for_init() will call node_setup(), which executes the callback after config_setup()
+        self.runner.cluster.wait_for_init(node_list=[new_node], timeout=900, check_node_health=False)
+        new_node.wait_node_fully_start()
+        self.runner.monitoring_set.reconfigure_scylla_monitoring()
+        return new_node
+
+    def _write_read_data_to_multi_dc_keyspace(self, dc_rf3: str, dc_rf1: str) -> None:
+        InfoEvent(message="Writing and reading data with new dc").publish()
+        write_cmd = (
+            f"cassandra-stress write no-warmup cl=ALL n=100000 -schema 'keyspace=keyspace_new_dc "
+            f"replication(strategy=NetworkTopologyStrategy,{dc_rf3}=3,{dc_rf1}=1) "
+            f"compression=LZ4Compressor compaction(strategy=SizeTieredCompactionStrategy)' "
+            f"-mode cql3 native compression=lz4 -rate threads=5 -pop seq=1..100000 -log interval=5"
+        )
+        write_thread = self.runner.tester.run_stress_thread(
+            stress_cmd=write_cmd, round_robin=True, stop_test_on_failure=False
+        )
+        self.runner.tester.verify_stress_thread(write_thread, error_handler=self.runner._nemesis_stress_failure_handler)
+        with self.runner.action_log_scope("Verify multi DC keyspace data"):
+            self._verify_multi_dc_keyspace_data(consistency_level="ALL")
+        # flush data to ensure it is seen in monitoring
+        for node in self.runner.cluster.nodes:
+            with self.runner.action_log_scope(f"Flush data in keyspace_new_dc on {node.name} node"):
+                node.run_nodetool("flush keyspace_new_dc")
+
+    def _verify_multi_dc_keyspace_data(self, consistency_level: str = "ALL"):
+        read_cmd = (
+            f"cassandra-stress read no-warmup cl={consistency_level} n=100000 -schema 'keyspace=keyspace_new_dc "
+            f"compression=LZ4Compressor' -mode cql3 native compression=lz4 -rate threads=5 "
+            f"-pop seq=1..100000 -log interval=5"
+        )
+        read_thread = self.runner.tester.run_stress_thread(
+            stress_cmd=read_cmd, round_robin=True, stop_test_on_failure=False
+        )
+        self.runner.tester.verify_stress_thread(read_thread, error_handler=self.runner._nemesis_stress_failure_handler)
+
+    def _switch_to_network_replication_strategy(self, keyspaces: List[str]) -> None:
+        """Switches replication strategy to NetworkTopology for given keyspaces."""
+        node = self.runner.cluster.data_nodes[0]
+        nodes_by_region = self.runner.tester.db_cluster.nodes_by_region(nodes=self.runner.tester.db_cluster.data_nodes)
+        region = list(nodes_by_region.keys())[0]
+        dc_name = self.runner.tester.db_cluster.get_nodetool_info(nodes_by_region[region][0])["Data Center"]
+        for keyspace in keyspaces:
+            replication_strategy = ReplicationStrategy.get(node, keyspace)
+            if not isinstance(replication_strategy, SimpleReplicationStrategy):
+                # no need to switch as already is NetworkTopology
+                continue
+            self.runner.log.info(f"Switching replication strategy to Network for '{keyspace}' keyspace")
+            if keyspace == "system_auth" and replication_strategy.replication_factors[0] != len(
+                nodes_by_region[region]
+            ):
+                self.runner.log.warning(
+                    f"system_auth keyspace is not replicated on all nodes "
+                    f"({replication_strategy.replication_factors[0]}/{len(nodes_by_region[region])})."
+                )
+            with self.runner.action_log_scope(f"Switching {keyspace} replication strategy to Network"):
+                network_replication = NetworkTopologyReplicationStrategy(
+                    **{dc_name: replication_strategy.replication_factors[0]}
+                )
+                network_replication.apply(node, keyspace)
+
+    def disrupt(self) -> None:
+        if self.runner.cluster.test_config.MULTI_REGION:
+            raise UnsupportedNemesis(
+                "add_remove_dc skipped for multi-dc scenario (https://github.com/scylladb/scylla-cluster-tests/issues/5369)"
+            )
+        InfoEvent(message="Starting New DC Nemesis").publish()
+        node = self.runner.cluster.data_nodes[0]
+        system_keyspaces = ["system_distributed", "system_traces"]
+        if not node.raft.is_consistent_topology_changes_enabled:  # auth-v2 is used when consistent topology is enabled
+            system_keyspaces.insert(0, "system_auth")
+        self._switch_to_network_replication_strategy(self.runner.cluster.get_test_keyspaces() + system_keyspaces)
+        datacenters = list(self.runner.tester.db_cluster.get_nodetool_status().keys())
+        initial_dc_name = datacenters[0]
+        self.runner.tester.create_keyspace(
+            "keyspace_new_dc", replication_factor={initial_dc_name: min(3, len(self.runner.cluster.data_nodes))}
+        )
+        node_added = False
+        with ExitStack() as context_manager:
+
+            def finalizer(exc_type, *_):
+                # in case of test end/killed, leave the cleanup alone
+                if exc_type is not KillNemesis:
+                    with self.runner.cluster.cql_connection_patient(node) as session:
+                        session.execute("DROP KEYSPACE IF EXISTS keyspace_new_dc")
+                    if node_added:
+                        self.runner.cluster.decommission(new_node)
+
+            context_manager.push(finalizer)
+
+            with temporary_replication_strategy_setter(node) as replication_strategy_setter:
+                with self.runner.action_log_scope("Add new node in new DC"):
+                    new_node = self._add_new_node_in_new_dc()
+                node_added = True
+                status = self.runner.tester.db_cluster.get_nodetool_status()
+                new_dc_list = [dc for dc in list(status.keys()) if dc.endswith("_nemesis_dc")]
+                assert new_dc_list, "new datacenter was not registered"
+                new_dc_name = new_dc_list[0]
+                for keyspace in system_keyspaces + ["keyspace_new_dc"]:
+                    strategy = ReplicationStrategy.get(node, keyspace)
+                    assert isinstance(strategy, NetworkTopologyReplicationStrategy), (
+                        "Should have been already switched to NetworkStrategy"
+                    )
+                    strategy.replication_factors_per_dc.update({new_dc_name: 1})
+                    replication_strategy_setter(**{keyspace: strategy})
+
+                for key, preserved_strategy in replication_strategy_setter.preserved.items():
+                    preserved_strategy.replication_factors_per_dc[new_dc_name] = 0
+
+                InfoEvent(message="execute rebuild on new datacenter").publish()
+                cmd = f"rebuild -- {initial_dc_name}"
+                with (
+                    wait_for_log_lines(
+                        node=new_node,
+                        start_line_patterns=["rebuild.*started with keyspaces=", "Rebuild starts"],
+                        end_line_patterns=["rebuild.*finished with keyspaces=", "Rebuild succeeded"],
+                        start_timeout=60,
+                        end_timeout=600,
+                    ),
+                    self.runner.action_log_scope(f"Run rebuild on the new datacenter with cmd: {cmd}"),
+                ):
+                    new_node.run_nodetool(sub_cmd=cmd, long_running=True, retry=0)
+                InfoEvent(message="Running full cluster repair on each data node").publish()
+                cmd = "repair -pr"
+                for cluster_node in self.runner.cluster.data_nodes:
+                    with self.runner.action_log_scope(f"Run repair on {cluster_node.name} node with cmd: {cmd}"):
+                        cluster_node.run_nodetool(sub_cmd=cmd, publish_event=True)
+                with self.runner.action_log_scope("Run write and then read data to multiDC keyspace"):
+                    self._write_read_data_to_multi_dc_keyspace(dc_rf3=initial_dc_name, dc_rf1=new_dc_name)
+
+            with self.runner.action_log_scope(f"Decommission of the new node {new_node.name}"):
+                self.runner.cluster.decommission(new_node)
+            node_added = False
+            self.runner.node_allocator.unset_running_nemesis(new_node, self.runner.current_disruption)
+
+            datacenters = list(self.runner.tester.db_cluster.get_nodetool_status().keys())
+            assert not [dc for dc in datacenters if dc.endswith("_nemesis_dc")], "new datacenter was not unregistered"
+            with self.runner.action_log_scope("Verify keyspace data after decommissioning"):
+                self._verify_multi_dc_keyspace_data(consistency_level="QUORUM")

--- a/sdcm/nemesis/monkey/add_remove_dc.py
+++ b/sdcm/nemesis/monkey/add_remove_dc.py
@@ -43,29 +43,48 @@ class AddRemoveDcNemesis(NemesisBaseClass):
 
     def _add_new_node_in_new_dc(self, is_zero_node=False) -> BaseNode:
         add_node_func_args = {
-            "count": 1,
+            "count": 2,
             "dc_idx": 0,
+            "rack": None,
             "enable_auto_bootstrap": True,
             "disruption_name": self.runner.current_disruption,
             "after_config": self._configure_new_dc,
             **({"is_zero_node": is_zero_node} if is_zero_node else {}),
         }
-        new_node = skip_on_capacity_issues(db_cluster=self.runner.tester.db_cluster)(self.runner.cluster.add_nodes)(
+        new_nodes = skip_on_capacity_issues(db_cluster=self.runner.tester.db_cluster)(self.runner.cluster.add_nodes)(
             **add_node_func_args
-        )[0]
+        )
         # wait_for_init() will call node_setup(), which executes the callback after config_setup()
-        self.runner.cluster.wait_for_init(node_list=[new_node], timeout=900, check_node_health=False)
-        new_node.wait_node_fully_start()
+        self.runner.cluster.wait_for_init(node_list=new_nodes, timeout=900, check_node_health=False)
+        for new_node in new_nodes:
+            new_node.wait_node_fully_start()
         self.runner.monitoring_set.reconfigure_scylla_monitoring()
-        return new_node
+        return new_nodes
 
-    def _write_read_data_to_multi_dc_keyspace(self, dc_rf3: str, dc_rf1: str) -> None:
+    def _create_new_keyspace(self, dc_rf3: str) -> None:
+        InfoEvent(message="Writing to new keyspace").publish()
+        write_cmd = (
+            f"cassandra-stress write no-warmup cl=ALL n=100000 -schema 'keyspace=keyspace_new_dc "
+            f"replication(strategy=NetworkTopologyStrategy,{dc_rf3}=3) "
+            f"compression=LZ4Compressor compaction(strategy=SizeTieredCompactionStrategy)' "
+            f"-mode cql3 native compression=lz4 -rate threads=5 -pop seq=1..100000 -log interval=5"
+        )
+        write_thread = self.runner.tester.run_stress_thread(
+            stress_cmd=write_cmd, round_robin=True, stop_test_on_failure=False
+        )
+        self.runner.tester.verify_stress_thread(write_thread, error_handler=self.runner._nemesis_stress_failure_handler)
+        # flush data to ensure it is seen in monitoring
+        for node in self.runner.cluster.nodes:
+            with self.runner.action_log_scope(f"Flush data in keyspace_new_dc on {node.name} node"):
+                node.run_nodetool("flush keyspace_new_dc")
+
+    def _write_read_data_to_multi_dc_keyspace(self, dc_rf3: str, dc_rf2: str) -> None:
         InfoEvent(message="Writing and reading data with new dc").publish()
         write_cmd = (
             f"cassandra-stress write no-warmup cl=ALL n=100000 -schema 'keyspace=keyspace_new_dc "
-            f"replication(strategy=NetworkTopologyStrategy,{dc_rf3}=3,{dc_rf1}=1) "
+            f"replication(strategy=NetworkTopologyStrategy,{dc_rf3}=3,{dc_rf2}=2) "
             f"compression=LZ4Compressor compaction(strategy=SizeTieredCompactionStrategy)' "
-            f"-mode cql3 native compression=lz4 -rate threads=5 -pop seq=1..100000 -log interval=5"
+            f"-mode cql3 native compression=lz4 -rate threads=5 -pop seq=100001..200000 -log interval=5"
         )
         write_thread = self.runner.tester.run_stress_thread(
             stress_cmd=write_cmd, round_robin=True, stop_test_on_failure=False
@@ -82,7 +101,7 @@ class AddRemoveDcNemesis(NemesisBaseClass):
         read_cmd = (
             f"cassandra-stress read no-warmup cl={consistency_level} n=100000 -schema 'keyspace=keyspace_new_dc "
             f"compression=LZ4Compressor' -mode cql3 native compression=lz4 -rate threads=5 "
-            f"-pop seq=1..100000 -log interval=5"
+            f"-pop seq=100001..200000 -log interval=5"
         )
         read_thread = self.runner.tester.run_stress_thread(
             stress_cmd=read_cmd, round_robin=True, stop_test_on_failure=False
@@ -127,9 +146,7 @@ class AddRemoveDcNemesis(NemesisBaseClass):
         self._switch_to_network_replication_strategy(self.runner.cluster.get_test_keyspaces() + system_keyspaces)
         datacenters = list(self.runner.tester.db_cluster.get_nodetool_status().keys())
         initial_dc_name = datacenters[0]
-        self.runner.tester.create_keyspace(
-            "keyspace_new_dc", replication_factor={initial_dc_name: min(3, len(self.runner.cluster.data_nodes))}
-        )
+        self._create_new_keyspace(dc_rf3=initial_dc_name)
         node_added = False
         with ExitStack() as context_manager:
 
@@ -139,13 +156,13 @@ class AddRemoveDcNemesis(NemesisBaseClass):
                     with self.runner.cluster.cql_connection_patient(node) as session:
                         session.execute("DROP KEYSPACE IF EXISTS keyspace_new_dc")
                     if node_added:
-                        self.runner.cluster.decommission(new_node)
+                        self.runner.decommission_nodes(new_nodes)
 
             context_manager.push(finalizer)
 
             with temporary_replication_strategy_setter(node) as replication_strategy_setter:
                 with self.runner.action_log_scope("Add new node in new DC"):
-                    new_node = self._add_new_node_in_new_dc()
+                    new_nodes = self._add_new_node_in_new_dc()
                 node_added = True
                 status = self.runner.tester.db_cluster.get_nodetool_status()
                 new_dc_list = [dc for dc in list(status.keys()) if dc.endswith("_nemesis_dc")]
@@ -156,7 +173,7 @@ class AddRemoveDcNemesis(NemesisBaseClass):
                     assert isinstance(strategy, NetworkTopologyReplicationStrategy), (
                         "Should have been already switched to NetworkStrategy"
                     )
-                    strategy.replication_factors_per_dc.update({new_dc_name: 1})
+                    strategy.replication_factors_per_dc.update({new_dc_name: 2})
                     replication_strategy_setter(**{keyspace: strategy})
 
                 for key, preserved_strategy in replication_strategy_setter.preserved.items():
@@ -164,29 +181,31 @@ class AddRemoveDcNemesis(NemesisBaseClass):
 
                 InfoEvent(message="execute rebuild on new datacenter").publish()
                 cmd = f"rebuild -- {initial_dc_name}"
-                with (
-                    wait_for_log_lines(
-                        node=new_node,
-                        start_line_patterns=["rebuild.*started with keyspaces=", "Rebuild starts"],
-                        end_line_patterns=["rebuild.*finished with keyspaces=", "Rebuild succeeded"],
-                        start_timeout=60,
-                        end_timeout=600,
-                    ),
-                    self.runner.action_log_scope(f"Run rebuild on the new datacenter with cmd: {cmd}"),
-                ):
-                    new_node.run_nodetool(sub_cmd=cmd, long_running=True, retry=0)
+                for new_node in new_nodes:
+                    with (
+                        wait_for_log_lines(
+                            node=new_node,
+                            start_line_patterns=["rebuild.*started with keyspaces=", "Rebuild starts"],
+                            end_line_patterns=["rebuild.*finished with keyspaces=", "Rebuild succeeded"],
+                            start_timeout=60,
+                            end_timeout=600,
+                        ),
+                        self.runner.action_log_scope(f"Run rebuild on the new datacenter with cmd: {cmd}"),
+                    ):
+                        new_node.run_nodetool(sub_cmd=cmd, long_running=True, retry=0)
                 InfoEvent(message="Running full cluster repair on each data node").publish()
                 cmd = "repair -pr"
                 for cluster_node in self.runner.cluster.data_nodes:
                     with self.runner.action_log_scope(f"Run repair on {cluster_node.name} node with cmd: {cmd}"):
                         cluster_node.run_nodetool(sub_cmd=cmd, publish_event=True)
                 with self.runner.action_log_scope("Run write and then read data to multiDC keyspace"):
-                    self._write_read_data_to_multi_dc_keyspace(dc_rf3=initial_dc_name, dc_rf1=new_dc_name)
+                    self._write_read_data_to_multi_dc_keyspace(dc_rf3=initial_dc_name, dc_rf2=new_dc_name)
 
-            with self.runner.action_log_scope(f"Decommission of the new node {new_node.name}"):
-                self.runner.cluster.decommission(new_node)
-            node_added = False
-            self.runner.node_allocator.unset_running_nemesis(new_node, self.runner.current_disruption)
+            for new_node in new_nodes:
+                with self.runner.action_log_scope(f"Decommission of the new node {new_node.name}"):
+                    self.runner.cluster.decommission(new_node)
+                node_added = False
+                self.runner.node_allocator.unset_running_nemesis(new_node, self.runner.current_disruption)
 
             datacenters = list(self.runner.tester.db_cluster.get_nodetool_status().keys())
             assert not [dc for dc in datacenters if dc.endswith("_nemesis_dc")], "new datacenter was not unregistered"

--- a/unit_tests/unit/nemesis/monkey/test_add_remove_dc.py
+++ b/unit_tests/unit/nemesis/monkey/test_add_remove_dc.py
@@ -1,0 +1,344 @@
+"""Tests for sdcm.nemesis.monkey.add_remove_dc module."""
+
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from sdcm.exceptions import KillNemesis, UnsupportedNemesis
+from sdcm.nemesis.monkey.add_remove_dc import AddRemoveDcNemesis
+from sdcm.utils.replication_strategy_utils import (
+    NetworkTopologyReplicationStrategy,
+    ReplicationStrategy,
+    SimpleReplicationStrategy,
+)
+
+_MODULE = "sdcm.nemesis.monkey.add_remove_dc"
+
+pytestmark = pytest.mark.usefixtures("events")
+
+
+def _clone_strategy(strategy):
+    """Creates a deep copy of a replication strategy for comparison.
+
+    Args:
+        strategy: A ReplicationStrategy instance (NetworkTopologyReplicationStrategy or SimpleReplicationStrategy).
+
+    Returns:
+        A new instance of the same strategy type with identical replication factors.
+    """
+    if isinstance(strategy, NetworkTopologyReplicationStrategy):
+        return NetworkTopologyReplicationStrategy(**strategy.replication_factors_per_dc)
+    return SimpleReplicationStrategy(strategy.replication_factors[0])
+
+
+class FakeReplicationStrategySetter:
+    """Context manager that records keyspace strategy updates."""
+
+    def __init__(self, name, events):
+        """Initializes the fake replication strategy setter.
+
+        Args:
+            name: Identifier for this setter instance (used in rollback events).
+            events: Shared list to record lifecycle events (e.g., rollback).
+        """
+        self.name = name
+        self.events = events
+        self.calls = []
+        self.preserved = {}
+        self.rollback_calls = []
+
+    def __enter__(self):
+        """Enters the context manager.
+
+        Returns:
+            Self for use in with-statement binding.
+        """
+        return self
+
+    def __exit__(self, *exc):
+        """Exits the context manager and triggers rollback.
+
+        Args:
+            *exc: Exception information (type, value, traceback).
+
+        Returns:
+            False to propagate any exception.
+        """
+        self.rollback_calls.append(self.preserved.copy())
+        self.events.append(f"{self.name}:rollback")
+        return False
+
+    def __call__(self, **keyspaces):
+        """Records a replication strategy update for the given keyspaces.
+
+        Preserves the original strategy on first update to each keyspace for rollback.
+
+        Args:
+            **keyspaces: Mapping of keyspace names to new ReplicationStrategy instances.
+        """
+        self.calls.append(keyspaces)
+        for keyspace, strategy in keyspaces.items():
+            if keyspace not in self.preserved:
+                self.preserved[keyspace] = _clone_strategy(ReplicationStrategy.get(None, keyspace))
+
+
+@pytest.fixture()
+def runner(base_runner):
+    """Base runner extended with add/remove-dc specific cluster state."""
+    status_by_dc = {"dc1": object()}
+
+    base_runner.cluster.test_config = MagicMock(MULTI_REGION=False)
+    base_runner.cluster.racks = ["rack1"]
+    base_runner.cluster.nodes = list(base_runner.cluster.data_nodes)
+    base_runner.cluster.is_features_enabled_on_node.return_value = True
+    base_runner.decommission_nodes = MagicMock()
+    base_runner.run_repair = MagicMock()
+    base_runner.current_disruption = "AddRemoveDcNemesis"
+    base_runner.monitoring_set = MagicMock()
+    base_runner._nemesis_stress_failure_handler = MagicMock()
+
+    base_runner.target_node.raft = MagicMock(is_consistent_topology_changes_enabled=True)
+
+    base_runner.tester.db_cluster = MagicMock()
+    base_runner.tester.db_cluster.get_nodetool_status.side_effect = lambda: dict(status_by_dc)
+
+    base_runner.status_by_dc = status_by_dc
+    return base_runner
+
+
+def test_disrupt_raises_unsupported_for_multi_region(runner):
+    """MULTI_REGION runs are rejected before any topology changes start."""
+    runner.cluster.test_config.MULTI_REGION = True
+
+    with pytest.raises(UnsupportedNemesis, match="multi-dc scenario"):
+        AddRemoveDcNemesis(runner).disrupt()
+
+    runner.tester.create_keyspace.assert_not_called()
+    runner.cluster.add_nodes.assert_not_called()
+    runner.run_repair.assert_not_called()
+    runner.decommission_nodes.assert_not_called()
+    assert not runner.executed
+
+
+def test_disrupt_updates_replication_and_cleans_new_dc(runner):
+    """disrupt() should update replication for the temporary DC and remove it afterwards."""
+    monkey = AddRemoveDcNemesis(runner)
+    new_nodes = [MagicMock(name="node-new-1"), MagicMock(name="node-new-2")]
+    events = []
+    first_setter = FakeReplicationStrategySetter("system-keyspaces", events)
+    second_setter = FakeReplicationStrategySetter("new-dc-rf", events)
+
+    def add_nodes():
+        monkey.new_nodes = new_nodes
+        runner.status_by_dc["dc1_nemesis_dc"] = object()
+
+    def decommission_nodes():
+        events.append("decommission")
+        runner.decommission_nodes(new_nodes)
+        monkey.new_nodes = []
+        runner.status_by_dc.pop("dc1_nemesis_dc", None)
+
+    monkey.add_nodes_in_new_dc = MagicMock(side_effect=add_nodes)
+    monkey.decommission_new_nodes = MagicMock(side_effect=decommission_nodes)
+    monkey.rebuild_node = MagicMock()
+    monkey.write_to_multi_dc_keyspace = MagicMock()
+    monkey.verify_multi_dc_keyspace = MagicMock()
+
+    def fake_get(node, keyspace):
+        # After first_setter preserves a system keyspace, subsequent gets should return NTS
+        if keyspace in first_setter.preserved:
+            return NetworkTopologyReplicationStrategy(**{monkey.initial_dc_name: monkey.new_ks_rf})
+        if keyspace in ("system_distributed", "system_traces"):
+            return SimpleReplicationStrategy(monkey.new_ks_rf)
+        return NetworkTopologyReplicationStrategy(**{monkey.initial_dc_name: monkey.new_ks_rf})
+
+    with (
+        patch(f"{_MODULE}.temporary_replication_strategy_setter", side_effect=[first_setter, second_setter]),
+        patch(f"{_MODULE}.ReplicationStrategy.get", side_effect=fake_get),
+        patch(f"{_MODULE}.is_tablets_feature_enabled", return_value=False),
+    ):
+        monkey.disrupt()
+
+    runner.tester.run_stress_thread.assert_called_once()
+    stress_kwargs = runner.tester.run_stress_thread.call_args.kwargs
+    expected_replication = f"replication(strategy=NetworkTopologyStrategy,{monkey.initial_dc_name}={monkey.new_ks_rf})"
+    assert f"keyspace={monkey.new_ks_name}" in stress_kwargs["stress_cmd"]
+    assert expected_replication in stress_kwargs["stress_cmd"]
+    assert stress_kwargs["round_robin"] is True
+    assert stress_kwargs["stop_test_on_failure"] is False
+    runner.tester.verify_stress_thread.assert_called_once_with(
+        runner.tester.run_stress_thread.return_value,
+        error_handler=runner._nemesis_stress_failure_handler,
+    )
+    monkey.add_nodes_in_new_dc.assert_called_once_with()
+    assert monkey.rebuild_node.call_args_list == [call(new_nodes[0]), call(new_nodes[1])]
+    runner.run_repair.assert_called_once_with()
+    monkey.write_to_multi_dc_keyspace.assert_called_once_with()
+    monkey.decommission_new_nodes.assert_called_once_with()
+    assert monkey.verify_multi_dc_keyspace.call_args_list == [
+        call(consistency_level="ALL"),
+        call(consistency_level="QUORUM"),
+    ]
+
+    assert list(first_setter.calls[0]) == ["system_distributed"]
+    switched_strategy = first_setter.calls[0]["system_distributed"]
+    assert isinstance(switched_strategy, NetworkTopologyReplicationStrategy)
+    assert switched_strategy.replication_factors_per_dc == {monkey.initial_dc_name: monkey.new_ks_rf}
+    preserved_strategy = first_setter.preserved["system_distributed"]
+    assert isinstance(preserved_strategy, SimpleReplicationStrategy)
+    assert preserved_strategy.replication_factors == [monkey.new_ks_rf]
+
+    updated_keyspaces = [next(iter(entry)) for entry in second_setter.calls]
+    assert updated_keyspaces == ["system_distributed", "system_traces", monkey.new_ks_name]
+    for entry in second_setter.calls:
+        strategy = next(iter(entry.values()))
+        assert strategy.replication_factors_per_dc == {
+            monkey.initial_dc_name: monkey.new_ks_rf,
+            "dc1_nemesis_dc": monkey.num_nodes_in_new_dc,
+        }
+
+    for preserved_strategy in second_setter.preserved.values():
+        assert preserved_strategy.replication_factors_per_dc == {
+            monkey.initial_dc_name: monkey.new_ks_rf,
+            "dc1_nemesis_dc": 0,
+        }
+
+    assert len(second_setter.rollback_calls) == 1
+    assert list(second_setter.rollback_calls[0]) == updated_keyspaces
+    assert events.index("new-dc-rf:rollback") < events.index("decommission")
+
+    assert monkey.new_dc_name is None
+
+
+def test_assert_new_dc_registered_retries_until_status_contains_new_dc(runner):
+    """assert_new_dc_registered() should retry until nodetool status shows the temporary DC."""
+    monkey = AddRemoveDcNemesis(runner)
+    runner.tester.db_cluster.get_nodetool_status.side_effect = [
+        {"dc1": object()},
+        {"dc1": object(), "dc1_nemesis_dc": object()},
+    ]
+    runner.tester.db_cluster.get_nodetool_status.reset_mock()
+
+    with patch("sdcm.utils.decorators.time.sleep") as sleep:
+        monkey.assert_new_dc_registered()
+
+    sleep.assert_called_once_with(30)
+    assert runner.tester.db_cluster.get_nodetool_status.call_count == 2
+
+
+def test_assert_new_dc_unregistered_retries_until_status_drops_new_dc(runner):
+    """assert_new_dc_unregistered() should retry until nodetool status drops the temporary DC."""
+    monkey = AddRemoveDcNemesis(runner)
+    runner.tester.db_cluster.get_nodetool_status.side_effect = [
+        {"dc1": object(), "dc1_nemesis_dc": object()},
+        {"dc1": object()},
+    ]
+    runner.tester.db_cluster.get_nodetool_status.reset_mock()
+
+    with patch("sdcm.utils.decorators.time.sleep") as sleep:
+        monkey.assert_new_dc_unregistered()
+
+    sleep.assert_called_once_with(30)
+    assert runner.tester.db_cluster.get_nodetool_status.call_count == 2
+
+
+@pytest.mark.parametrize(
+    "method_name,status,message",
+    [
+        pytest.param(
+            "assert_new_dc_registered",
+            {"dc1": object()},
+            "new datacenter was not registered",
+            id="registered",
+        ),
+        pytest.param(
+            "assert_new_dc_unregistered",
+            {"dc1": object(), "dc1_nemesis_dc": object()},
+            "new datacenter was not unregistered",
+            id="unregistered",
+        ),
+    ],
+)
+def test_assert_new_dc_state_methods_retry_three_times_before_raising(runner, method_name, status, message):
+    """DC state assertions should attempt the nodetool status check three times before failing."""
+    monkey = AddRemoveDcNemesis(runner)
+    runner.tester.db_cluster.get_nodetool_status.side_effect = None
+    runner.tester.db_cluster.get_nodetool_status.return_value = status
+    runner.tester.db_cluster.get_nodetool_status.reset_mock()
+
+    with patch("sdcm.utils.decorators.time.sleep") as sleep:
+        with pytest.raises(AssertionError, match=message):
+            getattr(monkey, method_name)()
+
+    assert runner.tester.db_cluster.get_nodetool_status.call_count == 3
+    assert sleep.call_args_list == [call(30), call(30), call(30)]
+
+
+def test_finalizer_drops_keyspace_and_decommissions_new_nodes(runner):
+    """finalizer() should clean up the keyspace and temporary nodes on regular exits."""
+    monkey = AddRemoveDcNemesis(runner)
+    monkey.new_nodes = [MagicMock(name="node-new")]
+    monkey.decommission_new_nodes = MagicMock()
+
+    monkey.finalizer(Exception, None, None)
+
+    assert runner.executed[-1] == f"DROP KEYSPACE IF EXISTS {monkey.new_ks_name}"
+    monkey.decommission_new_nodes.assert_called_once_with()
+
+
+def test_finalizer_skips_cleanup_on_kill_nemesis(runner):
+    """finalizer() should not drop keyspace or decommission when KillNemesis is raised."""
+    monkey = AddRemoveDcNemesis(runner)
+    monkey.new_nodes = [MagicMock(name="node-new")]
+    monkey.decommission_new_nodes = MagicMock()
+
+    monkey.finalizer(KillNemesis, None, None)
+
+    assert not runner.executed
+    monkey.decommission_new_nodes.assert_not_called()
+
+
+def test_finalizer_skips_decommission_when_no_new_nodes(runner):
+    """finalizer() should not call decommission when new_nodes is empty."""
+    monkey = AddRemoveDcNemesis(runner)
+    monkey.new_nodes = []
+    monkey.decommission_new_nodes = MagicMock()
+
+    monkey.finalizer(Exception, None, None)
+
+    assert runner.executed[-1] == f"DROP KEYSPACE IF EXISTS {monkey.new_ks_name}"
+    monkey.decommission_new_nodes.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "feature_enabled,expected_count",
+    [
+        pytest.param(True, 2, id="multi-rf-change-enabled"),
+        pytest.param(False, 1, id="multi-rf-change-disabled"),
+    ],
+)
+def test_num_nodes_in_new_dc_depends_on_multi_rf_change_feature(runner, feature_enabled, expected_count):
+    """num_nodes_in_new_dc should match the supported RF change size."""
+    runner.cluster.is_features_enabled_on_node.return_value = feature_enabled
+    monkey = AddRemoveDcNemesis(runner)
+
+    assert monkey.num_nodes_in_new_dc == expected_count
+    runner.cluster.is_features_enabled_on_node.assert_called_once_with(
+        node=runner.target_node, feature_list=["KEYSPACE_MULTI_RF_CHANGE"]
+    )
+
+
+def test_system_keyspaces_includes_auth_when_topology_changes_disabled(runner):
+    """system_keyspaces should include system_auth when consistent topology changes are off."""
+    runner.target_node.raft.is_consistent_topology_changes_enabled = False
+    monkey = AddRemoveDcNemesis(runner)
+
+    assert "system_auth" in monkey.system_keyspaces
+
+
+def test_system_keyspaces_excludes_auth_when_topology_changes_enabled(runner):
+    """system_keyspaces should NOT include system_auth when consistent topology changes are on."""
+    runner.target_node.raft.is_consistent_topology_changes_enabled = True
+    monkey = AddRemoveDcNemesis(runner)
+
+    assert "system_auth" not in monkey.system_keyspaces


### PR DESCRIPTION
Part of the RF Changes feature.
RF can now be changed from 0 to N in a single step.
- move nemesis in its own module
- add 2 nodes (instead of 1 to the new DC), se the feature can be tested
- write some data before adding the new dc, so there is something to migrate
- clean up and refactor the code for clarity, it has multiple helper functions

Fixes: SCYLLADB-526

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://argus.scylladb.com/tests/scylla-cluster-tests/eb1371ae-a8f0-4c03-97b5-f58988326ba4/nemesis
  Needs `nemesis_during_prepare=false`, otherwise stress commands of the longevity might end up on the new DC.
  [Old version](https://argus.scylladb.com/tests/scylla-cluster-tests/a62d992a-d095-43bb-b568-a97d5853c9a4) had same issue.

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)