### PR TITLE
feature(provision/aws): AZ fallback on capacity errors in modern path

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -213,6 +213,8 @@ bare_loaders: false
 
 aws_fallback_to_next_availability_zone: false
 
+fallback_to_next_availability_zone: true
+
 pre_filter_unavailable_availability_zones: true
 
 enable_argus: true

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -4035,9 +4035,18 @@ Availability zone to use. Specify multiple (comma separated) to deploy resources
 
 ## **aws_fallback_to_next_availability_zone** / SCT_AWS_FALLBACK_TO_NEXT_AVAILABILITY_ZONE
 
-Try all availability zones one by one in order to maximize the chances of getting the requested instance capacity.
+Deprecated alias of `fallback_to_next_availability_zone`. Kept for backward compatibility.
 
 **default:** N/A
+
+**type:** bool
+
+
+## **fallback_to_next_availability_zone** / SCT_FALLBACK_TO_NEXT_AVAILABILITY_ZONE
+
+On capacity errors, automatically retry provisioning in the next available AZ in the same region. Backend-agnostic parameter; supersedes `aws_fallback_to_next_availability_zone`.
+
+**default:** True
 
 **type:** bool
 

--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -433,17 +433,32 @@ class AWSCluster(cluster.BaseCluster):
         test_id = self.test_config.test_id()
         if not test_id:
             raise ValueError("test_id should be configured for using reuse_cluster")
-        availability_zone = self.params.get("availability_zone").split(",")[az_idx] if az_idx is not None else None
         ec2 = ec2_client.EC2ClientWrapper(region_name=self.region_names[dc_idx])
+        region_name = self.region_names[dc_idx]
         results = list_instances_aws(
             tags_dict={"TestId": test_id, "NodeType": self.node_type},
             running=True,
-            region_name=self.region_names[dc_idx],
+            region_name=region_name,
             group_as_region=True,
-            availability_zone=availability_zone,
             verbose=True,
         )
-        instances = results[self.region_names[dc_idx]]
+        instances = results[region_name]
+
+        if az_idx is not None and instances:
+            # bucket by actual AZ letter so instances can be found even if provisioning
+            # moved them away from params["availability_zone"] (AZ fallback flow)
+            by_az = {}
+            for instance in instances:
+                by_az.setdefault(instance["Placement"]["AvailabilityZone"][-1], []).append(instance)
+
+            configured_letters = [
+                letter.strip() for letter in (self.params.get("availability_zone") or "").split(",") if letter.strip()
+            ]
+            ordered_letters = configured_letters + sorted(
+                letter for letter in by_az if letter not in configured_letters
+            )
+            ordered_letters = [letter for letter in ordered_letters if letter in by_az]
+            instances = by_az[ordered_letters[az_idx]] if az_idx < len(ordered_letters) else []
 
         def sort_by_index(item):
             for tag in item["Tags"]:

--- a/sdcm/provision/aws/az_resolver.py
+++ b/sdcm/provision/aws/az_resolver.py
@@ -80,6 +80,17 @@ class NoValidAvailabilityZoneError(Exception):
     """Raised when no AZ supports all required instance types in the configured region(s)."""
 
 
+def is_az_fallback_enabled(params) -> bool:
+    """Return True when AZ fallback on capacity errors is enabled.
+
+    Reads `fallback_to_next_availability_zone` (new, backend-agnostic).
+    Falls back to the deprecated `aws_fallback_to_next_availability_zone` alias.
+    """
+    if (value := params.get("fallback_to_next_availability_zone")) is not None:
+        return bool(value)
+    return bool(params.get("aws_fallback_to_next_availability_zone"))
+
+
 class AZResolver:
     """Resolve `availability_zone` config to AZs supporting all required instance types."""
 
@@ -147,6 +158,67 @@ class AZResolver:
         else:
             LOGGER.info("AZResolver: availability_zone '%s' already valid for regions %s", original_value, region_names)
 
