### PR TITLE
feature(stress-tools): add cs_extra_jvm_opts for cassandra-stress JVM tuning

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -369,3 +369,4 @@ agent:
   tls: false
 
 c_s_driver_version: '3'
+cs_extra_jvm_opts: ''

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -3364,6 +3364,16 @@ enable debug for cassandra-stress
 **type:** bool
 
 
+## **cs_extra_jvm_opts** / SCT_CS_EXTRA_JVM_OPTS
+
+Extra JVM options passed to cassandra-stress via JVM_OPTS environment variable. Recommended for low-latency: '-XX:+UseZGC -XX:+ZGenerational -Xms8g -Xmx8g -XX:+AlwaysPreTouch' (requires Java 21+, which cassandra-stress 3.20.6+ ships with).
+
+**default:** N/A
+
+**type:** str
+* appendable
+
+
 ## **stress_cmd_mv** / SCT_STRESS_CMD_MV
 
 cassandra-stress commands. You can specify everything but the -node parameter, which is going to be provided by the test suite infrastructure. Multiple commands can be passed as a list

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1731,6 +1731,11 @@ class SCTConfiguration(BaseModel):
     cs_debug: Boolean = SctField(
         description="enable debug for cassandra-stress",
     )
+    cs_extra_jvm_opts: String = SctField(
+        description="Extra JVM options passed to cassandra-stress via JVM_OPTS environment variable. "
+        "Recommended for low-latency: '-XX:+UseZGC -XX:+ZGenerational -Xms8g -Xmx8g -XX:+AlwaysPreTouch' "
+        "(requires Java 21+, which cassandra-stress 3.20.6+ ships with).",
+    )
     stress_cmd_mv: StringOrList = SctField(
         description="cassandra-stress commands. You can specify everything but the -node parameter, which is going to be provided by the test suite infrastructure. Multiple commands can be passed as a list",
     )

--- a/sdcm/stress_thread.py
+++ b/sdcm/stress_thread.py
@@ -346,6 +346,10 @@ class CassandraStressThread(DockerBasedStressThread):
             cmd_runner_name = loader.ip_address
 
             cpu_options = ""
+            jvm_opts = ""
+            if cs_extra_jvm_opts := self.params.get("cs_extra_jvm_opts"):
+                jvm_opts = f" -e JVM_OPTS='{cs_extra_jvm_opts}'"
+                LOGGER.info("Passing JVM_OPTS to cassandra-stress container: %s", cs_extra_jvm_opts)
             cmd_runner = cleanup_context = RemoteDocker(
                 loader,
                 self.docker_image_name,
@@ -356,7 +360,8 @@ class CassandraStressThread(DockerBasedStressThread):
                 f"--label shell_marker={self.shell_marker}"
                 f" --entrypoint /bin/bash"
                 f" -w /"
-                f" -v {remote_hdr_file_name_full_path}:/{remote_hdr_file_name}",
+                f" -v {remote_hdr_file_name_full_path}:/{remote_hdr_file_name}"
+                f"{jvm_opts}",
             )
 
         stress_cmd = self.create_stress_cmd(cmd_runner, keyspace_idx, loader)
@@ -389,6 +394,13 @@ class CassandraStressThread(DockerBasedStressThread):
             hdrh_logger_context = contextlib.nullcontext()
 
         LOGGER.info("Stress command:\n%s", stress_cmd)
+
+        if self.params.get("cs_extra_jvm_opts"):
+            try:
+                env_check = cmd_runner.run("echo JVM_OPTS=$JVM_OPTS", ignore_status=True, verbose=False)
+                LOGGER.info("JVM_OPTS env inside container: %s", env_check.stdout.strip())
+            except Exception:  # noqa: BLE001
+                LOGGER.debug("Could not verify JVM_OPTS inside container", exc_info=True)
 
         tag = f"TAG: loader_idx:{loader_idx}-cpu_idx:{cpu_idx}-keyspace_idx:{keyspace_idx}"
 

--- a/test-cases/performance/perf-regression-latency-650gb-elasticity.yaml
+++ b/test-cases/performance/perf-regression-latency-650gb-elasticity.yaml
@@ -33,6 +33,8 @@ argus_email_report_template: email_report_performance.yaml
 email_recipients: ["scylla-perf-results@scylladb.com"]
 use_prepared_loaders: false
 use_hdrhistogram: true
+
+cs_extra_jvm_opts: '-XX:+UseZGC -XX:+ZGenerational -Xms8g -Xmx8g -XX:+AlwaysPreTouch'
 email_subject_postfix: 'elasticity test'
 nemesis_double_load_during_grow_shrink_duration: 30
 parallel_node_operations: true

--- a/test-cases/performance/perf-regression-latency-650gb-upgrade.yaml
+++ b/test-cases/performance/perf-regression-latency-650gb-upgrade.yaml
@@ -29,6 +29,8 @@ backtrace_stall_decoding: false
 email_recipients: ["scylla-perf-results@scylladb.com"]
 use_prepared_loaders: false
 use_hdrhistogram: true
