### PR TITLE
ci(aws): add us-east-2 to AWS_SUPPORTED_REGIONS

### DIFF
--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -397,6 +397,7 @@ AWS_SUPPORTED_REGIONS: list[str] = [
     "eu-west-3",
     "us-west-2",
     "us-east-1",
+    "us-east-2",
     "eu-north-1",
     "eu-central-1",
 ]
@@ -424,7 +425,7 @@ def count_regions(region_string: str) -> int:
         regions = json.loads(region_string.replace("'", '"'))
         if isinstance(regions, list):
             return len(regions)
-    except (json.JSONDecodeError, ValueError):
+    except json.JSONDecodeError, ValueError:
         # Not a JSON array — fall through to treat as a plain string
         pass
     if " " in region_string:

--- a/sdcm/utils/aws_peering.py
+++ b/sdcm/utils/aws_peering.py
@@ -69,23 +69,47 @@ class AwsVpcPeering:
         return origin_vpx, target_vpx
 
     @staticmethod
+    def _ensure_route(route_table, vpc_peering_id, origin_region, **route_kwargs):
+        try:
+            route_table.create_route(VpcPeeringConnectionId=vpc_peering_id, **route_kwargs)
+        except ClientError as ex:
+            if "already exists" not in str(ex):
+                raise
+            dest_cidr = route_kwargs.get("DestinationCidrBlock") or route_kwargs.get("DestinationIpv6CidrBlock")
+            for route in route_table.routes:
+                existing_cidr = route.destination_cidr_block or route.destination_ipv6_cidr_block
+                if existing_cidr == dest_cidr and route.vpc_peering_connection_id != vpc_peering_id:
+                    LOG.warning(
+                        "Replacing stale route %s in %s rt %s: %s -> %s",
+                        dest_cidr,
+                        origin_region.region_name,
+                        route_table.route_table_id,
+                        route.vpc_peering_connection_id,
+                        vpc_peering_id,
+                    )
+                    origin_region.client.replace_route(
+                        RouteTableId=route_table.route_table_id,
+                        VpcPeeringConnectionId=vpc_peering_id,
+                        **route_kwargs,
+                    )
+                    break
+
+    @staticmethod
     def configure_route_tables(origin_region, target_region, vpc_peering_id):
         for index in range(AwsRegion.SCT_SUBNET_PER_AZ):
             route_table = origin_region.sct_route_table(index=index)
-            try:
-                route_table.create_route(
-                    DestinationCidrBlock=str(target_region.vpc_ipv4_cidr), VpcPeeringConnectionId=vpc_peering_id
-                )
-            except ClientError as ex:
-                if "already exists" not in str(ex):
-                    raise
-            try:
-                route_table.create_route(
-                    DestinationIpv6CidrBlock=str(target_region.vpc_ipv6_cidr), VpcPeeringConnectionId=vpc_peering_id
-                )
-            except ClientError as ex:
-                if "already exists" not in str(ex):
-                    raise
+            AwsVpcPeering._ensure_route(
+                route_table,
+                vpc_peering_id,
+                origin_region,
+                DestinationCidrBlock=str(target_region.vpc_ipv4_cidr),
+            )
+            AwsVpcPeering._ensure_route(
+                route_table,
+                vpc_peering_id,
+                origin_region,
+                DestinationIpv6CidrBlock=str(target_region.vpc_ipv6_cidr),
+            )
 
     @staticmethod
     def open_security_group(origin_region, target_region):

