### PR TITLE
feature(provision/aws): upfront AZ filtering for capacity awareness

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -213,6 +213,8 @@ bare_loaders: false
 
 aws_fallback_to_next_availability_zone: false
 
+pre_filter_unavailable_availability_zones: true
+
 enable_argus: true
 
 # the default stress tools are now defined a separate file for each /default/docker_image/[tool]/values_[tool].yaml

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -4023,6 +4023,15 @@ Try all availability zones one by one in order to maximize the chances of gettin
 **type:** bool
 
 
+## **pre_filter_unavailable_availability_zones** / SCT_PRE_FILTER_UNAVAILABLE_AVAILABILITY_ZONES
+
+Filter availability zones upfront to only those that support all required instance types. Replaces invalid AZs with valid alternatives in the same region before any provisioning attempt. AWS only.
+
+**default:** True
+
+**type:** bool
+
+
 ## **num_nodes_to_rollback** / SCT_NUM_NODES_TO_ROLLBACK
 
 Number of nodes to upgrade and rollback in test_generic_cluster_upgrade

--- a/sdcm/provision/aws/az_resolver.py
+++ b/sdcm/provision/aws/az_resolver.py
@@ -1,0 +1,184 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2026 ScyllaDB
+
+import logging
+from typing import Callable
+
+from sdcm.utils.aws_region import AwsRegion
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _node_count_positive(value) -> bool:
+    """Indicates if an SCT node-count parameter resolves to >0 in any region."""
+    if value is None:
+        return False
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return value > 0
+    if isinstance(value, list):
+        return any(int(n) > 0 for n in value if str(n).strip().lstrip("-").isdigit())
+    if isinstance(value, str):
+        return any(int(n) > 0 for n in value.split() if n.strip().lstrip("-").isdigit())
+    return False
+
+
+def _has_loaders(params) -> bool:
+    return _node_count_positive(params.get("n_loaders"))
+
+
+def _has_monitor(params) -> bool:
+    return _node_count_positive(params.get("n_monitor_nodes"))
+
+
+def _has_oracle(params) -> bool:
+    return params.get("db_type") in ("mixed_scylla", "mixed_cassandra") and _node_count_positive(
+        params.get("n_test_oracle_db_nodes")
+    )
+
+
+def _has_zero_token(params) -> bool:
+    return bool(params.get("use_zero_nodes")) and _node_count_positive(params.get("n_db_zero_token_nodes"))
+
+
+def _has_vector_store(params) -> bool:
+    return _node_count_positive(params.get("n_vector_store_nodes"))
+
+
+def _always(params) -> bool:  # noqa: ARG001
+    return True
+
+
+# (instance-type param key, gate). The gate decides whether this type will actually
+# be launched by the test; types whose gate is False are excluded from the AZ-filter
+# intersection so SCT defaults like `instance_type_vector_store: 't4g.medium'` do not
+# constrain AZ choice for tests that have n_vector_store_nodes=0.
+_INSTANCE_TYPE_PARAM_GATES: tuple[tuple[str, Callable[[object], bool]], ...] = (
+    ("instance_type_db", _always),
+    ("instance_type_loader", _has_loaders),
+    ("instance_type_monitor", _has_monitor),
+    ("zero_token_instance_type_db", _has_zero_token),
+    ("instance_type_db_oracle", _has_oracle),
+    ("instance_type_db_target", _always),
+    ("nemesis_grow_shrink_instance_type", _always),
+    ("instance_type_vector_store", _has_vector_store),
+)
+
+
+class NoValidAvailabilityZoneError(Exception):
+    """Raised when no AZ supports all required instance types in the configured region(s)."""
+
+
+class AZResolver:
+    """Resolve `availability_zone` config to AZs supporting all required instance types."""
+
+    def __init__(self, params):
+        self._params = params
+
+    def required_instance_types(self) -> list[str]:
+        """Get the deduplicated list of instance types a test will launch."""
+        selected = []
+        for key, gate in _INSTANCE_TYPE_PARAM_GATES:
+            instance_type = self._params.get(key)
+            if instance_type and gate(self._params) and instance_type not in selected:
+                selected.append(instance_type)
+        return selected
+
+    def resolve(self) -> None:
+        """Filter `availability_zone` to AZs supporting all required types in every region.
+
+        If `pre_filter_unavailable_availability_zones` is False, returns without
+        modifying params. Multi-AZ configs ("a,b,c") have invalid AZs replaced with
+        valid alternatives that are valid across all configured regions.
+        Raises `NoValidAvailabilityZoneError` when no AZ letter is valid in every region.
+        """
+        if not self._params.get("pre_filter_unavailable_availability_zones"):
+            LOGGER.info("Upfront AZ filter disabled; skipping AZResolver.resolve()")
+            return
+
+        instance_types = self.required_instance_types()
+        if not instance_types:
+            LOGGER.info("No instance types declared; skipping AZ filter")
+            return
+
+        region_names = self._region_names()
+        if not region_names:
+            LOGGER.info("No region configured; skipping AZ filter")
+            return
+
+        configured_letters = self._configured_az_letters()
+        supported_letters = self._common_supported_letters(region_names, configured_letters, instance_types)
+        if not supported_letters:
+            raise NoValidAvailabilityZoneError(
+                f"No availability zone supports all required instance types {instance_types} "
+                f"across regions {region_names}; cannot proceed with provisioning."
+            )
+
+        resolved = [letter for letter in configured_letters if letter in supported_letters]
+        for letter in supported_letters:
+            if len(resolved) >= len(configured_letters):
+                break
+            if letter not in resolved:
+                resolved.append(letter)
+
+        new_value = ",".join(resolved)
+        original_value = self._params.get("availability_zone")
+        if new_value != original_value:
+            LOGGER.warning(
+                "AZResolver: availability_zone '%s' does not support all required "
+                "instance types %s in regions %s; replacing with '%s'",
+                original_value,
+                instance_types,
+                region_names,
+                new_value,
+            )
+            self._params["availability_zone"] = new_value
+        else:
+            LOGGER.info("AZResolver: availability_zone '%s' already valid for regions %s", original_value, region_names)
+
+    @staticmethod
+    def _common_supported_letters(
+        region_names: list[str], configured_letters: list[str], instance_types: list[str]
+    ) -> list[str]:
+        """Intersect supported AZ letters across all configured regions.
+
+        Returns letters in this order: configured letters first (preserving user
+        intent), then any additional supported letters sorted alphabetically.
+        """
+        common: set[str] | None = None
+        for region in region_names:
+            preferred_full = [f"{region}{letter}" for letter in configured_letters]
+            supported_full = AwsRegion(region_name=region).get_common_availability_zones(
+                instance_types=instance_types,
+                preferred_azs=preferred_full,
+            )
+            letters = {az[len(region) :] for az in supported_full}
+            common = letters if common is None else common & letters
+
+        if not common:
+            return []
+
+        configured_first = [l for l in configured_letters if l in common]
+        additional = sorted(common - set(configured_first))
+        return configured_first + additional
+
+    def _region_names(self) -> list[str]:
+        if regions := getattr(self._params, "region_names", None):
+            return list(regions)
+        raw = self._params.get("region_name") or ""
+        return raw.split()
+
+    def _configured_az_letters(self) -> list[str]:
+        raw = self._params.get("availability_zone") or ""
+        return [letter.strip() for letter in raw.split(",") if letter.strip()]