+
+cs_extra_jvm_opts: '-XX:+UseZGC -XX:+ZGenerational -Xms8g -Xmx8g -XX:+AlwaysPreTouch'
 use_placement_group: true
 email_subject_postfix: 'latency during upgrades'
 argus_email_report_template: email_report_performance.yaml

--- a/test-cases/performance/perf-regression-latency-650gb-with-nemesis.yaml
+++ b/test-cases/performance/perf-regression-latency-650gb-with-nemesis.yaml
@@ -32,6 +32,8 @@ backtrace_stall_decoding: false
 email_recipients: ["scylla-perf-results@scylladb.com"]
 use_prepared_loaders: false
 use_hdrhistogram: true
+
+cs_extra_jvm_opts: '-XX:+UseZGC -XX:+ZGenerational -Xms8g -Xmx8g -XX:+AlwaysPreTouch'
 use_placement_group: true
 use_capacity_reservation: true
 email_subject_postfix: 'latency during operations'

--- a/test-cases/performance/perf-regression-predefined-throughput-steps.yaml
+++ b/test-cases/performance/perf-regression-predefined-throughput-steps.yaml
@@ -77,6 +77,8 @@ email_recipients: ['scylla-perf-results@scylladb.com']
 
 use_hdrhistogram: true
 
+cs_extra_jvm_opts: '-XX:+UseZGC -XX:+ZGenerational -Xms8g -Xmx8g -XX:+AlwaysPreTouch'
+
 append_scylla_args: '--blocked-reactor-notify-ms 5 --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc --abort-on-internal-error 1 --abort-on-ebadf 1'
 append_scylla_yaml:
   auto_snapshot: false

--- a/unit_tests/integration/test_cassandra_stress_thread.py
+++ b/unit_tests/integration/test_cassandra_stress_thread.py
@@ -10,6 +10,9 @@
 # See LICENSE for more details.
 #
 # Copyright (c) 2022 ScyllaDB
+import subprocess
+import time
+
 import pytest
 
 from sdcm.stress_thread import CassandraStressThread
