### PR TITLE
ci(manager): bump scylla_version in manager Jenkins pipelines

### DIFF
--- a/jenkins-pipelines/manager/debian12-manager-install.jenkinsfile
+++ b/jenkins-pipelines/manager/debian12-manager-install.jenkinsfile
@@ -9,5 +9,5 @@ managerPipeline(
     test_name: 'mgmt_cli_test.ManagerInstallationTests.test_manager_installed_and_functional',
     test_config: '''["test-cases/manager/manager-installation-set-distro.yaml", "configurations/manager/debian12.yaml"]''',
 
-    scylla_version: '2025.1'
+    scylla_version: '2025.4'
 )

--- a/jenkins-pipelines/manager/debian12-manager-sanity.jenkinsfile
+++ b/jenkins-pipelines/manager/debian12-manager-sanity.jenkinsfile
@@ -9,7 +9,7 @@ managerPipeline(
     test_name: 'mgmt_cli_test.ManagerSanityTests.test_manager_sanity',
     test_config: '''["test-cases/manager/manager-regression-singleDC-set-distro.yaml", "configurations/manager/debian12.yaml", "configurations/disable_kms_key_rotation.yaml", "configurations/disable_client_encrypt.yaml"]''',
 
-    scylla_version: '2025.1',
+    scylla_version: '2025.4',
 
     downstream_jobs_to_run: 'debian12-upgrade-test'
 )

--- a/jenkins-pipelines/manager/debian12-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/debian12-manager-upgrade.jenkinsfile
@@ -7,7 +7,7 @@ managerPipeline(
     backend: 'aws',
     region: 'us-east-1',
 
-    scylla_version: '2025.1',
+    scylla_version: '2025.4',
 
     manager_version: '3.8',
     target_manager_version: 'master_latest',

--- a/jenkins-pipelines/manager/ubuntu22-manager-install.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu22-manager-install.jenkinsfile
@@ -9,5 +9,5 @@ managerPipeline(
     test_name: 'mgmt_cli_test.ManagerInstallationTests.test_manager_installed_and_functional',
     test_config: 'test-cases/manager/manager-installation-set-distro.yaml',
 
-    scylla_version: '2025.3'
+    scylla_version: '2026.1'
 )

--- a/jenkins-pipelines/manager/ubuntu22-manager-sanity.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu22-manager-sanity.jenkinsfile
@@ -9,7 +9,7 @@ managerPipeline(
     test_name: 'mgmt_cli_test.ManagerSanityTests.test_manager_sanity',
     test_config: '''["test-cases/manager/manager-regression-singleDC-set-distro.yaml", "configurations/disable_kms_key_rotation.yaml", "configurations/object_storage_s3.yaml", "configurations/object_storage_native_method.yaml"]''',
 
-    scylla_version: '2025.3',
+    scylla_version: '2026.1',
 
     downstream_jobs_to_run: 'ubuntu22-upgrade-test'
 )

--- a/jenkins-pipelines/manager/ubuntu22-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu22-manager-upgrade.jenkinsfile
@@ -7,7 +7,7 @@ managerPipeline(
     backend: 'aws',
     region: 'us-east-1',
 
-    scylla_version: '2025.3',
+    scylla_version: '2026.1',
 
     // Upgrade from the previous minor release (the last one)
     manager_version: '3.9',

--- a/jenkins-pipelines/manager/ubuntu24-manager-older-enterprise-sanity.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu24-manager-older-enterprise-sanity.jenkinsfile
@@ -7,7 +7,7 @@ managerPipeline(
     backend: 'aws',
     region: 'us-east-1',
 
-    scylla_version: '2024.1',
+    scylla_version: '2025.1',
 
     test_name: 'mgmt_cli_test.ManagerSanityTests.test_manager_sanity',
     test_config: '''["test-cases/manager/manager-regression-singleDC-set-distro.yaml", "configurations/manager/ubuntu24.yaml", "configurations/disable_kms_key_rotation.yaml"]''',

--- a/jenkins-pipelines/manager/ubuntu24-manager-older-enterprise-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu24-manager-older-enterprise-upgrade.jenkinsfile
@@ -7,7 +7,7 @@ managerPipeline(
     backend: 'aws',
     region: 'us-east-1',
 
-    scylla_version: '2024.1',
+    scylla_version: '2025.1',
 
     // Upgrade from some old Manager release which is still used in production
     // Use Metabase to check it (https://scylladb.metabaseapp.com/question/1685-manager-version)


### PR DESCRIPTION
## Summary

- **debian12** pipelines: `2025.1` → `2025.4` (install, sanity, upgrade)
- **ubuntu22** pipelines: `2025.3` → `2026.1` (install, sanity, upgrade)
- **ubuntu24 older-enterprise** pipelines: `2024.1` → `2025.1` (sanity, upgrade)

Keeps the manager CI pipelines aligned with currently supported ScyllaDB versions.