### PR TITLE
fix(provision/gce): add zone fallback on GCE resource pool exhaustion

### DIFF
--- a/defaults/aws_config.yaml
+++ b/defaults/aws_config.yaml
@@ -35,6 +35,8 @@ data_volume_disk_type: 'gp2'
 data_volume_disk_size: 500
 data_volume_disk_iops: 10000 # depend on type iops could be 100-16000 for io2|io3 and 3000-16000 for gp3
 
+fallback_to_next_availability_zone: true
+
 kms_key_rotation_interval: 60
 
 # TODO: this part should be moved to defaults/test_default.yaml when network interfaces configuration is supported for all backends

--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -213,7 +213,7 @@ bare_loaders: false
 
 aws_fallback_to_next_availability_zone: false
 
-fallback_to_next_availability_zone: true
+fallback_to_next_availability_zone: false
 
 pre_filter_unavailable_availability_zones: true
 

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -4046,7 +4046,7 @@ Deprecated alias of `fallback_to_next_availability_zone`. Kept for backward comp
 
 On capacity errors, automatically retry provisioning in the next available AZ in the same region. Backend-agnostic parameter; supersedes `aws_fallback_to_next_availability_zone`.
 
-**default:** True
+**default:** N/A
 
 **type:** bool
 

--- a/sdcm/cluster_gce.py
+++ b/sdcm/cluster_gce.py
@@ -26,8 +26,9 @@ from google.cloud import compute_v1
 
 from sdcm import cluster
 from sdcm.provision.gce.provisioner import GceProvisioner
+from sdcm.provision.gce.instance_provider import _is_zone_exhausted
 from sdcm.provision.network_configuration import NetworkInterface, ScyllaNetworkConfiguration, ssh_connection_ip_type
-from sdcm.provision.provisioner import PricingModel
+from sdcm.provision.provisioner import PricingModel, ProvisionError, ZoneResourcesExhaustedError
 from sdcm.provision.helpers.cloud_init import wait_cloud_init_completes
 from sdcm.sct_provision import region_definition_builder
 from sdcm.sct_provision.instances_provider import provision_instances_with_fallback
@@ -36,6 +37,7 @@ from sdcm.sct_events.gce_events import GceInstanceEvent
 from sdcm.utils.gce_utils import (
     GceLoggingClient,
     get_gce_compute_disks_client,
+    get_alternative_zones,
     wait_for_extended_operation,
     gce_private_addresses,
     gce_public_addresses,
@@ -440,6 +442,16 @@ class GCECluster(cluster.BaseCluster):
                     identifier += "%s: %s | " % (disk_type, disk_size)
         return identifier
 
+    @property
+    def is_az_fallback_enabled(self) -> bool:
+        """Return True when AZ fallback on capacity errors is enabled.
+
+        Reads `fallback_to_next_availability_zone`.
+        """
+        if (value := self.params.get("fallback_to_next_availability_zone")) is not None:
+            return bool(value)
+        return False
+
     def _create_instances(self, count, dc_idx=0, instance_type=None):
         region = self._definition_builder.regions[dc_idx]
         pricing_model = PricingModel.SPOT if "spot" in self.instance_provision else PricingModel.ON_DEMAND
@@ -454,12 +466,57 @@ class GCECluster(cluster.BaseCluster):
                     instance_type=instance_type,
                 )
             )
