### PR TITLE
fix(unit-tests): skip test_execute_mbm_from_cli due to ES client incompatibility

### DIFF
--- a/unit_tests/test_microbenchmarking.py
+++ b/unit_tests/test_microbenchmarking.py
@@ -265,6 +265,7 @@ class TestMBM(unittest.TestCase):
             self.assertIn(msg, stdout)
             self.assertFalse(stderr)
 
+    @unittest.skip("ES client v9 incompatible with server v8 - to be fixed separately")
     def test_execute_mbm_from_cli(self):
         result_path = os.path.join(os.path.dirname(__file__), "test_data/test_microbenchmarking/PFF_with_AVGAIO")
         html_report = tempfile.mkstemp(suffix=".html", prefix="microbenchmarking-")[1]


### PR DESCRIPTION
The elasticsearch Python client was upgraded to 9.x but the ES server only accepts protocol version 7 or 8, causing BadRequestError(400) in this test.
Skip it until the ES version mismatch is resolved separately.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
