### PR TITLE
fix(upgrade): fix enterprise detection and node-exporter version transition in rolling upgrades

### DIFF
--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -313,13 +313,11 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
 
             orig_is_enterprise = node.is_product_enterprise
             if node.distro.is_rhel_like:
-                result = node.remoter.run("sudo yum search scylla-enterprise 2>&1", ignore_status=True)
-                new_is_enterprise = bool(
-                    "scylla-enterprise.x86_64" in result.stdout or "No matches found" not in result.stdout
-                )
+                result = node.remoter.run("sudo yum search scylla-enterprise-server 2>&1", ignore_status=True)
+                new_is_enterprise = "scylla-enterprise-server" in result.stdout
             else:
-                result = node.remoter.run("sudo apt-cache search scylla-enterprise", ignore_status=True)
-                new_is_enterprise = "scylla-enterprise" in result.stdout
+                result = node.remoter.run("sudo apt-cache search scylla-enterprise-server", ignore_status=True)
+                new_is_enterprise = "scylla-enterprise-server" in result.stdout
 
             scylla_pkg = "scylla-enterprise" if new_is_enterprise else "scylla"
             ver_suffix = r"\*{}".format(new_version) if new_version else ""
@@ -342,11 +340,22 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
             with self.actions_log.action_scope("updating packages"):
                 if node.distro.is_rhel_like:
                     node.remoter.run(r"sudo yum update {}\* -y".format(scylla_pkg_ver))
+                    # scylla-node-exporter may have moved to an independent versioning scheme
+                    # (e.g. 1.11.1) which RPM considers a downgrade from the old scylla-versioned
+                    # package (e.g. 2026.x). Force-reinstall it so the transition is handled.
+                    node.remoter.run(
+                        "sudo yum install -y scylla-node-exporter || sudo yum reinstall -y scylla-node-exporter",
+                        ignore_status=True,
+                    )
                 else:
                     node.remoter.sudo("apt-get update")
                     node.remoter.sudo(
                         f"DEBIAN_FRONTEND=noninteractive apt-get dist-upgrade {scylla_pkg_ver} -y"
                         f' -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold"'
+                    )
+                    node.remoter.sudo(
+                        "DEBIAN_FRONTEND=noninteractive apt-get install -y scylla-node-exporter",
+                        ignore_status=True,
                     )
 
         node.remoter.sudo(
@@ -464,9 +473,11 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
             recover_conf(node)
             node.remoter.run("sudo systemctl daemon-reload")
         elif self.upgrade_rollback_mode == "minor_release":
-            node.remoter.run(r"sudo yum downgrade scylla\*%s-\* -y" % self.orig_ver.split("-")[0])
+            node.remoter.run(
+                r"sudo yum downgrade scylla\*%s-\* -y --allowerasing --nobest" % self.orig_ver.split("-")[0]
+            )
         else:
-            node.remoter.run(r"sudo yum downgrade scylla\* -y")
+            node.remoter.run(r"sudo yum downgrade scylla\* -y --allowerasing --nobest")
             recover_conf(node)
             node.remoter.run("sudo systemctl daemon-reload")
 


### PR DESCRIPTION
The enterprise detection logic used a fragile double-negative check ('No matches found' not in stdout) that incorrectly identified OSS repos as enterprise, causing 'yum update scylla-enterprise*' to find nothing and the upgrade assertion to fail.

Also handle scylla-node-exporter transitioning from scylla-versioned (e.g. 2026.x) to independently-versioned (e.g. 1.11.1) packages, which RPM considers a downgrade and skips during 'yum update scylla*'.

Additionally, fix yum downgrade during rollback on Rocky Linux 10: DNF fails when the base repo contains multiple minor versions of scylla-node-exporter with conflicting dependencies. Adding `--allowerasing --nobest` lets DNF resolve the conflict by replacing conflicting packages and falling back to an older compatible version.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://jenkins.scylladb.com/job/releng-testing/job/rolling-upgrade/job/rolling-upgrade-ubuntu2404-test/10/
- [x] https://jenkins.scylladb.com/job/releng-testing/job/rolling-upgrade/job/rolling-upgrade-rocky10-test/8/
- [x] https://jenkins.scylladb.com/job/releng-testing/job/rolling-upgrade/job/rolling-upgrade-ami-test/2/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)