### PR TITLE
feature(gce): enable use_dns_names support for GCE backend

### DIFF
--- a/defaults/gce_config.yaml
+++ b/defaults/gce_config.yaml
@@ -40,5 +40,34 @@ use_preinstalled_scylla: true
 
 kms_key_rotation_interval: 60
 
+scylla_network_config:
+- address: listen_address
+  listen_all: false
+  ip_type: ipv4
+  public: false
+  use_dns: false
+  nic: 0
+- address: rpc_address
+  listen_all: false
+  ip_type: ipv4
+  public: false
+  use_dns: false
+  nic: 0
+- address: broadcast_rpc_address
+  ip_type: ipv4
+  public: false
+  use_dns: false
+  nic: 0
+- address: broadcast_address
+  ip_type: ipv4
+  public: false
+  use_dns: false
+  nic: 0
+- address: test_communication
+  ip_type: ipv4
+  public: false
+  use_dns: false
+  nic: 0
+
 # we are using monitor images, see `gce_image_monitor`
 monitor_branch: null

--- a/sdcm/cluster_gce.py
+++ b/sdcm/cluster_gce.py
@@ -24,7 +24,7 @@ from google.cloud import compute_v1
 
 from sdcm import cluster
 from sdcm.provision.gce.provisioner import GceProvisioner
-from sdcm.provision.network_configuration import ssh_connection_ip_type
+from sdcm.provision.network_configuration import NetworkInterface, ScyllaNetworkConfiguration, ssh_connection_ip_type
 from sdcm.provision.provisioner import PricingModel
 from sdcm.provision.helpers.cloud_init import wait_cloud_init_completes
 from sdcm.sct_provision import region_definition_builder
@@ -124,6 +124,12 @@ class GCENode(cluster.BaseNode):
         # related issue: https://github.com/scylladb/scylla-cluster-tests/issues/1121
         time.sleep(10)
 
+        if self.parent_cluster.params.get("scylla_network_config"):
+            self.scylla_network_configuration = ScyllaNetworkConfiguration(
+                network_interfaces=self.network_interfaces,
+                scylla_network_config=self.parent_cluster.params["scylla_network_config"],
+            )
+
         super().init()
 
     def _create_kernel_panic_checker(self):
@@ -189,7 +195,26 @@ class GCENode(cluster.BaseNode):
 
     @property
     def network_interfaces(self):
-        pass
+        interfaces = []
+        for idx, iface in enumerate(self._instance.network_interfaces):
+            public_ip = None
+            if iface.access_configs:
+                public_ip = iface.access_configs[0].nat_i_p or None
+            interfaces.append(
+                NetworkInterface(
+                    ipv4_public_address=public_ip,
+                    ipv6_public_addresses=[],
+                    ipv4_private_addresses=[iface.network_i_p],
+                    ipv6_private_address="",
+                    dns_private_name=self.private_dns_name,
+                    dns_public_name=self.public_dns_name,
+                    device_index=idx,
+                    device_name=None,
+                    mac_address=None,
+                    use_dns_names=self.use_dns_names,
+                )
+            )
+        return interfaces
 
     @property
     def vm_region(self):

--- a/sdcm/cluster_gce.py
+++ b/sdcm/cluster_gce.py
@@ -11,6 +11,7 @@
 #
 # Copyright (c) 2020 ScyllaDB
 
+import json
 import os
 import time
 import logging
@@ -19,6 +20,7 @@ from functools import cached_property, cache
 from collections.abc import Callable
 
 import tenacity
+import yaml
 import google.api_core.exceptions
 from google.cloud import compute_v1
 
@@ -109,12 +111,46 @@ class GCENode(cluster.BaseNode):
             after_config=after_config,
         )
 
+    @cached_property
+    def network_configuration(self):
+        """Query MAC→device name mapping from the node, same pattern as AWS."""
+        network_devices = {}
+        if self.remoter:
+            if network_config_json := self.remoter.run("ip -j link", ignore_status=True).stdout.strip():
+                interfaces = json.loads(network_config_json)
+                network_devices = {
+                    interface["address"]: interface["ifname"]
+                    for interface in interfaces
+                    if interface.get("ifname") != "lo" and interface.get("address")
+                }
+            if not network_devices:
+                ip_link_cmd = """ip -o link | awk '$2 != "lo:" {gsub(/:/,"",$2);print $17": " $2}'"""
+                network_config = self.remoter.run(ip_link_cmd).stdout.strip()
+                network_devices = yaml.safe_load(network_config)
+            self.log.debug("Node %s ethernets: %s", self.name, network_devices)
+        return network_devices
+
     def refresh_network_interfaces_info(self):
