### PR TITLE
fix(unit-tests): add published_events property and mock SSH key for pytester

### DIFF
--- a/unit_tests/lib/events_utils.py
+++ b/unit_tests/lib/events_utils.py
@@ -11,6 +11,7 @@
 #
 # Copyright (c) 2020 ScyllaDB
 
+import json
 import time
 import shutil
 import tempfile
@@ -82,3 +83,19 @@ class EventsUtilsMixin:
     @classmethod
     def get_raw_events_log(cls):
         return get_events_main_device(_registry=cls.events_processes_registry).raw_events_log
+
+    @property
+    def published_events(self):
+        """Read all published events from the raw events log and return as list of dicts."""
+        events = []
+        raw_log = self.get_raw_events_log()
+        if raw_log.exists():
+            with open(raw_log, "r", encoding="utf-8") as f:
+                for raw_line in f:
+                    stripped = raw_line.strip()
+                    if stripped:
+                        try:
+                            events.append(json.loads(stripped))
+                        except json.JSONDecodeError:
+                            continue
+        return events

--- a/unit_tests/test_tester.py
+++ b/unit_tests/test_tester.py
@@ -292,6 +292,12 @@ class SubtestsSuccessTest(ClusterTesterForTests):
     ],
 )
 def test_tester_subclass(pytester, test_class, results, outcomes):
+    # pytester sets HOME to its temp path; create a mock SSH key file
+    # so the ExistingFile validator for user_credentials_path succeeds.
+    ssh_dir = pytester.path / ".ssh"
+    ssh_dir.mkdir()
+    (ssh_dir / "scylla_test_id_ed25519").write_text("mock-key")
+
     # Create a pytest file with the test class. We cannot just use the class directly
     # because it would not be collected. If we made it collectable it would be run as part of standard test run as well.
     # Which we do not want, as it is intended only to be run with pytester


### PR DESCRIPTION
## Summary
- Add `published_events` property to `EventsUtilsMixin` that reads published events from the raw events log, fixing 7 test failures in `unit_tests/unit/test_decode_backtrace.py`
- Create mock SSH key file in pytester HOME directory so `ExistingFile` validator for `user_credentials_path` succeeds in `test_tester_subclass`

## Root Cause
The `test_decode_backtrace.py` tests (introduced via commits on branch-2026.1) reference `events_function_scope.published_events` but `EventsUtilsMixin` never had this property defined.

## Test Results
Before: 8 failed, 1460 passed
After: 0 failed, 1468 passed