### PR TITLE
fix(mgmt): disable tablets for LocalStrategy keyspace in repair test

### DIFF
--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -506,7 +506,9 @@ class ManagerRepairTests(ManagerTestFunctionsMixIn):
         rf = self.get_rf_based_on_nodes_number() if self.db_node.test_config.MULTI_REGION else 3
         self.create_keyspace_and_basic_table(self.NETWORKSTRATEGY_KEYSPACE_NAME, replication_factor=rf)
 
-        self.create_keyspace_and_basic_table(self.LOCALSTRATEGY_KEYSPACE_NAME, replication_factor=0)
+        self.create_keyspace_and_basic_table(
+            self.LOCALSTRATEGY_KEYSPACE_NAME, replication_factor=0, tablets_config=TabletsConfiguration(enabled=False)
+        )
         repair_task = mgr_cluster.create_repair_task()
         task_final_status = repair_task.wait_and_get_final_status(timeout=7200)
         assert task_final_status == TaskStatus.DONE, "Task: {} final status is: {}.".format(

--- a/sdcm/mgmt/operations.py
+++ b/sdcm/mgmt/operations.py
@@ -488,9 +488,11 @@ class DatabaseOperations(ClusterTester):
             return base_id.replace("-", "")
         return base_id
 
-    def create_keyspace_and_basic_table(self, keyspace_name, table_name="example_table", replication_factor=1):
+    def create_keyspace_and_basic_table(
+        self, keyspace_name, table_name="example_table", replication_factor=1, tablets_config=None
+    ):
         self.log.info("creating keyspace {}".format(keyspace_name))
-        keyspace_existence = self.create_keyspace(keyspace_name, replication_factor)
+        keyspace_existence = self.create_keyspace(keyspace_name, replication_factor, tablets_config=tablets_config)
         assert keyspace_existence, "keyspace creation failed"
         # Keyspaces without tables won't appear in the repair, so the must have one
         self.log.info("creating the table {} in the keyspace {}".format(table_name, keyspace_name))


### PR DESCRIPTION
## Summary

- ScyllaDB 2026.2 removed the implicit NTS-only guard in `ks_prop_defs.cc` that previously exempted `LocalStrategy` from tablet replication, causing `test_repair_multiple_keyspace_types` to fail with `ConfigurationException: LocalStrategy doesn't support tablet replication`
- Thread `tablets_config` parameter through `create_keyspace_and_basic_table` in `sdcm/mgmt/operations.py` so callers can control tablet behaviour
- Explicitly pass `TabletsConfiguration(enabled=False)` at the `LocalStrategy` keyspace creation call site in `mgmt_cli_test.py`

### Testing
- [x] [ubuntu24-sanity-test](https://jenkins.scylladb.com/view/scylla-manager/job/manager-3.11/job/ubuntu24-sanity-test/6/)