### PR TITLE
fix(git): Only delete with sudo if necessary

### DIFF
--- a/sdcm/utils/git.py
+++ b/sdcm/utils/git.py
@@ -95,8 +95,9 @@ def get_git_status_info() -> GitStatus:
 def clone_repo(remoter, repo_url: str, destination_dir_name: str = "", clone_as_root=True, branch=None):
     try:
         LOGGER.debug("Cloning from %s...", repo_url)
-        rm_cmd = f"rm -rf ./{repo_url.split('/')[-1].split('.')[0]}"
-        remoter.sudo(rm_cmd, ignore_status=False)
+        repo_dir = f"./{repo_url.rsplit('/', maxsplit=1)[-1].split('.', maxsplit=1)[0]}"
+        if not remoter.run(f"rm -rf {repo_dir}", ignore_status=True):
+            remoter.sudo(f"rm -rf {repo_dir}", ignore_status=False)
         branch = f"--branch {branch}" if branch else ""
         clone_cmd = f"git clone {branch} {repo_url} {destination_dir_name}"
         if clone_as_root:


### PR DESCRIPTION
This improves the behavior of especially lint-pipelines, which needs the scylla-qa-internal repo.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] Tested locally, did not require sudo password to run `lint-pipelines` in a fresh worktree

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