--- a/sdcm/provision/aws/capacity_errors.py
+++ b/sdcm/provision/aws/capacity_errors.py
@@ -1,0 +1,33 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2026 ScyllaDB
+
+import re
+
+from botocore.exceptions import ClientError
+
+CAPACITY_ERROR_CODES: list[str] = [
+    "InsufficientInstanceCapacity",
+    "Unsupported",
+    "InsufficientCapacity",
+]
+
+_AWS_ERROR_CODE_RE = re.compile(r"An error occurred \(([A-Za-z]+)\)")
+
+
+def is_capacity_error(exception: BaseException) -> bool:
+    """Return True if `exception` is an AWS capacity-shortage `ClientError`."""
+    if not isinstance(exception, ClientError):
+        return False
+    error_code = exception.response.get("Error", {}).get("Code", "")
+    codes = {error_code} | set(_AWS_ERROR_CODE_RE.findall(str(exception)))
+    return bool(codes & set(CAPACITY_ERROR_CODES))

--- a/sdcm/provision/aws/capacity_reservation.py
+++ b/sdcm/provision/aws/capacity_reservation.py
@@ -21,6 +21,7 @@ import boto3
 
 from sdcm.exceptions import CapacityReservationError
 from sdcm.test_config import TestConfig
+from sdcm.utils.aws_region import AwsRegion
 from sdcm.utils.common import all_aws_regions
 from sdcm.utils.parallel_object import ParallelObject
 from sdcm.utils.aws_utils import tags_as_ec2_tags
@@ -87,28 +88,20 @@ class SCTCapacityReservation:
         cls.reservations = result
 
     @staticmethod