-        pass
+        if "network_configuration" in self.__dict__:
+            del self.__dict__["network_configuration"]
+        if self.scylla_network_configuration:
+            self.scylla_network_configuration.network_interfaces = self.network_interfaces
 
     @staticmethod
     def is_gce() -> bool:
         return True
+
+    @cached_property
+    def cql_address(self):
+        if self.scylla_network_configuration:
+            address = (
+                self.scylla_network_configuration.test_communication
+                if self.test_config.IP_SSH_CONNECTIONS == "public"
+                else self.scylla_network_configuration.broadcast_rpc_address
+            )
+            self.log.debug("cql_address is: %s", address)
+            return address
+        return super().cql_address
 
     @cluster.terminate_on_failure
     def init(self):
@@ -124,13 +160,20 @@ class GCENode(cluster.BaseNode):
         # related issue: https://github.com/scylladb/scylla-cluster-tests/issues/1121
         time.sleep(10)
 
+        super().init()
+
         if self.parent_cluster.params.get("scylla_network_config"):
             self.scylla_network_configuration = ScyllaNetworkConfiguration(
                 network_interfaces=self.network_interfaces,
                 scylla_network_config=self.parent_cluster.params["scylla_network_config"],
             )
-
-        super().init()
+            self.log.debug(
+                "Node %s scylla_network_config: %s", self.name, self.parent_cluster.params["scylla_network_config"]
+            )
+            self.log.debug(
+                "Node %s network_interfaces: %s", self.name, self.scylla_network_configuration.network_interfaces
+            )
+            self.refresh_network_interfaces_info()
 
     def _create_kernel_panic_checker(self):
         return GCPKernelPanicChecker(
@@ -196,6 +239,8 @@ class GCENode(cluster.BaseNode):
     @property
     def network_interfaces(self):
         interfaces = []
+        devices = self.network_configuration if self.remoter else {}
+        device_names = list(devices.values()) if devices else []
         for idx, iface in enumerate(self._instance.network_interfaces):
             public_ip = None
             if iface.access_configs:
@@ -206,10 +251,10 @@ class GCENode(cluster.BaseNode):
                     ipv6_public_addresses=[],
                     ipv4_private_addresses=[iface.network_i_p],
                     ipv6_private_address="",
-                    dns_private_name=self.private_dns_name,
-                    dns_public_name=self.public_dns_name,
+                    dns_private_name=self.private_dns_name if self.remoter else "",
+                    dns_public_name=self.public_dns_name if self.remoter else "",
                     device_index=idx,
-                    device_name=None,
+                    device_name=device_names[idx] if idx < len(device_names) else "",
                     mac_address=None,
                     use_dns_names=self.use_dns_names,
                 )

--- a/sdcm/provision/network_configuration.py
+++ b/sdcm/provision/network_configuration.py
@@ -30,13 +30,31 @@ class ScyllaNetworkConfiguration:
         self.scylla_network_config = scylla_network_config
 
     @property
+    def _use_dns_names(self) -> bool:
+        """Check if any network interface has use_dns_names enabled."""
+        return any(iface.use_dns_names for iface in self.network_interfaces)
+
+    def _get_dns_private_name(self, address_config: dict) -> str:
+        """Get DNS private name for the interface specified in address_config."""
+        if not (interface := [conf for conf in self.network_interfaces if address_config["nic"] == conf.device_index]):
+            raise NetworkInterfaceNotFound(
+                f"Not found network interface with device_index {address_config['nic']}. "
+                f"Check 'scylla_network_config' definition in the test configuration"
+            )
+        return interface[0].dns_private_name
+
+    @property
     def listen_address(self):
         listen_address_config = [conf for conf in self.scylla_network_config if conf["address"] == "listen_address"][0]
+        if self._use_dns_names:
+            return self._get_dns_private_name(listen_address_config)
         return self.get_ip_by_address_config(address_config=listen_address_config)
 
     @property
     def rpc_address(self):
         rpc_address_config = [conf for conf in self.scylla_network_config if conf["address"] == "rpc_address"][0]
