### PR TITLE
improvement(oci): properly handle rate limiter errors

### DIFF
--- a/sdcm/utils/oci_utils.py
+++ b/sdcm/utils/oci_utils.py
@@ -38,6 +38,15 @@ from sdcm.utils.metaclasses import Singleton
 
 LOGGER = logging.getLogger(__name__)
 
+OCI_RETRY_STRATEGY = oci.retry.RetryStrategyBuilder(
+    max_attempts_check=True,
+    max_attempts=10,
+    retry_max_wait_between_calls_seconds=60,
+    retry_base_sleep_time_seconds=3,
+    service_error_retry_on_any_5xx=True,
+    service_error_retry_config={429: []},
+).get_retry_strategy()
+
 # Suppress verbose OCI SDK logging
 logging.getLogger("oci").setLevel(logging.WARNING)
 
@@ -117,42 +126,42 @@ class OciService(metaclass=Singleton):
         config = self.config.copy()
         if region:
             config["region"] = region
-        return ComputeClient(config)
+        return ComputeClient(config, retry_strategy=OCI_RETRY_STRATEGY)
 
     def get_identity_client(self, region: str | None = None) -> IdentityClient:
         """Get Identity client for specified region."""
         config = self.config.copy()
         if region:
             config["region"] = region
-        return IdentityClient(config)
+        return IdentityClient(config, retry_strategy=OCI_RETRY_STRATEGY)
 
     def get_network_client(self, region: str | None = None) -> VirtualNetworkClient:
         """Get Virtual Network client for specified region."""
         config = self.config.copy()
         if region:
             config["region"] = region
-        return VirtualNetworkClient(config)
+        return VirtualNetworkClient(config, retry_strategy=OCI_RETRY_STRATEGY)
 
     def get_object_storage_client(self, region: str | None = None) -> ObjectStorageClient:
         """Get Object Storage client for specified region."""
         config = self.config.copy()
         if region:
             config["region"] = region
-        return ObjectStorageClient(config)
+        return ObjectStorageClient(config, retry_strategy=OCI_RETRY_STRATEGY)
 
     def get_block_storage_client(self, region: str | None = None) -> BlockstorageClient:
         """Get Block Storage client for specified region."""
         config = self.config.copy()
         if region:
             config["region"] = region
-        return BlockstorageClient(config)
+        return BlockstorageClient(config, retry_strategy=OCI_RETRY_STRATEGY)
 
     def get_work_request_client(self, region: str | None = None) -> WorkRequestClient:
         """Get Work Request client for specified region."""
         config = self.config.copy()
         if region:
             config["region"] = region
-        return WorkRequestClient(config)
+        return WorkRequestClient(config, retry_strategy=OCI_RETRY_STRATEGY)
 
 
 def get_availability_domains(compartment_id: str, region: str | None = None) -> list[str]:


### PR DESCRIPTION
In test runs we happen to get the following error periodically:
```
  Failed to terminate OCI instance <db-node-name> (id: <ocid>): {
      'target_service': 'compute',
      'status': 429,
      'code': 'TooManyRequests',
      'message': 'Too many requests for the user',
      'operation_name': 'terminate_instance',
      ...
  }
```

And it leads to the orphaphing of the cloud resources.

So, fix it by using the `oci.retry.RetryStrategyBuilder` for `OCI` clients we initialize in `SCT`.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
