### PR TITLE
fix(perf-regression): relocate i8g perf jobs from EU to US regions

### DIFF
--- a/vars/perfRegressionParallelPipelinebyRegion.groovy
+++ b/vars/perfRegressionParallelPipelinebyRegion.groovy
@@ -153,22 +153,22 @@ def call(Map pipelineParams) {
                             ],
                             [
                                 job_name: 'scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-with-nemesis-i8g-vnodes',
-                                region: 'eu-west-2',
+                                region: 'us-east-2',
                                 versions: ['master'],
                                 pre_release: [],
                                 sub_tests: ['"test_latency_mixed_with_nemesis"', '"test_latency_read_with_nemesis"', '"test_latency_write_with_nemesis"'],
                                 labels: ['master-monthly'],
-                                job_throttle_category: 'SCT-perf-eu-west-2-i8g',
+                                job_throttle_category: 'SCT-perf-us-east-2-i8g',
                                 arch: 'aarch64'
                             ],
                             [
                                 job_name: 'scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-with-nemesis-i8g-vnodes',
-                                region: 'eu-west-2',
+                                region: 'us-east-2',
                                 ignore_versions: ['2025.2', '2025.1', '2024.2', '2024.1', 'master'],
                                 pre_release: [],
                                 sub_tests: ['"test_latency_mixed_with_nemesis"'],
                                 labels: [],
-                                job_throttle_category: 'SCT-perf-eu-west-2-i8g',
+                                job_throttle_category: 'SCT-perf-us-east-2-i8g',
                                 arch: 'aarch64'
                             ],
                             [
@@ -297,44 +297,44 @@ def call(Map pipelineParams) {
                             ],
                             [
                                 job_name: 'scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-during-rolling-upgrade-i8g-tablets',
-                                region: 'eu-west-2',
+                                region: 'us-west-2',
                                 versions: ['master'],
                                 pre_release: [],
                                 sub_tests: ['"test_latency_mixed_with_upgrade"'],
                                 labels: ['master-3weeks'],
                                 rolling_upgrade_test: true,
-                                job_throttle_category: 'SCT-perf-eu-west-2-i8g',
+                                job_throttle_category: 'SCT-perf-us-west-2-i8g',
                                 arch: 'aarch64'
                             ],
                             [
                                 job_name: 'scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-during-rolling-upgrade-i8g-tablets',
-                                region: 'eu-west-2',
+                                region: 'us-west-2',
                                 ignore_versions: ['2025.2', '2025.1', '2024.2', '2024.1', 'master'],
                                 pre_release: [],
                                 sub_tests: ['"test_latency_mixed_with_upgrade"'],
                                 labels: [],
                                 rolling_upgrade_test: true,
-                                job_throttle_category: 'SCT-perf-eu-west-2-i8g',
+                                job_throttle_category: 'SCT-perf-us-west-2-i8g',
                                 arch: 'aarch64'
                             ],
                             [
                                 job_name: 'scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-with-nemesis-i8g-tablets',
-                                region: 'eu-north-1',
+                                region: 'us-east-2',
                                 versions: ['master'],
                                 pre_release: [],
                                 sub_tests: ['"test_latency_mixed_with_nemesis"'],
                                 labels: ['master-3weeks'],
-                                job_throttle_category: 'SCT-perf-eu-north-1-i8g',
+                                job_throttle_category: 'SCT-perf-us-east-2-i8g',
                                 arch: 'aarch64'
                             ],
                             [
                                 job_name: 'scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-with-nemesis-i8g-tablets',
-                                region: 'eu-north-1',
+                                region: 'us-east-2',
                                 ignore_versions: ['2025.2', '2025.1', '2024.2', '2024.1', 'master'],
                                 pre_release: [],
                                 sub_tests: ['"test_latency_read_with_nemesis"', '"test_latency_mixed_with_nemesis"'],
                                 labels: [],
-                                job_throttle_category: 'SCT-perf-eu-north-1-i8g',
+                                job_throttle_category: 'SCT-perf-us-east-2-i8g',
                                 arch: 'aarch64'
                             ],
                             [


### PR DESCRIPTION
Moved several enterprise perf-regression latency 650gb jobs from EU regions (eu-west-2, eu-north-1) to US regions (us-west-2, us-east-2) and updated the corresponding job_throttle_category values to reflect the new region assignments.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