+        if self._use_dns_names:
+            return self._get_dns_private_name(rpc_address_config)
         return self.get_ip_by_address_config(address_config=rpc_address_config)
 
     @property
@@ -44,6 +62,8 @@ class ScyllaNetworkConfiguration:
         if broadcast_rpc_address_config := [
             conf for conf in self.scylla_network_config if conf["address"] == "broadcast_rpc_address"
         ]:
+            if self._use_dns_names:
+                return self._get_dns_private_name(broadcast_rpc_address_config[0])
             return self.get_ip_by_address_config(address_config=broadcast_rpc_address_config[0])
         else:
             return self.rpc_address

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -2995,7 +2995,7 @@ class SCTConfiguration(BaseModel):
 
         # 16 Validate use_dns_names
         if self.get("use_dns_names"):
-            if cluster_backend not in ("aws",):
+            if cluster_backend and cluster_backend not in ("aws", "gce"):
                 raise ValueError(f"use_dns_names is not supported for {cluster_backend} backend")
 
         # 17 Validate scylla network configuration mandatory values

--- a/unit_tests/test_gce_use_dns_names.py
+++ b/unit_tests/test_gce_use_dns_names.py
@@ -1,92 +1,251 @@
+import json
+
 import pytest
 from unittest.mock import MagicMock
 
 from sdcm.cluster_gce import GCENode
-from sdcm.provision.network_configuration import NetworkInterface
+from sdcm.provision.network_configuration import NetworkInterface, ScyllaNetworkConfiguration
 from sdcm.sct_config import SCTConfiguration
 
 
-def test_gce_node_network_interfaces_with_public_ip():
-    """network_interfaces returns correct NetworkInterface with public IP."""
-    mock_iface = MagicMock()
-    mock_iface.network_i_p = "10.0.0.1"
-    mock_iface.access_configs = [MagicMock(nat_i_p="34.1.2.3")]
-
+def _make_gce_node_mock(
+    interfaces,
+    remoter=None,
+    use_dns_names=True,
+    private_dns="node-1.c.my-project.internal",
+    public_dns="34.1.2.3.bc.googleusercontent.com",
+):
     node = MagicMock(spec=GCENode)
-    node._instance = MagicMock(network_interfaces=[mock_iface])
-    node.private_dns_name = "node-1.us-east1-b.c.my-project.internal"
-    node.public_dns_name = "34.1.2.3.bc.googleusercontent.com"
-    node.use_dns_names = True
+    node._instance = MagicMock(network_interfaces=interfaces)
+    node.remoter = remoter
+    node.use_dns_names = use_dns_names
+    node.private_dns_name = private_dns
+    node.public_dns_name = public_dns
+    node.network_configuration = {}
+    return node
+
+
+def _make_gce_iface(ip, public_ip=None):
+    iface = MagicMock()
+    iface.network_i_p = ip
+    if public_ip:
+        iface.access_configs = [MagicMock(nat_i_p=public_ip)]
+    else:
+        iface.access_configs = []
+    return iface
+
+
+def test_gce_node_network_interfaces_with_remoter_and_device_names():
+    mock_iface = _make_gce_iface("10.0.0.1", "34.1.2.3")
+    remoter = MagicMock()
+    node = _make_gce_node_mock([mock_iface], remoter=remoter)
+    node.network_configuration = {"aa:bb:cc:dd:ee:f0": "ens4"}
 
     result = GCENode.network_interfaces.fget(node)
 
     assert len(result) == 1
-    assert isinstance(result[0], NetworkInterface)
     assert result[0].ipv4_private_addresses == ["10.0.0.1"]
     assert result[0].ipv4_public_address == "34.1.2.3"
-    assert result[0].dns_private_name == "node-1.us-east1-b.c.my-project.internal"
+    assert result[0].dns_private_name == "node-1.c.my-project.internal"
     assert result[0].dns_public_name == "34.1.2.3.bc.googleusercontent.com"
     assert result[0].use_dns_names is True
     assert result[0].device_index == 0
