### PR TITLE
fix: remove extra blank line in test_config.py (precommit fix for branch-2025.4)

### DIFF
--- a/unit_tests/test_config.py
+++ b/unit_tests/test_config.py
@@ -1094,7 +1094,6 @@ class TestCommonTags:
         assert "JenkinsJob" not in tags
 
 
-
 @pytest.mark.parametrize(
     "raw_value,expected",
     [


### PR DESCRIPTION
## Summary
- Removes an extra blank line in `unit_tests/test_config.py` that `ruff-format` flagged as a precommit failure on `branch-2025.4`.
- Replaces #14645 which had the wrong commit (a cherry-pick of the GCE zones fix instead of the actual formatting fix).