### PR TITLE
fix(tester): guard DECODING_QUEUE.close() with hasattr check

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -3986,7 +3986,7 @@ class ClusterTester(unittest.TestCase):
         self.stop_resources()
 
         with silence(parent=self, name="closing decoding queue as needed"):
-            if self.test_config.BACKTRACE_DECODING:
+            if self.test_config.BACKTRACE_DECODING and hasattr(self.test_config.DECODING_QUEUE, "close"):
                 self.test_config.DECODING_QUEUE.close()
 
         # NOTE: running on K8S we need to gather logs otherwise a lot of


### PR DESCRIPTION
## Summary
- Guard `DECODING_QUEUE.close()` call in teardown with `hasattr` check
- In unit tests, `DECODING_QUEUE` can be a `queue.Queue` (stdlib) instead of `multiprocessing.Queue` because `MagicMock` objects can't be pickled into a multiprocessing queue
- `queue.Queue` lacks a `.close()` method, causing `AttributeError` on teardown that fails `test_longevity`

Fixes the failure seen in https://github.com/scylladb/scylla-cluster-tests/pull/14564#issuecomment-4409071908