### PR TITLE
Restore config files deleted in #14588 that are still referenced by pipelines

### DIFF
--- a/configurations/cs-compaction-strategy-lcs.yaml
+++ b/configurations/cs-compaction-strategy-lcs.yaml
@@ -1,0 +1,1 @@
+compaction_strategy: "LeveledCompactionStrategy"

--- a/test-cases/enterprise-features/ics/longevity/ics-longevity-large-partition-4days.yaml
+++ b/test-cases/enterprise-features/ics/longevity/ics-longevity-large-partition-4days.yaml
@@ -1,0 +1,1 @@
+compaction_strategy: 'IncrementalCompactionStrategy'


### PR DESCRIPTION
## Summary
- Restores `configurations/cs-compaction-strategy-lcs.yaml` — referenced by `jenkins-pipelines/performance_staging/perf-regression-scylla-gradual-throughput-grow-gauss-lcs.jenkinsfile`
- Restores `test-cases/enterprise-features/ics/longevity/ics-longevity-large-partition-4days.yaml` — referenced by `jenkins-pipelines/oss/features/ICS/ics-longevity-large-partition-4days.jenkinsfile`
- Both were deleted in #14588 but are still in use by pipelines