### PR TITLE
fix(cluster): accept after_config in all BaseNode subclass __init__

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -7680,7 +7680,17 @@ class NoMonitorSet:
 
 
 class LocalNode(BaseNode):
-    def __init__(self, name, parent_cluster, ssh_login_info=None, base_logdir=None, node_prefix=None, dc_idx=0, rack=0):
+    def __init__(
+        self,
+        name,
+        parent_cluster,
+        ssh_login_info=None,
+        base_logdir=None,
+        node_prefix=None,
+        dc_idx=0,
+        rack=0,
+        after_config=None,
+    ):
         super().__init__(
             name=name,
             parent_cluster=parent_cluster,
@@ -7689,6 +7699,7 @@ class LocalNode(BaseNode):
             node_prefix=node_prefix,
             dc_idx=dc_idx,
             rack=rack,
+            after_config=after_config,
         )
 
     @property

--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -1432,6 +1432,7 @@ class VectorStoreAWSNode(VectorStoreNodeMixin, AWSNode):
         base_logdir=None,
         dc_idx=0,
         rack=0,
+        after_config=None,
     ):
         super().__init__(
             ec2_instance=ec2_instance,
@@ -1444,6 +1445,7 @@ class VectorStoreAWSNode(VectorStoreNodeMixin, AWSNode):
             base_logdir=base_logdir,
             dc_idx=dc_idx,
             rack=rack,
+            after_config=after_config,
         )
 
     def init(self):

--- a/sdcm/cluster_baremetal.py
+++ b/sdcm/cluster_baremetal.py
@@ -44,6 +44,7 @@ class PhysicalMachineNode(cluster.BaseNode):
         credentials,
         base_logdir=None,
         node_prefix=None,
+        after_config=None,
     ):
         ssh_login_info = {
             "hostname": None,
@@ -58,6 +59,7 @@ class PhysicalMachineNode(cluster.BaseNode):
             base_logdir=base_logdir,
             ssh_login_info=ssh_login_info,
             node_prefix=node_prefix,
+            after_config=after_config,
         )
 
     def init(self):

--- a/sdcm/cluster_cloud.py
+++ b/sdcm/cluster_cloud.py
@@ -420,6 +420,7 @@ class CloudVSNode(CloudNode):
         base_logdir: str | None = None,
         dc_idx: int = 0,
         rack: int = 0,
+        after_config=None,
     ):
         super().__init__(
             cloud_instance_data=cloud_instance_data,
@@ -429,6 +430,7 @@ class CloudVSNode(CloudNode):
             base_logdir=base_logdir,
             dc_idx=dc_idx,
             rack=rack,
+            after_config=after_config,
         )
 
     def _get_ssh_address(self, localhost) -> dict:
@@ -475,6 +477,7 @@ class CloudManagerNode(CloudNode):
         base_logdir: str | None = None,
         dc_idx: int = 0,
         rack: int = 0,
+        after_config=None,
     ):
         # minimal cloud_instance_data for manager node (most of the node details will be fetched via SDM)
         cloud_instance_data = {
@@ -493,6 +496,7 @@ class CloudManagerNode(CloudNode):
             base_logdir=base_logdir,
             dc_idx=dc_idx,
             rack=rack,
+            after_config=after_config,
         )
 
     def _get_ssh_address(self, localhost) -> dict:

--- a/sdcm/cluster_docker.py
+++ b/sdcm/cluster_docker.py
@@ -308,6 +308,7 @@ class VectorStoreDockerNode(VectorStoreNodeMixin, DockerNode):
         base_logdir: Optional[str] = None,
         ssh_login_info: Optional[dict] = None,
         node_index: int = 1,
+        after_config=None,
     ) -> None:
         super().__init__(
             parent_cluster=parent_cluster,
@@ -316,6 +317,7 @@ class VectorStoreDockerNode(VectorStoreNodeMixin, DockerNode):
             base_logdir=base_logdir,
             ssh_login_info=ssh_login_info,
             node_index=node_index,
+            after_config=after_config,
         )
 
     def node_container_run_args(self, seed_ip=None):
@@ -827,6 +829,7 @@ class DockerMonitoringNode(cluster.BaseNode):
         base_logdir: Optional[str] = None,
         node_index: int = 1,
         ssh_login_info: Optional[dict] = None,