+    assert result[0].device_name == "ens4"
 
 
-def test_gce_node_network_interfaces_no_public_ip():
-    """Empty nat_i_p normalizes to None (not empty string)."""
-    mock_iface = MagicMock()
-    mock_iface.network_i_p = "10.0.0.2"
-    mock_iface.access_configs = [MagicMock(nat_i_p="")]
-
-    node = MagicMock(spec=GCENode)
-    node._instance = MagicMock(network_interfaces=[mock_iface])
-    node.private_dns_name = "node-2.us-east1-b.c.my-project.internal"
-    node.public_dns_name = ""
-    node.use_dns_names = False
+def test_gce_node_network_interfaces_without_remoter():
+    mock_iface = _make_gce_iface("10.0.0.1", "34.1.2.3")
+    node = _make_gce_node_mock([mock_iface], remoter=None)
 
     result = GCENode.network_interfaces.fget(node)
 
-    assert len(result) == 1
+    assert result[0].dns_private_name == ""
+    assert result[0].dns_public_name == ""
+    assert result[0].device_name == ""
+
+
+def test_gce_node_network_interfaces_no_public_ip():
+    mock_iface = _make_gce_iface("10.0.0.2", "")
+    remoter = MagicMock()
+    node = _make_gce_node_mock(
+        [mock_iface], remoter=remoter, use_dns_names=False, private_dns="node-2.c.my-project.internal", public_dns=""
+    )
+    node.network_configuration = {"aa:bb:cc:dd:ee:f0": "ens4"}
+
+    result = GCENode.network_interfaces.fget(node)
+
     assert result[0].ipv4_public_address is None
 
 
 def test_gce_node_network_interfaces_no_access_configs():
-    """No access_configs means public IP is None."""
-    mock_iface = MagicMock()
-    mock_iface.network_i_p = "10.0.0.3"
-    mock_iface.access_configs = []
-
-    node = MagicMock(spec=GCENode)
-    node._instance = MagicMock(network_interfaces=[mock_iface])
-    node.private_dns_name = "node-3.us-east1-b.c.my-project.internal"
-    node.public_dns_name = ""
-    node.use_dns_names = False
+    mock_iface = _make_gce_iface("10.0.0.3")
+    remoter = MagicMock()
+    node = _make_gce_node_mock(
+        [mock_iface], remoter=remoter, use_dns_names=False, private_dns="node-3.c.my-project.internal", public_dns=""
+    )
+    node.network_configuration = {}
 
     result = GCENode.network_interfaces.fget(node)
 
     assert result[0].ipv4_public_address is None
+    assert result[0].device_name == ""
 
 
 def test_gce_node_network_interfaces_multiple_interfaces():
-    """Multiple interfaces get correct device_index values."""
-    iface0 = MagicMock()
-    iface0.network_i_p = "10.0.0.1"
-    iface0.access_configs = [MagicMock(nat_i_p="34.1.2.3")]
-
-    iface1 = MagicMock()
-    iface1.network_i_p = "10.0.1.1"
-    iface1.access_configs = []
-
-    node = MagicMock(spec=GCENode)
-    node._instance = MagicMock(network_interfaces=[iface0, iface1])
-    node.private_dns_name = "node-1.us-east1-b.c.my-project.internal"
-    node.public_dns_name = "34.1.2.3.bc.googleusercontent.com"
-    node.use_dns_names = False
+    iface0 = _make_gce_iface("10.0.0.1", "34.1.2.3")
+    iface1 = _make_gce_iface("10.0.1.1")
+    remoter = MagicMock()
+    node = _make_gce_node_mock([iface0, iface1], remoter=remoter, use_dns_names=False)
+    node.network_configuration = {"aa:bb:cc:dd:ee:f0": "ens4", "aa:bb:cc:dd:ee:f1": "ens5"}
 
     result = GCENode.network_interfaces.fget(node)
 
     assert len(result) == 2
     assert result[0].device_index == 0
+    assert result[0].device_name == "ens4"
     assert result[1].device_index == 1
+    assert result[1].device_name == "ens5"
     assert result[1].ipv4_public_address is None