-    def _get_supported_availability_zones(ec2, instance_types: List[str], initial_az: str) -> List[str]:
-        response = ec2.describe_instance_type_offerings(
-            LocationType="availability-zone",
-            Filters=[
-                {"Name": "instance-type", "Values": list(instance_types)},
-            ],
+    def _get_supported_availability_zones(
+        ec2,  # noqa: ARG004
+        instance_types: List[str],
+        region: str,
+        availability_zone: str,
+    ) -> List[str]:
+        # ec2 client in signature is for backward compatibility
+        aws_region = AwsRegion(region_name=region)
+        first_letter = next((part.strip() for part in (availability_zone or "").split(",") if part.strip()), "")
+        preferred = [f"{region}{first_letter}"] if first_letter else []
+        return aws_region.get_common_availability_zones(
+            instance_types=list(instance_types),
+            preferred_azs=preferred,
         )
-        offerings = response["InstanceTypeOfferings"]
-        azs = set.intersection(
-            *[
-                {offering["Location"] for offering in offerings if offering["InstanceType"] == instance_type}
-                for instance_type in instance_types
-            ]
-        )
-        azs = list(azs)
-        try:  # put initial az as first one to try
-            azs.remove(initial_az)
-            azs.insert(0, initial_az)
-        except ValueError:
-            LOGGER.warning("Initial availability zone %s does not support required instances", initial_az)
-        LOGGER.info("Supported availability zones for instance types %s: %s", instance_types, azs)
-        return azs
 
     @staticmethod
     def is_capacity_reservation_enabled(params: dict) -> bool:
@@ -152,7 +145,10 @@ class SCTCapacityReservation:
         LOGGER.info("Creating capacity reservation for test %s with request: %s", test_id, request)
         reservations = {}
         for availability_zone in cls._get_supported_availability_zones(
-            ec2=ec2, instance_types=list(request.keys()), initial_az=region + params.get("availability_zone")
+            ec2=ec2,
+            instance_types=list(request.keys()),
+            region=region,
+            availability_zone=params.get("availability_zone"),
         ):
             reservations[availability_zone[-1]] = {}
             LOGGER.info("Creating capacity reservation in %s", availability_zone)

--- a/sdcm/provision/aws/dedicated_host.py
+++ b/sdcm/provision/aws/dedicated_host.py
@@ -23,6 +23,7 @@ import tenacity
 
 
 from sdcm.wait import exponential_retry
+from sdcm.utils.aws_region import AwsRegion
 from sdcm.utils.aws_utils import tags_as_ec2_tags
 from sdcm.utils.common import all_aws_regions
 from sdcm.utils.parallel_object import ParallelObject
@@ -52,28 +53,18 @@ class SCTDedicatedHosts:
         )
 
     @staticmethod
-    def _get_supported_availability_zones(ec2, instance_types: list[str], initial_az: str) -> list[str]:
-        response = ec2.describe_instance_type_offerings(
-            LocationType="availability-zone",
-            Filters=[
-                {"Name": "instance-type", "Values": instance_types},
-            ],
+    def _get_supported_availability_zones(
+        ec2,  # noqa: ARG004
+        instance_types: list[str],
+        initial_az: str,
+    ) -> list[str]:
+        # ec2 client in signature is for backward compatibility; underlying call uses AwsRegion
+        region = initial_az[:-1] if initial_az else ""
+        preferred = [initial_az] if initial_az else []
+        return AwsRegion(region_name=region).get_common_availability_zones(
+            instance_types=list(instance_types),
+            preferred_azs=preferred,
         )
-        offerings = response["InstanceTypeOfferings"]
-        azs = set.intersection(
-            *[
-                {offering["Location"] for offering in offerings if offering["InstanceType"] == instance_type}
-                for instance_type in instance_types
-            ]
-        )
-        azs = list(azs)
-        try:  # put initial az as first one to try
-            azs.remove(initial_az)
-            azs.insert(0, initial_az)
-        except ValueError:
-            LOGGER.warning("Initial availability zone %s does not support required instances", initial_az)
-        LOGGER.info("Supported availability zones for instance types %s: %s", instance_types, azs)
-        return azs
 
     @classmethod
     def reserve(cls, params) -> None:

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1981,6 +1981,10 @@ class SCTConfiguration(BaseModel):
     aws_fallback_to_next_availability_zone: Boolean = SctField(
         description="Try all availability zones one by one in order to maximize the chances of getting the requested instance capacity.",
     )
+    pre_filter_unavailable_availability_zones: Boolean = SctField(
+        description="Filter availability zones upfront to only those that support all required instance types. "
+        "Replaces invalid AZs with valid alternatives in the same region before any provisioning attempt. AWS only.",
+    )
     num_nodes_to_rollback: int = SctField(
         description="Number of nodes to upgrade and rollback in test_generic_cluster_upgrade",
     )

--- a/sdcm/sct_provision/aws/layout.py
+++ b/sdcm/sct_provision/aws/layout.py
@@ -13,6 +13,7 @@
 
 from functools import cached_property
 
+from sdcm.provision.aws.az_resolver import AZResolver
 from sdcm.provision.aws.capacity_reservation import SCTCapacityReservation
 from sdcm.provision.aws.dedicated_host import SCTDedicatedHosts
 from sdcm.sct_provision.aws.cluster import OracleDBCluster, DBCluster, LoaderCluster, MonitoringCluster, PlacementGroup
@@ -27,6 +28,8 @@ class SCTProvisionAWSLayout(SCTProvisionLayout, cluster_backend="aws"):
 
     def provision(self):
         use_scylla_cloud = self._params.get("cluster_backend") == "xcloud" or self._params.get("xcloud_provider")
+
+        AZResolver(self._params).resolve()
 
         if self.placement_group:
             self.placement_group.provision()

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -80,6 +80,7 @@ from sdcm.cluster_k8s.eks import MonitorSetEKS
 from sdcm.cluster_cloud import ScyllaCloudCluster
 from sdcm.cql_stress_cassandra_stress_thread import CqlStressCassandraStressThread
 from sdcm.mgmt import get_scylla_manager_tool
+from sdcm.provision.aws.az_resolver import AZResolver
 from sdcm.provision.aws.capacity_reservation import SCTCapacityReservation
 from sdcm.kafka.kafka_cluster import LocalKafkaCluster
 from sdcm.provision.aws.emr_provisioner import EmrClusterProvisioner, ensure_emr_roles
@@ -1900,6 +1901,8 @@ class ClusterTester(unittest.TestCase):
 
         regions = self.params.get("region_name").split()
         services = get_ec2_services(regions)
+
+        AZResolver(self.params).resolve()
 
         for _ in regions:
             self.credentials.append(UserRemoteCredentials(key_file=user_credentials))

--- a/sdcm/utils/aws_region.py
+++ b/sdcm/utils/aws_region.py
@@ -101,6 +101,36 @@ class AwsRegion:
         )
         return [offering["Location"] for offering in response["InstanceTypeOfferings"]]
 
