### PR TITLE
fix(provision/aws): poll cloud-config.service in user-script

### DIFF
--- a/sdcm/provision/aws/configuration_script.py
+++ b/sdcm/provision/aws/configuration_script.py
@@ -27,7 +27,7 @@ class AWSConfigurationScriptBuilder(ConfigurationScriptBuilder):
     aws_ipv6_workaround: bool = False
 
     def _wait_before_running_script(self) -> str:
-        return 'while ! systemctl status cloud-init.service | grep "active (exited)"; do sleep 1; done\n'
+        return 'while ! systemctl status cloud-config.service | grep "active (exited)"; do sleep 1; done\n'
 
     def _script_body(self) -> str:
         script = enable_ssm_agent_script()


### PR DESCRIPTION
Cloud-init 26.x dropped the umbrella `cloud-init.service` unit starting from Ubuntu 26.04, so the wait loop for this status at the top of every AWS user-script cycles forever and results in aborting tests atfer ~45 min. The fix changes to polling `cloud-config.service` instead. The unit exists since cloud-init 18.x (Ubuntu 22.x+) and when used, preserves the original intent of defensive wait before running user script.

Fixes: SCT-362

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :green_circle: [artifacts-ami-test on Ubuntu26.04 SMI (original issue)](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/artifacts/job/artifacts-ami-test/13/)
- [x] :green_circle: [artifacts-ami-test on the current AMI from master](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/artifacts/job/artifacts-ami-test/14/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