+
+
+def test_gce_network_configuration_parses_ip_json_link():
+    node = MagicMock(spec=GCENode)
+    node.remoter = MagicMock()
+    node.name = "test-node-1"
+    ip_json_output = json.dumps(
+        [
+            {"ifname": "lo", "address": "00:00:00:00:00:00"},
+            {"ifname": "ens4", "address": "42:01:0a:80:00:02"},
+            {"ifname": "ens5", "address": "42:01:0a:80:01:02"},
+        ]
+    )
+    node.remoter.run.return_value = MagicMock(stdout=ip_json_output)
+    node.log = MagicMock()
+
+    result = GCENode.network_configuration.func(node)
+
+    assert result == {"42:01:0a:80:00:02": "ens4", "42:01:0a:80:01:02": "ens5"}
+
+
+def test_gce_network_configuration_without_remoter():
+    node = MagicMock(spec=GCENode)
+    node.remoter = None
+    node.name = "test-node-2"
+    node.log = MagicMock()
+
+    result = GCENode.network_configuration.func(node)
+
+    assert result == {}
+
+
+def test_gce_refresh_network_interfaces_info():
+    class FakeNode:
+        network_configuration = {"old": "data"}
+        scylla_network_configuration = MagicMock()
+        network_interfaces = [MagicMock()]
+
+    node = FakeNode()
+    GCENode.refresh_network_interfaces_info(node)
+
+    assert not hasattr(node, "network_configuration") or "network_configuration" not in node.__dict__
+    assert node.scylla_network_configuration.network_interfaces == node.network_interfaces
+
+
+def test_gce_refresh_network_interfaces_info_no_scylla_config():
+    class FakeNode:
+        scylla_network_configuration = None
+        network_interfaces = []
+
+    node = FakeNode()
+    GCENode.refresh_network_interfaces_info(node)
+
+
+def test_scylla_network_config_device_with_gce_interfaces():
+    """ScyllaNetworkConfiguration.device works with GCE-style interfaces (non-None device_name)."""
+    interfaces = [
+        NetworkInterface(
+            ipv4_public_address="34.1.2.3",
+            ipv6_public_addresses=[],
+            ipv4_private_addresses=["10.0.0.1"],
+            ipv6_private_address="",
+            dns_private_name="node-1.c.my-project.internal",
+            dns_public_name="",
+            device_index=0,
+            device_name="ens4",
+            mac_address=None,
+            use_dns_names=True,
+        )
+    ]
+    scylla_network_config = [
+        {"address": "listen_address", "ip_type": "ipv4", "public": False, "nic": 0, "use_dns": False},
+        {"address": "rpc_address", "ip_type": "ipv4", "public": False, "nic": 0, "use_dns": False},
+        {"address": "broadcast_rpc_address", "ip_type": "ipv4", "public": False, "nic": 0, "use_dns": False},
+        {"address": "broadcast_address", "ip_type": "ipv4", "public": False, "nic": 0},
+        {"address": "test_communication", "ip_type": "ipv4", "public": True, "nic": 0},
+    ]
+    config = ScyllaNetworkConfiguration(
+        network_interfaces=interfaces,
+        scylla_network_config=scylla_network_config,
+    )
+    assert config.device == "ens4"
+
+
+def test_scylla_network_config_device_empty_string():
+    """ScyllaNetworkConfiguration.device returns empty string when device_name is empty."""
+    interfaces = [
+        NetworkInterface(
+            ipv4_public_address="34.1.2.3",
+            ipv6_public_addresses=[],
+            ipv4_private_addresses=["10.0.0.1"],
+            ipv6_private_address="",
+            dns_private_name="",
+            dns_public_name="",
+            device_index=0,
+            device_name="",
+            mac_address=None,
+            use_dns_names=False,
+        )
+    ]
+    scylla_network_config = [
+        {"address": "listen_address", "ip_type": "ipv4", "public": False, "nic": 0, "use_dns": False},
+        {"address": "rpc_address", "ip_type": "ipv4", "public": False, "nic": 0, "use_dns": False},
+        {"address": "broadcast_rpc_address", "ip_type": "ipv4", "public": False, "nic": 0, "use_dns": False},
+        {"address": "broadcast_address", "ip_type": "ipv4", "public": False, "nic": 0},
+        {"address": "test_communication", "ip_type": "ipv4", "public": True, "nic": 0},
+    ]
+    config = ScyllaNetworkConfiguration(
+        network_interfaces=interfaces,
+        scylla_network_config=scylla_network_config,
+    )
+    assert config.device == ""
+
+
+def test_gce_cql_address_uses_scylla_network_configuration():
+    node = MagicMock(spec=GCENode)
+    node.scylla_network_configuration = MagicMock()
+    node.scylla_network_configuration.broadcast_rpc_address = "node-1.c.my-project.internal"
+    node.scylla_network_configuration.test_communication = "34.1.2.3"
+    node.test_config = MagicMock()
+    node.test_config.IP_SSH_CONNECTIONS = "private"
+    node.log = MagicMock()
+
+    result = GCENode.cql_address.func(node)
+
+    assert result == "node-1.c.my-project.internal"
+
+
+def test_gce_cql_address_public_uses_test_communication():
+    node = MagicMock(spec=GCENode)
+    node.scylla_network_configuration = MagicMock()
+    node.scylla_network_configuration.broadcast_rpc_address = "node-1.c.my-project.internal"
+    node.scylla_network_configuration.test_communication = "34.1.2.3"
+    node.test_config = MagicMock()
+    node.test_config.IP_SSH_CONNECTIONS = "public"
+    node.log = MagicMock()
+
+    result = GCENode.cql_address.func(node)
+
+    assert result == "34.1.2.3"
 
 
 @pytest.fixture()
