### PR TITLE
fix(longevity-50gb): Disable simulated_racks dues to multi-az

### DIFF
--- a/test-cases/longevity/longevity-50GB-3days-authorization-and-tls-ssl.yaml
+++ b/test-cases/longevity/longevity-50GB-3days-authorization-and-tls-ssl.yaml
@@ -8,6 +8,7 @@ stress_read_cmd: ["cassandra-stress read cl=QUORUM duration=4320m -mode cql3 nat
 
 run_fullscan: ['{"mode": "table_and_aggregate", "ks_cf": "keyspace1.standard1", "interval": 60}']
 availability_zone: 'a,b,c'
+simulated_racks: 0
 n_db_nodes: 6
 n_loaders: 3
 


### PR DESCRIPTION
Since the test has multiple availability zones, disable simulated racks as the interaction produces unexpected results.

Fixes: SCT-84

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] Before: https://argus.scylladb.com/tests/scylla-cluster-tests/d3a16144-8b29-4cc8-b158-b1b60a192daa
- [x] After: https://argus.scylladb.com/tests/scylla-cluster-tests/6c62bb86-5e58-4e42-8018-90f55206dff5
  Checked by setting `SCT_SIMULATED_RACKS=0`

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
