### PR TITLE
improvement(xcloud): add VS nodes to xcloud weekly provisioning trigger

### DIFF
--- a/jenkins-pipelines/master-triggers/sct_triggers/xcloud-weekly-provisioning-trigger.xml
+++ b/jenkins-pipelines/master-triggers/sct_triggers/xcloud-weekly-provisioning-trigger.xml
@@ -2,7 +2,7 @@
   <actions/>
   <description>Triggers Scylla Cloud provisioning tests on weekly basis every Saturday at 6:00
 
-  Tests Scylla Cloud provisioning capabilities using PR-provision-test configuration.
+  Tests Scylla Cloud provisioning capabilities using PR-provision-test configuration (including Vector Search nodes).
   </description>
   <keepDependencies>false</keepDependencies>
   <properties>
@@ -53,8 +53,10 @@
 provision_type=on_demand
 region=us-east-1
 xcloud_provider=aws
+n_vector_store_nodes=2
 post_behavior_db_nodes=destroy
 post_behavior_monitor_nodes=destroy
+post_behavior_vector_store_nodes=destroy
 requested_by_user=dimakr</properties>
               <textParamValueOnNewLine>false</textParamValueOnNewLine>
             </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
@@ -71,8 +73,10 @@ requested_by_user=dimakr</properties>
 provision_type=on_demand
 gce_datacenter=us-east1
 xcloud_provider=gce
+n_vector_store_nodes=2
 post_behavior_db_nodes=destroy
 post_behavior_monitor_nodes=destroy
+post_behavior_vector_store_nodes=destroy
 requested_by_user=dimakr</properties>
               <textParamValueOnNewLine>false</textParamValueOnNewLine>
             </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>

--- a/vars/longevityPipeline.groovy
+++ b/vars/longevityPipeline.groovy
@@ -108,6 +108,9 @@ def call(Map pipelineParams) {
             string(defaultValue: "${pipelineParams.get('post_behavior_vector_store_nodes', 'destroy')}",
                    description: 'keep|keep-on-failure|destroy',
                    name: 'post_behavior_vector_store_nodes')
+            string(defaultValue: "${pipelineParams.get('n_vector_store_nodes', '')}",
+                   description: 'Number of Vector Search nodes to deploy.',
+                   name: 'n_vector_store_nodes')
 
             // Cluster Reuse
             separator(name: 'CLUSTER_REUSE', sectionHeader: 'Cluster Reuse')

--- a/vars/provisionResources.groovy
+++ b/vars/provisionResources.groovy
@@ -138,6 +138,9 @@ def call(Map params, String region){
     if [[ -n "${params.post_behavior_vector_store_nodes ? params.post_behavior_vector_store_nodes : ''}" ]] ; then
         export SCT_POST_BEHAVIOR_VECTOR_STORE_NODES="${params.post_behavior_vector_store_nodes}"
     fi
+    if [[ -n "${params.n_vector_store_nodes ? params.n_vector_store_nodes : ''}" ]] ; then
+        export SCT_N_VECTOR_STORE_NODES="${params.n_vector_store_nodes}"
+    fi
 
     if [[ -n "${params.provision_type ? params.provision_type : ''}" ]] ; then
         export SCT_INSTANCE_PROVISION="${params.provision_type}"

--- a/vars/runCleanupResource.groovy
+++ b/vars/runCleanupResource.groovy
@@ -61,6 +61,9 @@ def call(Map params, String region){
     if [[ -n "${params.post_behavior_vector_store_nodes ? params.post_behavior_vector_store_nodes : ''}" ]] ; then
         export SCT_POST_BEHAVIOR_VECTOR_STORE_NODES="${params.post_behavior_vector_store_nodes}"
     fi
+    if [[ -n "${params.n_vector_store_nodes ? params.n_vector_store_nodes : ''}" ]] ; then
+        export SCT_N_VECTOR_STORE_NODES="${params.n_vector_store_nodes}"
+    fi
 
     echo "Starting to clean resources ..."
     RUNNER_IP=\$(cat sct_runner_ip||echo "")

--- a/vars/runSctTest.groovy
+++ b/vars/runSctTest.groovy
@@ -182,6 +182,9 @@ def call(Map params, String region, functional_test = false, Map pipelineParams 
     if [[ -n "${params.post_behavior_vector_store_nodes ? params.post_behavior_vector_store_nodes : ''}" ]] ; then
         export SCT_POST_BEHAVIOR_VECTOR_STORE_NODES="${params.post_behavior_vector_store_nodes}"
     fi
+    if [[ -n "${params.n_vector_store_nodes ? params.n_vector_store_nodes : ''}" ]] ; then
+        export SCT_N_VECTOR_STORE_NODES="${params.n_vector_store_nodes}"
+    fi
 
     if [[ -n "${params.provision_type ? params.provision_type : ''}" ]] ; then
         export SCT_INSTANCE_PROVISION="${params.provision_type}"


### PR DESCRIPTION
We periodically suffer from VS-on-ScyllaCloud deployment regressions in SCT, which are not noticed until a dedicated task requires such deployemnt.

This change adds VS nodes deployment to a weekly trigger for xcloud provisioning pipeline

Closes: SCT-358

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] to be tested by weekly trigger

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