@@ -120,7 +279,6 @@ def azure_base_env(monkeypatch):
 
 
 def test_use_dns_names_gce_does_not_raise(gce_base_env):
-    """use_dns_names=True with cluster_backend=gce must NOT raise ValueError."""
     try:
         SCTConfiguration()
     except ValueError as exc:
@@ -129,7 +287,6 @@ def test_use_dns_names_gce_does_not_raise(gce_base_env):
 
 
 def test_use_dns_names_aws_does_not_raise(aws_base_env):
-    """use_dns_names=True with cluster_backend=aws must NOT raise ValueError."""
     try:
         SCTConfiguration()
     except ValueError as exc:
@@ -138,7 +295,6 @@ def test_use_dns_names_aws_does_not_raise(aws_base_env):
 
 
 def test_use_dns_names_none_backend_does_not_raise(monkeypatch):
-    """use_dns_names=True with cluster_backend=None (e.g. send-email) must NOT raise."""
     monkeypatch.setenv("SCT_USE_DNS_NAMES", "true")
     monkeypatch.delenv("SCT_CLUSTER_BACKEND", raising=False)
     try:
@@ -149,6 +305,5 @@ def test_use_dns_names_none_backend_does_not_raise(monkeypatch):
 
 
 def test_use_dns_names_azure_raises(azure_base_env):
-    """use_dns_names=True with cluster_backend=azure must raise ValueError."""
     with pytest.raises(ValueError, match="use_dns_names is not supported for azure backend"):
         SCTConfiguration()

