### PR TITLE
fix(ci-oci): export `SCT_OCI_INSTANCE_TYPE_DB` in `runSctTest.groovy`

### DIFF
--- a/vars/runSctTest.groovy
+++ b/vars/runSctTest.groovy
@@ -140,6 +140,9 @@ def call(Map params, String region, functional_test = false, Map pipelineParams 
     if [[ -n "${params.oci_image_db ? params.oci_image_db : ''}" ]] ; then
         export SCT_OCI_IMAGE_DB="${params.oci_image_db}"
     fi
+    if [[ -n "${params.oci_instance_type_db ? params.oci_instance_type_db : ''}" ]] ; then
+        export SCT_OCI_INSTANCE_TYPE_DB="${params.oci_instance_type_db}"
+    fi
     if [[ -n "${params.scylla_version ? params.scylla_version : ''}" ]] ; then
         export SCT_SCYLLA_VERSION="${params.scylla_version}"
     fi


### PR DESCRIPTION
The Jenkinsfile sets the `oci_instance_type_db` in the run configuration for `OCI` provision tests,
but `runSctTest.groovy` never exported it as SCT_OCI_INSTANCE_TYPE_DB.
The value only reached the `provisionResources` step (which has its own export), but not the run-test step.
On branches where backend required-param validation runs unconditionally,
this causes `oci_instance_type_db missing from config for oci` error during `setUp`.

So, fix it by adding the missing env var export in the runSctTest.groovy

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- https://jenkins.scylladb.com/job/sct-github-PRs-scan/job/scylla-cluster-tests/job/PR-14661/1

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
