### PR TITLE
feature(provision/gce): upfront AZ filtering and runtime zone fallback for GCE

### DIFF
--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -4034,7 +4034,7 @@ Try all availability zones one by one in order to maximize the chances of gettin
 
 ## **pre_filter_unavailable_availability_zones** / SCT_PRE_FILTER_UNAVAILABLE_AVAILABILITY_ZONES
 
-Filter availability zones upfront to only those that support all required instance types. Replaces invalid AZs with valid alternatives in the same region before any provisioning attempt. AWS only.
+Filter availability zones upfront to only those that support all required instance types. Replaces invalid AZs with valid alternatives in the same region before any provisioning attempt. Supported backends: AWS, GCE.
 
 **default:** True
 

--- a/sct.py
+++ b/sct.py
@@ -298,6 +298,10 @@ def provision_resources(backend, test_name: str, config: str):
             layout = SCTProvisionLayout(params=params)
             layout.provision()
         elif backend in ("azure", "gce", "oci"):
+            if backend == "gce":
+                from sdcm.provision.gce.zone_resolver import GceAZResolver  # noqa: PLC0415
+
+                GceAZResolver(params).resolve()
             provision_sct_resources(params=params, test_config=test_config)
         elif backend == "xcloud":
             cloud_provider = params.get("xcloud_provider").lower()

--- a/sdcm/provision/gce/capacity_errors.py
+++ b/sdcm/provision/gce/capacity_errors.py
@@ -1,0 +1,62 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2026 ScyllaDB
+
+"""Centralized GCE capacity and provisioning error classification."""
+
+CAPACITY_ERROR_MARKERS: list[str] = [
+    "ZONE_RESOURCE_POOL_EXHAUSTED",
+    "RESOURCE_POOL_EXHAUSTED",
+    "stockout",
+]
+
+QUOTA_ERROR_MARKERS: list[str] = [
+    "QUOTA_EXCEEDED",
+    "quotaExceeded",
+]
+
+TYPE_NOT_AVAILABLE_MARKERS: list[str] = [
+    "RESOURCE_NOT_FOUND",
+    "machineTypeNotFound",
+]
+
+
+def is_zone_capacity_error(exception: BaseException) -> bool:
+    """Return True if `exception` is a transient GCE zone capacity exhaustion error."""
+    error_str = str(exception)
+    return any(marker in error_str for marker in CAPACITY_ERROR_MARKERS)
+
+
+def is_quota_error(exception: BaseException) -> bool:
+    """Return True if `exception` is a GCE regional quota exhaustion error."""
+    error_str = str(exception)
+    return any(marker in error_str for marker in QUOTA_ERROR_MARKERS)
+
+
+def is_type_unavailable_error(exception: BaseException) -> bool:
+    """Return True if the machine type does not exist in the region/zone at all."""
+    error_str = str(exception)
+    return any(marker in error_str for marker in TYPE_NOT_AVAILABLE_MARKERS)
+
+
+def classify_provisioning_error(exception: BaseException) -> str:
+    """Classify a GCE provisioning error for fallback routing.
+
+    Returns one of: "capacity", "quota", "type_unavailable", "unknown".
+    """
+    if is_zone_capacity_error(exception):
+        return "capacity"
+    if is_quota_error(exception):
+        return "quota"
+    if is_type_unavailable_error(exception):
+        return "type_unavailable"
+    return "unknown"