--- a/vars/byoLongevityPipeline.groovy
+++ b/vars/byoLongevityPipeline.groovy
@@ -40,7 +40,7 @@ def call() {
                description: 'aws|gce',
                name: 'backend')
             string(defaultValue: "eu-west-1",
-               description: 'Supported: us-east-1 | eu-west-1 | eu-west-2 | eu-north-1 | eu-central-1 | us-west-2 | random (randomly select region)',
+               description: 'Supported: us-east-1 | us-east-2 | us-west-2 | eu-west-1 | eu-west-2 | eu-west-3 | eu-north-1 | eu-central-1 | ca-central-1 | random (randomly select region)',
                name: 'region')
             string(defaultValue: "us-east1",
                    description: 'GCE datacenter supported: us-east1',

--- a/vars/getJenkinsLabels.groovy
+++ b/vars/getJenkinsLabels.groovy
@@ -43,6 +43,7 @@ def call(String backend, String region=null, String datacenter=null, String loca
                           'aws-eu-central-1': 'aws-sct-builders-eu-central-1-v3-asg',
                           'aws-us-east-1' : 'aws-sct-builders-us-east-1-v3-asg',
                           'aws-us-west-2' : 'aws-sct-builders-us-west-2-v3-asg',
+                          'aws-us-east-2' : 'aws-sct-builders-us-east-2-v3-asg',
                           'aws-eu-west-3' : 'aws-sct-builders-eu-west-3-v3-asg',
                           'aws-ca-central-1' : 'aws-sct-builders-ca-central-1-v3-asg',
                           'gce-us-east1': "${gcp_project}-builders-us-east1-template-v8",
@@ -68,7 +69,7 @@ def call(String backend, String region=null, String datacenter=null, String loca
         def supported_regions = []
 
         if (cloud_provider == 'aws') {
-            supported_regions = ["eu-west-2", "eu-north-1", "eu-central-1", "us-west-2", "eu-west-3", "ca-central-1"]
+            supported_regions = ["eu-west-2", "eu-north-1", "eu-central-1", "us-west-2", "us-east-2", "eu-west-3", "ca-central-1"]
         } else if (cloud_provider == 'gce') {
             supported_regions = ["us-east1", "us-east4", "us-west1", "us-central1"]
             region = datacenter

--- a/vars/longevityPipeline.groovy
+++ b/vars/longevityPipeline.groovy
@@ -36,7 +36,7 @@ def call(Map pipelineParams) {
                    name: 'xcloud_env')
 
             string(defaultValue: "${pipelineParams.get('region', 'eu-west-1')}",
-               description: 'Supported: us-east-1 | eu-west-1 | eu-west-2 | eu-north-1 | eu-central-1 | us-west-2 | random (randomly select region)',
+               description: 'Supported: us-east-1 | us-east-2 | us-west-2 | eu-west-1 | eu-west-2 | eu-west-3 | eu-north-1 | eu-central-1 | ca-central-1 | random (randomly select region)',
                name: 'region')
             string(defaultValue: "${pipelineParams.get('gce_datacenter', 'us-east1')}",
                    description: 'GCE datacenter',

--- a/vars/managerPipeline.groovy
+++ b/vars/managerPipeline.groovy
@@ -64,7 +64,7 @@ def call(Map pipelineParams) {
                description: 'aws|gce',
                name: 'backend')
             string(defaultValue: "${pipelineParams.get('region', 'eu-west-1')}",
-               description: 'Supported: us-east-1 | eu-west-1 | eu-west-2 | eu-north-1 | eu-central-1 | us-west-2 | random (randomly select region)',
+               description: 'Supported: us-east-1 | us-east-2 | us-west-2 | eu-west-1 | eu-west-2 | eu-west-3 | eu-north-1 | eu-central-1 | ca-central-1 | random (randomly select region)',
                name: 'region')
             string(defaultValue: "${pipelineParams.get('gce_datacenter', 'us-east1')}",
                    description: 'GCE datacenter',

--- a/vars/perfRegressionParallelPipeline.groovy
+++ b/vars/perfRegressionParallelPipeline.groovy
@@ -30,7 +30,7 @@ def call(Map pipelineParams) {
                    description: 'Scylla Cloud environment (only used when backend=xcloud). Supported environments: lab',
                    name: 'xcloud_env')
             string(defaultValue: "${pipelineParams.get('region', 'eu-west-1')}",
-               description: 'us-east-1|eu-west-1',
+               description: 'Supported: us-east-1 | us-east-2 | us-west-2 | eu-west-1 | eu-west-2 | eu-west-3 | eu-north-1 | eu-central-1 | ca-central-1 | random (randomly select region)',
                name: 'region')
             string(defaultValue: "${pipelineParams.get('availability_zone', '')}",
                 description: 'Availability zone',

--- a/vars/perfSearchBestConfigParallelPipeline.groovy
+++ b/vars/perfSearchBestConfigParallelPipeline.groovy
@@ -21,7 +21,7 @@ def call(Map pipelineParams) {
                name: 'backend')
 
             string(defaultValue: "${pipelineParams.get('region', 'eu-west-1')}",
-               description: 'us-east-1|eu-west-1',
+               description: 'Supported: us-east-1 | us-east-2 | us-west-2 | eu-west-1 | eu-west-2 | eu-west-3 | eu-north-1 | eu-central-1 | ca-central-1 | random (randomly select region)',
                name: 'region')
 
             string(defaultValue: "${pipelineParams.get('availability_zone', '')}",

--- a/vars/rollingOperatorUpgradePipeline.groovy
+++ b/vars/rollingOperatorUpgradePipeline.groovy
@@ -18,7 +18,7 @@ def call(Map pipelineParams) {
             choice(choices: ["${pipelineParams.get('backend', 'k8s-gke')}", 'k8s-eks', 'k8s-gke'],
                    name: 'backend')
             string(defaultValue: "${pipelineParams.get('region', '')}",
-               description: 'Supported: us-east-1 | eu-west-1 | eu-west-2 | eu-north-1 | eu-central-1 | us-west-2 | random (randomly select region)',
+               description: 'Supported: us-east-1 | us-east-2 | us-west-2 | eu-west-1 | eu-west-2 | eu-west-3 | eu-north-1 | eu-central-1 | ca-central-1 | random (randomly select region)',
                name: 'region')
             string(defaultValue: "${pipelineParams.get('availability_zone', 'b')}",
                description: 'Availability zone',

--- a/vars/rollingUpgradePipeline.groovy
+++ b/vars/rollingUpgradePipeline.groovy
@@ -28,7 +28,7 @@ def call(Map pipelineParams) {
                name: 'backend')
 
             string(defaultValue: "${pipelineParams.get('region', 'eu-west-1')}",
-               description: 'Supported: us-east-1 | eu-west-1 | eu-west-2 | eu-north-1 | eu-central-1 | us-west-2 | random (randomly select region)',
+               description: 'Supported: us-east-1 | us-east-2 | us-west-2 | eu-west-1 | eu-west-2 | eu-west-3 | eu-north-1 | eu-central-1 | ca-central-1 | random (randomly select region)',
                name: 'region')
             string(defaultValue: "${pipelineParams.get('gce_datacenter', 'us-east1')}",
                    description: 'GCE datacenter',

--- a/vars/simpleTrigger.groovy
+++ b/vars/simpleTrigger.groovy
@@ -6,7 +6,7 @@ def call(List jobs) {
             string(name: "scylla_ami_id", defaultValue: "", description: "AMI ID for ScyllaDB")
             string(name: "region",
                    defaultValue: "'eu-west-1'",
-                   description: "Supported: us-east-1 | eu-west-1 | eu-west-2 | eu-north-1 | eu-central-1 | us-west-2 | random (randomly select region)")
+                   description: "Supported: us-east-1 | us-east-2 | us-west-2 | eu-west-1 | eu-west-2 | eu-west-3 | eu-north-1 | eu-central-1 | ca-central-1 | random (randomly select region)")
             string(name: "provision_type",
                    defaultValue: "spot",
                    description: "spot|on_demand|spot_fleet")


### PR DESCRIPTION
## Summary
- Add `us-east-2` to `AWS_SUPPORTED_REGIONS` constant in `sdcm/sct_config.py`
- Enables perf tests using i8g.4xlarge instances in us-east-2

## Backends Affected
- [x] AWS

## Related PRs
- scylla-pkg: https://github.com/scylladb/scylla-pkg/pull/6220
- scylla-monitoring: https://github.com/scylladb/scylla-monitoring/pull/2853

## Testing
- [x] 🟢 [longevity-100gb-4h-test #219](https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/longevity-100gb-4h-test/219/)                                                                    


Ref: [QAINFRA-103]

[QAINFRA-103]: https://scylladb.atlassian.net/browse/QAINFRA-103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