+    def get_fallback_candidates(self) -> list[list[str]]:
+        """Build ordered AZ candidate sets for capacity-error fallback.
+
+        Each candidate preserves the configured `availability_zone` shape:
+        single-AZ stays single-AZ, and multi-AZ stays multi-AZ. The first
+        candidate is the configured AZ list with unsupported letters dropped and
+        backfilled from supported alternatives. Later candidates replace one
+        supported AZ per slot. For multi-region configs, AZ letters are
+        intersected across regions so every candidate is valid everywhere.
+
+        Single-AZ config "a", supported ["a","b","c"] -> [["a"], ["b"], ["c"]]
+        Single-AZ config "c", supported ["a","b"]     -> [["a"], ["b"]]   # 'c' dropped, 'a' backfilled
+        Multi-AZ config "a,b,c", supported ["a","b","c","d"]
+            -> [["a","b","c"], ["d","b","c"], ["a","d","c"], ["a","b","d"]]
+        """
+        configured_letters = self._configured_az_letters()
+        if not configured_letters:
+            return []
+
+        supported_letters = self._supported_az_letters()
+        if not supported_letters:
+            return [configured_letters]
+
+        primary = [letter for letter in configured_letters if letter in supported_letters]
+        for letter in supported_letters:
+            if len(primary) >= len(configured_letters):
+                break
+            if letter not in primary:
+                primary.append(letter)
+
+        if not primary:
+            return [configured_letters]
+
+        candidates = [primary]
+        seen = {tuple(primary)}
+
+        for slot_index in range(len(primary)):
+            for letter in supported_letters:
+                if letter in primary:
+                    continue
+                candidate = list(primary)
+                candidate[slot_index] = letter
+                if tuple(candidate) not in seen:
+                    candidates.append(candidate)
+                    seen.add(tuple(candidate))
+
+        return candidates
+
+    def _supported_az_letters(self) -> list[str]:
+        """Return AZ letters supported in EVERY configured region for the required types.
+
+        When no instance types are declared, returns the configured AZ letters as-is.
+        """
+        instance_types = self.required_instance_types()
+        region_names = self._region_names()
+
+        if not instance_types or not region_names:
+            return self._configured_az_letters()
+
+        return self._common_supported_letters(region_names, self._configured_az_letters(), instance_types)
+
     @staticmethod
     def _common_supported_letters(
         region_names: list[str], configured_letters: list[str], instance_types: list[str]
@@ -169,7 +241,7 @@ class AZResolver:
         if not common:
             return []
 
-        configured_first = [l for l in configured_letters if l in common]
+        configured_first = [letter for letter in configured_letters if letter in common]
         additional = sorted(common - set(configured_first))
         return configured_first + additional
 

--- a/sdcm/provision/aws/capacity_errors.py
+++ b/sdcm/provision/aws/capacity_errors.py
@@ -31,3 +31,13 @@ def is_capacity_error(exception: BaseException) -> bool:
     error_code = exception.response.get("Error", {}).get("Code", "")
     codes = {error_code} | set(_AWS_ERROR_CODE_RE.findall(str(exception)))
     return bool(codes & set(CAPACITY_ERROR_CODES))
+
+
+class ProvisioningCapacityExhausted(Exception):
+    """Raised when a provision plan exits with no instances, signalling capacity exhaustion.
+
+    The AWS spot path silently swallows ``SpotCapacityNotAvailable`` / ``SpotPriceTooLow``
+    and returns an empty result instead of propagating a ``ClientError``. Cluster code
+    raises this exception in that case so the AZ-fallback layer can treat it the same
+    as an on-demand capacity ``ClientError``.
+    """

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1988,7 +1988,11 @@ class SCTConfiguration(BaseModel):
               "Same for multi-region scenario.""",
     )
     aws_fallback_to_next_availability_zone: Boolean = SctField(
-        description="Try all availability zones one by one in order to maximize the chances of getting the requested instance capacity.",
+        description="Deprecated alias of `fallback_to_next_availability_zone`. Kept for backward compatibility.",
+    )
+    fallback_to_next_availability_zone: Boolean = SctField(
+        description="On capacity errors, automatically retry provisioning in the next available AZ in the same region. "
+        "Backend-agnostic parameter; supersedes `aws_fallback_to_next_availability_zone`.",
     )
     pre_filter_unavailable_availability_zones: Boolean = SctField(
         description="Filter availability zones upfront to only those that support all required instance types. "

--- a/sdcm/sct_provision/aws/cluster.py
+++ b/sdcm/sct_provision/aws/cluster.py
@@ -15,8 +15,9 @@ import abc
 from functools import cached_property
 from typing import List, Tuple
 
-from pydantic import BaseModel, ConfigDict, computed_field
+from pydantic import BaseModel, ConfigDict, PrivateAttr, computed_field
 from sdcm import cluster
+from sdcm.provision.aws.capacity_errors import ProvisioningCapacityExhausted
 from sdcm.provision.aws.instance_parameters import AWSInstanceParams
 from sdcm.provision.aws.provisioner import AWSInstanceProvisioner
 from sdcm.provision.common.provision_plan import ProvisionPlan
@@ -69,6 +70,9 @@ class ClusterBase(BaseModel):
     _INSTANCE_PARAMS_BUILDER = None
     _USER_PARAM = None
     _USE_PLACEMENT_GROUP = True
+    # tracks instances launched by this cluster (so that AZ-fallback can terminate
+    # partial provisions when a later AZ fails)
+    _provisioned_instances: list = PrivateAttr(default_factory=list)
 
     @property
     def _provisioner(self):
@@ -222,7 +226,6 @@ class ClusterBase(BaseModel):
     def provision(self):
         if self._node_nums == [0]:
             return []
-        total_instances_provisioned = []
         for region_id in range(len(self._regions_with_nodes)):
             az_nodes = self._az_nodes(region_id=region_id)
             for az_id, _ in enumerate(self._azs):
@@ -239,9 +242,9 @@ class ClusterBase(BaseModel):
                     node_count=node_count,
                 )
                 if not instances:
