### PR TITLE
fix(sct-config): strip whitespace from environment variable values at ingestion

### DIFF
--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -3189,7 +3189,10 @@ class SCTConfiguration(BaseModel):
             if field_env and any(key.startswith(field_env) for key in os.environ.keys()):
                 if field_env in os.environ.keys():
                     try:
-                        environment_vars[field_name] = from_env_func(os.environ[field_env])
+                        raw_value = os.environ[field_env]
+                        if isinstance(raw_value, str):
+                            raw_value = raw_value.strip()
+                        environment_vars[field_name] = from_env_func(raw_value)
                     except Exception as ex:  # noqa: BLE001
                         raise ValueError("failed to parse {} from environment variable".format(field_env)) from ex
                 nested_keys = [key for key in os.environ if key.startswith(field_env + ".")]
@@ -3198,10 +3201,13 @@ class SCTConfiguration(BaseModel):
                     dict_value = {}
                     for key in nested_keys:
                         nest_key, *_ = key.split(".")[1:]
+                        nested_value = os.environ.get(key)
+                        if isinstance(nested_value, str):
+                            nested_value = nested_value.strip()
                         if nest_key.isdigit():
-                            list_value.insert(int(nest_key), os.environ.get(key))
+                            list_value.insert(int(nest_key), nested_value)
                         else:
-                            dict_value[nest_key] = os.environ.get(key)
+                            dict_value[nest_key] = nested_value
                     current_value = environment_vars.get(field_name)
                     if current_value and isinstance(current_value, dict):
                         current_value.update(dict_value)

--- a/unit_tests/unit/test_config.py
+++ b/unit_tests/unit/test_config.py
@@ -808,3 +808,18 @@ def test_migrator_source_hosts_and_test_id_mutually_exclusive(monkeypatch):
     conf = sct_config.SCTConfiguration()
     with pytest.raises(ValueError, match="mutually exclusive"):
         conf.verify_configuration()
+
+
+@pytest.mark.parametrize(
+    "raw_value,expected",
+    [
+        ("  2025.1.0  ", "2025.1.0"),
+        ("\t5.4.0\n", "5.4.0"),
+        ("2025.1.0", "2025.1.0"),
+    ],
+)
+def test_env_var_whitespace_is_stripped(monkeypatch, raw_value, expected):
+    """Environment variable values with leading/trailing whitespace are trimmed (SCT-340)."""
+    monkeypatch.setenv("SCT_SCYLLA_VERSION", raw_value)
+    conf = sct_config.SCTConfiguration()
+    assert conf.get("scylla_version") == expected


### PR DESCRIPTION
## Summary

- Strip leading/trailing whitespace from all `SCT_*` environment variable values at ingestion time in `_load_environment_variables()`
- Covers direct env vars and nested key patterns (list/dict)
- Adds parametrized unit test verifying whitespace trimming

## Rationale

A stray space or newline in a pipeline parameter value (e.g. a version string, IP address, or branch name) propagates through all pipeline phases — including provisioning — and causes hard-to-diagnose failures. A single defensive `.strip()` at the Python ingestion boundary eliminates this entire class of errors regardless of how the value arrives (Jenkins UI, env var, CI script).

Fix: SCT-340

## Manual Testing Required

### What Copilot Couldn't Test

- [ ] **End-to-end pipeline with whitespace in params**: Trigger a Jenkins pipeline with intentional trailing space in `scylla_version` and verify it provisions and runs correctly