--- a/unit_tests/test_gce_use_dns_names.py
+++ b/unit_tests/test_gce_use_dns_names.py
@@ -1,0 +1,154 @@
+import pytest
+from unittest.mock import MagicMock
+
+from sdcm.cluster_gce import GCENode
+from sdcm.provision.network_configuration import NetworkInterface
+from sdcm.sct_config import SCTConfiguration
+
+
+def test_gce_node_network_interfaces_with_public_ip():
+    """network_interfaces returns correct NetworkInterface with public IP."""
+    mock_iface = MagicMock()
+    mock_iface.network_i_p = "10.0.0.1"
+    mock_iface.access_configs = [MagicMock(nat_i_p="34.1.2.3")]
+
+    node = MagicMock(spec=GCENode)
+    node._instance = MagicMock(network_interfaces=[mock_iface])
+    node.private_dns_name = "node-1.us-east1-b.c.my-project.internal"
+    node.public_dns_name = "34.1.2.3.bc.googleusercontent.com"
+    node.use_dns_names = True
+
+    result = GCENode.network_interfaces.fget(node)
+
+    assert len(result) == 1
+    assert isinstance(result[0], NetworkInterface)
+    assert result[0].ipv4_private_addresses == ["10.0.0.1"]
+    assert result[0].ipv4_public_address == "34.1.2.3"
+    assert result[0].dns_private_name == "node-1.us-east1-b.c.my-project.internal"
+    assert result[0].dns_public_name == "34.1.2.3.bc.googleusercontent.com"
+    assert result[0].use_dns_names is True
+    assert result[0].device_index == 0
+
+
+def test_gce_node_network_interfaces_no_public_ip():
+    """Empty nat_i_p normalizes to None (not empty string)."""
+    mock_iface = MagicMock()
+    mock_iface.network_i_p = "10.0.0.2"
+    mock_iface.access_configs = [MagicMock(nat_i_p="")]
+
+    node = MagicMock(spec=GCENode)
+    node._instance = MagicMock(network_interfaces=[mock_iface])
+    node.private_dns_name = "node-2.us-east1-b.c.my-project.internal"
+    node.public_dns_name = ""
+    node.use_dns_names = False
+
+    result = GCENode.network_interfaces.fget(node)
+
+    assert len(result) == 1
+    assert result[0].ipv4_public_address is None
+
+
+def test_gce_node_network_interfaces_no_access_configs():
+    """No access_configs means public IP is None."""
+    mock_iface = MagicMock()
+    mock_iface.network_i_p = "10.0.0.3"
+    mock_iface.access_configs = []
+
+    node = MagicMock(spec=GCENode)
+    node._instance = MagicMock(network_interfaces=[mock_iface])
+    node.private_dns_name = "node-3.us-east1-b.c.my-project.internal"
+    node.public_dns_name = ""
+    node.use_dns_names = False
+
+    result = GCENode.network_interfaces.fget(node)
+
+    assert result[0].ipv4_public_address is None
+
+
+def test_gce_node_network_interfaces_multiple_interfaces():
+    """Multiple interfaces get correct device_index values."""
+    iface0 = MagicMock()
+    iface0.network_i_p = "10.0.0.1"
+    iface0.access_configs = [MagicMock(nat_i_p="34.1.2.3")]
+
+    iface1 = MagicMock()
+    iface1.network_i_p = "10.0.1.1"
+    iface1.access_configs = []
+
+    node = MagicMock(spec=GCENode)
+    node._instance = MagicMock(network_interfaces=[iface0, iface1])
+    node.private_dns_name = "node-1.us-east1-b.c.my-project.internal"
+    node.public_dns_name = "34.1.2.3.bc.googleusercontent.com"
+    node.use_dns_names = False
+
+    result = GCENode.network_interfaces.fget(node)
+
+    assert len(result) == 2
+    assert result[0].device_index == 0
+    assert result[1].device_index == 1
+    assert result[1].ipv4_public_address is None
+
+
+@pytest.fixture()
+def gce_base_env(monkeypatch):
+    monkeypatch.setenv("SCT_CLUSTER_BACKEND", "gce")
+    monkeypatch.setenv("SCT_GCE_DATACENTER", "us-east1")
+    monkeypatch.setenv(
+        "SCT_GCE_IMAGE_DB", "https://www.googleapis.com/compute/v1/projects/scylla-images/global/images/scylla-5-4-0"
+    )
+    monkeypatch.setenv("SCT_SCYLLA_VERSION", "5.4.0")
+    monkeypatch.setenv("SCT_USE_DNS_NAMES", "true")
+    monkeypatch.setattr(
+        "sdcm.sct_config.get_scylla_gce_images_versions",
+        lambda version: [MagicMock(self_link="fake-link", name="scylla-5-4-0")],
+    )
+
+
+@pytest.fixture()
+def aws_base_env(monkeypatch):
+    monkeypatch.setenv("SCT_CLUSTER_BACKEND", "aws")
+    monkeypatch.setenv("SCT_AMI_ID_DB_SCYLLA", "ami-1234")
+    monkeypatch.setenv("SCT_INSTANCE_TYPE_DB", "i4i.large")
+    monkeypatch.setenv("SCT_USE_DNS_NAMES", "true")
+
+
+@pytest.fixture()
+def azure_base_env(monkeypatch):
+    monkeypatch.setenv("SCT_CLUSTER_BACKEND", "azure")
+    monkeypatch.setenv("SCT_AZURE_REGION_NAME", '["eastus"]')
+    monkeypatch.setenv("SCT_USE_DNS_NAMES", "true")
+
+
+def test_use_dns_names_gce_does_not_raise(gce_base_env):
+    """use_dns_names=True with cluster_backend=gce must NOT raise ValueError."""
+    try:
+        SCTConfiguration()
+    except ValueError as exc:
+        if "use_dns_names" in str(exc):
+            pytest.fail(f"use_dns_names raised ValueError for gce backend: {exc}")
+
+
+def test_use_dns_names_aws_does_not_raise(aws_base_env):
+    """use_dns_names=True with cluster_backend=aws must NOT raise ValueError."""
+    try:
+        SCTConfiguration()
+    except ValueError as exc:
+        if "use_dns_names" in str(exc):
+            pytest.fail(f"use_dns_names raised ValueError for aws backend: {exc}")
+
+
+def test_use_dns_names_none_backend_does_not_raise(monkeypatch):
+    """use_dns_names=True with cluster_backend=None (e.g. send-email) must NOT raise."""
+    monkeypatch.setenv("SCT_USE_DNS_NAMES", "true")
+    monkeypatch.delenv("SCT_CLUSTER_BACKEND", raising=False)
+    try:
+        SCTConfiguration()
+    except ValueError as exc:
+        if "use_dns_names" in str(exc):
+            pytest.fail(f"use_dns_names raised ValueError for None backend: {exc}")
+
+
+def test_use_dns_names_azure_raises(azure_base_env):
+    """use_dns_names=True with cluster_backend=azure must raise ValueError."""
+    with pytest.raises(ValueError, match="use_dns_names is not supported for azure backend"):
+        SCTConfiguration()