-        return provision_instances_with_fallback(
-            self.provisioners[dc_idx],
-            definitions=definitions,
-            pricing_model=pricing_model,
-            fallback_on_demand=self.params.get("instance_provision_fallback_on_demand"),
-        )
+        try:
+            return provision_instances_with_fallback(
+                self.provisioners[dc_idx],
+                definitions=definitions,
+                pricing_model=pricing_model,
+                fallback_on_demand=self.params.get("instance_provision_fallback_on_demand"),
+            )
+        except (ZoneResourcesExhaustedError, ProvisionError) as exc:
+            if isinstance(exc, ProvisionError) and not _is_zone_exhausted(exc):
+                raise
+            if not self.is_az_fallback_enabled:
+                raise
+            if count > 1:
+                self.log.warning(
+                    "AZ fallback is only supported for single-node provisioning (count=%d), not retrying", count
+                )
+                raise
+            exhausted_zone = self.provisioners[dc_idx].availability_zone
+            self.log.warning("Zone %s exhausted, trying alternative zones in region %s", exhausted_zone, region)
+            alternative_zones = get_alternative_zones(region, exhausted_zone)
+            if not alternative_zones:
+                raise
+            for alt_zone in alternative_zones:
+                self.log.info("Attempting zone %s-%s as fallback", region, alt_zone)
+                try:
+                    new_provisioner = GceProvisioner(
+                        test_id=str(self.test_config.test_id()),
+                        region=region,
+                        availability_zone=alt_zone,
+                        network_name=self._gce_network,
+                    )
+                    result = provision_instances_with_fallback(
+                        new_provisioner,
+                        definitions=definitions,
+                        pricing_model=pricing_model,
+                        fallback_on_demand=self.params.get("instance_provision_fallback_on_demand"),
+                    )
+                    # Update provisioner and zone for this dc_idx on success
+                    self.provisioners[dc_idx] = new_provisioner
+                    self._gce_zone_names[dc_idx] = new_provisioner.availability_zone
+                    self.log.info("Successfully provisioned instances in fallback zone %s-%s", region, alt_zone)
+                    return result
+                except (ZoneResourcesExhaustedError, ProvisionError) as fallback_exc:
+                    if isinstance(fallback_exc, ProvisionError) and not _is_zone_exhausted(fallback_exc):
+                        raise
+                    self.log.warning("Fallback zone %s-%s also exhausted, trying next", region, alt_zone)
+                    continue
+            raise ZoneResourcesExhaustedError(
+                f"All zones in region {region} are exhausted: tried {exhausted_zone} and "
+                f"{[f'{region}-{z}' for z in alternative_zones]}"
+            ) from exc
 
     def _destroy_instance(self, name: str, dc_idx: int):
         target_node = self._get_instances_by_name(dc_idx=dc_idx, name=name)

--- a/sdcm/provision/gce/instance_provider.py
+++ b/sdcm/provision/gce/instance_provider.py
@@ -126,6 +126,13 @@ class VirtualMachineProvider:
                 )
                 pending_instance_creations.append((definition, operation, normalized_name, user_data, startup_script))
             except google.api_core.exceptions.GoogleAPIError as err:
+                if _is_zone_exhausted(err):
+                    LOGGER.error(
+                        "Zone %s resource pool exhausted during insert request for %s",
+                        self.zone,
+                        normalized_name,
+                    )
+                    raise ZoneResourcesExhaustedError(f"Zone {self.zone} resource pool exhausted: {err}") from err
                 LOGGER.error("Error when sending create vm request for instance %s: %s", normalized_name, str(err))
                 error_to_raise = err
 
@@ -136,11 +143,20 @@ class VirtualMachineProvider:
                     definition, operation, normalized_name, pricing_model, user_data, startup_script
                 )
                 instances.append(instance)
+            except ZoneResourcesExhaustedError:
+                # Zone exhaustion is unrecoverable; let it propagate immediately.
+                # Successfully-created instances remain in self._cache so callers
+                # can clean them up before retrying in a different zone.
+                raise
             except google.api_core.exceptions.GoogleAPIError as err:
                 LOGGER.error("Error when waiting for instance %s: %s", normalized_name, str(err))
                 error_to_raise = err
 
         if error_to_raise:
+            if _is_zone_exhausted(error_to_raise):
+                raise ZoneResourcesExhaustedError(
+                    f"Zone {self.zone} resource pool exhausted: {error_to_raise}"
+                ) from error_to_raise
             raise ProvisionError(f"Failed to create instances: {error_to_raise}") from error_to_raise
         return instances
 

--- a/sdcm/utils/gce_utils.py
+++ b/sdcm/utils/gce_utils.py
@@ -128,7 +128,6 @@ def get_alternative_zones(region: str, exhausted_zone: str) -> list[str]:
         return []
     exhausted_letter = exhausted_zone[-1] if len(exhausted_zone) > 1 else exhausted_zone
     alternatives = [z for z in zone_letters if z != exhausted_letter]
