### PR TITLE
improvement(migrator): report metrics to Argus

### DIFF
--- a/sdcm/argus_results.py
+++ b/sdcm/argus_results.py
@@ -192,6 +192,25 @@ class ManagerSnapshotDetails(StaticGenericResultTable):
         ]
 
 
+class MigratorBenchmarkResult(StaticGenericResultTable):
+    class Meta:
+        name = "spark-migrator - benchmark"
+        description = (
+            "Target-Scylla p99 write latency, throughput, dataset size and speed during spark-migrator runs "
+            "(max/avg over the migration window)"
+        )
+        Columns = [
+            ColumnMetadata(name="P99 write max", unit="ms", type=ResultType.FLOAT, higher_is_better=False),
+            ColumnMetadata(name="P99 write avg", unit="ms", type=ResultType.FLOAT, higher_is_better=False),
+            ColumnMetadata(name="Throughput max", unit="op/s", type=ResultType.INTEGER, higher_is_better=True),
+            ColumnMetadata(name="Throughput avg", unit="op/s", type=ResultType.INTEGER, higher_is_better=True),
+            ColumnMetadata(name="Data size", unit="GB", type=ResultType.FLOAT, higher_is_better=False),
+            ColumnMetadata(name="Speed", unit="MB/s", type=ResultType.FLOAT, higher_is_better=True),
+            ColumnMetadata(name="duration", unit="HH:MM:SS", type=ResultType.DURATION, higher_is_better=False),
+            ColumnMetadata(name="start time", unit="", type=ResultType.TEXT),
+        ]
+
+
 class PerfSimpleQueryResult(StaticGenericResultTable):
     def __init__(self, workload: str, parameters: dict):
         super().__init__(name=f"{workload} - Perf Simple Query", description=json.dumps(parameters))