### PR DESCRIPTION
## Summary

- Enable the existing `use_dns_names` feature (currently AWS-only) for the GCE backend
- GCE instances already have internal DNS (`<name>.<zone>.c.<project>.internal`) — this PR wires it into the SCT node addressing system
- No external DNS setup required: GCE internal DNS is automatic for all instances in the same VPC

## Changes

| File | Change |
|------|--------|
| `sdcm/sct_config.py` | Allow `gce` backend in `use_dns_names` validation (was AWS-only) |
| `sdcm/cluster_gce.py` | Implement `GCENode.network_interfaces` property (was stub); create `ScyllaNetworkConfiguration` in `GCENode.init()` when `scylla_network_config` is set |
| `sdcm/provision/gce/provisioner.py` | Populate `private_dns_name` in `VmInstance` using GCE internal FQDN format |
| `unit_tests/test_gce_use_dns_names.py` | 7 unit tests covering new functionality |
| `test-cases/longevity/longevity-10gb-3h-gce-use-dns-names.yaml` | Manual validation test config |

## How it works

When `use_dns_names: true` is set with a GCE backend:
1. `GCENode.network_interfaces` builds `NetworkInterface` objects with `dns_private_name` from GCE metadata (`instance/hostname` → e.g. `node-1.us-east1-b.c.project-id.internal`)
2. `GCENode.init()` creates `ScyllaNetworkConfiguration` (same as AWS) when `scylla_network_config` is set
3. `BaseNode.scylla_listen_address` returns the DNS name instead of IP
4. `BaseCluster.seed_nodes_addresses` uses DNS names for seed node configuration

## Backends Affected
- [x] GCE — Modified `cluster_gce.py`, `provision/gce/provisioner.py`

## Manual Testing Required

### What couldn't be tested automatically

- [x] **End-to-end GCE cluster with `use_dns_names: true`**: Requires GCE credentials and ~3h
  ```bash
  hydra run-test longevity_test.LongevityTest.test_custom_time \
    --backend gce \
    --config test-cases/longevity/longevity-10gb-3h-gce-use-dns-names.yaml
  ```
  Expected: Cluster provisions, Scylla nodes communicate via DNS names, stress runs successfully

- [x] **Faster smoke test (1h)** using existing nemesis pipeline:
  ```bash
  hydra run-test longevity_test.LongevityTest.test_custom_time \
    --backend gce \
    --config configurations/nemesis/longevity-5gb-1h-nemesis.yaml \
    --config configurations/nemesis/DrainerMonkey.yaml
  ```
  (add `use_dns_names: true` to config stack)

- [x] **Verify scylla.yaml**: Confirm seed nodes in scylla.yaml contain DNS names, not IPs

## Required Labels
- `test-provision-gce`

### Testing

- [x] 🟢 [longevity-100gb-4h-test #224](https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/longevity-100gb-4h-test/224/)
- [x] 🟢 [longevity-100gb-4h-test #225](https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/longevity-100gb-4h-test/225/)
- [x] 🟢 [longevity-10gb-3h-gce-test #68](https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/longevity-10gb-3h-gce-test/68/)
