### PR TITLE
fix(sct-runner): increase nofile soft limit from `4096` to `65536`

### DIFF
--- a/docker/env/hydra.sh
+++ b/docker/env/hydra.sh
@@ -284,6 +284,7 @@ function run_in_docker () {
         --env TERM \
         --net=host \
         --ulimit core=-1 \
+        --ulimit nofile=65536:65536 \
         -v /var/lib/systemd/coredump:/var/lib/systemd/coredump \
         --name="${SCT_TEST_ID}_$(date +%s)" \
         ${DOCKER_REGISTRY}/${DOCKER_REPO}:${VERSION} \

--- a/sdcm/sct_runner.py
+++ b/sdcm/sct_runner.py
@@ -311,9 +311,9 @@ class SctRunner(ABC):
             until [ -f /var/lib/cloud/instance/boot-finished ]; do sleep 1; done
 
             echo "fs.aio-max-nr = {AIO_MAX_NR_RECOMMENDED_VALUE}" >> /etc/sysctl.conf
-            echo "{login_user} soft nofile 4096" >> /etc/security/limits.conf
-            echo "jenkins soft nofile 4096" >> /etc/security/limits.conf
-            echo "root soft nofile 4096" >> /etc/security/limits.conf
+            echo "{login_user} soft nofile 65536" >> /etc/security/limits.conf
+            echo "jenkins soft nofile 65536" >> /etc/security/limits.conf
+            echo "root soft nofile 65536" >> /etc/security/limits.conf
 
             # Configure default user account.
             sudo -u {login_user} mkdir -p /home/{login_user}/.ssh || true


### PR DESCRIPTION
The SCT runner host was hitting file descriptor exhaustion (EMFILE)
during the `stress_after_cluster_upgrade` phase of multi-DC latency regression tests.
With 20+ concurrent latte workloads across 10 loader nodes,
the cumulative SSH sessions and log file handles exceeded the 4096 soft limit.

Bump the limit to the 65536 to match limits used by other SCT components (c-s, sct-agent).

Closes: #SCT-338

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