@@ -156,6 +159,69 @@ def test_05_cassandra_stress_compression(request, docker_scylla, params, compres
     request.addfinalizer(cleanup_thread)
 
     cs_thread.run()
+
+    output, _ = cs_thread.parse_results()
+    assert "latency mean" in output[0]
+    assert float(output[0]["latency mean"]) > 0
+
+    assert "latency 99th percentile" in output[0]
+    assert float(output[0]["latency 99th percentile"]) > 0
+
+
+def test_06_cassandra_stress_with_extra_jvm_opts(request, docker_scylla, params):
+    jvm_opts = "-XX:+UseZGC -XX:+ZGenerational -Xms512m -Xmx512m -XX:+AlwaysPreTouch"
+    params["cs_extra_jvm_opts"] = jvm_opts
+
+    loader_set = LocalLoaderSetDummy(params=params)
+
+    cmd = (
+        "cassandra-stress write cl=ONE duration=30s -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=1) "
+        "compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native "
+        "-rate threads=5 -pop seq=1..10000000 -log interval=5"
+    )
+
+    cs_thread = CassandraStressThread(loader_set, cmd, node_list=[docker_scylla], timeout=120, params=params)
+
+    def cleanup_thread():
+        cs_thread.kill()
+
+    request.addfinalizer(cleanup_thread)
+
+    cs_thread.run()
+
+    # Wait briefly for the Java process to start inside the container
+    time.sleep(5)
+
+    # Find the cassandra-stress container by shell_marker label
+    result = subprocess.run(
+        ["docker", "ps", "--filter", f"label=shell_marker={cs_thread.shell_marker}", "--format", "{{.ID}}"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    container_id = result.stdout.strip().split("\n")[0]
+    assert container_id, "Could not find cassandra-stress container"
+
+    # Verify JVM_OPTS env var is set inside the container
+    result = subprocess.run(
+        ["docker", "exec", container_id, "bash", "-c", "echo $JVM_OPTS"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    actual_jvm_opts = result.stdout.strip()
+    assert actual_jvm_opts == jvm_opts, f"JVM_OPTS not set correctly inside container: {actual_jvm_opts!r}"
+
+    result = subprocess.run(
+        ["docker", "exec", container_id, "bash", "-c", "cat /proc/$(pgrep -x java | head -1)/cmdline | tr '\\0' ' '"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    java_cmdline = result.stdout
+    assert "-XX:+UseZGC" in java_cmdline, f"ZGC flag not found in Java cmdline: {java_cmdline}"
+    assert "-XX:+ZGenerational" in java_cmdline, f"ZGenerational flag not found in Java cmdline: {java_cmdline}"
+    assert "-Xms512m" in java_cmdline, f"-Xms512m not found in Java cmdline: {java_cmdline}"
 
     output, _ = cs_thread.parse_results()
     assert "latency mean" in output[0]


### PR DESCRIPTION
## Summary
- Add `cs_extra_jvm_opts` configuration parameter that passes extra JVM options to cassandra-stress via the `JVM_OPTS` environment variable in the Docker container
- Enables tuning GC settings to reduce JVM GC pauses causing flaky P99 latency spikes in performance tests
- Uses ZGC Generational (`-XX:+UseZGC -XX:+ZGenerational`) with 8GB heap for sub-millisecond GC pauses
- Add integration test verifying JVM opts are passed through to the Java process and c-s completes successfully
- **This is a temporary workaround** until https://github.com/scylladb/cassandra-stress/pull/80 is adapted to make ZGC the default in the cassandra-stress Docker image itself

## Motivation
Root cause analysis of mixed workload P99 flaky latency at step 480K ops/s ([SCT-289](https://scylladb.atlassian.net/browse/SCT-289)) identified cassandra-stress JVM GC pauses during step transitions as the cause. Scylla server-side P99 is stable at 2.4-2.6ms while client-side P99 varies from 6.8ms to 324.7ms due to JVM GC.

## Results ✅

Two consecutive successful runs with ZGC Generational proving the fix works:

| Run | Link | Result |
|-----|------|--------|
| Run 1 | [Argus](https://argus.scylladb.com/tests/scylla-cluster-tests/8e13db2b-6104-40e2-98d6-61cf8a7b0706/results) | ✅ Passed - all throughput steps stable |
| Run 2 | [Argus](https://argus.scylladb.com/tests/scylla-cluster-tests/8e13db2b-6104-40e2-98d6-61cf8a7b0706/results) | ✅ Passed - results looking very good |

Logs confirm JVM_OPTS are correctly passed to all 4 loaders and verified inside containers:
```
Passing JVM_OPTS to cassandra-stress container: -XX:+UseZGC -XX:+ZGenerational -Xms8g -Xmx8g -XX:+AlwaysPreTouch
JVM_OPTS env inside container: JVM_OPTS=-XX:+UseZGC -XX:+ZGenerational -Xms8g -Xmx8g -XX:+AlwaysPreTouch
```

## Changes
| File | Change |
|------|--------|
| `sdcm/sct_config.py` | New `cs_extra_jvm_opts` String config parameter |
| `defaults/test_default.yaml` | Default empty string |
| `sdcm/stress_thread.py` | Pass `-e JVM_OPTS='...'` to Docker container when set, with logging & verification |
| `docs/configuration_options.md` | Auto-generated docs update |
| `unit_tests/integration/test_cassandra_stress_thread.py` | Integration test asserting ZGC flags reach Java process cmdline |
| `test-cases/performance/perf-regression-predefined-throughput-steps.yaml` | Enable ZGC for predefined throughput steps |
| `test-cases/performance/perf-regression-latency-650gb-upgrade.yaml` | Enable ZGC for latency upgrade tests |
| `test-cases/performance/perf-regression-latency-650gb-elasticity.yaml` | Enable ZGC for elasticity tests |
| `test-cases/performance/perf-regression-latency-650gb-with-nemesis.yaml` | Enable ZGC for nemesis tests |

## Usage
```yaml
# In test-case YAML:
cs_extra_jvm_opts: '-XX:+UseZGC -XX:+ZGenerational -Xms8g -Xmx8g -XX:+AlwaysPreTouch'
```

## Note on long-term fix
This PR is a **temporary workaround** applied at the SCT level. The proper long-term fix is https://github.com/scylladb/cassandra-stress/pull/80 which will bake ZGC settings directly into the cassandra-stress Docker image, making `cs_extra_jvm_opts` unnecessary for GC tuning.

## Manual Testing Required
- [x] Run integration test: `uv run python -m pytest unit_tests/integration/test_cassandra_stress_thread.py::test_06_cassandra_stress_with_extra_jvm_opts -x`
- [x] Run performance test with tuned JVM settings to verify P99 improvement (2 successful runs)

Closes SCT-289

[SCT-289]: https://scylladb.atlassian.net/browse/SCT-289

### Testing

- [x] ✅ [scylla-enterprise-perf-regression-predefined-throughput-steps-i8g-tablets-test #3](https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/performance/job/branch-perf-v17/job/scylla-enterprise/job/perf-regression/job/scylla-enterprise-perf-regression-predefined-throughput-steps-i8g-tablets-test/3/) - [Argus results](https://argus.scylladb.com/tests/scylla-cluster-tests/8e13db2b-6104-40e2-98d6-61cf8a7b0706/results)
- [x] ✅ [scylla-enterprise-perf-regression-predefined-throughput-steps-i8g-tablets-test #4](https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/performance/job/branch-perf-v17/job/scylla-enterprise/job/perf-regression/job/scylla-enterprise-perf-regression-predefined-throughput-steps-i8g-tablets-test/4/)