### PR TITLE
fix(gce-provision): add all availability zones for us-central1 region

### DIFF
--- a/sdcm/utils/gce_utils.py
+++ b/sdcm/utils/gce_utils.py
@@ -92,7 +92,7 @@ SUPPORTED_REGIONS = {
     "us-east1": "cd",
     "us-east4": "abc",
     "us-west1": "abc",
-    "us-central1": "a",
+    "us-central1": "abcf",
 }
 
 


### PR DESCRIPTION
The us-central1 region was configured with only zone 'a', limiting instance placement options and reducing availability. Updated to include all supported zones (a, b, c, f) to match the actual GCE region capabilities and improve resource allocation flexibility.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
