### PR TITLE
fix: remove JsonOutput.toJson() from gce_datacenter and use single-quoted shell exports

### DIFF
--- a/vars/artifactsPipeline.groovy
+++ b/vars/artifactsPipeline.groovy
@@ -188,7 +188,7 @@ def call(Map pipelineParams) {
                                                         export SCT_REGION_NAME='${params.region}'
                                                     fi
                                                     if [[ -n "${params.gce_datacenter ? params.gce_datacenter : ''}" ]] ; then
-                                                        export SCT_GCE_DATACENTER=${params.gce_datacenter}
+                                                        export SCT_GCE_DATACENTER='${params.gce_datacenter}'
                                                     fi
                                                     if [[ -n "${params.azure_region_name ? params.azure_region_name : ''}" ]] ; then
                                                         export SCT_AZURE_REGION_NAME=${params.azure_region_name}

--- a/vars/getJobTimeouts.groovy
+++ b/vars/getJobTimeouts.groovy
@@ -16,7 +16,7 @@ List<Integer> call(Map params, String region){
     fi
 
     if [[ -n "${params.gce_datacenter ? params.gce_datacenter : ''}" ]] ; then
-        export SCT_GCE_DATACENTER=${groovy.json.JsonOutput.toJson(params.gce_datacenter)}
+        export SCT_GCE_DATACENTER='${params.gce_datacenter}'
     fi
 
     if [[ -n "${params.azure_region_name ? params.azure_region_name : ''}" ]] ; then

--- a/vars/managerPipeline.groovy
+++ b/vars/managerPipeline.groovy
@@ -319,7 +319,7 @@ def call(Map pipelineParams) {
 
                                         // handle params which can be a json list
                                         def region = initAwsRegionParam(params.region, builder.region)
-                                        def datacenter = groovy.json.JsonOutput.toJson(params.gce_datacenter)
+                                        def datacenter = params.gce_datacenter ?: ""
                                         def oci_region = ""
                                         if (params.oci_region_name) {
                                             oci_region = initAwsRegionParam(params.oci_region_name, builder.region)
@@ -334,7 +334,7 @@ def call(Map pipelineParams) {
 
                                         export SCT_CLUSTER_BACKEND="${params.backend}"
                                         export SCT_REGION_NAME=${region}
-                                        export SCT_GCE_DATACENTER=${datacenter}
+                                        export SCT_GCE_DATACENTER='${datacenter}'
                                         if [[ -n "${params.azure_region_name ? params.azure_region_name : ''}" ]] ; then
                                             export SCT_AZURE_REGION_NAME=${params.azure_region_name}
                                         fi

--- a/vars/perfSearchBestConfigParallelPipeline.groovy
+++ b/vars/perfSearchBestConfigParallelPipeline.groovy
@@ -304,7 +304,7 @@ def call(Map pipelineParams) {
                                                         fi
 
                                                         if [[ -n "${params.gce_datacenter ? params.gce_datacenter : ''}" ]] ; then
-                                                            export SCT_GCE_DATACENTER=${params.gce_datacenter}
+                                                            export SCT_GCE_DATACENTER='${params.gce_datacenter}'
                                                         fi
 
                                                         export SCT_EMAIL_RECIPIENTS="${email_recipients}"

--- a/vars/provisionResources.groovy
+++ b/vars/provisionResources.groovy
@@ -41,7 +41,7 @@ def call(Map params, String region){
     fi
 
     if [[ -n "${params.gce_datacenter ? params.gce_datacenter : ''}" ]] ; then
-        export SCT_GCE_DATACENTER=${params.gce_datacenter}
+        export SCT_GCE_DATACENTER='${params.gce_datacenter}'
     fi
 
     if [[ -n "${params.azure_region_name ? params.azure_region_name : ''}" ]] ; then

--- a/vars/runCleanupResource.groovy
+++ b/vars/runCleanupResource.groovy
@@ -2,10 +2,7 @@
 
 def call(Map params, String region){
     def current_region = initAwsRegionParam(params.region, region)
-    def current_gce_datacenter = ""
-    if (params.gce_datacenter) {
-        current_gce_datacenter = groovy.json.JsonOutput.toJson(params.gce_datacenter)
-    }
+    def current_gce_datacenter = params.gce_datacenter ?: ""
     def current_oci_region = ""
     if (params.oci_region_name) {
         current_oci_region = initAwsRegionParam(params.oci_region_name, region)
@@ -38,7 +35,7 @@ def call(Map params, String region){
         export SCT_REGION_NAME=${current_region}
     fi
     if [[ -n "${params.gce_datacenter ? params.gce_datacenter : ''}" ]] ; then
-        export SCT_GCE_DATACENTER=${current_gce_datacenter}
+        export SCT_GCE_DATACENTER='${current_gce_datacenter}'
     fi
     if [[ -n "${params.azure_region_name ? params.azure_region_name : ''}" ]] ; then
         export SCT_AZURE_REGION_NAME=${params.azure_region_name}

--- a/vars/runCollectLogs.groovy
+++ b/vars/runCollectLogs.groovy
@@ -3,10 +3,7 @@
 
 def call(Map params, String region){
     def current_region = initAwsRegionParam(params.region, region)
-    def current_gce_datacenter = ""
-    if (params.gce_datacenter) {
-        current_gce_datacenter = groovy.json.JsonOutput.toJson(params.gce_datacenter)
-    }
+    def current_gce_datacenter = params.gce_datacenter ?: ""
     def current_oci_region = ""
     if (params.oci_region_name) {
         current_oci_region = initAwsRegionParam(params.oci_region_name, region)
@@ -22,7 +19,7 @@ def call(Map params, String region){
     export SCT_CLUSTER_BACKEND="${params.backend}"
     export SCT_REGION_NAME=${current_region}
     if [[ -n "${params.gce_datacenter ? params.gce_datacenter : ''}" ]] ; then
-        export SCT_GCE_DATACENTER=${current_gce_datacenter}
+        export SCT_GCE_DATACENTER='${current_gce_datacenter}'
     fi
     if [[ -n "${params.azure_region_name ? params.azure_region_name : ''}" ]] ; then
         export SCT_AZURE_REGION_NAME=${params.azure_region_name}

--- a/vars/runSctTest.groovy
+++ b/vars/runSctTest.groovy
@@ -3,10 +3,7 @@
 def call(Map params, String region, functional_test = false, Map pipelineParams = [:]){
     // handle params which can be a json list
     def current_region = initAwsRegionParam(params.region, region)
-    def current_gce_datacenter = ""
-    if (params.gce_datacenter) {
-        current_gce_datacenter = groovy.json.JsonOutput.toJson(params.gce_datacenter)
-    }
+    def current_gce_datacenter = params.gce_datacenter ?: ""
     def current_oci_region = ""
     if (params.oci_region_name) {
         current_oci_region = initAwsRegionParam(params.oci_region_name, region)
@@ -65,7 +62,7 @@ def call(Map params, String region, functional_test = false, Map pipelineParams 
     fi
 
     if [[ -n "${params.gce_datacenter ? params.gce_datacenter : ''}" ]] ; then
-        export SCT_GCE_DATACENTER=${current_gce_datacenter}
+        export SCT_GCE_DATACENTER='${current_gce_datacenter}'
     fi
 
     if [[ -n "${params.azure_region_name ? params.azure_region_name : ''}" ]] ; then


### PR DESCRIPTION
JsonOutput.toJson() on a string like '["us-east1","us-east4"]' wraps it in additional JSON string encoding, corrupting the value so Python's ast.literal_eval() cannot parse it as a list. The parameter value is already a valid Python list literal as provided by the user.

Use single-quoted shell exports to preserve the value exactly as-is, preventing both word splitting on spaces and issues with inner double quotes in the list literal.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [muliDC GCE test](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/yulia/job/longevity-cdc-8h-multi-dc-topology-changes-streaming-vnodes-test/). Provisioning failed due to `Machine type with name 'z3-highmem-16-highlssd' does not exist in zone 'us-west1-c'`
- [x] [single DC](https://argus.scylladb.com/tests/scylla-cluster-tests/e755eb69-0e92-4657-ae4f-38a83de2579b) Provisioning failed due to capacity problem
- [x] [artifact test](https://argus.scylladb.com/tests/scylla-cluster-tests/50ceec9f-6b7a-4c36-a53c-7a6f67b5291c)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