-                    raise RuntimeError("End of provision plan reached, but no instances provisioned")
-                total_instances_provisioned.extend(instances)
-        return total_instances_provisioned
+                    raise ProvisioningCapacityExhausted("End of provision plan reached, but no instances provisioned")
+                self._provisioned_instances.extend(instances)
+        return list(self._provisioned_instances)
 
 
 class DBCluster(ClusterBase):
@@ -337,7 +340,6 @@ class DBCluster(ClusterBase):
     def provision(self):
         if self._node_nums == [0]:
             return []
-        total_instances_provisioned = []
         for region_id in range(len(self._regions_with_nodes)):
             az_nodes, az_zero_nodes = self._az_nodes(region_id=region_id)
             for az_id, _ in enumerate(self._azs):
@@ -354,8 +356,10 @@ class DBCluster(ClusterBase):
                         node_count=node_count,
                     )
                     if not instances:
-                        raise RuntimeError("End of provision plan reached, but no instances provisioned")
-                    total_instances_provisioned.extend(instances)
+                        raise ProvisioningCapacityExhausted(
+                            "End of provision plan reached, but no instances provisioned"
+                        )
+                    self._provisioned_instances.extend(instances)
 
                 if zero_node_count:
                     instance_parameters = self._zero_token_instance_parameters(
@@ -372,9 +376,11 @@ class DBCluster(ClusterBase):
                         node_count=zero_node_count,
                     )
                     if not instances:
-                        raise RuntimeError("End of provision plan reached, but no instances provisioned")
-                    total_instances_provisioned.extend(instances)
-        return total_instances_provisioned
+                        raise ProvisioningCapacityExhausted(
+                            "End of provision plan reached, but no instances provisioned"
+                        )
+                    self._provisioned_instances.extend(instances)
+        return list(self._provisioned_instances)
 
 
 class OracleDBCluster(ClusterBase):

--- a/sdcm/sct_provision/aws/layout.py
+++ b/sdcm/sct_provision/aws/layout.py
@@ -11,14 +11,30 @@
 #
 # Copyright (c) 2021 ScyllaDB
 
+import logging
 from functools import cached_property
 
-from sdcm.provision.aws.az_resolver import AZResolver
+from botocore.exceptions import ClientError
+
+from sdcm.provision.aws.az_resolver import AZResolver, is_az_fallback_enabled
+from sdcm.provision.aws.capacity_errors import ProvisioningCapacityExhausted, is_capacity_error
 from sdcm.provision.aws.capacity_reservation import SCTCapacityReservation
 from sdcm.provision.aws.dedicated_host import SCTDedicatedHosts
+from sdcm.provision.aws.utils import ec2_clients
 from sdcm.sct_provision.aws.cluster import OracleDBCluster, DBCluster, LoaderCluster, MonitoringCluster, PlacementGroup
 from sdcm.sct_provision.common.layout import SCTProvisionLayout
 from sdcm.test_config import TestConfig
