### PR TITLE
fix(oci): use recent ScyllaDB image built with automation

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,7 +36,7 @@ def createRunConfiguration(String backend) {
         // TODO: set scylla version when we have Scylla releases in OCI
         configuration.scylla_version = ''
         // TODO: unset the image when 'scylla_version' gets specified
-        configuration.oci_image_db = 'ocid1.image.oc1.iad.aaaaaaaawlq4rpsf5j3blmia6vxuu3d7tdv5ir5x3izs4ogxmdyibskhpoxq'
+        configuration.oci_image_db = 'ocid1.image.oc1.iad.aaaaaaaa6ytiwaqasjpphbmmw5tqsjptdhmjuiyfo6pyvuy6x44xrq4xkxtq'
     } else if (backend.contains('docker')) {
         // use latest version of nightly image for docker backend, until we get rid off rebuilding docker image for SCT
         configuration.scylla_version = 'latest'


### PR DESCRIPTION
Previously we had a manually built image configured for usage with the simple provision test.
Switch it to one of the recent OCI images which get built using common image building automation.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
