### PR TITLE
fix: remove extra blank line in test_config.py (precommit fix for PR-14637)

### DIFF
--- a/unit_tests/test_config.py
+++ b/unit_tests/test_config.py
@@ -1094,7 +1094,6 @@ class TestCommonTags:
         assert "JenkinsJob" not in tags
 
 
-
 @pytest.mark.parametrize(
     "raw_value,expected",
     [


### PR DESCRIPTION
## Summary
- Fixes precommit failure in PR #14637 by removing an extra blank line in `unit_tests/test_config.py` that `ruff-format` flagged.

Relates to #14637