### PR TITLE
fix(sct-config): apply backend required params validation for all backends

### DIFF
--- a/defaults/oci_config.yaml
+++ b/defaults/oci_config.yaml
@@ -9,6 +9,8 @@ instance_provision: "on_demand" # NOTE: DenseIO shapes cannot be 'spot'
 oci_region_name:
   - us-ashburn-1
 
+oci_instance_type_db: "VM.DenseIO.E5.Flex:8"
+
 oci_instance_type_loader: "VM.Standard3.Flex:4:32"
 oci_image_loader: ""  # NOTE: Code will automatically take latest ubuntu:24.04
 ami_loader_user: 'ubuntu'

--- a/jenkins-pipelines/oss/jepsen/jepsen-all.jenkinsfile
+++ b/jenkins-pipelines/oss/jepsen/jepsen-all.jenkinsfile
@@ -4,6 +4,7 @@
 def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 jepsenPipeline(
+    backend: 'gce',
     test_config: 'test-cases/jepsen/jepsen.yaml',
     test_name: 'jepsen_test',
     provision_type: 'on_demand',

--- a/jenkins-pipelines/oss/raft/jepsen-with-raft.jenkinsfile
+++ b/jenkins-pipelines/oss/raft/jepsen-with-raft.jenkinsfile
@@ -4,6 +4,7 @@
 def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 jepsenPipeline(
+    backend: 'gce',
     test_config: 'test-cases/jepsen/jepsen_with_raft.yaml',
     provision_type: 'on_demand',
     post_behavior_db_nodes: 'destroy',

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -3317,6 +3317,8 @@ class SCTConfiguration(BaseModel):
                     if cmd.startswith("latte"):
                         script_name_regx = re.compile(r"([/\w-]*\.rn)")
                         script_name = script_name_regx.search(cmd).group(1)
+                        if script_name.startswith("scylla-qa-internal"):
+                            continue
                         full_path = pathlib.Path(get_sct_root_path()) / script_name
                         assert full_path.exists(), f"{full_path} doesn't exists, please check your configuration"
 
@@ -3686,6 +3688,8 @@ class SCTConfiguration(BaseModel):
     def _validate_scylla_d_overrides_files_exists(self):
         if scylla_d_overrides_files := self.get("scylla_d_overrides_files"):
             for config_file_path in scylla_d_overrides_files:
+                if config_file_path.startswith("scylla-qa-internal"):
+                    continue
                 config_file = pathlib.Path(get_sct_root_path()) / config_file_path
                 assert config_file.exists(), f"{config_file} doesn't exists, please check your configuration"
 
@@ -3702,7 +3706,7 @@ class SCTConfiguration(BaseModel):
                 self.backend_required_params["aws"].extend(
                     ["ami_id_vector_store", "instance_type_vector_store", "ami_vector_store_user"]
                 )
-                self._check_backend_defaults(backend, self.backend_required_params[backend])
+            self._check_backend_defaults(backend, self.backend_required_params[backend])
         else:
             raise ValueError("Unsupported backend [{}]".format(backend))
 


### PR DESCRIPTION
The Pydantic migration PR (https://github.com/scylladb/scylla-cluster-tests/pull/13104) had a mistake where the check
for the required SCT config options was made only for `AWS` backend using vector store nodes.
It made all other backends such as `OCI`, `GCE` and `Azure` not validate their required params.
It allowed to reach the `run test` phase and fail late instead of `early`.

So, fix it by making the `_check_backend_defaults` method be called for any supported backend.

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