+    def get_common_availability_zones(
+        self,
+        instance_types: list[str],
+        preferred_azs: list[str] | None = None,
+    ) -> list[str]:
+        """Return AZs in the region that support ALL given instance types."""
+        if not instance_types:
+            return []
+
+        offerings = self.client.describe_instance_type_offerings(
+            LocationType="availability-zone",
+            Filters=[{"Name": "instance-type", "Values": list(instance_types)}],
+        )["InstanceTypeOfferings"]
+        azs_per_type = [{o["Location"] for o in offerings if o["InstanceType"] == itype} for itype in instance_types]
+        common_azs = set.intersection(*azs_per_type)
+
+        preferred_azs = preferred_azs or []
+        missing = [az for az in preferred_azs if az not in common_azs]
+        if missing:
+            LOGGER.warning(
+                "Preferred availability zones %s do not support all required instance types %s", missing, instance_types
+            )
+
+        # preferred valid AZs come first
+        ordered = [az for az in preferred_azs if az in common_azs]
+        ordered += [az for az in sorted(common_azs) if az not in ordered]
+
+        LOGGER.info("Availability zones in %s supporting %s: %s", self.region_name, instance_types, ordered)
+        return ordered
+
     @cached_property
     def vpc_ipv6_cidr(self):
         return ip_network(self.sct_vpc.ipv6_cidr_block_association_set[0]["Ipv6CidrBlock"])