+
+
+LOGGER = logging.getLogger(__name__)
+
+_CLUSTER_CACHED_PROPS: tuple[str, ...] = (
+    "db_cluster",
+    "loader_cluster",
+    "monitoring_cluster",
+    "cs_db_cluster",
+    "placement_group",
+)
 
 
 class SCTProvisionAWSLayout(SCTProvisionLayout, cluster_backend="aws"):
@@ -27,9 +43,56 @@ class SCTProvisionAWSLayout(SCTProvisionLayout, cluster_backend="aws"):
         return TestConfig()
 
     def provision(self):
-        use_scylla_cloud = self._params.get("cluster_backend") == "xcloud" or self._params.get("xcloud_provider")
-
         AZResolver(self._params).resolve()
+
+        # capacity reservation handles its own AZ fallback internally
+        if SCTCapacityReservation.is_capacity_reservation_enabled(self._params):
+            self._do_provision()
+            return
+
+        if not is_az_fallback_enabled(self._params):
+            self._do_provision()
+            return
+
+        candidates = AZResolver(self._params).get_fallback_candidates()
+        if not candidates:
+            self._do_provision()
+            return
+
+        original_az = self._params.get("availability_zone")
+        last_error: Exception | None = None
+        for attempt_idx, candidate in enumerate(candidates):
+            self._params["availability_zone"] = ",".join(candidate)
+
+            if attempt_idx > 0:
+                LOGGER.warning(
+                    "Capacity error in previous AZ; retrying in '%s' (attempt %d/%d)",
+                    self._params["availability_zone"],
+                    attempt_idx + 1,
+                    len(candidates),
+                )
+                self._clear_cluster_caches()
+
+            try:
+                self._do_provision()
+                return
+            except (ClientError, ProvisioningCapacityExhausted) as exc:
+                # ClientError is the on-demand path (raised by ec2.create_instances);
+                # ProvisioningCapacityExhausted is the spot path.
+                if isinstance(exc, ClientError) and not is_capacity_error(exc):
+                    raise
+                last_error = exc
+                LOGGER.warning(
+                    "Provision failed with capacity error in AZ '%s': %s", self._params["availability_zone"], exc
+                )
+                self._cleanup_partial_provision()
+
+        self._params["availability_zone"] = original_az
+        tried = ", ".join("+".join(c) for c in candidates)
+        raise RuntimeError(f"Provisioning failed in all {len(candidates)} AZ candidate(s): {tried}") from last_error
+
+    def _do_provision(self):
+        use_scylla_cloud = self._params.get("cluster_backend") == "xcloud" or self._params.get("xcloud_provider")
 
         if self.placement_group:
             self.placement_group.provision()
@@ -45,6 +108,53 @@ class SCTProvisionAWSLayout(SCTProvisionLayout, cluster_backend="aws"):
             self.loader_cluster.provision()
         if self.cs_db_cluster:
             self.cs_db_cluster.provision()
+
+    def _cleanup_partial_provision(self) -> None:
+        """Terminate instances launched by any cluster that completed before the capacity error.
+
+        Multi-region provisioning can leave partial instances spread across more than one
+        region, so terminate per-region rather than against a single hardcoded region.
+        """
+        instance_ids_by_region: dict[str, list[str]] = {}
+        for prop in _CLUSTER_CACHED_PROPS:
+            if (cluster_obj := self.__dict__.get(prop)) is None:
+                continue
+            for instance in getattr(cluster_obj, "_provisioned_instances", None) or []:
+                instance_id = getattr(instance, "instance_id", None) or getattr(instance, "id", None)
+                region = self._instance_region(instance)
+                if not instance_id or not region:
+                    if instance_id:
+                        LOGGER.warning("Cannot determine region for instance %s; skipping cleanup", instance_id)
+                    continue
+                instance_ids_by_region.setdefault(region, []).append(instance_id)
+
+        if not instance_ids_by_region:
+            return
+
+        for region, instance_ids in instance_ids_by_region.items():
+            LOGGER.info(
+                "Terminating %d partially-provisioned instance(s) in %s: %s",
+                len(instance_ids),
+                region,
+                instance_ids,
+            )
+            try:
+                ec2_clients[region].terminate_instances(InstanceIds=instance_ids)
+            except Exception as exc:  # noqa: BLE001
+                LOGGER.warning("Failed to terminate instances in %s: %s", region, exc)
+
+    @staticmethod
+    def _instance_region(instance) -> str | None:
+        """Resolve the AWS region of a boto3 EC2 Instance from its bound client metadata."""
+        meta = getattr(instance, "meta", None)
+        client = getattr(meta, "client", None)
+        client_meta = getattr(client, "meta", None)
+        return getattr(client_meta, "region_name", None)
+
+    def _clear_cluster_caches(self) -> None:
+        """Drop cached cluster objects so the next attempt re-reads `availability_zone`."""
+        for prop in _CLUSTER_CACHED_PROPS:
+            self.__dict__.pop(prop, None)
 
     @cached_property
     def db_cluster(self):

