### PR TITLE
fix(oci): properly propagate the rack index

### DIFF
--- a/sdcm/cluster_oci.py
+++ b/sdcm/cluster_oci.py
@@ -325,7 +325,7 @@ class OciCluster(cluster.BaseCluster):
         nodes = []
 
         instance_dc = 0 if self.params.get("simulated_regions") else dc_idx
-        instances = self._create_instances(count, instance_dc, instance_type=instance_type)
+        instances = self._create_instances(count, instance_dc, instance_type=instance_type, rack=rack)
 
         self.log.debug("instances: %s", instances)
         for node_index, instance in enumerate(instances, start=self._node_index + 1):
@@ -359,21 +359,22 @@ class OciCluster(cluster.BaseCluster):
         except Exception as ex:  # noqa: BLE001
             raise CreateOciNodeError("Failed to create node: %s" % ex) from ex
 
-    def _create_instances(self, count, dc_idx=0, instance_type=None) -> List[VmInstance]:
+    def _create_instances(self, count, dc_idx=0, instance_type=None, rack=None) -> List[VmInstance]:
         region = self._definition_builder.regions[dc_idx]
         assert region, "no region provided, please add `oci_region_name` param"
         pricing_model = PricingModel.SPOT if "spot" in self.instance_provision else PricingModel.ON_DEMAND
         definitions = []
         for node_index in range(self._node_index + 1, self._node_index + count + 1):
-            definitions.append(
-                self._definition_builder.build_instance_definition(
-                    region=region,
-                    node_type=self.node_type,
-                    index=node_index,
-                    dc_idx=dc_idx,
-                    instance_type=instance_type,
-                )
+            definition = self._definition_builder.build_instance_definition(
+                region=region,
+                node_type=self.node_type,
+                index=node_index,
+                dc_idx=dc_idx,
+                instance_type=instance_type,
             )
+            if rack is not None:
+                definition.rack_index = rack
+            definitions.append(definition)
         return provision_instances_with_fallback(
             self.provisioners[dc_idx],
             definitions=definitions,

--- a/sdcm/provision/oci/virtual_machine_provider.py
+++ b/sdcm/provision/oci/virtual_machine_provider.py
@@ -72,8 +72,11 @@ class VirtualMachineProvider:
         az_to_use = az_list[0]
         if definition and len(az_list) > 1:
             try:
-                node_index = int(definition.tags.get("NodeIndex", 1))
-                az_to_use = az_list[(node_index - 1) % len(az_list)]
+                if definition.rack_index is not None:
+                    az_to_use = az_list[definition.rack_index % len(az_list)]
+                else:
+                    node_index = int(definition.tags.get("NodeIndex", 1))
+                    az_to_use = az_list[(node_index - 1) % len(az_list)]
             except (ValueError, TypeError):
                 LOGGER.warning(
                     "Could not determine valid NodeIndex for instance %s, using first AZ: %s",

--- a/sdcm/provision/provisioner.py
+++ b/sdcm/provision/provisioner.py
@@ -55,6 +55,7 @@ class InstanceDefinition:
         default_factory=list, repr=False
     )  # None when no cloud-init use at all
     use_public_ip: bool = False
+    rack_index: int | None = None  # explicit rack index for rack-aware placement
 
 
 class ProvisionError(Exception):


### PR DESCRIPTION
In the OCI backend the rack parameter passed to the `add_nodes`
was never propagated to the `_create_instances` method.
    
So, fix it by adding the `rack_index` attr to the `InstanceDefinition` class
and utilize for the creation of the OCI VMs.
    
Closes: #SCT-337

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