--- a/unit_tests/unit/provisioner/test_az_resolver.py
+++ b/unit_tests/unit/provisioner/test_az_resolver.py
@@ -1,0 +1,270 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2026 ScyllaDB
+
+from unittest.mock import patch
+
+import pytest
+
+from sdcm.provision.aws.az_resolver import AZResolver, NoValidAvailabilityZoneError, _node_count_positive
+
+
+class _DotDict(dict):
+    __getattr__ = dict.__getitem__
+    __setattr__ = dict.__setitem__
+    __delattr__ = dict.__delitem__
+
+
+def _make_params(**overrides):
+    params = _DotDict(
+        {
+            "cluster_backend": "aws",
+            "region_name": "us-east-1",
+            "availability_zone": "a",
+            "instance_type_db": "i4i.large",
+            "instance_type_loader": "t3.small",
+            "instance_type_monitor": "t3.small",
+            "n_db_nodes": 3,
+            "n_loaders": 1,
+            "n_monitor_nodes": 1,
+            "pre_filter_unavailable_availability_zones": True,
+            **overrides,
+        }
+    )
+    params.region_names = params["region_name"].split()
+    return params
+
+
+@pytest.fixture(name="mock_aws_region_cls")
+def mock_aws_region_cls_fixture():
+    """Patch AwsRegion with a mock returning configurable AZ lists."""
+    with patch("sdcm.provision.aws.az_resolver.AwsRegion") as mock_cls:
+        instance = mock_cls.return_value
+        # default: every type is offered in a, b, c, d
+        instance.get_common_availability_zones.return_value = ["us-east-1a", "us-east-1b", "us-east-1c", "us-east-1d"]
+        instance.region_name = "us-east-1"
+        yield mock_cls, instance
+
+
+def test_required_instance_types_collects_all_role_types_when_active():
+    params = _make_params(
+        instance_type_db="i4i.large",
+        instance_type_loader="t3.small",
+        instance_type_monitor="t3.medium",
+        instance_type_db_oracle="i3.large",
+        instance_type_db_target="m6g.large",
+        nemesis_grow_shrink_instance_type="i4i.xlarge",
+        zero_token_instance_type_db="t3.micro",
+        instance_type_vector_store="t4g.medium",
+        n_loaders=1,
+        n_monitor_nodes=1,
+        n_test_oracle_db_nodes=1,
+        db_type="mixed_scylla",
+        n_db_zero_token_nodes=1,
+        use_zero_nodes=True,
+        n_vector_store_nodes=2,
+    )
+    types = AZResolver(params).required_instance_types()
+    assert set(types) == {
+        "i4i.large",
+        "t3.small",
+        "t3.medium",
+        "i3.large",
+        "m6g.large",
+        "i4i.xlarge",
+        "t3.micro",
+        "t4g.medium",
+    }
+
+
+def test_required_instance_types_skips_empty_and_missing():
+    params = _make_params(
+        instance_type_db="i4i.large",
+        instance_type_loader="",
+        instance_type_monitor=None,
+        # instance_type_db_oracle missing entirely
+        n_loaders=0,
+        n_monitor_nodes=0,
+    )
+    assert AZResolver(params).required_instance_types() == ["i4i.large"]
+
+
+def test_required_instance_types_excludes_types_with_zero_node_count():
+    """Instance types whose node count is 0 or feature flag is off must not constrain AZ filtering."""
+    params = _make_params(
+        instance_type_db="i4i.large",
+        instance_type_loader="c6i.xlarge",  # excluded: n_loaders=0
+        instance_type_monitor="t3.large",  # excluded: n_monitor_nodes=0
+        instance_type_vector_store="t4g.medium",  # excluded: n_vector_store_nodes=0
+        instance_type_db_oracle="i8g.2xlarge",  # excluded: db_type != mixed
+        zero_token_instance_type_db="i4i.large",  # excluded: use_zero_nodes=False
+        n_loaders=0,
+        n_monitor_nodes=0,
+        n_vector_store_nodes=0,
+        n_test_oracle_db_nodes=1,
+        db_type="scylla",
+        use_zero_nodes=False,
+    )
+    assert AZResolver(params).required_instance_types() == ["i4i.large"]
+
+
+def test_resolve_disabled_returns_unchanged(mock_aws_region_cls):
+    params = _make_params(pre_filter_unavailable_availability_zones=False, availability_zone="a,b")
+    AZResolver(params).resolve()
+    assert params["availability_zone"] == "a,b"
+
+
+def test_resolve_replaces_invalid_az_with_valid_alternative(mock_aws_region_cls):
+    _, region_instance = mock_aws_region_cls
+    # configured "a" not in the supported list - must be replaced
+    region_instance.get_common_availability_zones.return_value = ["us-east-1b", "us-east-1c"]
+    params = _make_params(availability_zone="a")
+    AZResolver(params).resolve()
+    assert params["availability_zone"] in {"b", "c"}
+
+
+def test_resolve_multi_az_drops_unsupported_and_fills_alternatives(mock_aws_region_cls):
+    _, region_instance = mock_aws_region_cls
+    region_instance.get_common_availability_zones.return_value = ["us-east-1a", "us-east-1c", "us-east-1d"]
+    # configured a,b,e — only "a" supported; must replace b + e with valid alternatives
+    params = _make_params(availability_zone="a,b,e")
+    AZResolver(params).resolve()
+    result = params["availability_zone"].split(",")
+    assert len(result) == 3
+    assert set(result) <= {"a", "c", "d"}  # only valid AZs, no duplicates implied by len check
+    assert "a" in result
+    assert "b" not in result
+    assert "e" not in result
+    assert len(set(result)) == 3
+
+
+def test_resolve_raises_when_no_valid_az_in_region(mock_aws_region_cls):
+    _, region_instance = mock_aws_region_cls
+    region_instance.get_common_availability_zones.return_value = []
+    params = _make_params(availability_zone="a")
+    with pytest.raises(NoValidAvailabilityZoneError):
+        AZResolver(params).resolve()
+
+
+def test_resolve_target_intersection_when_target_differs_from_db(mock_aws_region_cls):
+    _, region_instance = mock_aws_region_cls
+    # only "c" supports both db (x86) and target (arm)
+    region_instance.get_common_availability_zones.return_value = ["us-east-1c"]
+    params = _make_params(
+        instance_type_db="i4i.large",
+        instance_type_db_target="m6g.large",
+        availability_zone="a",
+    )
+    AZResolver(params).resolve()
+    assert params["availability_zone"] == "c"
+
+
+@pytest.fixture(name="mock_multi_region")
+def mock_multi_region_fixture():
+    """Patch AwsRegion to return configurable per-region AZ lists."""
+    region_returns: dict[str, list[str]] = {}
+
+    class _RegionStub:
+        def __init__(self, region_name):
+            self.region_name = region_name
+
+        def get_common_availability_zones(self, instance_types, preferred_azs):  # noqa: ARG002
+            return region_returns.get(self.region_name, [])
+
+    with patch("sdcm.provision.aws.az_resolver.AwsRegion", _RegionStub):
+        yield region_returns
+
+
+def test_resolve_multi_region_intersects_supported_az_letters(mock_multi_region):
+    mock_multi_region["us-east-1"] = ["us-east-1a", "us-east-1b"]
+    mock_multi_region["eu-west-1"] = ["eu-west-1b", "eu-west-1c"]
+    params = _make_params(region_name="us-east-1 eu-west-1", availability_zone="a")
+    AZResolver(params).resolve()
+    assert params["availability_zone"] == "b"
+
+
+def test_resolve_multi_region_raises_when_no_common_letter(mock_multi_region):
+    mock_multi_region["us-east-1"] = ["us-east-1a", "us-east-1b"]
+    mock_multi_region["eu-west-1"] = ["eu-west-1c", "eu-west-1d"]
+    params = _make_params(region_name="us-east-1 eu-west-1", availability_zone="a")
+    with pytest.raises(NoValidAvailabilityZoneError):
+        AZResolver(params).resolve()
+
+
+def test_resolve_multi_region_multi_az_drops_unsupported_and_fills(mock_multi_region):
+    """Multi-AZ × multi-region: letter must be supported in EVERY region; drop+fill applies."""
+    mock_multi_region["us-east-1"] = ["us-east-1a", "us-east-1b", "us-east-1c", "us-east-1d"]
+    mock_multi_region["eu-west-1"] = ["eu-west-1b", "eu-west-1c", "eu-west-1d"]
+    params = _make_params(region_name="us-east-1 eu-west-1", availability_zone="a,b,c")
+    AZResolver(params).resolve()
+    result = params["availability_zone"].split(",")
+    assert set(result) == {"b", "c", "d"}
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        # scalars
+        (None, False),
+        (True, True),
+        (False, False),
+        (0, False),
+        (1, True),
+        (3, True),
+        (-1, False),
+        (0.0, False),
+        (1.5, True),
+        # lists
+        ([], False),
+        ([0, 0], False),
+        ([2, 0], True),
+        ([-1, 0], False),
+        (["2", "0"], True),
+        (["0"], False),
+        # strings
+        ("", False),
+        ("0", False),
+        ("3", True),
+        ("3 4", True),
+        ("0 0", False),
+        ("-1", False),
+        ("abc", False),
+        # unsupported types
+        ({"a": 1}, False),
+    ],
+)
+def test_node_count_positive(value, expected):
+    assert _node_count_positive(value) is expected
+
+
+def test_required_instance_types_skips_target_when_none():
+    """`instance_type_db_target` unset / None must not constrain AZ filtering."""
+    params = _make_params(
+        instance_type_db="i4i.large",
+        instance_type_db_target=None,
+        nemesis_grow_shrink_instance_type="",
+        instance_type_loader="",
+        n_loaders=0,
+        instance_type_monitor="",
+        n_monitor_nodes=0,
+    )
+    assert AZResolver(params).required_instance_types() == ["i4i.large"]
+
+
+@pytest.mark.parametrize("az_value", ["", None])
+def test_resolve_with_unset_availability_zone_stays_unset(mock_aws_region_cls, az_value):
+    """Empty / None `availability_zone` means no explicit user choice; resolver leaves it effectively unset."""
+    _, region_instance = mock_aws_region_cls
+    region_instance.get_common_availability_zones.return_value = ["us-east-1b", "us-east-1c"]
+    params = _make_params(availability_zone=az_value)
+    AZResolver(params).resolve()
+    assert not params["availability_zone"]