+        after_config=None,
     ) -> None:
         super().__init__(
             name=f"{node_prefix}-{node_index}",
@@ -834,6 +837,7 @@ class DockerMonitoringNode(cluster.BaseNode):
             base_logdir=base_logdir,
             node_prefix=node_prefix,
             ssh_login_info=ssh_login_info,
+            after_config=after_config,
         )
         self.node_index = node_index
 

--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -1925,6 +1925,7 @@ class BasePodContainer(cluster.BaseNode):
         base_logdir: Optional[str] = None,
         dc_idx: int = 0,
         rack=0,
+        after_config=None,
     ):
         self.node_index = node_index
         cluster.BaseNode.__init__(
@@ -1935,6 +1936,7 @@ class BasePodContainer(cluster.BaseNode):
             node_prefix=node_prefix,
             dc_idx=dc_idx,
             rack=rack,
+            after_config=after_config,
         )
         self.k8s_cluster = self.parent_cluster.k8s_clusters[self.dc_idx]
         self._rack_name = None
@@ -2509,6 +2511,7 @@ class LoaderPodContainer(BasePodContainer):
         base_logdir: Optional[str] = None,
         dc_idx: int = 0,
         rack=0,
+        after_config=None,
     ):
         self.loader_cluster_name = parent_cluster.loader_cluster_name
         self.loader_name = name
@@ -2521,6 +2524,7 @@ class LoaderPodContainer(BasePodContainer):
             base_logdir=base_logdir,
             dc_idx=dc_idx,
             rack=rack,
+            after_config=after_config,
         )
 
     def init(self):

--- a/sdcm/utils/docker_remote.py
+++ b/sdcm/utils/docker_remote.py
@@ -17,7 +17,14 @@ LOGGER = logging.getLogger(__name__)
 
 class RemoteDocker(BaseNode):
     def __init__(
-        self, node, image_name, ports=None, command_line="tail -f /dev/null", extra_docker_opts="", docker_network=None
+        self,
+        node,
+        image_name,
+        ports=None,
+        command_line="tail -f /dev/null",
+        extra_docker_opts="",
+        docker_network=None,
+        after_config=None,
     ):
         self.node = node
         self._internal_ip_address = None
@@ -35,7 +42,7 @@ class RemoteDocker(BaseNode):
         self.docker_id = res.stdout.strip()
         self.image_name = image_name
         self.docker_network = docker_network
-        super().__init__(name=image_name, parent_cluster=node.parent_cluster)
+        super().__init__(name=image_name, parent_cluster=node.parent_cluster, after_config=after_config)
 
     @property
     def internal_ip_address(self):

--- a/unit_tests/unit/test_cluster.py
+++ b/unit_tests/unit/test_cluster.py
@@ -11,6 +11,8 @@
 #
 # Copyright (c) 2020 ScyllaDB
 
+import importlib
+import inspect
 import logging
 import tempfile
 import time
@@ -20,7 +22,7 @@ from datetime import datetime, timezone
 import pytest
 from invoke import Result
 
-from sdcm.cluster import BaseMonitorSet
+from sdcm.cluster import BaseMonitorSet, BaseNode
 from sdcm.db_log_reader import DbLogReader
 from sdcm.sct_events.database import SYSTEM_ERROR_EVENTS_PATTERNS
 from sdcm.sct_events.filters import DbEventsFilter
@@ -875,3 +877,103 @@ def test_base_node_init_with_none_ssh_login_info():
     node.init()
 
     assert isinstance(node.remoter, LocalCmdRunner), f"Expected LocalCmdRunner, got {type(node.remoter)}"