@@ -447,6 +466,21 @@ def send_manager_snapshot_details_to_argus(argus_client: ArgusClient, snapshot_d
     for key, value in snapshot_details.items():
         result_table.add_result(column=key, row="#1", value=value, status=Status.UNSET)
     submit_results_to_argus(argus_client, result_table)
+
+
+def send_migrator_results_to_argus(argus_client: ArgusClient, metrics: dict) -> None:
+    """Submit spark-migrator benchmark metrics to Argus."""
+    if not argus_client:
+        LOGGER.warning("Will not submit migrator results to argus - no client initialized")
+        return
+
+    if not metrics:
+        return
+
+    metrics_table = MigratorBenchmarkResult()
+    for column, value in metrics.items():
+        metrics_table.add_result(column=column, row="#1", value=value, status=Status.UNSET)
+    submit_results_to_argus(argus_client, metrics_table)
 
 
 def send_iotune_results_to_argus(argus_client: ArgusClient, results: dict, node, params):

--- a/spark_migrator_test.py
+++ b/spark_migrator_test.py
@@ -19,12 +19,14 @@ import random
 import re
 import time
 from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timezone
 
 from cassandra import ConsistencyLevel
 from cassandra.cluster import Cluster as CassandraCluster
 from cassandra.concurrent import execute_concurrent_with_args
 from cassandra.query import SimpleStatement
 
+from sdcm.argus_results import send_migrator_results_to_argus
 from sdcm.cluster import BaseNode
 from sdcm.spark_migrator import (
     MigratorConfig,
@@ -70,6 +72,95 @@ class SparkMigratorTest(ClusterTester):
         self.log.info("Migrator JAR available at %s", s3_uri)
         self.params["emr_spark_migrator_jar_path"] = s3_uri
 
+    def _collect_migration_metrics(self, start: float, end: float, data_size_bytes: int | None = None) -> dict:
+        """Query Prometheus over [start, end] and return MigratorBenchmarkResult columns."""
+        if not self.prometheus_db:
+            self.log.warning("No prometheus_db available — migrator metrics skipped")
+            return {}
+
+        def floats(series):
+            if not series:
+                return []
+            return [float(raw) for _, raw in series if raw.lower() != "nan"]
+
+        def avg(values):
+            return sum(values) / len(values)
+
+        try:
+            write_lat_us = floats(self.prometheus_db.get_latency_write_99(start, end))
+            throughput = floats(self.prometheus_db.get_throughput(start, end))
+        except Exception as exc:  # noqa: BLE001
+            self.log.warning("Prometheus query for migrator metrics failed: %s", exc)
+            return {}
+
+        if not (write_lat_us or throughput):
+            return {}
+
+        columns: dict = {}
+        if write_lat_us:
+            columns["P99 write max"] = max(write_lat_us) / 1000.0  # µs → ms
+            columns["P99 write avg"] = avg(write_lat_us) / 1000.0
+        if throughput:
+            columns["Throughput max"] = int(max(throughput))
+            columns["Throughput avg"] = int(avg(throughput))
+        duration = end - start
+        if data_size_bytes and duration > 0:
+            columns["Data size"] = data_size_bytes / (1024**3)
+            columns["Speed"] = data_size_bytes / (1024**2) / duration
+        columns["duration"] = int(duration)
+        columns["start time"] = datetime.fromtimestamp(start, tz=timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+        return columns
+
+    def _report_migration_to_argus(self, write_window, data_size_bytes: int | None = None):
+        """Build the migrator benchmark table and submit it to Argus."""
+        try:
+            argus_client = self.test_config.argus_client()
+        except Exception as exc:  # noqa: BLE001
+            self.log.warning("Argus client unavailable — skipping migrator results submission: %s", exc)
+            return
+
+        if not argus_client:
+            self.log.warning("Argus client unavailable — skipping migrator results submission")
+            return
+
+        try:
+            send_migrator_results_to_argus(
+                argus_client, self._collect_migration_metrics(*write_window, data_size_bytes=data_size_bytes)
+            )
+        except Exception as exc:  # noqa: BLE001
+            self.log.warning("Failed to submit migrator results to Argus: %s", exc)
+
+    def _get_source_data_size_bytes(self, source_cluster, keyspace: str) -> int | None:
+        """Estimate logical bytes of source keyspace via 'nodetool cfstats' summed across nodes."""
+        try:
+            with source_cluster.cql_connection_patient(source_cluster.nodes[0]) as session:
+                row = session.execute(
+                    "SELECT replication FROM system_schema.keyspaces WHERE keyspace_name = %s", (keyspace,)
+                ).one()
+
+            rep = (row.replication or {}) if row else {}
+            klass = rep.get("class", "")
+            if "NetworkTopologyStrategy" in klass:
+                rf = sum(
+                    int(value)
+                    for key, value in rep.items()
+                    if key not in {"class", "replication_factor"} and str(value).isdigit()
+                )
+            elif "LocalStrategy" in klass:
+                rf = 1
+            else:
+                rf = int(rep.get("replication_factor", "1"))
+
+            total_bytes = 0
+            for node in source_cluster.nodes:
+                stats = node.get_cfstats(keyspace)
+                total_bytes += int(stats.get("Space used (live)", 0))
+        except Exception as exc:  # noqa: BLE001
+            self.log.warning("Failed to estimate source data size for keyspace %s: %s", keyspace, exc)
+            return None
+
+        return total_bytes // max(rf, 1) or None
+
     def test_full_migration(self):
         """Run a full table migration from Scylla source to Scylla target.
 
@@ -107,14 +198,15 @@ class SparkMigratorTest(ClusterTester):
             )
 
         self.log.info("Submitting spark-migrator job...")
-        start_time = time.time()
+        write_start = time.time()
         result = runner.run_migration(
             cluster_id=self.emr_cluster.cluster_id,
             jar_s3_path=jar_path,
             migrator_config=migrator_config,
             timeout_minutes=self.params.get("migrator_step_timeout_minutes") or 360,
         )
-        duration = time.time() - start_time
+        write_end = time.time()
+        duration = write_end - write_start
 
         self.migration_results = {
             "step_id": result["step_id"],
@@ -124,7 +216,8 @@ class SparkMigratorTest(ClusterTester):
 
         self.log.info("Migration completed in %.1f seconds", duration)
 
-        # Validate migration
+        self._report_migration_to_argus(write_window=(write_start, write_end))
+
         self._validate_migration()
 
     def test_migration_from_external_source(self):
@@ -192,13 +285,17 @@ class SparkMigratorTest(ClusterTester):
             target_keyspace,
             target_table,
         )
-        result = runner.run_migration(
+        write_start = time.time()
+        runner.run_migration(
             cluster_id=self.emr_cluster.cluster_id,
             jar_s3_path=jar_path,
             migrator_config=migrator_config,
             timeout_minutes=self.params.get("migrator_step_timeout_minutes") or 360,
         )
-        self.log.info("Migration completed in %.1f seconds", result["duration_seconds"])
+        write_end = time.time()
+        self.log.info("Migration completed in %.1f seconds", write_end - write_start)
+
+        self._report_migration_to_argus(write_window=(write_start, write_end))
 
         self._validate_external_migration(
             source_hosts,
@@ -383,13 +480,18 @@ class SparkMigratorTest(ClusterTester):
             region_name=region,
         )
 
+        write_start = time.time()
         result = runner.run_migration(
             cluster_id=self.emr_cluster.cluster_id,
             jar_s3_path=jar_path,
             migrator_config=migrator_config,
             timeout_minutes=self.params.get("migrator_step_timeout_minutes") or 360,
         )
+        write_end = time.time()
         self.log.info("Migration completed in %.1f seconds", result["duration_seconds"])
+
+        data_size_bytes = self._get_source_data_size_bytes(self.cs_db_cluster, source_keyspace)
+        self._report_migration_to_argus(write_window=(write_start, write_end), data_size_bytes=data_size_bytes)
 
         self._validate_migration_count_and_sample(
             source_cluster=self.cs_db_cluster,
@@ -500,13 +602,18 @@ class SparkMigratorTest(ClusterTester):
             region_name=region,
         )
 
+        write_start = time.time()
         result = runner.run_migration(
             cluster_id=self.emr_cluster.cluster_id,
             jar_s3_path=jar_path,
             migrator_config=migrator_config,
             timeout_minutes=self.params.get("migrator_step_timeout_minutes") or 360,
         )
+        write_end = time.time()
         self.log.info("Migration completed in %.1f seconds", result["duration_seconds"])
+
+        data_size_bytes = self._get_source_data_size_bytes(self.cs_db_cluster, source_keyspace)
+        self._report_migration_to_argus(write_window=(write_start, write_end), data_size_bytes=data_size_bytes)
 
         if self.params.get("migrator_run_validator"):
             self._run_validator(runner, jar_path, migrator_config)

--- a/unit_tests/unit/test_migrator_argus_results.py
+++ b/unit_tests/unit/test_migrator_argus_results.py
@@ -1,0 +1,91 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2026 ScyllaDB
+
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+
+from sdcm.argus_results import (
+    MigratorBenchmarkResult,
+    send_migrator_results_to_argus,
+)
+
+
+EXPECTED_BENCHMARK_COLUMNS = {
+    "P99 write max",
+    "P99 write avg",
+    "Throughput max",
+    "Throughput avg",
+    "Data size",
+    "Speed",
+    "duration",
+    "start time",
+}
+
+
+@pytest.fixture
+def argus_client():
+    return MagicMock()
+
+
+@pytest.fixture
+def sample_metrics():
+    return {
+        "P99 write max": 12.5,
+        "P99 write avg": 8.3,
+        "Throughput max": 50_000,
+        "Throughput avg": 30_000,
+        "Data size": 100.0,
+        "Speed": 170.6,
+        "duration": 600.0,
+        "start time": "2026-05-15 10:00:00 UTC",
+    }
+
+
+def test_migrator_benchmark_result_schema():
+    table = MigratorBenchmarkResult()
+    assert {col.name for col in table.columns} == EXPECTED_BENCHMARK_COLUMNS
+    assert table.name == "spark-migrator - benchmark"
+    assert table.description
+
+
+def test_send_migrator_results_submits_benchmark_table(argus_client, sample_metrics):
+    send_migrator_results_to_argus(argus_client, sample_metrics)
+
+    argus_client.submit_results.assert_called_once()
+    submitted_result = argus_client.submit_results.call_args.args[0]
+    assert isinstance(submitted_result, MigratorBenchmarkResult)
+
+    assert {cell.row for cell in submitted_result.results} == {"#1"}
+    values = {cell.column: cell.value for cell in submitted_result.results}
+    assert values["P99 write max"] == pytest.approx(12.5)
+    assert values["P99 write avg"] == pytest.approx(8.3)
+    assert values["Throughput max"] == 50_000
+    assert values["Throughput avg"] == 30_000
+    assert values["Data size"] == pytest.approx(100.0)
+    assert values["Speed"] == pytest.approx(170.6)
+    assert values["duration"] == pytest.approx(600.0)
+    assert values["start time"] == "2026-05-15 10:00:00 UTC"
+
+
+def test_send_migrator_results_skips_when_empty(argus_client):
+    send_migrator_results_to_argus(argus_client, {})
+
+    argus_client.submit_results.assert_not_called()
+
+
+def test_send_migrator_results_without_client_returns_quietly(sample_metrics, caplog):
+    with caplog.at_level(logging.WARNING, logger="sdcm.argus_results"):
+        send_migrator_results_to_argus(None, sample_metrics)
+    assert any("no client initialized" in rec.message for rec in caplog.records)


### PR DESCRIPTION
Capture P99 write latency, throughput (max and avg) and duration (migration itself) metrics. Submit the collected metrics to Argus run in question.

Closes: SCT-184

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :green_circle: [scylla-migrator-test](https://jenkins.scylladb.com/job/scylla-staging/job/dimakr/job/scylla-migrator-test/26/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