--- a/unit_tests/unit/provisioner/test_capacity_errors.py
+++ b/unit_tests/unit/provisioner/test_capacity_errors.py
@@ -1,0 +1,43 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2026 ScyllaDB
+
+import pytest
+from botocore.exceptions import ClientError
+
+from sdcm.provision.aws.capacity_errors import is_capacity_error
+
+
+def _client_error(code: str, message: str) -> ClientError:
+    return ClientError({"Error": {"Code": code, "Message": message}}, "RunInstances")
+
+
+@pytest.mark.parametrize(
+    "exc,expected",
+    [
+        # direct capacity error code
+        (_client_error("InsufficientInstanceCapacity", "No capacity in eu-west-1a."), True),
+        # wrapped error: real code buried in the message, extracted via "An error occurred (X)" pattern
+        (
+            _client_error("ClientError", "An error occurred (InsufficientInstanceCapacity) when calling RunInstances"),
+            True,
+        ),
+        # distinct AWS error code sharing a prefix with a capacity code must not match
+        (_client_error("UnsupportedOperation", "Operation not supported in this region."), False),
+    ],
+)
+def test_is_capacity_error(exc, expected):
+    assert is_capacity_error(exc) is expected
+
+
+def test_is_capacity_error_false_for_non_client_exception():
+    assert is_capacity_error(ValueError("just a value error")) is False

