### PR TITLE
fix(provision/gce): prevent live migration from disrupting tests

### DIFF
--- a/sdcm/provision/gce/instance_provider.py
+++ b/sdcm/provision/gce/instance_provider.py
@@ -274,6 +274,13 @@ class VirtualMachineProvider:
             instance.scheduling.on_host_maintenance = "TERMINATE"
             instance.scheduling.provisioning_model = compute_v1.Scheduling.ProvisioningModel.SPOT.name
             instance.scheduling.instance_termination_action = "STOP"
+        elif definition.type.startswith("e2-"):
+            # e2 family supports only on_host_maintenance=MIGRATE for non-spot VMs
+            instance.scheduling.on_host_maintenance = "MIGRATE"
+        else:
+            # avoid live migration and unexpected restarts disrupting tests
+            instance.scheduling.on_host_maintenance = "TERMINATE"
+            instance.scheduling.automatic_restart = False
 
         # Network tags and service accounts
         network_tags = self.network_provider.get_network_tags(allow_public_access=definition.use_public_ip)

--- a/sdcm/utils/gce_utils.py
+++ b/sdcm/utils/gce_utils.py
@@ -624,6 +624,13 @@ def create_instance(  # noqa: PLR0913
         instance.scheduling.on_host_maintenance = "TERMINATE"
         instance.scheduling.provisioning_model = compute_v1.Scheduling.ProvisioningModel.SPOT.name
         instance.scheduling.instance_termination_action = instance_termination_action
+    elif machine_type.split("/")[-1].startswith("e2-"):
+        # e2 family supports only on_host_maintenance=MIGRATE for non-spot VMs
+        instance.scheduling.on_host_maintenance = "MIGRATE"
+    else:
+        # avoid live migration and unexpected restarts disrupting tests
+        instance.scheduling.on_host_maintenance = "TERMINATE"
+        instance.scheduling.automatic_restart = False
 
     if custom_hostname is not None:
         # Set the custom hostname for the instance

--- a/unit_tests/unit/test_gce_scheduling_policy.py
+++ b/unit_tests/unit/test_gce_scheduling_policy.py
@@ -1,0 +1,92 @@
+"""SCT-345: GCE instances must be created with on_host_maintenance=TERMINATE and
+automatic_restart=False to prevent live migration from disrupting tests.
+
+Covers both creation paths: VirtualMachineProvider (DB/loader/monitor nodes) and
+sdcm.utils.gce_utils.create_instance (SCT runner VM).
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from google.cloud import compute_v1
+
+from sdcm.provision.gce.instance_provider import VirtualMachineProvider
+from sdcm.provision.provisioner import InstanceDefinition, PricingModel
+from sdcm.utils.gce_utils import create_instance
+
+
+def _scheduling_set_explicitly(instance: compute_v1.Instance, field: str) -> bool:
+    """Confirm the field was explicitly set, not just proto-plus default."""
+    return compute_v1.Scheduling.pb(instance.scheduling).HasField(field)
+
+
+def _assert_terminate_no_restart(instance: compute_v1.Instance) -> None:
+    assert instance.scheduling.on_host_maintenance == "TERMINATE"
+    assert _scheduling_set_explicitly(instance, "automatic_restart")
+    assert instance.scheduling.automatic_restart is False
+
+
+@patch("sdcm.provision.gce.instance_provider.get_gce_service_accounts", return_value=None)
+def test_instance_provider_default_branch_sets_terminate_and_no_auto_restart(_mock_sa) -> None:
+    disk_provider = MagicMock()
+    disk_provider.create_disks_config.return_value = [
+        {
+            "boot": True,
+            "device_name": "boot",
+            "initialize_params": {"source_image": "img", "disk_size_gb": 50, "disk_type": "pd-standard"},
+        },
+    ]
+    network_provider = MagicMock()
+    network_provider.get_network_tags.return_value = []
+    network_provider.get_network_url.return_value = "global/networks/default"
+
+    with patch(
+        "sdcm.provision.gce.instance_provider.get_gce_compute_instances_client",
+        return_value=(MagicMock(), {}),
+    ):
+        provider = VirtualMachineProvider(
+            project_id="test-project",
+            zone="us-central1-a",
+            test_id="test-id",
+            disk_provider=disk_provider,
+            network_provider=network_provider,
+        )
+    definition = InstanceDefinition(
+        name="test-node-1",
+        image_id="projects/p/global/images/test-image",
+        type="n2-standard-4",
+        user_name="scyllaadm",
+        ssh_key=SimpleNamespace(name="test-key", public_key=b"ssh-rsa AAA test@example.com"),
+        tags={"env": "test"},
+    )
+    provider._build_and_insert_instance(
+        definition=definition,
+        pricing_model=PricingModel.ON_DEMAND,
+        user_data="",
+        startup_script="",
+        normalized_name="test-node-1",
+    )
+
+    instance = provider._instances_client.insert.call_args.kwargs["request"].instance_resource
+    _assert_terminate_no_restart(instance)
+
+
+def test_create_instance_default_branch_sets_terminate_and_no_auto_restart() -> None:
+    instance_client = MagicMock()
+    instance_client.get.return_value = compute_v1.Instance()
+
+    with (
+        patch("sdcm.utils.gce_utils.get_gce_compute_instances_client", return_value=(instance_client, {})),
+        patch("sdcm.utils.gce_utils.wait_for_extended_operation"),
+    ):
+        create_instance(
+            project_id="test-project",
+            zone="us-central1-a",
+            instance_name="test-runner",
+            disks=[compute_v1.AttachedDisk(boot=True, device_name="boot")],
+            machine_type="n2-standard-1",
+            network_name="default",
+        )
+
+    instance = instance_client.insert.call_args.kwargs["request"].instance_resource
+    _assert_terminate_no_restart(instance)


### PR DESCRIPTION
GCE provider default MIGRATE policy allows live-migrating VMs during host maintenance, and it can cause unpredictable latency spikes and performance degradation anomalies that result in test failures.

The fix sets on_host_maintenance=TERMINATE and automatic_restart=False policy values by default when creating GCE instances.
e2 family is kept on MIGRATE (GCE rejects TERMINATE for non-spot e2 VMs).

Fixes: SCT-345

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :green_circle: [rolling-upgrade-alternator-test (original issue scenario)](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/upgrades/job/rolling-upgrade-alternator-test/9/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
