### PR TITLE
fix: filter raft topology barrier_and_drain closed_error in node-disrupting nemesis

### DIFF
--- a/sdcm/nemesis/__init__.py
+++ b/sdcm/nemesis/__init__.py
@@ -805,7 +805,7 @@ class NemesisRunner:
         time.sleep(60)
 
     def disrupt_hard_reboot_node(self):
-        with ignore_raft_topology_cmd_failing():
+        with suppress_expected_unavailability_errors():
             self.reboot_node(target_node=self.target_node, hard=True)
         with self.action_log_scope(f"Wait for {self.target_node.name} node to be fully started"):
             self.target_node.wait_node_fully_start()
@@ -1317,8 +1317,11 @@ class NemesisRunner:
             self.set_target_node(allow_only_last_node_in_rack=True)
 
         target_is_seed = self.target_node.is_seed
-        with self.action_log_scope(
-            f"Decommission {self.target_node.name} node. is_zero_token_node: {self.target_node._is_zero_token_node}"
+        with (
+            suppress_expected_unavailability_errors(),
+            self.action_log_scope(
+                f"Decommission {self.target_node.name} node. is_zero_token_node: {self.target_node._is_zero_token_node}"
+            ),
         ):
             dc_topology_rf_change = self.cluster.decommission(self.target_node)
         new_node = None
@@ -5580,7 +5583,10 @@ class NemesisRunner:
                     self.cluster.decommission(new_node, timeout=decommission_timeout)
 
     def disrupt_disable_binary_gossip_execute_major_compaction(self):
-        with nodetool_context(node=self.target_node, start_command="disablebinary", end_command="enablebinary"):
+        with (
+            suppress_expected_unavailability_errors(),
+            nodetool_context(node=self.target_node, start_command="disablebinary", end_command="enablebinary"),
+        ):
             self.actions_log.info("Executed nodetool disablebinary")
             self.target_node.run_nodetool("statusbinary")
             self.target_node.run_nodetool("status")

--- a/sdcm/sct_events/setup.py
+++ b/sdcm/sct_events/setup.py
@@ -196,7 +196,7 @@ def enable_default_filters(sct_config: SCTConfiguration):
     DbEventsFilter(
         db_event=DatabaseLogEvent.RUNTIME_ERROR,
         line=r".*raft_topology - topology change coordinator fiber got error std::runtime_error"
-        r" \(raft topology: exec_global_command\(barrier\) failed with seastar::rpc::closed_error"
+        r" \(raft topology: exec_global_command\(barrier(?:_and_drain)?\) failed with seastar::rpc::closed_error"
         r" \(connection is closed\)\)",
     ).publish()
 


### PR DESCRIPTION
## Summary

Fixes transient `raft topology: exec_global_command(barrier_and_drain) failed with seastar::rpc::closed_error (connection is closed)` false-positive errors that cause test failures in multiple nemesis.

This error is self-resolving (coordinator retries successfully within seconds) and is expected whenever a node is killed/rebooted/gossip-disabled while the topology coordinator holds an RPC connection to it.

## Changes

### `sdcm/sct_events/setup.py`
- Extend the permanent global `DbEventsFilter` regex to cover both `exec_global_command(barrier)` and `exec_global_command(barrier_and_drain)` variants using `(?:_and_drain)?`

### `sdcm/nemesis/__init__.py`
- **`disrupt_hard_reboot_node`**: upgrade from `ignore_raft_topology_cmd_failing()` to `suppress_expected_unavailability_errors()` for full coverage (also covers raft transport errors, drain rpc, etc.)
- **`disrupt_disable_binary_gossip_execute_major_compaction`**: add `ignore_raft_topology_cmd_failing()` — disabling gossip causes RPC teardown that triggers barrier failures on the topology coordinator (originally reported in SCT-141)
- **`_nodetool_decommission`**: add `ignore_raft_topology_cmd_failing()` — decommission streaming races with `barrier_and_drain` (see SCYLLADB-2099)

## Related

- Closes SCT-141
- Related: SCYLLADB-2099
- Reference fix pattern: https://github.com/scylladb/scylla-cluster-tests/pull/13601