--- a/unit_tests/unit/test_aws_region.py
+++ b/unit_tests/unit/test_aws_region.py
@@ -1,0 +1,98 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2026 ScyllaDB
+
+from unittest.mock import MagicMock, patch
+import pytest
+
+from sdcm.utils.aws_region import AwsRegion
+
+
+@pytest.fixture(name="aws_region")
+def aws_region_fixture():
+    with (
+        patch("sdcm.utils.aws_region.boto3.client", return_value=MagicMock()) as mock_client,
+        patch("sdcm.utils.aws_region.boto3.resource"),
+        patch("sdcm.utils.common.all_aws_regions", return_value=["us-east-1", "eu-west-1"]),
+    ):
+        region = AwsRegion(region_name="us-east-1")
+        region._mock_ec2 = mock_client.return_value
+        yield region
+
+
+def _set_offerings(region: AwsRegion, offerings: list[tuple[str, str]]) -> None:
+    region._mock_ec2.describe_instance_type_offerings.return_value = {
+        "InstanceTypeOfferings": [{"Location": loc, "InstanceType": itype} for loc, itype in offerings]
+    }
+
+
+def test_get_common_availability_zones_intersection(aws_region):
+    _set_offerings(
+        aws_region,
+        [
+            ("us-east-1a", "i4i.large"),
+            ("us-east-1b", "i4i.large"),
+            ("us-east-1d", "i4i.large"),
+            ("us-east-1a", "t3.small"),
+            ("us-east-1d", "t3.small"),
+        ],
+    )
+    result = aws_region.get_common_availability_zones(["i4i.large", "t3.small"])
+    # only AZs supporting BOTH types
+    assert set(result) == {"us-east-1a", "us-east-1d"}
+
+
+@pytest.mark.parametrize(
+    "preferred_azs,expected_prefix",
+    [
+        (["us-east-1d"], ["us-east-1d"]),
+        (["us-east-1d", "us-east-1b"], ["us-east-1d", "us-east-1b"]),
+    ],
+)
+def test_get_common_availability_zones_preferred_first(aws_region, preferred_azs, expected_prefix):
+    _set_offerings(
+        aws_region,
+        [
+            ("us-east-1a", "i4i.large"),
+            ("us-east-1b", "i4i.large"),
+            ("us-east-1c", "i4i.large"),
+            ("us-east-1d", "i4i.large"),
+        ],
+    )
+    result = aws_region.get_common_availability_zones(["i4i.large"], preferred_azs=preferred_azs)
+    assert result[: len(expected_prefix)] == expected_prefix
+
+
+def test_get_common_availability_zones_empty_when_no_overlap(aws_region):
+    _set_offerings(
+        aws_region,
+        [
+            ("us-east-1a", "i4i.large"),
+            ("us-east-1b", "t3.small"),
+        ],
+    )
+    assert aws_region.get_common_availability_zones(["i4i.large", "t3.small"]) == []
+
+
+def test_get_common_availability_zones_preferred_unavailable_ignored(aws_region):
+    _set_offerings(
+        aws_region,
+        [
+            ("us-east-1a", "i4i.large"),
+            ("us-east-1b", "i4i.large"),
+        ],
+    )
+    # preferred AZ does not support the type — should be silently dropped from prefix,
+    # remaining AZs returned in some order
+    result = aws_region.get_common_availability_zones(["i4i.large"], preferred_azs=["us-east-1c"])
+    assert set(result) == {"us-east-1a", "us-east-1b"}
+    assert "us-east-1c" not in result