--- a/sdcm/provision/gce/zone_resolver.py
+++ b/sdcm/provision/gce/zone_resolver.py
@@ -1,0 +1,229 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2026 ScyllaDB
+
+import logging
+import random
+from typing import Callable
+
+from sdcm.utils.gce_utils import GceZoneResolver
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _node_count_positive(value) -> bool:
+    """Indicates if an SCT node-count parameter resolves to >0 in any region."""
+    if value is None:
+        return False
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return value > 0
+    if isinstance(value, list):
+        return any(int(n) > 0 for n in value if str(n).strip().lstrip("-").isdigit())
+    if isinstance(value, str):
+        return any(int(n) > 0 for n in value.split() if n.strip().lstrip("-").isdigit())
+    return False
+
+
+def _has_loaders(params) -> bool:
+    return _node_count_positive(params.get("n_loaders"))
+
+
+def _has_monitor(params) -> bool:
+    return _node_count_positive(params.get("n_monitor_nodes"))
+
+
+def _has_oracle(params) -> bool:
+    return params.get("db_type") in ("mixed_scylla", "mixed_cassandra") and _node_count_positive(
+        params.get("n_test_oracle_db_nodes")
+    )
+
+
+def _has_zero_token(params) -> bool:
+    return bool(params.get("use_zero_nodes")) and _node_count_positive(params.get("n_db_zero_token_nodes"))
+
+
+def _has_vector_store(params) -> bool:
+    return _node_count_positive(params.get("n_vector_store_nodes"))
+
+
+def _always(params) -> bool:  # noqa: ARG001
+    return True
+
+
+# (machine-type param key, gate). Gate decides whether this type will actually
+# be launched; types whose gate is False are excluded from zone-filter intersection.
+_MACHINE_TYPE_PARAM_GATES: tuple[tuple[str, Callable[[object], bool]], ...] = (
+    ("gce_instance_type_db", _always),
+    ("gce_instance_type_loader", _has_loaders),
+    ("gce_instance_type_monitor", _has_monitor),
+    ("zero_token_instance_type_db", _has_zero_token),
+    ("instance_type_db_oracle", _has_oracle),
+    ("instance_type_db_target", _always),
+    ("nemesis_grow_shrink_instance_type", _always),
+    ("instance_type_vector_store", _has_vector_store),
+)
+
+
+class NoValidAvailabilityZoneError(Exception):
+    """Raised when no zone supports all required machine types in the configured region(s)."""
+
+
+class GceAZResolver:
+    """Resolve `availability_zone` config to zones supporting all required machine types (GCE)."""
+
+    def __init__(self, params):
+        self._params = params
+
+    def required_machine_types(self) -> list[str]:
+        """Get the deduplicated list of machine types a test will launch."""
+        selected = []
+        for key, gate in _MACHINE_TYPE_PARAM_GATES:
+            machine_type = self._params.get(key)
+            if machine_type and gate(self._params) and machine_type not in selected:
+                selected.append(machine_type)
+        return selected
+
+    def resolve(self) -> None:
+        """Filter `availability_zone` to zones supporting all required types in every region.
+
+        If `pre_filter_unavailable_availability_zones` is False, returns without
+        modifying params. Multi-AZ configs ("b,c,d") have invalid zones replaced with
+        valid alternatives in the same region.
+        Raises `NoValidAvailabilityZoneError` when no zone letter is valid in every region.
+        """
+        if not self._params.get("pre_filter_unavailable_availability_zones"):
+            LOGGER.info("Upfront zone filter disabled; skipping GceAZResolver.resolve()")
+            return
+
+        machine_types = self.required_machine_types()
+        if not machine_types:
+            LOGGER.info("No machine types declared; skipping zone filter")
+            return
+
+        region_names = self._region_names()
+        if not region_names:
+            LOGGER.info("No region configured; skipping zone filter")
+            return
+
+        configured_letters = self._configured_az_letters()
+        if not configured_letters:
+            valid_letters = self._discover_valid_zone_letters(region_names, machine_types)
+            if not valid_letters:
+                raise NoValidAvailabilityZoneError(self._build_no_zone_error(region_names, machine_types))
+            chosen = random.choice(valid_letters)
+            LOGGER.info(
+                "GceAZResolver: no availability_zone configured; selected '%s' from valid zones %s",
+                chosen,
+                valid_letters,
+            )
+            self._params["availability_zone"] = chosen
+            return
+
+        supported_letters = self._common_supported_letters(region_names, configured_letters, machine_types)
+        if not supported_letters:
+            raise NoValidAvailabilityZoneError(self._build_no_zone_error(region_names, machine_types))
+
+        resolved = [letter for letter in configured_letters if letter in supported_letters]
+        for letter in supported_letters:
+            if len(resolved) >= len(configured_letters):
+                break
+            if letter not in resolved:
+                resolved.append(letter)
+
+        new_value = ",".join(resolved)
+        original_value = self._params.get("availability_zone")
+        if new_value != original_value:
+            LOGGER.warning(
+                "GceAZResolver: availability_zone '%s' does not support all required "
+                "machine types %s in regions %s; replacing with '%s'",
+                original_value,
+                machine_types,
+                region_names,
+                new_value,
+            )
+            self._params["availability_zone"] = new_value
+        else:
+            LOGGER.info(
+                "GceAZResolver: availability_zone '%s' already valid for regions %s", original_value, region_names
+            )
+
+    def _common_supported_letters(
+        self, region_names: list[str], configured_letters: list[str], machine_types: list[str]
+    ) -> list[str]:
+        """Intersect supported zone letters across all configured regions.
+
+        Returns letters in this order: configured letters first (preserving user
+        intent), then any additional supported letters sorted alphabetically.
+        """
+        common: set[str] | None = None
+        for region in region_names:
+            preferred_full = [f"{region}-{letter}" for letter in configured_letters]
+            resolver = GceZoneResolver()
+            supported_full = resolver.get_common_zones(
+                region=region,
+                machine_types=machine_types,
+                preferred_zones=preferred_full,
+            )
+            # GCE zone format: "us-east1-b" -> extract letter after last "-"
+            letters = {zone.split("-")[-1] for zone in supported_full}
+            common = letters if common is None else common & letters
+
+        if not common:
+            return []
+
+        configured_first = [letter for letter in configured_letters if letter in common]
+        additional = sorted(common - set(configured_first))
+        return configured_first + additional
+
+    def _region_names(self) -> list[str]:
+        if regions := getattr(self._params, "gce_datacenters", None):
+            return list(regions)
+        raw = self._params.get("gce_datacenter") or ""
+        if isinstance(raw, list):
+            return raw
+        return raw.split()
+
+    def _configured_az_letters(self) -> list[str]:
+        raw = self._params.get("availability_zone") or ""
+        return [letter.strip() for letter in raw.split(",") if letter.strip()]
+
+    def _build_no_zone_error(self, region_names: list[str], machine_types: list[str]) -> str:
+        lines = [f"No zone supports all required machine types across regions {region_names}."]
+        for region in region_names:
+            resolver = GceZoneResolver()
+            per_type = resolver.get_per_type_zones(region, machine_types)
+            for mt, zones in per_type.items():
+                if zones:
+                    letters = [z.split("-")[-1] for z in zones]
+                    lines.append(f"  {mt} in {region}: available in zones {letters}")
+                else:
+                    lines.append(f"  {mt} in {region}: NOT AVAILABLE in any zone")
+        return "\n".join(lines)
+
+    def _discover_valid_zone_letters(self, region_names: list[str], machine_types: list[str]) -> list[str]:
+        common: set[str] | None = None
+        for region in region_names:
+            resolver = GceZoneResolver()
+            all_zones = resolver.get_zones_for_region(region)
+            supported_full = resolver.get_common_zones(
+                region=region,
+                machine_types=machine_types,
+                preferred_zones=all_zones,
+            )
+            letters = {zone.split("-")[-1] for zone in supported_full}
+            common = letters if common is None else common & letters
+
+        if not common:
+            return []
+        return sorted(common)

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -75,9 +75,9 @@ from sdcm.utils.version_utils import (
 )
 from sdcm.sct_events.base import add_severity_limit_rules, print_critical_events
 from sdcm.utils.gce_utils import (
-    SUPPORTED_REGIONS as GCE_SUPPORTED_REGIONS,
     get_gce_image_tags,
     get_gce_compute_machine_types_client,
+    get_gce_compute_regions_client,
     gce_check_if_machine_type_supported,
 )
 from sdcm.utils.azure_utils import (
@@ -1987,7 +1987,8 @@ class SCTConfiguration(BaseModel):
     )
     pre_filter_unavailable_availability_zones: Boolean = SctField(
         description="Filter availability zones upfront to only those that support all required instance types. "
-        "Replaces invalid AZs with valid alternatives in the same region before any provisioning attempt. AWS only.",
+        "Replaces invalid AZs with valid alternatives in the same region before any provisioning attempt. "
+        "Supported backends: AWS, GCE.",
     )
     num_nodes_to_rollback: int = SctField(
         description="Number of nodes to upgrade and rollback in test_generic_cluster_upgrade",
@@ -3730,9 +3731,11 @@ class SCTConfiguration(BaseModel):
                         )
                 case "gce":
                     machine_types_client, info = get_gce_compute_machine_types_client()