-    random.shuffle(alternatives)
     return alternatives
 
 

--- a/test-cases/artifacts/amazon2023.yaml
+++ b/test-cases/artifacts/amazon2023.yaml
@@ -15,5 +15,6 @@ scylla_linux_distro: 'centos'
 test_duration: 60
 use_preinstalled_scylla: false
 user_prefix: 'artifacts-al2023'
+fallback_to_next_availability_zone: true
 
 user_credentials_path: '~/.ssh/scylla_test_id_ed25519'

--- a/test-cases/artifacts/ami.yaml
+++ b/test-cases/artifacts/ami.yaml
@@ -12,3 +12,4 @@ region_name: 'us-east-1'
 scylla_linux_distro: 'centos'
 test_duration: 60
 user_prefix: 'artifacts-ami'
+fallback_to_next_availability_zone: true

--- a/test-cases/artifacts/centos9.yaml
+++ b/test-cases/artifacts/centos9.yaml
@@ -15,5 +15,6 @@ scylla_linux_distro: 'centos'
 test_duration: 60
 user_prefix: 'artifacts-centos9'
 use_preinstalled_scylla: false
+fallback_to_next_availability_zone: true
 
 user_credentials_path: '~/.ssh/scylla_test_id_ed25519'

--- a/test-cases/artifacts/oel76.yaml
+++ b/test-cases/artifacts/oel76.yaml
@@ -15,3 +15,4 @@ scylla_linux_distro: 'centos'
 test_duration: 60
 use_preinstalled_scylla: false
 user_prefix: 'artifacts-oel76'
+fallback_to_next_availability_zone: true

--- a/test-cases/artifacts/oel8.yaml
+++ b/test-cases/artifacts/oel8.yaml
@@ -15,3 +15,4 @@ scylla_linux_distro: 'centos'
 test_duration: 60
 use_preinstalled_scylla: false
 user_prefix: 'artifacts-oel8'
+fallback_to_next_availability_zone: true

--- a/test-cases/artifacts/oel9.yaml
+++ b/test-cases/artifacts/oel9.yaml
@@ -15,3 +15,4 @@ scylla_linux_distro: 'centos'
 test_duration: 60
 use_preinstalled_scylla: false
 user_prefix: 'artifacts-oel9'
+fallback_to_next_availability_zone: true

--- a/test-cases/artifacts/ubuntu2004-fips.yaml
+++ b/test-cases/artifacts/ubuntu2004-fips.yaml
@@ -19,3 +19,4 @@ server_encrypt: true
 internode_encryption: 'all'
 test_duration: 60
 user_prefix: 'artifacts-ubuntu2004-fips'
+fallback_to_next_availability_zone: true

--- a/test-cases/artifacts/ubuntu2204.yaml
+++ b/test-cases/artifacts/ubuntu2204.yaml
@@ -15,3 +15,4 @@ scylla_linux_distro: 'ubuntu-jammy'
 test_duration: 60
 user_prefix: 'artifacts-ubuntu2204'
 use_preinstalled_scylla: false
+fallback_to_next_availability_zone: true

--- a/test-cases/artifacts/ubuntu2404.yaml
+++ b/test-cases/artifacts/ubuntu2404.yaml
@@ -15,5 +15,6 @@ scylla_linux_distro: 'ubuntu-noble'
 test_duration: 60
 user_prefix: 'artifacts-ubuntu2404'
 use_preinstalled_scylla: false
+fallback_to_next_availability_zone: true
 
 user_credentials_path: '~/.ssh/scylla_test_id_ed25519'

--- a/test-cases/artifacts/ubuntu2604.yaml
+++ b/test-cases/artifacts/ubuntu2604.yaml
@@ -15,5 +15,6 @@ scylla_linux_distro: 'ubuntu-resolute'
 test_duration: 60
 user_prefix: 'artifacts-ubuntu2604'
 use_preinstalled_scylla: false
+fallback_to_next_availability_zone: true
 
 user_credentials_path: '~/.ssh/scylla_test_id_ed25519'