### PR DESCRIPTION
Phases 1-2 implementation of the plan: [docs/plans/infrastructure/aws-capacity-az-fallback.md](https://github.com/scylladb/scylla-cluster-tests/blob/da3ffd7d51b90b15f10b922b029cc8c6f92dc41b/docs/plans/infrastructure/aws-capacity-az-fallback.md)

Tests frequently fail at provision time when the configured AZ does not offer the requested instance type.
The change centralize AZ discovery and capacity-error classification. Adds AZResolver that runs before provisioning in both legacy and modern paths to drop unsupported AZs (replacing them with valid alternatives in the same region). Covers existing role types plus dynamically-added ones (instance_type_db_target, nemesis_grow_shrink_instance_type).
Raises exception before any RunInstances call, when no AZ supports the full type set.

Gated by pre_filter_unavailable_availability_zones SCT config parameter (default true).

Refs: https://scylladb.atlassian.net/browse/SCT-295

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [invalid AZ 'f' in us-east-1 is replaced with valid alternative](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/pr-provision-test/267/)
AZResolver detects that the configured AZ does not offer all required instance types, replaces with a valid alternative in the same region, and provisioning proceeds in the new AZ.

Some logs from the run:
AZResolver fired with replacement
```
❯ grep "AZResolver:" sct-55aead5f.log
< t:2026-05-08 23:33:54,455 f:az_resolver.py  l:147  c:sdcm.provision.aws.az_resolver p:WARNING > AZResolver: availability_zone 'f' does not support all required instance types ['i8g.2xlarge', 'c6i.xlarge', 't3.large'] in regions ['us-east-1']; replacing with 'a'
```
Prefered AZ from AwsRegion:
```
❯ grep "Preferred availability zones\|Availability zones in us-east-1 supporting" sct-55aead5f.log
< t:2026-05-08 23:33:54,453 f:aws_region.py   l:123  c:sdcm.utils.aws_region p:WARNING > Preferred availability zones ['us-east-1f'] do not support all required instance types ['i8g.2xlarge', 'c6i.xlarge', 't3.large']
< t:2026-05-08 23:33:54,453 f:aws_region.py   l:131  c:sdcm.utils.aws_region p:INFO  > Availability zones in us-east-1 supporting ['i8g.2xlarge', 'c6i.xlarge', 't3.large']: ['us-east-1a', 'us-east-1b', 'us-east-1c', 'us-east-1d']
```
EC2 activities moved to replacement AZ - no `us-east-1f` log entries after the resolver handled the replacement:
```
❯ grep "us-east-1f" sct-55aead5f.log
< t:2026-05-08 23:33:54,453 f:aws_region.py   l:123  c:sdcm.utils.aws_region p:WARNING > Preferred availability zones ['us-east-1f'] do not support all required instance types ['i8g.2xlarge', 'c6i.xlarge', 't3.large']
```
Subnet lookup in the replacement AZ
```
❯ grep -E "AvailabilityZone.: .us-east-1a.|SCT-2-subnet-us-east-1a" sct-55aead5f.log | head
< t:2026-05-08 23:33:55,191 f:aws_region.py   l:153  c:sdcm.utils.aws_region p:DEBUG > Found Subnets: {'Subnets': [{'AvailabilityZoneId': 'use1-az1', 'MapCustomerOwnedIpOnLaunch': False, 'OwnerId': '797456418907', 'AssignIpv6AddressOnCreation': True, 'Ipv6CidrBlockAssociationSet': [{'AssociationId': 'subnet-cidr-assoc-018122b708b8b5919', 'Ipv6CidrBlock': '2600:1f18:7f4:3c00::/64', 'Ipv6CidrBlockState': {'State': 'associated'}, 'Ipv6AddressAttribute': 'public', 'IpSource': 'amazon'}], 'Tags': [{'Key': 'Name', 'Value': 'SCT-2-subnet-us-east-1a'}], 'SubnetArn': 'arn:aws:ec2:us-east-1:797456418907:subnet/subnet-0a09ba4421ec6aaa8', 'EnableDns64': False, 'Ipv6Native': False, 'PrivateDnsNameOptionsOnLaunch': {'HostnameType': 'ip-name', 'EnableResourceNameDnsARecord': False, 'EnableResourceNameDnsAAAARecord': False}, 'BlockPublicAccessStates': {'InternetGatewayBlockMode': 'off'}, 'SubnetId': 'subnet-0a09ba4421ec6aaa8', 'State': 'available', 'VpcId': 'vpc-0935da7392dc9d4d8', 'CidrBlock': '10.12.0.0/22', 'AvailableIpAddressCount': 986, 'AvailabilityZone': 'us-east-1a', 'DefaultForAz': False, 'MapPublicIpOnLaunch': True}], 'ResponseMetadata': {'RequestId': '0a18d4c5-219e-48eb-b846-5bd0eb99170a', 'HTTPStatusCode': 200, 'HTTPHeaders': {'x-amzn-requestid': '0a18d4c5-219e-48eb-b846-5bd0eb99170a', 'cache-control': 'no-cache, no-store', 'strict-transport-security': 'max-age=31536000; includeSubDomains', 'content-type': 'text/xml;charset=UTF-8', 'content-length': '1675', 'date': 'Fri, 08 May 2026 23:33:55 GMT', 'server': 'AmazonEC2'}, 'RetryAttempts': 0}}
```
- [x] [no AZ supports all specified types; fail fast before any instances are run](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/pr-provision-test/268/)
The exception is raised during provisioning step (as expected):
```
12:50:14  sdcm.provision.aws.az_resolver.NoValidAvailabilityZoneError: No availability zone supports all required instance types ['dl1.24xlarge', 'hpc7g.16xlarge', 't3.large'] across regions ['us-east-1']; cannot proceed with provisioning.
```


### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