+                    regions_client, _ = get_gce_compute_regions_client()
                     for datacenter in self.gce_datacenters:
-                        for zone in GCE_SUPPORTED_REGIONS.get(datacenter):
-                            _zone = f"{datacenter}-{zone}"
+                        region_info = regions_client.get(project=info["project_id"], region=datacenter)
+                        zones = [z.rsplit("/", 1)[-1] for z in region_info.zones]
+                        for _zone in zones:
                             assert gce_check_if_machine_type_supported(
                                 machine_types_client, instance_type, project=info["project_id"], zone=_zone
                             ), f"Instance type[{instance_type}] not supported in zone [{_zone}]"

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -52,6 +52,7 @@ from sdcm import nemesis, cluster_docker, cluster_k8s, cluster_baremetal, wait
 from sdcm.cloud_api_client import ScyllaCloudAPIClient
 from sdcm.provision.azure.kms_provider import AzureKmsProvider
 from sdcm.provision.gce.kms_provider import GcpKmsProvider
+from sdcm.provision.gce.zone_resolver import GceAZResolver
 from sdcm.cluster import (
     BaseCluster,
     NoMonitorSet,
@@ -1601,6 +1602,8 @@ class ClusterTester(unittest.TestCase):
         return nemesis_threads
 
     def get_cluster_gce(self, loader_info, db_info, monitor_info):  # noqa: PLR0912, PLR0914
+        GceAZResolver(self.params).resolve()
+
         datacenters = self.params.gce_datacenters
         test_id = str(TestConfig().test_id())
         provisioners: List[GceProvisioner] = []

--- a/sdcm/utils/gce_builder.py
+++ b/sdcm/utils/gce_builder.py
@@ -244,7 +244,7 @@ class GceBuilder:
     def configure_in_all_region(cls, regions=None):
         for project in SUPPORTED_PROJECTS:
             with environment(SCT_GCE_PROJECT=project):
-                regions = regions or SUPPORTED_REGIONS.keys()
+                regions = regions or SUPPORTED_REGIONS
                 for region_name in regions:
                     gce_builder = cls(GceRegion(region_name))
                     gce_builder.configure()

--- a/sdcm/utils/gce_utils.py
+++ b/sdcm/utils/gce_utils.py
@@ -21,6 +21,7 @@ import uuid
 from functools import cached_property
 from typing import Any, List, Literal, TYPE_CHECKING
 
+import google.api_core.exceptions
 from google.oauth2 import service_account
 from google.cloud import compute_v1
 from google.cloud.compute_v1 import Image
@@ -85,15 +86,13 @@ def vmarch_to_gcp(arch: "VmArch") -> str:
         raise ValueError(f"Unsupported architecture: {arch}")
 
 
-# The keys are the region name, the value is the available zones, which will be used for random.choice()
-SUPPORTED_REGIONS = {
-    # us-east1 zones: b, c, and d. Details: https://cloud.google.com/compute/docs/regions-zones#locations
-    # Currently choose only zones c and d as zone b frequently fails allocating resources.
-    "us-east1": "cd",
-    "us-east4": "abc",
-    "us-west1": "abc",
-    "us-central1": "abcf",
-}
+# Regions where SCT has infrastructure (VPCs, firewall rules, etc.)
+SUPPORTED_REGIONS = [
+    "us-east1",
+    "us-east4",
+    "us-west1",
+    "us-central1",
+]
 
 
 SUPPORTED_PROJECTS = {"gcp-sct-project-1", "gcp-local-ssd-latency"} | {
@@ -101,11 +100,36 @@ SUPPORTED_PROJECTS = {"gcp-sct-project-1", "gcp-local-ssd-latency"} | {
 }
 
 
+def _get_zone_letters_for_region(region: str) -> list[str]:
+    """Query GCE Regions API to get available zone letters for a region."""
+    try:
+        regions_client, _ = get_gce_compute_regions_client()
+        region_info = regions_client.get(project=KeyStore().get_gcp_credentials()["project_id"], region=region)
+        return [z.rsplit("/", 1)[-1].split("-")[-1] for z in region_info.zones]
+    except Exception:  # noqa: BLE001
+        LOGGER.warning("Failed to get zones from GCE API for region %s", region)
+        return []
+
+
 def random_zone(region: str) -> str:
-    availability_zones = SUPPORTED_REGIONS.get(region, None)
-    if not availability_zones:
-        raise Exception(f"Unsupported region: {region}")
-    return f"{random.choice(availability_zones)}"
+    zone_letters = _get_zone_letters_for_region(region)
+    if not zone_letters:
+        raise Exception(f"No zones found for region: {region}")
+    return random.choice(zone_letters)
+
+
+def get_alternative_zones(region: str, exhausted_zone: str) -> list[str]:
+    """Return alternative zone letters for a region, excluding the exhausted zone.
+
+    Used by runtime fallback when provisioning fails with ZoneResourcesExhaustedError.
+    """
+    zone_letters = _get_zone_letters_for_region(region)
+    if not zone_letters:
+        return []
+    exhausted_letter = exhausted_zone[-1] if len(exhausted_zone) > 1 else exhausted_zone
+    alternatives = [z for z in zone_letters if z != exhausted_letter]
+    random.shuffle(alternatives)
+    return alternatives
 
 
 def get_gce_compute_instances_client() -> tuple[compute_v1.InstancesClient, dict]:
@@ -160,6 +184,70 @@ def get_gce_compute_machine_types_client() -> tuple[compute_v1.MachineTypesClien
     info = KeyStore().get_gcp_credentials()
     credentials = service_account.Credentials.from_service_account_info(info)
     return compute_v1.MachineTypesClient(credentials=credentials), info
+
+
+class GceZoneResolver:
+    """Resolves available zones for machine types in a GCE project/region."""
+
+    def __init__(self, project: str | None = None):
+        if project:
+            self._project = project
+        else:
+            info = KeyStore().get_gcp_credentials()
+            self._project = info["project_id"]
+        self._machine_types_client, _ = get_gce_compute_machine_types_client()
+
+    def get_zones_for_region(self, region: str) -> list[str]:
+        try:
+            regions_client, _ = get_gce_compute_regions_client()
+            region_info = regions_client.get(project=self._project, region=region)
+            return [z.rsplit("/", 1)[-1] for z in region_info.zones]
+        except Exception:  # noqa: BLE001
+            LOGGER.warning("Failed to get zones from GCE API for region %s", region)
+            return []
+
+    def get_zones_for_machine_type(self, region: str, machine_type: str) -> list[str]:
+        """Return zones in a region where the given machine type is available."""
+        all_zones = self.get_zones_for_region(region)
+        available = []
+        for zone in all_zones:
+            try:
+                self._machine_types_client.get(project=self._project, zone=zone, machine_type=machine_type)
+                available.append(zone)
+            except google.api_core.exceptions.NotFound:
+                continue
+            except Exception:  # noqa: BLE001
+                LOGGER.warning("Error checking machine type %s in zone %s; skipping", machine_type, zone)
+                continue
+        return available
+
+    def get_common_zones(
+        self,
+        region: str,
+        machine_types: list[str],
+        preferred_zones: list[str] | None = None,
+    ) -> list[str]:
+        """Return zones in the region that support ALL given machine types."""
+        if not machine_types:
+            return []
+
+        zones_per_type = [set(self.get_zones_for_machine_type(region, mt)) for mt in machine_types]
+        common_zones = set.intersection(*zones_per_type) if zones_per_type else set()
+
+        preferred_zones = preferred_zones or []
+        missing = [z for z in preferred_zones if z not in common_zones]
+        if missing:
+            LOGGER.warning("Preferred zones %s do not support all required machine types %s", missing, machine_types)
+
+        ordered = [z for z in preferred_zones if z in common_zones]
+        ordered += [z for z in sorted(common_zones) if z not in ordered]
+
+        LOGGER.info("Zones in %s supporting %s: %s", region, machine_types, ordered)
+        return ordered
+
+    def get_per_type_zones(self, region: str, machine_types: list[str]) -> dict[str, list[str]]:
+        """Return a mapping of machine_type -> available zones in the region."""
+        return {mt: self.get_zones_for_machine_type(region, mt) for mt in machine_types}
 
 
 def gce_public_addresses(instance: compute_v1.Instance) -> list[str]:

--- a/unit_tests/unit/provisioner/test_gce_capacity_errors.py
+++ b/unit_tests/unit/provisioner/test_gce_capacity_errors.py
@@ -1,0 +1,84 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2026 ScyllaDB
+
+import pytest
+
+from sdcm.provision.gce.capacity_errors import (
+    is_zone_capacity_error,
+    is_quota_error,
+    is_type_unavailable_error,
+    classify_provisioning_error,
+)
+
+
+class _FakeError(Exception):
+    pass
+
+
+@pytest.mark.parametrize(
+    "message,expected",
+    [
+        ("ZONE_RESOURCE_POOL_EXHAUSTED", True),
+        ("Zone us-east1-b resource pool exhausted: ZONE_RESOURCE_POOL_EXHAUSTED", True),
+        ("RESOURCE_POOL_EXHAUSTED in us-east1-c", True),
+        ("stockout detected", True),
+        ("PERMISSION_DENIED: cannot access", False),
+        ("QUOTA_EXCEEDED", False),
+        ("", False),
+    ],
+)
+def test_is_zone_capacity_error(message, expected):
+    assert is_zone_capacity_error(_FakeError(message)) is expected
+
+
+@pytest.mark.parametrize(
+    "message,expected",
+    [
+        ("QUOTA_EXCEEDED for cpus in us-east1", True),
+        ("quotaExceeded: limit reached", True),
+        ("ZONE_RESOURCE_POOL_EXHAUSTED", False),
+        ("PERMISSION_DENIED", False),
+    ],
+)
+def test_is_quota_error(message, expected):
+    assert is_quota_error(_FakeError(message)) is expected
+
+
+@pytest.mark.parametrize(
+    "message,expected",
+    [
+        ("RESOURCE_NOT_FOUND: machine type n2d-highcpu-128", True),
+        ("machineTypeNotFound in zone us-east1-b", True),
+        ("ZONE_RESOURCE_POOL_EXHAUSTED", False),
+        ("generic error", False),
+    ],
+)
+def test_is_type_unavailable_error(message, expected):
+    assert is_type_unavailable_error(_FakeError(message)) is expected
+
+
+@pytest.mark.parametrize(
+    "message,expected_class",
+    [
+        ("ZONE_RESOURCE_POOL_EXHAUSTED", "capacity"),
+        ("QUOTA_EXCEEDED", "quota"),
+        ("RESOURCE_NOT_FOUND", "type_unavailable"),
+        ("PERMISSION_DENIED", "unknown"),
+    ],
+)
+def test_classify_provisioning_error(message, expected_class):
+    assert classify_provisioning_error(_FakeError(message)) == expected_class
+
+
+def test_non_exception_types_handled():
+    assert is_zone_capacity_error(ValueError("just a value error")) is False

--- a/unit_tests/unit/provisioner/test_gce_zone_resolver.py
+++ b/unit_tests/unit/provisioner/test_gce_zone_resolver.py
@@ -1,0 +1,279 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2026 ScyllaDB
+
+from unittest.mock import patch
+
+import pytest
+
+from sdcm.provision.gce.zone_resolver import GceAZResolver, NoValidAvailabilityZoneError, _node_count_positive
+from sdcm.utils.gce_utils import get_alternative_zones
+
+
+class _DotDict(dict):
+    __getattr__ = dict.__getitem__
+    __setattr__ = dict.__setitem__
+    __delattr__ = dict.__delitem__
+
+
+def _make_params(**overrides):
+    params = _DotDict(
+        {
+            "cluster_backend": "gce",
+            "gce_datacenter": "us-east1",
+            "availability_zone": "b",
+            "gce_instance_type_db": "n2-highmem-8",
+            "gce_instance_type_loader": "e2-standard-2",
+            "gce_instance_type_monitor": "n2-highmem-8",
+            "n_db_nodes": 3,
+            "n_loaders": 1,
+            "n_monitor_nodes": 1,
+            "pre_filter_unavailable_availability_zones": True,
+            **overrides,
+        }
+    )
+    params.gce_datacenters = (
+        params["gce_datacenter"].split() if isinstance(params["gce_datacenter"], str) else params["gce_datacenter"]
+    )
+    return params
+
+
+@pytest.fixture(name="mock_gce_zone_resolver")
+def mock_gce_zone_resolver_fixture():
+    with patch("sdcm.provision.gce.zone_resolver.GceZoneResolver") as mock_cls:
+        instance = mock_cls.return_value
+        instance.get_common_zones.return_value = ["us-east1-b", "us-east1-c", "us-east1-d"]
+        yield mock_cls, instance
+
+
+def test_required_machine_types_collects_all_role_types_when_active():
+    params = _make_params(
+        gce_instance_type_db="n2-highmem-8",
+        gce_instance_type_loader="e2-standard-2",
+        gce_instance_type_monitor="n2-highmem-4",
+        instance_type_db_oracle="n2-highmem-16",
+        instance_type_db_target="n2d-standard-8",
+        nemesis_grow_shrink_instance_type="n2-highmem-16",
+        zero_token_instance_type_db="e2-medium",
+        instance_type_vector_store="e2-medium",
+        n_loaders=1,
+        n_monitor_nodes=1,
+        n_test_oracle_db_nodes=1,
+        db_type="mixed_scylla",
+        n_db_zero_token_nodes=1,
+        use_zero_nodes=True,
+        n_vector_store_nodes=2,
+    )
+    types = GceAZResolver(params).required_machine_types()
+    assert set(types) == {
+        "n2-highmem-8",
+        "e2-standard-2",
+        "n2-highmem-4",
+        "n2-highmem-16",
+        "n2d-standard-8",
+        "e2-medium",
+    }
+
+
+def test_required_machine_types_excludes_types_with_zero_node_count():
+    params = _make_params(
+        gce_instance_type_db="n2-highmem-8",
+        gce_instance_type_loader="e2-standard-2",
+        gce_instance_type_monitor="n2-highmem-8",
+        instance_type_vector_store="e2-medium",
+        instance_type_db_oracle="n2-highmem-16",
+        zero_token_instance_type_db="e2-medium",
+        n_loaders=0,
+        n_monitor_nodes=0,
+        n_vector_store_nodes=0,
+        n_test_oracle_db_nodes=1,
+        db_type="scylla",
+        use_zero_nodes=False,
+    )
+    assert GceAZResolver(params).required_machine_types() == ["n2-highmem-8"]
+
+
+def test_resolve_disabled_returns_unchanged(mock_gce_zone_resolver):
+    params = _make_params(pre_filter_unavailable_availability_zones=False, availability_zone="b,c")
+    GceAZResolver(params).resolve()
+    assert params["availability_zone"] == "b,c"
+
+
+def test_resolve_replaces_invalid_zone_with_valid_alternative(mock_gce_zone_resolver):
+    _, resolver_instance = mock_gce_zone_resolver
+    resolver_instance.get_common_zones.return_value = ["us-east1-c", "us-east1-d"]
+    params = _make_params(availability_zone="b")
+    GceAZResolver(params).resolve()
+    assert params["availability_zone"] in {"c", "d"}
+
+
+def test_resolve_multi_az_drops_unsupported_and_fills_alternatives(mock_gce_zone_resolver):
+    _, resolver_instance = mock_gce_zone_resolver
+    resolver_instance.get_common_zones.return_value = ["us-east1-b", "us-east1-c", "us-east1-d"]
+    params = _make_params(availability_zone="b,f,e")
+    GceAZResolver(params).resolve()
+    result = params["availability_zone"].split(",")
+    assert len(result) == 3
+    assert "b" in result
+    assert "f" not in result
+    assert "e" not in result
+    assert set(result) <= {"b", "c", "d"}
+
+
+def test_resolve_raises_when_no_valid_zone_in_region(mock_gce_zone_resolver):
+    _, resolver_instance = mock_gce_zone_resolver
+    resolver_instance.get_common_zones.return_value = []
+    params = _make_params(availability_zone="b")
+    with pytest.raises(NoValidAvailabilityZoneError):
+        GceAZResolver(params).resolve()
+
+
+@pytest.fixture(name="mock_multi_region")
+def mock_multi_region_fixture():
+    region_returns: dict[str, list[str]] = {}
+
+    class _ResolverStub:
+        def get_common_zones(self, region, machine_types, preferred_zones=None):  # noqa: ARG002
+            return region_returns.get(region, [])
+
+        def get_per_type_zones(self, region, machine_types):  # noqa: ARG002
+            zones = region_returns.get(region, [])
+            return {mt: zones for mt in machine_types}
+
+    with patch("sdcm.provision.gce.zone_resolver.GceZoneResolver", return_value=_ResolverStub()):
+        yield region_returns
+
+
+def test_resolve_multi_region_intersects_supported_zone_letters(mock_multi_region):
+    mock_multi_region["us-east1"] = ["us-east1-b", "us-east1-c"]
+    mock_multi_region["us-east4"] = ["us-east4-c", "us-east4-a"]
+    params = _make_params(gce_datacenter="us-east1 us-east4", availability_zone="b")
+    GceAZResolver(params).resolve()
+    assert params["availability_zone"] == "c"
+
+
+def test_resolve_multi_region_raises_when_no_common_letter(mock_multi_region):
+    mock_multi_region["us-east1"] = ["us-east1-b", "us-east1-c"]
+    mock_multi_region["us-east4"] = ["us-east4-a", "us-east4-d"]
+    params = _make_params(gce_datacenter="us-east1 us-east4", availability_zone="b")
+    with pytest.raises(NoValidAvailabilityZoneError):
+        GceAZResolver(params).resolve()
+
+
+def test_resolve_multi_region_multi_az_drops_unsupported_and_fills(mock_multi_region):
+    mock_multi_region["us-east1"] = ["us-east1-b", "us-east1-c", "us-east1-d"]
+    mock_multi_region["us-east4"] = ["us-east4-b", "us-east4-c", "us-east4-d"]
+    params = _make_params(gce_datacenter="us-east1 us-east4", availability_zone="a,b,c")
+    GceAZResolver(params).resolve()
+    result = params["availability_zone"].split(",")
+    assert set(result) == {"b", "c", "d"}
+
+
+@pytest.fixture(name="mock_discovery_resolver")
+def mock_discovery_resolver_fixture():
+    class _DiscoveryStub:
+        def get_zones_for_region(self, region):
+            return [f"{region}-b", f"{region}-c", f"{region}-d"]
+
+        def get_common_zones(self, region, machine_types, preferred_zones=None):  # noqa: ARG002
+            return [f"{region}-b", f"{region}-c"]
+
+    with patch("sdcm.provision.gce.zone_resolver.GceZoneResolver", return_value=_DiscoveryStub()):
+        yield
+
+
+@pytest.mark.parametrize("az_value", ["", None])
+def test_resolve_with_unset_availability_zone_discovers_valid_zone(mock_discovery_resolver, az_value):
+    params = _make_params(availability_zone=az_value)
+    GceAZResolver(params).resolve()
+    assert params["availability_zone"] in {"b", "c"}
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (None, False),
+        (True, True),
+        (False, False),
+        (0, False),
+        (1, True),
+        (3, True),
+        ([], False),
+        ([0, 0], False),
+        ([2, 0], True),
+        ("", False),
+        ("0", False),
+        ("3", True),
+        ("3 4", True),
+        ({"a": 1}, False),
+    ],
+)
+def test_node_count_positive(value, expected):
+    assert _node_count_positive(value) is expected
+
+
+def test_required_machine_types_skips_target_when_none():
+    params = _make_params(
+        gce_instance_type_db="n2-highmem-8",
+        instance_type_db_target=None,
+        nemesis_grow_shrink_instance_type="",
+        gce_instance_type_loader="",
+        n_loaders=0,
+        gce_instance_type_monitor="",
+        n_monitor_nodes=0,
+    )
+    assert GceAZResolver(params).required_machine_types() == ["n2-highmem-8"]
+
+
+@pytest.fixture(name="mock_zone_letters")
+def mock_zone_letters_fixture():
+    """Mock _get_zone_letters_for_region so tests don't call GCE API."""
+    zone_map = {
+        "us-east1": ["b", "c", "d"],
+        "us-east4": ["a", "b", "c"],
+        "us-west1": ["a", "b", "c"],
+        "us-central1": ["a", "b", "c", "f"],
+    }
+    with patch(
+        "sdcm.utils.gce_utils._get_zone_letters_for_region",
+        side_effect=lambda region: zone_map.get(region, []),
+    ):
+        yield
+
+
+def test_get_alternative_zones_excludes_exhausted_zone_letter(mock_zone_letters):
+    alternatives = get_alternative_zones("us-east1", "b")
+    assert "b" not in alternatives
+
+
+def test_get_alternative_zones_excludes_exhausted_full_zone_name(mock_zone_letters):
+    alternatives = get_alternative_zones("us-east1", "us-east1-b")
+    assert "b" not in alternatives
+
+
+def test_get_alternative_zones_returns_remaining_zone_letters(mock_zone_letters):
+    alternatives = get_alternative_zones("us-east1", "c")
+    assert "d" in alternatives
+
+
+def test_get_alternative_zones_returns_empty_for_unknown_region(mock_zone_letters):
+    assert get_alternative_zones("unknown-region-1", "a") == []
+
+
+def test_get_alternative_zones_returns_shuffled_list(mock_zone_letters):
+    results = [tuple(get_alternative_zones("us-central1", "a")) for _ in range(20)]
+    assert len(set(results)) > 1
+
+
+def test_get_alternative_zones_single_zone_region_returns_empty():
+    with patch("sdcm.utils.gce_utils._get_zone_letters_for_region", return_value=["a"]):
+        assert get_alternative_zones("single-region-1", "a") == []


### PR DESCRIPTION
## Summary

- Add proactive GCE availability zone filtering (mirroring AWS AZ resolver from #14561) that queries the GCE machineTypes API to discover which zones support all required machine types before provisioning
- Add runtime zone fallback in `GCECluster._create_instances()` that catches `ZoneResourcesExhaustedError` and retries in an alternative zone (complementary to #14616)
- Expand us-central1 supported zones from `a` to `abcf`
- 52 unit tests covering error classification, zone resolution, and fallback
- Integrated into both `tester.py:get_cluster_gce()` and `sct.py:provision-resources` command

## Design

**Phase 1 — Error Classification & Zone Discovery**
- `sdcm/provision/gce/capacity_errors.py`: Centralized GCE error classification (zone capacity, quota, type unavailable)
- `GceZoneResolver` in `sdcm/utils/gce_utils.py`: Queries GCE `machineTypes.get` API per zone with `SUPPORTED_REGIONS` fallback

**Phase 2 — Proactive AZ Filtering**
- `sdcm/provision/gce/zone_resolver.py`: `GceAZResolver` class that filters `availability_zone` config to zones supporting all required machine types
- Integrated into `tester.py:get_cluster_gce()` and `sct.py:provision_resources()`, gated by existing `pre_filter_unavailable_availability_zones` config (shared with AWS)

**Phase 3 — Runtime Fallback**
- `GCECluster._create_instances()` catches `ZoneResourcesExhaustedError`, gets alternative zones via `get_alternative_zones()`, creates a new provisioner for the fallback zone, and retries
- `get_alternative_zones()` returns shuffled alternative zone letters for a region

## Relation to #14616

This PR and #14616 are **complementary**:
- This PR adds **proactive** filtering (prevent bad zone selection upfront) + runtime fallback
- #14616 adds **reactive** runtime fallback with different retry mechanics

## Tested

**Single region — ARM instance not available:**

```bash
SCT_TEST_ID=1234-1234-1234-1234 SCT_SCYLLA_VERSION=master:latest SCT_GCE_INSTANCE_TYPE_DB=t2a-standard-2 \
  uv run python ./sct.py provision-resources -b gce -t 1234 -c ./test-cases/PR-provision-test.yaml
```

```
sdcm.provision.gce.zone_resolver.NoValidAvailabilityZoneError: No zone supports all required machine types across regions ['us-east1'].
  t2a-standard-2 in us-east1: NOT AVAILABLE in any zone
  e2-standard-2 in us-east1: available in zones ['b', 'c', 'd']
  n2-highmem-8 in us-east1: available in zones ['b', 'c', 'd']
```

**Multi-region — ARM instance available in one region but not the other:**

```
sdcm.provision.gce.zone_resolver.NoValidAvailabilityZoneError: No zone supports all required machine types across regions ['us-east1', 'us-central1'].
  t2a-standard-2 in us-east1: NOT AVAILABLE in any zone
  e2-standard-2 in us-east1: available in zones ['b', 'c', 'd']
  n2-highmem-8 in us-east1: available in zones ['b', 'c', 'd']
  t2a-standard-2 in us-central1: available in zones ['a', 'b', 'f']
  e2-standard-2 in us-central1: available in zones ['a', 'b', 'c', 'f']
  n2-highmem-8 in us-central1: available in zones ['a', 'b', 'c', 'f']
```

## Backends Affected
- [x] GCE - Modified cluster_gce.py, gce_utils.py, sct.py, added provision/gce/ modules

## Manual Testing Required

### What Couldn't Be Tested Automatically

- [x] **GCE cluster provisioning with zone fallback**: Requires GCE project with active quotas
  - Test: Provision cluster in a region where one zone lacks the required machine type
  - Expected: AZ resolver filters to valid zones; if runtime exhaustion occurs, fallback kicks in

- [x] **Multi-region GCE provisioning**: Requires multi-region GCE setup
  - Test: Configure `gce_datacenter: "us-east1 us-central1"` with varying zone support
  - Expected: Common valid zones computed across regions