### PR TITLE
fix(manager): scope backup restore verification to backed-up keyspaces

### DIFF
--- a/mgmt_upgrade_test.py
+++ b/mgmt_upgrade_test.py
@@ -214,12 +214,16 @@ class ManagerUpgradeTest(ManagerTestFunctionsMixIn, ClusterTester):
             )
 
         with self.subTest("Restoring an older version backup task with newer version of Manager"):
-            self.verify_backup_success(mgr_cluster=mgr_cluster, backup_task=backup_task)
+            self.verify_backup_success(mgr_cluster=mgr_cluster, backup_task=backup_task, ks_names=["keyspace1"])
             self.run_verification_read_stress()
 
         with self.subTest("Restoring an older version backup task with newer version of Manager, using a restore task"):
             self.verify_backup_success(
-                mgr_cluster=mgr_cluster, backup_task=backup_task, restore_data_with_task=True, timeout=600
+                mgr_cluster=mgr_cluster,
+                backup_task=backup_task,
+                restore_data_with_task=True,
+                timeout=600,
+                ks_names=["keyspace1"],
             )
             self.run_verification_read_stress()
 


### PR DESCRIPTION
The `verify_backup_success` calls in the restore subtests were truncating ALL non-system tables but then trying to restore from a backup that only contained `keyspace1`. This caused a `KeyError` in `restore_backup_without_manager` when it encountered keyspaces not present in the backup (`keyspace2`, `ks1`), leaving all tables empty. The subsequent subtest then failed with 'No non-system tables were found' because `filter_empty_tables=True` filtered out all the truncated (empty) tables.

Fix by passing `ks_names=['keyspace1']` to match the backup task's scope.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [ubuntu24-upgrade-test](https://jenkins.scylladb.com/view/scylla-manager/job/manager-3.11/job/ubuntu24-upgrade-test/4/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code