--- a/unit_tests/unit/provisioner/test_az_resolver.py
+++ b/unit_tests/unit/provisioner/test_az_resolver.py
@@ -15,7 +15,12 @@ from unittest.mock import patch
 
 import pytest
 
-from sdcm.provision.aws.az_resolver import AZResolver, NoValidAvailabilityZoneError, _node_count_positive
+from sdcm.provision.aws.az_resolver import (
+    AZResolver,
+    NoValidAvailabilityZoneError,
+    _node_count_positive,
+    is_az_fallback_enabled,
+)
 
 
 class _DotDict(dict):
@@ -268,3 +273,47 @@ def test_resolve_with_unset_availability_zone_stays_unset(mock_aws_region_cls, a
     params = _make_params(availability_zone=az_value)
     AZResolver(params).resolve()
     assert not params["availability_zone"]
+
+
+@pytest.mark.parametrize(
+    "new_param, alias, expected",
+    [
+        (None, True, True),
+        (False, True, False),
+    ],
+)
+def test_is_az_fallback_enabled(new_param, alias, expected):
+    params = _make_params(fallback_to_next_availability_zone=new_param, aws_fallback_to_next_availability_zone=alias)
+    assert is_az_fallback_enabled(params) is expected
+
+
+def test_get_fallback_candidates_single_az(mock_aws_region_cls):
+    _, region_instance = mock_aws_region_cls
+    region_instance.get_common_availability_zones.return_value = ["us-east-1a", "us-east-1b", "us-east-1c"]
+    params = _make_params(availability_zone="a")
+    assert AZResolver(params).get_fallback_candidates() == [["a"], ["b"], ["c"]]
+
+
+def test_get_fallback_candidates_multi_az(mock_aws_region_cls):
+    _, region_instance = mock_aws_region_cls
+    region_instance.get_common_availability_zones.return_value = [
+        "us-east-1a",
+        "us-east-1b",
+        "us-east-1c",
+        "us-east-1d",
+    ]
+    params = _make_params(availability_zone="a,b,c")
+    candidates = AZResolver(params).get_fallback_candidates()
+    # first candidate is the configured set; subsequent candidates replace one slot at a time with "d"
+    assert candidates[0] == ["a", "b", "c"]
+    assert ["d", "b", "c"] in candidates
+    assert ["a", "d", "c"] in candidates
+    assert ["a", "b", "d"] in candidates
+
+
+def test_get_fallback_candidates_enumerates_alternatives_when_upfront_filter_disabled(mock_aws_region_cls):
+    """Fallback enumeration must NOT depend on `pre_filter_unavailable_availability_zones`."""
+    _, region_instance = mock_aws_region_cls
+    region_instance.get_common_availability_zones.return_value = ["us-east-1a", "us-east-1b"]
+    params = _make_params(availability_zone="c", pre_filter_unavailable_availability_zones=False)
+    assert AZResolver(params).get_fallback_candidates() == [["a"], ["b"]]

--- a/unit_tests/unit/provisioner/test_layout_az_fallback.py
+++ b/unit_tests/unit/provisioner/test_layout_az_fallback.py
@@ -1,0 +1,221 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2026 ScyllaDB
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from botocore.exceptions import ClientError
+
+from sdcm.cluster_aws import AWSCluster
+from sdcm.provision.aws.capacity_errors import ProvisioningCapacityExhausted
+from sdcm.sct_provision.aws.layout import SCTProvisionAWSLayout
+
+
+class _DotDict(dict):
+    __getattr__ = dict.__getitem__
+    __setattr__ = dict.__setitem__
+    __delattr__ = dict.__delitem__
+
+
+def _make_params(**overrides):
+    params = _DotDict(
+        {
+            "cluster_backend": "aws",
+            "region_name": "us-east-1",
+            "availability_zone": "a",
+            "instance_type_db": "i4i.large",
+            "instance_type_loader": "t3.small",
+            "instance_type_monitor": "t3.small",
+            "pre_filter_unavailable_availability_zones": True,
+            "fallback_to_next_availability_zone": True,
+            "aws_fallback_to_next_availability_zone": False,
+            "use_capacity_reservation": False,
+            "instance_provision": "spot",
+            "test_id": "test-id-123",
+            "n_db_nodes": 3,
+            **overrides,
+        }
+    )
+    params.region_names = params["region_name"].split()
+    return params
+
+
+@pytest.fixture(name="patched_aws_region")
+def patched_aws_region_fixture():
+    with patch("sdcm.provision.aws.az_resolver.AwsRegion") as mock_cls:
+        instance = mock_cls.return_value
+        instance.get_common_availability_zones.return_value = ["us-east-1a", "us-east-1b", "us-east-1c"]
+        instance.region_name = "us-east-1"
+        yield instance
+
+
+@pytest.fixture(name="patched_capacity_reservation")
+def patched_capacity_reservation_fixture():
+    with (
+        patch("sdcm.sct_provision.aws.layout.SCTCapacityReservation") as mock_cr,
+        patch("sdcm.sct_provision.aws.layout.SCTDedicatedHosts"),
+    ):
+        mock_cr.is_capacity_reservation_enabled.return_value = False
+        mock_cr.reserve.return_value = None
+        yield mock_cr
+
+
+def _capacity_error() -> ClientError:
+    return ClientError(
+        error_response={"Error": {"Code": "InsufficientInstanceCapacity", "Message": "Insufficient capacity."}},
+        operation_name="RunInstances",
+    )
+
+
+def test_provision_retries_on_capacity_error(patched_aws_region, patched_capacity_reservation):  # noqa: ARG001
+    """Core fallback flow: capacity error -> cleanup -> cache clear -> retry next AZ -> success."""
+    params = _make_params()
+    layout = SCTProvisionAWSLayout(params)
+    seen_azs: list[str] = []
+
+    def fake_do_provision():
+        seen_azs.append(params["availability_zone"])
+        if len(seen_azs) == 1:
+            raise _capacity_error()
+
+    with (
+        patch.object(layout, "_do_provision", side_effect=fake_do_provision),
+        patch.object(layout, "_cleanup_partial_provision") as mock_cleanup,
+        patch.object(layout, "_clear_cluster_caches") as mock_clear,
+    ):
+        layout.provision()
+        assert seen_azs == ["a", "b"]
+        mock_cleanup.assert_called_once()
+        mock_clear.assert_called_once()
+    assert params["availability_zone"] == "b"
+
+
+def test_provision_non_capacity_error_propagates(patched_aws_region, patched_capacity_reservation):  # noqa: ARG001
+    """Non-capacity errors (e.g. AuthFailure) must not trigger AZ retry."""
+    layout = SCTProvisionAWSLayout(_make_params())
+    other_error = ClientError({"Error": {"Code": "AuthFailure", "Message": "Not authorized"}}, "RunInstances")
+    with patch.object(layout, "_do_provision", side_effect=other_error):
+        with patch.object(layout, "_cleanup_partial_provision") as mock_cleanup:
+            with pytest.raises(ClientError):
+                layout.provision()
+            mock_cleanup.assert_not_called()
+
+
+def test_provision_retries_on_spot_capacity_exhausted(patched_aws_region, patched_capacity_reservation):  # noqa: ARG001
+    """Spot path raises ProvisioningCapacityExhausted (no ClientError) when capacity is unavailable;
+    AZ fallback must treat it the same as an on-demand capacity ClientError."""
+    params = _make_params(instance_provision="spot")
+    layout = SCTProvisionAWSLayout(params)
+    seen_azs: list[str] = []
+
+    def fake_do_provision():
+        seen_azs.append(params["availability_zone"])
+        if len(seen_azs) == 1:
+            raise ProvisioningCapacityExhausted("End of provision plan reached, but no instances provisioned")
+
+    with (
+        patch.object(layout, "_do_provision", side_effect=fake_do_provision),
+        patch.object(layout, "_cleanup_partial_provision") as mock_cleanup,
+        patch.object(layout, "_clear_cluster_caches") as mock_clear,
+    ):
+        layout.provision()
+        assert seen_azs == ["a", "b"]
+        mock_cleanup.assert_called_once()
+        mock_clear.assert_called_once()
+    assert params["availability_zone"] == "b"
+
+
+def test_provision_capacity_reservation_enabled_skips_layout_fallback(patched_aws_region, patched_capacity_reservation):  # noqa: ARG001
+    """CR owns AZ iteration; layout-level retry would double-fallback and orphan reservations."""
+    patched_capacity_reservation.is_capacity_reservation_enabled.return_value = True
+    layout = SCTProvisionAWSLayout(_make_params(use_capacity_reservation=True, instance_provision="on_demand"))
+    with patch.object(layout, "_do_provision", side_effect=_capacity_error()) as mock_do:
+        with pytest.raises(ClientError):
+            layout.provision()
+    assert mock_do.call_count == 1
+
+
+def _fake_instance(instance_id: str, region: str) -> SimpleNamespace:
+    """Build a stub with the boto3 Instance shape used by `_cleanup_partial_provision`."""
+    return SimpleNamespace(
+        instance_id=instance_id,
+        meta=SimpleNamespace(client=SimpleNamespace(meta=SimpleNamespace(region_name=region))),
+    )
+
+
+def test_cleanup_partial_provision_groups_terminations_by_region():
+    """Partial instances from different regions must be terminated against each region's client."""
+    layout = SCTProvisionAWSLayout(_make_params(region_name="us-east-1 eu-west-1"))
+    layout.__dict__["db_cluster"] = SimpleNamespace(
+        _provisioned_instances=[_fake_instance("i-aaa", "us-east-1"), _fake_instance("i-bbb", "eu-west-1")]
+    )
+    layout.__dict__["loader_cluster"] = SimpleNamespace(_provisioned_instances=[_fake_instance("i-ccc", "us-east-1")])
+
+    us_client, eu_client = MagicMock(), MagicMock()
+    fake_clients = {"us-east-1": us_client, "eu-west-1": eu_client}
+    with patch.dict("sdcm.sct_provision.aws.layout.ec2_clients", fake_clients, clear=False):
+        layout._cleanup_partial_provision()
+
+    us_client.terminate_instances.assert_called_once()
+    eu_client.terminate_instances.assert_called_once()
+    assert sorted(us_client.terminate_instances.call_args.kwargs["InstanceIds"]) == ["i-aaa", "i-ccc"]
+    assert eu_client.terminate_instances.call_args.kwargs["InstanceIds"] == ["i-bbb"]
+
+
+def _aws_describe_instance(instance_id: str, az: str, node_index: int = 0) -> dict:
+    return {
+        "InstanceId": instance_id,
+        "Placement": {"AvailabilityZone": az},
+        "Tags": [{"Key": "NodeIndex", "Value": str(node_index)}],
+    }
+
+
+def _fake_aws_cluster(availability_zone: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        region_names=["us-east-1"],
+        node_type="scylla-db",
+        params={"availability_zone": availability_zone},
+        test_config=SimpleNamespace(test_id=lambda: "test-id-123"),
+    )
+
+
+@pytest.fixture(name="patched_ec2_for_get_instances")
+def patched_ec2_for_get_instances_fixture():
+    with (
+        patch("sdcm.cluster_aws.list_instances_aws") as mock_list,
+        patch("sdcm.cluster_aws.ec2_client.EC2ClientWrapper") as mock_wrapper_cls,
+    ):
+        mock_wrapper_cls.return_value.get_instance.side_effect = lambda iid: SimpleNamespace(instance_id=iid)
+        yield mock_list
+
+
+def test_get_instances_finds_instances_relocated_by_az_fallback(patched_ec2_for_get_instances):
+    """Instances live in AZ 'b' after fallback while params still say 'a'; az_idx=0 must still find them."""
+    patched_ec2_for_get_instances.return_value = {
+        "us-east-1": [
+            _aws_describe_instance("i-0b1", "us-east-1b", node_index=0),
+            _aws_describe_instance("i-0b2", "us-east-1b", node_index=1),
+        ]
+    }
+    instances = AWSCluster._get_instances(_fake_aws_cluster(availability_zone="a"), dc_idx=0, az_idx=0)
+    assert [i.instance_id for i in instances] == ["i-0b1", "i-0b2"]
+
+
+def test_get_instances_returns_empty_when_az_idx_out_of_bounds(patched_ec2_for_get_instances):
+    """az_idx beyond the number of populated AZs returns [] rather than raising IndexError."""
+    patched_ec2_for_get_instances.return_value = {
+        "us-east-1": [_aws_describe_instance("i-0a1", "us-east-1a", node_index=0)],
+    }
+    result = AWSCluster._get_instances(_fake_aws_cluster(availability_zone="a"), dc_idx=0, az_idx=5)
+    assert result == []


### PR DESCRIPTION
Phases 3 implementation of the plan: [docs/plans/infrastructure/aws-capacity-az-fallback.md](https://github.com/scylladb/scylla-cluster-tests/blob/da3ffd7d51b90b15f10b922b029cc8c6f92dc41b/docs/plans/infrastructure/aws-capacity-az-fallback.md)

When provisioning fails with a capacity-shortage error in the modern AWS provisioning path, automatically retry in the next available AZ within the same region. Partial provisions are cleaned up before each retry. Non-capacity errors propagate is unchanged. The capacity-reservation path keeps its own AZ iteration.

Enabled by the fallback_to_next_availability_zone SCT config parameter (default true; aws_fallback_to_next_availability_zone remains as a deprecated alias).

Refs: https://scylladb.atlassian.net/browse/SCT-295
Refs: https://github.com/scylladb/scylla-cluster-tests/pull/14561

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :green_circle: [fallback to an available ZA](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/pr-provision-test/298/)
Fallback to available AZ during provisioning step of the pipeline:
- Upfront AZ filtering is disabled
- 1st AZ is not available:
```
13:43:13  Provision failed with capacity error in AZ 'a': An error occurred (InsufficientInstanceCapacity) when calling the RunInstances operation (reached max retries: 4): We currently do not have sufficient r8gd.xlarge capacity in the Availability Zone you requested (eu-west-1a). Our system will be working on provisioning additional capacity. You can currently get r8gd.xlarge capacity by not specifying an Availability Zone in your request or choosing eu-west-1b.
```
- retrying next AZ
```
13:43:13  Capacity error in previous AZ; retrying in 'b' (attempt 2/2)
```
- Eventually the instances are created:
```
13:43:14  Created instances: [ec2.Instance(id='i-0e63d54d75016044b'), ec2.Instance(id='i-0832360042e13755e'), ec2.Instance(id='i-0382aca86b8f40cb0')].
```
- [x] :orange_circle: [fallback on all available AZs failed (as expected, when there are no resources)](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/pr-provision-test/304/)
Fallback through available AZs during provisioning step of the pipeline, until all are tried:
- Upfront AZ filtering is disabled
- 1st AZ is not available:
```
17:44:30  Provision failed with capacity error in AZ 'a': An error occurred (InsufficientInstanceCapacity) when calling the RunInstances operation (reached max retries: 4): We currently do not have sufficient r8gd.xlarge capacity in the Availability Zone you requested (eu-west-1a). Our system will be working on provisioning additional capacity. You can currently get r8gd.xlarge capacity by not specifying an Availability Zone in your request or choosing eu-west-1b.
```
- 2nd AZ is not available:
```
17:44:38  Provision failed with capacity error in AZ 'b': An error occurred (InsufficientInstanceCapacity) when calling the RunInstances operation (reached max retries: 4): We currently do not have sufficient r8gd.xlarge capacity in the Availability Zone you requested (eu-west-1b). Our system will be working on provisioning additional capacity. You can currently get r8gd.xlarge capacity by not specifying an Availability Zone in your request or choosing eu-west-1a.
```
- Eventually provisioning step is failing
```
17:44:38    File "/home/ubuntu/scylla-cluster-tests/sdcm/sct_provision/aws/layout.py", line 93, in provision
17:44:38      raise RuntimeError(f"Provisioning failed in all {len(candidates)} AZ candidate(s): {tried}") from last_error
17:44:38  RuntimeError: Provisioning failed in all 2 AZ candidate(s): a, b
```

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
