### PR TITLE
feature(hydra): Add get-official-supported-versions command

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -143,7 +143,7 @@ from sdcm.utils.version_utils import get_s3_scylla_repos_mapping, parse_scylla_v
 import sdcm.provision.azure.utils as azure_utils
 from utils.build_system.create_test_release_jobs import JenkinsPipelines
 from utils.build_system.throttle_categories import ThrottleCategoryManager, ThrottleCategory
-from utils.get_supported_scylla_base_versions import UpgradeBaseVersion
+from utils.get_supported_scylla_base_versions import UpgradeBaseVersion, fetch_official_supported_versions
 from sdcm.utils.docker_utils import get_ip_address_of_container
 from sdcm.utils.hdrhistogram import make_hdrhistogram_summary_by_interval
 from unit_tests.unit.nemesis.fake_cluster import FakeTester
@@ -1319,6 +1319,36 @@ def get_scylla_base_versions(
     for version in version_list:
         tbl.add_row(version, version_detector.repo_maps[version])
     click.echo(rich_table_to_string(tbl, title="Base Versions"))
+    return
+
+
+@cli.command("get-official-supported-versions", help="Get officially supported ScyllaDB versions")
+@click.option(
+    "-o",
+    "--only-print-versions",
+    type=bool,
+    default=False,
+    required=False,
+    help="Print only the versions as plain output instead of the table view",
+)
+def get_official_supported_versions(only_print_versions):
+    """
+    Fetch officially supported ScyllaDB versions from the scylladb-docs-homepage repository.
+    Returns versions that have status "Supported" in the upstream supported_versions.json.
+    """
+    add_file_logger()
+
+    version_list = fetch_official_supported_versions()
+    click.echo(f"Official Supported Versions: {' '.join(version_list)}")
+
+    if only_print_versions:
+        click.echo(" ".join(version_list))
+        return
+
+    tbl = Table("Supported Versions", show_lines=False)
+    for version in version_list:
+        tbl.add_row(version)
+    click.echo(rich_table_to_string(tbl, title="Supported Versions"))
     return
 
 

--- a/unit_tests/unit/test_get_official_supported_versions.py
+++ b/unit_tests/unit/test_get_official_supported_versions.py
@@ -1,0 +1,100 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2026 ScyllaDB
+
+"""Unit tests for fetch_official_supported_versions and the CLI command."""
+
+from unittest.mock import patch, MagicMock
+
+from click.testing import CliRunner
+
+from sct import get_official_supported_versions
+from utils.get_supported_scylla_base_versions import fetch_official_supported_versions
+
+SAMPLE_RESPONSE = {
+    "data": [
+        {"version": "ScyllaDB 2026.1", "status": "Supported"},
+        {"version": "ScyllaDB 2025.4", "status": "Supported"},
+        {"version": "ScyllaDB 2025.3", "status": " Not supported"},
+        {"version": "ScyllaDB 2025.2", "status": "Not supported"},
+        {"version": "ScyllaDB 2025.1 (LTS)", "status": "Supported"},
+        {"version": "Enterprise 2024.2", "status": "Not supported"},
+    ]
+}
+
+
+def _mock_session_get(url, timeout=30):
+    resp = MagicMock()
+    resp.json.return_value = SAMPLE_RESPONSE
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+def test_fetch_official_supported_versions_filters_supported():
+    """Only versions with status 'Supported' are returned."""
+    mock_session = MagicMock()
+    mock_session.get.side_effect = _mock_session_get
+
+    with patch("utils.get_supported_scylla_base_versions.create_retry_session", return_value=mock_session):
+        result = fetch_official_supported_versions()
+
+    assert result == ["2026.1", "2025.4", "2025.1"]
+
+
+def test_fetch_official_supported_versions_extracts_version_number():
+    """Version numbers are extracted from strings like 'ScyllaDB 2025.1 (LTS)'."""
+    mock_session = MagicMock()
+    resp = MagicMock()
+    resp.json.return_value = {
+        "data": [
+            {"version": "ScyllaDB 2025.1 (LTS)", "status": "Supported"},
+        ]
+    }
+    resp.raise_for_status = MagicMock()
+    mock_session.get.return_value = resp
+
+    with patch("utils.get_supported_scylla_base_versions.create_retry_session", return_value=mock_session):
+        result = fetch_official_supported_versions()
+
+    assert result == ["2025.1"]
+
+
+def test_fetch_official_supported_versions_empty_data():
+    """Returns empty list when no versions are supported."""
+    mock_session = MagicMock()
+    resp = MagicMock()
+    resp.json.return_value = {"data": []}
+    resp.raise_for_status = MagicMock()
+    mock_session.get.return_value = resp
+
+    with patch("utils.get_supported_scylla_base_versions.create_retry_session", return_value=mock_session):
+        result = fetch_official_supported_versions()
+
+    assert result == []
+
+
+def test_cli_get_official_supported_versions_output():
+    """CLI command prints supported versions and exits 0."""
+    with (
+        patch(
+            "sct.fetch_official_supported_versions",
+            return_value=["2026.1", "2025.4", "2025.1"],
+        ),
+        patch("sct.add_file_logger"),
+    ):
+        runner = CliRunner()
+        result = runner.invoke(get_official_supported_versions)
+
+    assert result.exit_code == 0
+    assert "2026.1" in result.output
+    assert "2025.4" in result.output
+    assert "2025.1" in result.output

--- a/utils/get_supported_scylla_base_versions.py
+++ b/utils/get_supported_scylla_base_versions.py
@@ -4,6 +4,7 @@ import sys
 import re
 import os
 
+from sdcm.utils.session import create_retry_session
 from sdcm.utils.version_utils import (
     is_enterprise,
     get_all_versions,
@@ -279,3 +280,41 @@ class UpgradeBaseVersion:
         version_list = self.get_supported_scylla_base_versions(supported_versions)
         LOGGER.info("Got supported releases version list: %s", version_list)
         return supported_versions, version_list
+
+
+SUPPORTED_VERSIONS_URL = (
+    "https://raw.githubusercontent.com/scylladb/scylladb-docs-homepage/main/docs/_static/data/supported_versions.json"
+)
+
+
+def fetch_official_supported_versions(url: str = SUPPORTED_VERSIONS_URL) -> list[str]:
+    """Fetch officially supported ScyllaDB versions from the scylladb-docs-homepage repository.
+
+    Reads the supported_versions.json file, filters entries with status "Supported",
+    and extracts the version number (e.g. "ScyllaDB 2026.1" -> "2026.1").
+
+    Args:
+        url: URL to the supported_versions.json file.
+
+    Returns:
+        List of supported version strings, e.g. ["2026.1", "2025.4", "2025.1"].
+    """
+    LOGGER.info("Fetching official supported versions from %s", url)
+    session = create_retry_session()
+    response = session.get(url, timeout=30)
+    response.raise_for_status()
+    data = response.json()
+
+    supported = []
+    for entry in data.get("data", []):
+        status = entry.get("status", "").strip()
+        if status != "Supported":
+            continue
+        version_str = entry.get("version", "")
+        # Extract version number from strings like "ScyllaDB 2026.1" or "ScyllaDB 2025.1 (LTS)"
+        match = re.search(r"(\d{4}\.\d+)", version_str)
+        if match:
+            supported.append(match.group(1))
+
+    LOGGER.info("Official supported versions: %s", supported)
+    return supported


### PR DESCRIPTION
Add fetch_official_supported_versions() function that retrieves currently supported ScyllaDB versions from the scylladb-docs-homepage repository's supported_versions.json. Versions with status 'Supported' are filtered and their version numbers extracted (e.g. 'ScyllaDB 2026.1' -> '2026.1'). Expose this as a new get-official-supported-versions CLI command in sct.py.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] tested locally on my machine

`--only-print-versions false`
```
(get_supported_scylla_versions) $ ./docker/env/hydra.sh get-official-supported-versions

Official Versions 
┏━━━━━━━━━━━━━━━━┓
┃ Version Family ┃
┡━━━━━━━━━━━━━━━━┩
│ 2026.1         │
│ 2025.4         │
│ 2025.1         │
└────────────────┘
```

`--only-print-versions true`
```
(get_supported_scylla_versions) $ ./docker/env/hydra.sh get-official-supported-versions --only-print-versions true

Official Versions: 2026.1 2025.4 2025.1
```


### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
