### PR TITLE
improvement(defaults): change default compaction_strategy to ICS

### DIFF
--- a/configurations/cs-compaction-strategy-lcs.yaml
+++ b/configurations/cs-compaction-strategy-lcs.yaml
@@ -1,1 +1,0 @@
-compaction_strategy: "LeveledCompactionStrategy"

--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -89,7 +89,7 @@ server_encrypt_mtls: false
 
 scylla_encryption_options: ''
 
-compaction_strategy: 'SizeTieredCompactionStrategy'
+compaction_strategy: 'IncrementalCompactionStrategy'
 
 use_preinstalled_scylla: false
 

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -3059,7 +3059,7 @@ Time to wait for compaction to finish at the end of prepare stage. Use only when
 
 Compaction strategy to use for pre-created schema
 
-**default:** SizeTieredCompactionStrategy
+**default:** IncrementalCompactionStrategy
 
 **type:** str
 * appendable

--- a/test-cases/enterprise-features/ics/longevity/ics-longevity-large-partition-4days.yaml
+++ b/test-cases/enterprise-features/ics/longevity/ics-longevity-large-partition-4days.yaml
@@ -1,1 +1,0 @@
-compaction_strategy: 'IncrementalCompactionStrategy'

--- a/test-cases/enterprise-features/ics/longevity/ics-longevity-toggle-strategy-large-partitions-24h.yaml
+++ b/test-cases/enterprise-features/ics/longevity/ics-longevity-toggle-strategy-large-partitions-24h.yaml
@@ -1,6 +1,5 @@
 test_duration: 1600
 
-compaction_strategy: 'IncrementalCompactionStrategy'
 nemesis_class_name: "SisyphusMonkey"
 nemesis_selector: 'ToggleTableIcsMonkey'
 nemesis_interval: 30


### PR DESCRIPTION
Set the default compaction strategy to ICS so pre-created schemas no longer use SizeTieredCompactionStrategy.
Remove obsolete files and delete compaction entries that relied on the old default. Tests that require STCS should explicitly set it in their configs.

Fixes https://scylladb.atlassian.net/browse/SCT-341

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
