### PR TITLE
fix(cql): enable control-connection fallback for zero nodes

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4571,6 +4571,8 @@ class BaseCluster:
         kwargs = dict(contact_points=node_ips, port=port, ssl_context=ssl_context)
         if self.test_config.IP_SSH_CONNECTIONS == "public":
             kwargs["allow_control_connection_query_fallback"] = ControlConnectionQueryFallback.SkipPoolCreation
+        elif self.params.get("use_zero_nodes"):
+            kwargs["allow_control_connection_query_fallback"] = ControlConnectionQueryFallback.Fallback
         cluster_driver = ClusterDriver(
             auth_provider=auth_provider,
             compression=compression,


### PR DESCRIPTION
Test with zero-nodes is failed with error: 
```
(TestFrameworkEvent Severity.ERROR) period_type=one-time event_id=db688d0b-5bbf-49ba-bb4e-f4266041decb, source=LongevityTest.SetUp()
exception=('Unable to connect to any servers', ['10.4.9.249', '10.3.2.222', '10.4.3.97', '10.3.7.245', '10.4.10.81', '10.3.5.237', '10.3.10.161', '10.4.0.131', '10.3.1.198', '10.4.7.51', '10.4.7.150', '10.3.10.209']) 
```
After investigation with ai the root cause was found: when sct create an exclusive connection to zero-node, python-driver remove all other contact-points and remove zero node from contact point because it is not in token-ring. this cause raft verification failed and aborting test. Full report is here: 
[root-cause-connection-error.md](https://github.com/user-attachments/files/27762772/root-cause-connection-error.md)

Job: https://argus.scylladb.com/tests/scylla-cluster-tests/fdb7be97-ce51-452a-a2eb-ecc8af5385de

After talk with @dkropachev , it suggest to use new python driver feature for this case.

Enable ControlConnectionQueryFallback.Fallback for use_zero_nodes sessions so queries can continue through the driver control connection when zero-token topologies leave no usable node pools.

Refs: https://github.com/scylladb/python-driver/pull/878

Backport to 2026.1 is need if python driver was changed to 3.29.10 

Fixes: SCYLLADB-1949


### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
 - [ Job is passed](https://argus.scylladb.com/tests/scylla-cluster-tests/cef9fe25-64d0-4452-b6b5-0b1d091e55a1)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