+
+
+# backend modules whose `BaseNode` subclasses must be loaded into the class hierarchy
+_BACKEND_MODULES = (
+    "sdcm.cluster_aws",
+    "sdcm.cluster_azure",
+    "sdcm.cluster_baremetal",
+    "sdcm.cluster_cloud",
+    "sdcm.cluster_docker",
+    "sdcm.cluster_gce",
+    "sdcm.cluster_k8s",
+    "sdcm.cluster_k8s.eks",
+    "sdcm.cluster_k8s.gke",
+    "sdcm.cluster_k8s.mini_k8s",
+    "sdcm.cluster_oci",
+    "sdcm.utils.docker_remote",
+)
+
+
+def _all_base_node_subclasses() -> list[type]:
+    """Return all `BaseNode` subclasses from the `sdcm` package, excluding test fixtures."""
+    for module_name in _BACKEND_MODULES:
+        importlib.import_module(module_name)
+
+    all_subclasses = set()
+    stack = list(BaseNode.__subclasses__())
+    while stack:
+        cls = stack.pop()
+        if cls not in all_subclasses:
+            all_subclasses.add(cls)
+            stack.extend(cls.__subclasses__())
+
+    production = [cls for cls in all_subclasses if cls.__module__.startswith("sdcm.")]
+    return sorted(production, key=lambda c: c.__name__)
+
+
+# classes that use cloud-SDK clients in __init__ and need those patched out during construction
+_INIT_CONSTRUCT_PATCHES: dict[str, tuple[str, ...]] = {
+    "GCENode": ("sdcm.cluster_gce.GceLoggingClient",),
+}
+
+# `BaseNode.__init__` kwargs a subclass intentionally does NOT accept.
+_NO_SSH = frozenset({"ssh_login_info"})
+_NO_DC_RACK = frozenset({"dc_idx", "rack"})
+_NARROWED_KWARGS: dict[str, frozenset[str]] = {
+    "AWSNode": _NO_SSH,
+    "AzureNode": _NO_SSH,
+    "BasePodContainer": _NO_SSH,
+    "CloudManagerNode": _NO_SSH,
+    "CloudNode": _NO_SSH,
+    "CloudVSNode": _NO_SSH,
+    "GCENode": _NO_SSH,
+    "LoaderPodContainer": _NO_SSH,
+    "OciNode": _NO_SSH,
+    "VectorStoreAWSNode": _NO_SSH,
+    "DockerMonitoringNode": _NO_DC_RACK,
+    "DockerNode": _NO_DC_RACK,
+    "VectorStoreDockerNode": _NO_DC_RACK,
+    "PhysicalMachineNode": _NO_DC_RACK | _NO_SSH,
+    "RemoteDocker": _NO_DC_RACK | _NO_SSH | frozenset({"base_logdir", "node_prefix"}),
+}
+
+
+def _build_init_kwargs(cls: type) -> dict:
+    """Build the minimal kwargs needed to construct `cls` for this test."""
+    kwargs: dict[str, object] = {}
+    constructor_params = inspect.signature(cls.__init__).parameters
+
+    for name, param in constructor_params.items():
+        if name == "self" or param.default is not inspect.Parameter.empty:
+            continue
+        if name == "cloud_instance_data":
+            kwargs[name] = {}
+            continue
+        if name == "parent_cluster":
+            parent_cluster = unittest.mock.MagicMock(name="parent_cluster")
+            parent_cluster.params = {}
+            kwargs[name] = parent_cluster
+            continue
+        kwargs[name] = unittest.mock.MagicMock(name=name)
+
+    narrowed_kwargs = _NARROWED_KWARGS.get(cls.__name__, frozenset())
+    for name, param in inspect.signature(BaseNode.__init__).parameters.items():
+        if param.default is inspect.Parameter.empty or name in kwargs or name in narrowed_kwargs:
+            continue
+        kwargs[name] = param.default
+
+    return kwargs
+
+
+@pytest.mark.parametrize("cls", _all_base_node_subclasses(), ids=lambda cls: cls.__name__)
+def test_base_node_subclass_constructs_with_forwarded_kwargs(cls, monkeypatch):
+    """Verify each `BaseNode` subclass can be constructed polymorphically."""
+    if "__init__" not in cls.__dict__:
+        pytest.skip(f"{cls.__name__} inherits __init__ from a parent")
+
+    for target in _INIT_CONSTRUCT_PATCHES.get(cls.__name__, ()):
+        monkeypatch.setattr(target, unittest.mock.MagicMock())
+
+    cls(**_build_init_kwargs(cls))


### PR DESCRIPTION
Commit cabef28b2 forwarded a new `after_config` kwarg through `_create_node` of every backend, but missed a few `BaseNode` subclasses where `__init__` is overridden. These constructors raise `TypeError: ... unexpected keyword argument 'after_config'` error, when used.

The fix updates the affected subclasses to accept `after_config=None` and forward it to `super().__init__`.

Fixes: SCT-357

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :green_circle: [xcloud backend deployment with VS nodes](https://jenkins.scylladb.com/job/scylla-staging/job/dimakr/job/pr-provision-test-new/300/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
