### PR TITLE
fix(manager): ignore snapshot oversized allocation in test_backup_feature

### DIFF
--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -58,10 +58,12 @@ from sdcm.mgmt.operations import ManagerTestFunctionsMixIn, SnapshotData
 from sdcm.sct_events.system import InfoEvent
 from sdcm.sct_events.group_common_events import (
     ignore_no_space_errors,
+    ignore_snapshot_listing_oversized_allocation,
     ignore_stream_mutation_fragments_errors,
     ignore_aborted_snapshot_upload_storage_io_errors,
 )
 from sdcm.utils.tablets.common import TabletsConfiguration
+from sdcm.utils.version_utils import ComparableScyllaVersion
 
 
 class ManagerRestoreTests(ManagerTestFunctionsMixIn):
@@ -260,8 +262,15 @@ class ManagerBackupTests(ManagerRestoreTests):
         for node in self.db_cluster.nodes:
             node.run_nodetool("compact")
 
-        backup_task.start(continue_task=False)
-        backup_task.wait_and_get_final_status(step=10)
+        ctx = (
+            ignore_snapshot_listing_oversized_allocation()
+            if ComparableScyllaVersion(self.db_cluster.nodes[0].scylla_version) <= "2026.2.0"
+            else nullcontext()
+        )
+        with ctx:
+            backup_task.start(continue_task=False)
+            backup_task.wait_and_get_final_status(step=10)
+
         snapshot_file_list_post_purge = self.get_all_snapshot_files(cluster_id=mgr_cluster.id)
         orphan_files_post_rerun = snapshot_file_list_post_purge.intersection(orphan_files_pre_rerun)
         assert not orphan_files_post_rerun, "orphan files were not deleted!"

--- a/sdcm/sct_events/group_common_events.py
+++ b/sdcm/sct_events/group_common_events.py
@@ -659,6 +659,19 @@ def ignore_aborted_snapshot_upload_storage_io_errors():
         yield
 
 
+@contextmanager
+def ignore_snapshot_listing_oversized_allocation():
+    with ExitStack() as stack:
+        stack.enter_context(
+            EventsSeverityChangerFilter(
+                new_severity=Severity.WARNING,
+                event_class=DatabaseLogEvent,
+                regex=r".*OVERSIZED_ALLOCATION.*storage_service_json::snapshot",
+            )
+        )
+        yield
+
+
 def decorate_with_context(context_list: list[Callable | ContextManager] | Callable | ContextManager):
     """
     helper to decorate a function to run with a list of callables that return context managers


### PR DESCRIPTION
## Summary

Adds `ignore_snapshot_listing_oversized_allocation()` context manager to suppress `OVERSIZED_ALLOCATION` events (downgrade ERROR → WARNING) when the backtrace contains `storage_service_json::snapshot`.

Applied around `backup_task.start` / `wait_and_get_final_status` in `test_backup_purge_removes_orphan_files`.

### Testing

https://jenkins.scylladb.com/view/scylla-manager/job/manager-3.11/job/sct-feature-test-backup/5/