### PR TITLE
fix(mgmt_cli_test): set scylla ownership on TLS cert files after copy

### DIFF
--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -707,6 +707,7 @@ class ManagerEncryptionTests(ManagerTestFunctionsMixIn):
             node.remoter.sudo(f"mkdir -p {SCYLLA_SSL_CONF_DIR}")
             node.remoter.send_files(src=f"{ssl_dir}/", dst="/tmp/ssl_conf_tmp/")
             node.remoter.sudo(f"cp -r /tmp/ssl_conf_tmp/. {SCYLLA_SSL_CONF_DIR}/")
+            node.remoter.sudo(f"chown -R scylla:scylla {SCYLLA_SSL_CONF_DIR}")
             node.remoter.run("rm -rf /tmp/ssl_conf_tmp/")
 
         for node in self.db_cluster.nodes:


### PR DESCRIPTION
The test_client_encryption subtest fails with Scylla unable to start:

```
  filesystem error: open failed: Permission denied
  [/etc/scylla/ssl_conf/client-facing.crt]
```

The enable_client_encryption() method copies certificates to nodes via `sudo cp -r`, which creates files owned by root:root. Since Scylla runs as User=scylla (systemd unit), it cannot read these files at startup, causing wait_db_up() to time out after 300s.

This worked previously because Scylla startup scripts corrected `/etc/scylla` ownership automatically. Recent Scylla-side hardening removed or restricted this behavior, exposing the missing chown in our test code.

Add `chown -R scylla:scylla` on the ssl_conf directory after copying to ensure the scylla process can read the certificate files regardless of the node umask or startup script behavior.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [debian12-sanity-test, Scylla 2026.2.0-rc1](https://jenkins.scylladb.com/view/scylla-manager/job/manager-3.11/job/debian12-sanity-test/6/)
- [x] [debian12-sanity-test, Scylla 2025.4](https://jenkins.scylladb.com/view/scylla-manager/job/manager-3.11/job/debian12-sanity-test/7/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code