### PR TITLE
docs: clarify unit test guidelines to discourage all class-based test patterns

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -225,13 +225,13 @@ High-risk methods with 5+ overrides: `add_nodes`, `_create_instances`, `wait_for
 
 ### Unit Testing Guidelines
 
-**IMPORTANT: Use pytest style, NOT unittest.TestCase**
+**IMPORTANT: Use pytest style, NOT class-based tests**
 
 All unit tests in `unit_tests/` should follow pytest conventions:
 
-**❌ DON'T:** `class TestMyFeature(unittest.TestCase)` with `setUp()` and `self.assertEqual()`
+**❌ DON'T:** Use `class Test*` groupings — whether `unittest.TestCase` subclasses or plain pytest classes. Avoid `setUp()`, `self.assertEqual()`, and class methods for shared logic.
 
-**✅ DO:** Use pytest functions, fixtures, and simple `assert` statements
+**✅ DO:** Use top-level `def test_*` functions, fixtures, and simple `assert` statements. Use module-level helper functions for shared setup logic.
 
 **Key Principles:**
 


### PR DESCRIPTION
Expand the DON'T/DO guidance to explicitly prohibit plain pytest classes (not just unittest.TestCase subclasses), and recommend module-level helper functions instead of class methods for shared setup logic.

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code