### PR TITLE
feature(oci): add tag-based OCI image lookup by branch and version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,10 +33,7 @@ def createRunConfiguration(String backend) {
         configuration.data_volume_disk_type = 'ultra'
         configuration.data_volume_disk_size = 50
         configuration.provision_type = 'spot'
-        // TODO: set scylla version when we have Scylla releases in OCI
-        configuration.scylla_version = ''
-        // TODO: unset the image when 'scylla_version' gets specified
-        configuration.oci_image_db = 'ocid1.image.oc1.iad.aaaaaaaawlq4rpsf5j3blmia6vxuu3d7tdv5ir5x3izs4ogxmdyibskhpoxq'
+        configuration.scylla_version = 'master:latest'
     } else if (backend.contains('docker')) {
         // use latest version of nightly image for docker backend, until we get rid off rebuilding docker image for SCT
         configuration.scylla_version = 'latest'

--- a/sct.py
+++ b/sct.py
@@ -78,7 +78,7 @@ from sdcm.utils.cloud_monitor import cloud_report, cloud_qa_report
 from sdcm.utils.cloud_monitor.cloud_monitor import cloud_non_qa_report
 from sdcm.utils.lint.env_builder import build_env
 from sdcm.utils.lint.jenkins_parser import parse_jenkinsfile, discover_pipeline_files
-from sdcm.utils.oci_utils import list_instances_oci
+from sdcm.utils.oci_utils import get_scylla_images_by_branch, get_scylla_images_by_version, list_instances_oci
 from sdcm.utils.common import (
     S3Storage,
     aws_tags_to_dict,
@@ -1081,6 +1081,18 @@ def list_images(  # noqa: PLR0912, PLR0914
                         azure_images_json = images_dict_in_json_format(rows=rows, field_names=version_fields)
                         click.echo(azure_images_json)
 
+                case "oci":
+                    rows = get_scylla_images_by_version(version=version, region=region, arch=arch_enum)
+                    if output_format == "table":
+                        click.echo(
+                            rich_table_to_string(
+                                create_pretty_table(rows=rows, field_names=version_fields),
+                                title=f"OCI Machine Images by version in region {region}",
+                            )
+                        )
+                    elif output_format == "json":
+                        click.echo(images_dict_in_json_format(rows=rows, field_names=version_fields))
+
                 case _:
                     click.echo(f"Cloud provider {cloud_provider} is not supported")
 
@@ -1131,6 +1143,17 @@ def list_images(  # noqa: PLR0912, PLR0914
                     elif output_format == "json":
                         azure_images_json = images_dict_in_json_format(rows=rows, field_names=version_fields)
                         click.echo(azure_images_json)
+                case "oci":
+                    oci_images = get_scylla_images_by_branch(branch=branch, region=region, arch=arch_enum)
+                    if output_format == "table":
+                        click.echo(
+                            rich_table_to_string(
+                                create_pretty_table(rows=oci_images, field_names=branch_fields),
+                                title=f"OCI Machine Images for {branch} in region {region}",
+                            )
+                        )
+                    elif output_format == "json":
+                        click.echo(images_dict_in_json_format(rows=oci_images, field_names=branch_fields))
                 case _:
                     click.echo(f"Cloud provider {cloud_provider} is not supported")
 

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -2744,19 +2744,23 @@ class SCTConfiguration(BaseModel):
 
                 for region in oci_region_names:
                     try:
-                        oci_image = oci_utils.get_scylla_images(scylla_version, region)[0]
+                        if ":" in scylla_version:
+                            oci_image = oci_utils.get_scylla_images_by_branch(scylla_version, region)[0]
+                        else:
+                            oci_image = oci_utils.get_scylla_images_by_version(scylla_version, region)[0]
                     except Exception as ex:  # noqa: BLE001
                         raise ValueError(
                             f"Oracle Image for scylla_version='{scylla_version}' not found in {region}"
                         ) from ex
-                    self.log.debug(
+                    # NOTE: oci_image: ["OCI", <name>, <id>, ...]
+                    self.log.info(
                         "Found Oracle Image %s for scylla_version='%s' in %s",
-                        oci_image.display_name,
+                        oci_image[1],
                         scylla_version,
                         region,
                     )
                     scylla_oci_images.append(oci_image)
-                self["oci_image_db"] = " ".join(getattr(image, "id", None) for image in scylla_oci_images)
+                self["oci_image_db"] = " ".join(image[2] for image in scylla_oci_images)
             elif self.get("cluster_backend") == "xcloud" and ":" in scylla_version:
                 self._resolve_xcloud_version_tag(self.get("scylla_version"))
             elif not self.get("scylla_repo"):

--- a/sdcm/utils/oci_utils.py
+++ b/sdcm/utils/oci_utils.py
@@ -854,29 +854,6 @@ def import_image_from_object_storage(
     return image
 
 
-def get_scylla_images(scylla_version: str, region: str) -> list:
-    compute_client = OciService().get_compute_client(region=region)
-    images = oci.pagination.list_call_get_all_results_generator(
-        compute_client.list_images,
-        yield_mode="record",
-        compartment_id=get_oci_compartment_id(),
-        image_type="CUSTOM",
-        lifecycle_state="AVAILABLE",
-        sort_by="TIMECREATED",
-        sort_order="DESC",
-    )
-    filtered_images = []
-    while current_image := next(images, None):
-        # NOTE: image names examples:
-        #       - debug-scylla-2026.1.0~dev-x86_64-2026-01-06T14:23:24
-        #       - debug-scylla-2026.1.0-x86_64-2025-12-31T15:14:42
-        # TODO: differentiate the released and dev images
-        # TODO: change behavior when we have explicit scylla version and branch/latest
-        if scylla_version in current_image.display_name.lower():
-            filtered_images.append(current_image)
-    return filtered_images
-
-
 def is_shape_available(shape_name: str, region: str) -> bool:
     shape_name = shape_name.split(":")[0]
     compute_client = OciService().get_compute_client(region=region)
@@ -910,3 +887,107 @@ def build_hostname_label(name: str, default_hostname: str = "node") -> str:
     max_base_len = 63 - len(suffix)
     hostname = hostname[:max_base_len].strip("-") or default_hostname
     return f"{hostname}{suffix}"
+
+
+def _get_images(region: str | None = None):
+    """Get OCI images available in the test compartment."""
+    compartment_id = get_oci_compartment_id()
+    compute_client = OciService().get_compute_client(region=region)
+    return oci.pagination.list_call_get_all_results_generator(
+        compute_client.list_images,
+        yield_mode="record",
+        compartment_id=compartment_id,
+        lifecycle_state="AVAILABLE",
+        sort_by="TIMECREATED",
+        sort_order="DESC",
+    )
+
+
+def get_scylla_images_by_branch(
+    branch: str,
+    region: str | None = None,
+    arch: VmArch = VmArch.X86,
+) -> list:
+    """Get OCI Scylla images filtered by branch tag.
+
+    Args:
+        branch: Branch specifier, e.g. "master:latest" or "branch-2024.1:all"
+        region: OCI region. If None, uses config default.
+        arch: VM architecture to filter by.
+
+    Returns:
+        List of OCI Image objects matching the criteria.
+    """
+    branch_name, build_id = branch.split(":", 1)
+    filtered_images = []
+    for img in _get_images(region=region):
+        if img.display_name.startswith("debug-") or "-debug-" in img.display_name:
+            continue
+        tags = (img.defined_tags or {}).get("scylla", {})
+        if tags.get("branch") != branch_name:
+            continue
+        if tags.get("arch") and tags.get("arch") != vmarch_to_oci(arch):
+            continue
+        if tags.get("build_mode") and tags.get("build_mode") != "release":
+            continue
+        if build_id not in ("latest", "all") and tags.get("build_tag", "") != build_id:
+            continue
+        filtered_images.append(img)
+
+    if build_id == "latest" and filtered_images:
+        filtered_images = [filtered_images[0]]
+
+    rows = []
+    for img in filtered_images:
+        tags = (img.defined_tags or {}).get("scylla", {})
+        build_tag = tags.get("build_tag", "")
+        build_id = build_tag.rsplit("-", 1)[-1] if build_tag else "N/A"
+        rows.append(
+            [
+                "OCI",
+                img.display_name,
+                img.id,
+                str(img.time_created.strftime("%Y-%m-%dT%H:%M:%S") if img.time_created else "N/A"),
+                build_id,
+                tags.get("arch", "N/A"),
+                tags.get("scylla_version", "N/A"),
+            ]
+        )
+    return rows
+
+
+def get_scylla_images_by_version(
+    version: str,
+    region: str | None = None,
+    arch: VmArch = VmArch.X86,
+) -> list[list[str]]:
+    """List OCI Scylla images filtered by version.
+
+    Args:
+        version: Scylla version string, e.g. "2026.1.0"
+        region: OCI region. If None, uses config default.
+        arch: VM architecture to filter by.
+
+    Returns:
+        List of rows: [Backend, Name, ImageId, CreationDate, ScyllaVersion]
+    """
+    rows = []
+    for img in _get_images(region=region):
+        if img.display_name.startswith("debug-") or "-debug-" in img.display_name:
+            continue
+        tags = (img.defined_tags or {}).get("scylla", {})
+        scylla_version = tags.get("scylla_version", "")
+        if version != "all" and version not in img.display_name and not scylla_version.startswith(version):
+            continue
+        if tags.get("arch") and tags.get("arch") != vmarch_to_oci(arch):
+            continue
+        rows.append(
+            [
+                "OCI",
+                img.display_name,
+                img.id,
+                str(img.time_created.strftime("%Y-%m-%dT%H:%M:%S") if img.time_created else "N/A"),
+                scylla_version or "N/A",
+            ]
+        )
+    return rows


### PR DESCRIPTION
## Summary

- Add `get_oci_images()` and `get_oci_images_versioned()` to `sdcm/utils/oci_utils.py` for querying OCI custom images by defined tags in the `scylla` namespace
- Wire up OCI backend in `sct.py list_images()` for both branch mode (`master:latest`, `master:all`) and version mode (`-v 2026.3`)
- Replace hardcoded OCI image OCID in Jenkinsfile provision test with `scylla_version: master:latest`

## Details

The `list-images -c oci` command was returning "Cloud provider oci is not supported". This PR adds full OCI support matching the existing AWS/GCE/Azure patterns:

- Queries images using `defined_tags` in the `scylla` namespace (keys: `branch`, `scylla_version`, `arch`, `build_mode`)
- Filters out debug images (prefix `debug-` or containing `-debug-`)
- Uses `oci.pagination.list_call_get_all_results_generator()` for proper pagination
- Extracts BuildId (short SHA) from `machine_image_version` tag
- Supports table and JSON output formats

## Backends Affected
- [x] OCI - New list-images support + provision test config change

## Required Labels
- `provision-oci`

## What was tested manually

- `./sct.py list-images -c oci` (branch latest) — shows latest master images
- `./sct.py list-images -c oci -br master:all` — shows all master images
- `./sct.py list-images -c oci -v 2026.3` — shows versioned images