--- a/unit_tests/unit/provisioner/test_gce_zone_resolver.py
+++ b/unit_tests/unit/provisioner/test_gce_zone_resolver.py
@@ -269,9 +269,11 @@ def test_get_alternative_zones_returns_empty_for_unknown_region(mock_zone_letter
     assert get_alternative_zones("unknown-region-1", "a") == []
 
 
-def test_get_alternative_zones_returns_shuffled_list(mock_zone_letters):
+def test_get_alternative_zones_returns_deterministic_order(mock_zone_letters):
+    """Alternative zones are returned in deterministic order for predictable fallback."""
     results = [tuple(get_alternative_zones("us-central1", "a")) for _ in range(20)]
-    assert len(set(results)) > 1
+    assert len(set(results)) == 1
+    assert results[0] == ("b", "c", "f")
 
 
 def test_get_alternative_zones_single_zone_region_returns_empty():


### PR DESCRIPTION
When a GCE zone is exhausted (ZONE_RESOURCE_POOL_EXHAUSTED), ZoneResourcesExhaustedError was raised but never caught, crashing the test. Add zone-level fallback in GCECluster._create_instances() that tries alternative zones in the same region before giving up. Also expand us-central1 from single zone 'a' to 'abcf'.

Fixes: https://scylladb.atlassian.net/browse/SCT-350

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [artifacts-ubuntu2204-test](https://argus.scylladb.com/tests/scylla-cluster-tests/12caffa6-340b-4b22-b461-4ea3f5a6d7c0)

I ran the test with simulation of the failure. The instance was provided with fallback into another AZ
```
19:33:24  < t:2026-05-18 16:33:23,847 f:cluster_gce.py  l:555  c:sdcm.cluster         p:INFO  > GCE Cluster artifacts-ubuntu2204-jenkins-db-cluster-12caffa6 | Image: ubuntu-2204-lts | Root Disk: pd-ssd 50 GB | Local SSD: 1 | : Found no provisioned instances. Provision them.
19:33:25  < t:2026-05-18 16:33:24,120 f:cluster_gce.py  l:398  c:sdcm.cluster         p:WARNING > GCE Cluster artifacts-ubuntu2204-jenkins-db-cluster-12caffa6 | Image: ubuntu-2204-lts | Root Disk: pd-ssd 50 GB | Local SSD: 1 | : Zone us-east1-c exhausted, trying alternative zones in region us-east1
19:33:25  < t:2026-05-18 16:33:24,121 f:cluster_gce.py  l:403  c:sdcm.cluster         p:INFO  > GCE Cluster artifacts-ubuntu2204-jenkins-db-cluster-12caffa6 | Image: ubuntu-2204-lts | Root Disk: pd-ssd 50 GB | Local SSD: 1 | : Attempting zone us-east1-d as fallback
19:33:25  < t:2026-05-18 16:33:24,682 f:instance_provider.py l:120  c:sdcm.provision.gce.instance_provider p:INFO  > Creating 'artifacts-ubuntu2204-jenkins-db-node-12caffa6-0-1' VM in zone us-east1-d...
19:33:25  < t:2026-05-18 16:33:24,682 f:instance_provider.py l:121  c:sdcm.provision.gce.instance_provider p:INFO  > Instance params: InstanceDefinition(name='artifacts-ubuntu2204-jenkins-db-node-12caffa6-0-1', image_id='https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/family/ubuntu-2204-lts', type='n2-standard-2', user_name='scylla-test', tags={'RunByUser': 'julia.yakovlev', 'TestName': 'artifacts_test.ArtifactsTest.test_scylla_service', 'TestId': '12caffa6-340b-4b22-b461-4ea3f5a6d7c0', 'version': 'scylla-staging', 'CreatedBy': 'SCT', 'JenkinsJobTag': 'jenkins-scylla-staging-yulia-artifacts-ubuntu2204-test-25', 'JenkinsJob': 'jenkins-scylla-staging-yulia-artifacts-ubuntu2204-test', 'billing_project': 'no_billing_project', 'NodeType': 'scylla-db', 'keep_action': 'terminate', 'NodeIndex': '1'}, arch=<VmArch.X86: 'x86_64'>, root_disk_size=50, root_disk_type='pd-ssd', data_disks=[DataDisk(type='local-ssd', size=375, iops=0, count=1)], use_public_ip=False, rack_index=None)
19:33:25  < t:2026-05-18 16:33:24,819 f:instance_provider.py l:287  c:sdcm.provision.gce.instance_provider p:INFO  > Creating instance artifacts-ubuntu2204-jenkins-db-node-12caffa6-0-1 in zone us-east1-d...
19:33:36  < t:2026-05-18 16:33:36,011 f:instance_provider.py l:166  c:sdcm.provision.gce.instance_provider p:INFO  > Instance artifacts-ubuntu2204-jenkins-db-node-12caffa6-0-1 created successfully
```

- [x] [arm artifact test](https://argus.scylladb.com/tests/scylla-cluster-tests/dcd4302c-2203-4a69-be59-70ab98230d82)
- [x] [arm artifact test with fallback simulation](https://argus.scylladb.com/tests/scylla-cluster-tests/98c269fb-5c92-466b-b586-68cb61183e0f)
```
14:43:34  < t:2026-05-25 11:43:33,542 f:cluster_gce.py  l:408  c:sdcm.cluster         p:WARNING > GCE Cluster artifacts-ubuntu2204-jenkins-db-cluster-98c269fb | Image: ubuntu-2204-lts | Root Disk: pd-ssd 50 GB | Local SSD: 1 | : Zone us-central1-c exhausted, trying alternative zones in region us-central1
14:43:34  < t:2026-05-25 11:43:34,069 f:cluster_gce.py  l:433  c:sdcm.cluster         p:INFO  > GCE Cluster artifacts-ubuntu2204-jenkins-db-cluster-98c269fb | Image: ubuntu-2204-lts | Root Disk: pd-ssd 50 GB | Local SSD: 1 | : Attempting zone us-central1-a as fallback
```

- [x] [artifacts-ubuntu2604-arm-test with fallback simulation](https://argus.scylladb.com/tests/scylla-cluster-tests/d945e48b-7619-4458-85e4-efe1fd2553b3)
```
15:26:16  < t:2026-05-25 12:26:16,413 f:cluster_gce.py  l:408  c:sdcm.cluster         p:WARNING > GCE Cluster artifacts-ubuntu2604-jenkins-db-cluster-d945e48b | Image: ubuntu-2604-lts-arm64 | Root Disk: pd-ssd 50 GB | pd-standard: 50 | : Zone us-central1-f exhausted, trying alternative zones in region us-central1
15:26:18  < t:2026-05-25 12:26:17,180 f:cluster_gce.py  l:433  c:sdcm.cluster         p:INFO  > GCE Cluster artifacts-ubuntu2604-jenkins-db-cluster-d945e48b | Image: ubuntu-2604-lts-arm64 | Root Disk: pd-ssd 50 GB | pd-standard: 50 | : Attempting zone us-central1-a as fallback
```

- [x] [artifacts-gce-image-test with fallback simulation](https://argus.scylladb.com/tests/scylla-cluster-tests/00665c9b-735e-4f91-9c25-c4d282a397ad)
```
16:21:22  < t:2026-05-25 13:21:21,992 f:cluster_gce.py  l:408  c:sdcm.cluster         p:WARNING > GCE Cluster artifacts-gce-image-jenkins-db-cluster-00665c9b | Image: 4903389776318144561 | Root Disk: pd-ssd 50 GB | Local SSD: 8 | : Zone us-central1-f exhausted, trying alternative zones in region us-central1
16:21:22  < t:2026-05-25 13:21:22,643 f:cluster_gce.py  l:433  c:sdcm.cluster         p:INFO  > GCE Cluster artifacts-gce-image-jenkins-db-cluster-00665c9b | Image: 4903389776318144561 | Root Disk: pd-ssd 50 GB | Local SSD: 8 | : Attempting zone us-central1-a as fallback
```

- [x] [artifacts-gce-image](https://argus.scylladb.com/tests/scylla-cluster-tests/c6424290-4a3c-4e27-81c5-5d13e4eb4cb6)
- [x] [rolling-upgrade-ubuntu2404-test](https://argus.scylladb.com/tests/scylla-cluster-tests/2696c394-85fc-4cf4-bce4-777b14452749)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)