### PR TITLE
test(manager): add WORM backup test for GCE

### DIFF
--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -20,6 +20,8 @@ import time
 from contextlib import nullcontext
 from datetime import timedelta
 
+from google.api_core.exceptions import Forbidden
+
 from sdcm import mgmt
 from sdcm.argus_results import (
     send_manager_benchmark_results_to_argus,
@@ -34,6 +36,7 @@ from sdcm.mgmt.common import (
     reconfigure_scylla_manager,
     get_persistent_snapshots,
     get_backup_size,
+    BackupRetentionLockMode,
     ObjectStorageUploadMode,
 )
 from sdcm.provision.helpers.certificate import (
@@ -309,6 +312,57 @@ class ManagerBackupTests(ManagerRestoreTests):
                 clean_enospc_on_node(target_node=target_node, sleep_time=30)
         self.log.info("finishing test_enospc_before_restore")
 
+    def test_worm_backup(self):
+        self.log.info("starting test_worm_backup")
+        mgr_cluster = self.db_cluster.get_cluster_manager()
+
+        self.log.info("Create WORM backup bucket")
+        worm_bucket_name = f"manager-worm-backup-test-{self.test_id[:8]}"
+        location = f"gcs:{worm_bucket_name}"
+        worm_bucket = self.create_worm_bucket(region=self.params.gce_datacenters[0], bucket_name=worm_bucket_name)
+
+        try:
+            self.log.info("Wait 30s for backup location accessibility after bucket creation")
+            # We tried to use `scylla-manager-agent check-location` here instead of dummy sleep, but the approach
+            # turned out to be not stable enough - check-location could proceed while the follow-up sctool backup
+            # could fail immediately due to bucket access issue. The reason - check-location command issued in test
+            # initializes rclone from scratch with fresh tokens, while backup runs through the SM agent server may
+            # hold stale tokens. A fixed sleep is the most robust approach here.
+            time.sleep(30)
+
+            self.log.info("Create backup task and wait for its completion")
+            backup_task = mgr_cluster.create_backup_task(
+                location_list=[location],
+                method=self.backup_method,
+                retention_days=1,
+                retention_lock_mode=BackupRetentionLockMode.UNLOCKED,
+            )
+            task_status = backup_task.wait_and_get_final_status(timeout=1500)
+            assert task_status == TaskStatus.DONE, f"Backup task ended in {task_status} instead of {TaskStatus.DONE}"
+
+            snapshot_files = self.get_all_snapshot_files(
+                cluster_id=mgr_cluster.id,
+                bucket_location=worm_bucket_name,
+                only_sstables=False,
+            )
+            assert snapshot_files, "No snapshot files found after backup"
+
+            self.log.info("Try to delete locked backup files")
+            for file_path in snapshot_files:
+                blob = worm_bucket.blob(file_path)
+                try:
+                    blob.delete()
+                    raise AssertionError(f"Deletion of locked file {file_path} unexpectedly succeeded")
+                except Forbidden:
+                    self.log.debug("File %s is properly locked (deletion forbidden)", file_path)
+            self.log.info("All snapshot files are properly protected by object lock")
+
+        finally:
+            self.destroy_worm_bucket(bucket=worm_bucket)
+            mgr_cluster.delete()
+
+        self.log.info("finishing test_worm_backup")
+
     def test_backup_feature(self):
         self.generate_load_and_wait_for_results()
         with self.subTest("Backup Multiple KS' and Tables"):
@@ -319,6 +373,10 @@ class ManagerBackupTests(ManagerRestoreTests):
             self.test_backup_rate_limit()
         with self.subTest("Test Backup Purge Removes Orphans Files"):
             self.test_backup_purge_removes_orphan_files()
+        if self.params.get("cluster_backend") == "gce":
+            # WORM backup feature is currently available for GCP only
+            with self.subTest("Test WORM backup with object lock"):
+                self.test_worm_backup()
         with self.subTest("Test Backup end of space"):  # Preferably at the end
             self.test_enospc_during_backup()
         with self.subTest("Test Restore end of space"):

--- a/sdcm/mgmt/cli.py
+++ b/sdcm/mgmt/cli.py
@@ -720,6 +720,8 @@ class ManagerCluster(ScyllaManagerBase):
         num_retries=None,
         rate_limit_list=None,
         retention=None,
+        retention_days=None,
+        retention_lock_mode=None,
         show_tables=None,
         snapshot_parallel_list=None,
         start_date=None,
@@ -747,6 +749,10 @@ class ManagerCluster(ScyllaManagerBase):
             cmd += " --rate-limit {} ".format(rate_limit_string)
         if retention is not None:
             cmd += " --retention {} ".format(retention)
+        if retention_days is not None:
+            cmd += " --retention-days {} ".format(retention_days)
+        if retention_lock_mode is not None:
+            cmd += " --retention-lock-mode {} ".format(retention_lock_mode)
         if show_tables is not None:
             cmd += " --show-tables {} ".format(show_tables)
         if snapshot_parallel_list is not None:

--- a/sdcm/mgmt/common.py
+++ b/sdcm/mgmt/common.py
@@ -1,7 +1,7 @@
 import logging
 import re
 from datetime import datetime, timedelta
-from enum import Enum
+from enum import Enum, StrEnum
 from typing import Optional, TYPE_CHECKING
 
 import yaml
@@ -52,6 +52,12 @@ class ScyllaManagerError(Exception):
 # ---------------------------------------------------------------------------
 # Enum classes (alphabetical)
 # ---------------------------------------------------------------------------
+
+
+class BackupRetentionLockMode(StrEnum):
+    DISABLED = "disabled"
+    UNLOCKED = "unlocked"
+    LOCKED = "locked"
 
 
 class HostRestStatus(Enum):

--- a/sdcm/mgmt/common.py
+++ b/sdcm/mgmt/common.py
@@ -1,10 +1,10 @@
+import logging
 import re
 from datetime import datetime, timedelta
 from enum import Enum
-import logging
-import yaml
 from typing import Optional, TYPE_CHECKING
 
+import yaml
 from pydantic import BaseModel, ConfigDict
 
 if TYPE_CHECKING:
@@ -12,6 +12,10 @@ if TYPE_CHECKING:
 
 from sdcm.utils.distro import Distro
 from sdcm.utils.version_utils import find_scylla_repo
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
 
 DEFAULT_TASK_TIMEOUT = 7200  # 2 hours
 LOGGER = logging.getLogger(__name__)
@@ -24,6 +28,177 @@ LOGGER = logging.getLogger(__name__)
 # │ 10.12.4.25  │     100% │ 422.413GiB │ 422.413GiB │           0B │     0B │
 BACKUP_SIZE_REGEX = re.compile(r".+100% │ (.*?) │ ", re.MULTILINE)
 SIZE_PATTERN = re.compile(r"^([\d.]+)\s*([KMGTPE]?i?B)$", re.IGNORECASE)
+
+MANAGER_REPO_PATTERNS = {
+    "rhel": "https://downloads.scylladb.com/rpm/centos/scylladb-manager-{version}.repo",
+    "debian": "https://downloads.scylladb.com/deb/debian/scylladb-manager-{version}.list",
+}
+MANAGER_REPO_MASTER_LATEST = {
+    "rhel": "https://downloads.scylladb.com/manager/rpm/unstable/centos/master/latest/scylla-manager.repo",
+    "debian": "https://downloads.scylladb.com/manager/deb/unstable/unified-deb/master/latest/scylla-manager.list",
+}
+
+# ---------------------------------------------------------------------------
+# Exception classes
+# ---------------------------------------------------------------------------
+
+
+class ScyllaManagerError(Exception):
+    """
+    A custom exception for Manager related errors
+    """
+
+
+# ---------------------------------------------------------------------------
+# Enum classes (alphabetical)
+# ---------------------------------------------------------------------------
+
+
+class HostRestStatus(Enum):
+    UP = "UP"
+    DOWN = "DOWN"
+    TIMEOUT = "TIMEOUT"
+    UNAUTHORIZED = "UNAUTHORIZED"
+    HTTP = "HTTP"
+
+    @classmethod
+    def from_str(cls, output_str):
+        try:
+            output_str = output_str.upper()
+            if output_str == "-":
+                return cls.DOWN
+            return getattr(cls, output_str)
+        except AttributeError as err:
+            raise ScyllaManagerError("Could not recognize returned host rest status: {}".format(output_str)) from err
+
+
+class HostSsl(Enum):
+    ON = "ON"
+    OFF = "OFF"
+
+    @classmethod
+    def from_str(cls, output_str):
+        if "SSL" in output_str:
+            return HostSsl.ON
+        return HostSsl.OFF
+
+
+class HostStatus(Enum):
+    UP = "UP"
+    DOWN = "DOWN"
+    TIMEOUT = "TIMEOUT"
+
+    @classmethod
+    def from_str(cls, output_str):
+        try:
+            output_str = output_str.upper()
+            if output_str == "-":
+                return cls.DOWN
+            return getattr(cls, output_str)
+        except AttributeError as err:
+            raise ScyllaManagerError("Could not recognize returned host status: {}".format(output_str)) from err
+
+
+class ObjectStorageUploadMode(str, Enum):
+    AUTO = "auto"
+    RCLONE = "rclone"
+    NATIVE = "native"
+
+
+class TaskStatus:
+    NEW = "NEW"
+    RUNNING = "RUNNING"
+    DONE = "DONE"
+    UNKNOWN = "UNKNOWN"
+    ERROR = "ERROR"
+    ERROR_FINAL = "ERROR (4/4)"
+    STOPPING = "STOPPING"
+    STOPPED = "STOPPED"
+    WAITING = "WAITING"
+    STARTING = "STARTING"
+    ABORTED = "ABORTED"
+    SKIPPED = "SKIPPED"
+
+    @classmethod
+    def from_str(cls, output_str) -> str:
+        try:
+            output_str = output_str.upper()
+            return getattr(cls, output_str)
+        except AttributeError as err:
+            raise ScyllaManagerError("Could not recognize returned task status: {}".format(output_str)) from err
+
+    @classmethod
+    def all_statuses(cls):
+        return set(getattr(cls, name) for name in dir(cls) if name.isupper())
+
+
+# ---------------------------------------------------------------------------
+# Data model classes (alphabetical)
+# ---------------------------------------------------------------------------
+
+
+class AgentBackupParameters(BaseModel):
+    checkers: Optional[int] = 100
+    transfers: Optional[int] = 2
+    low_level_retries: Optional[int] = 20
+
+    model_config = ConfigDict(arbitrary_types_allowed=False)
+
+
+class TaskRunDetails(BaseModel):
+    """Details of a Manager task run.
+
+    Attributes:
+        next_run: The datetime of the next scheduled run
+        latest_run_id: The ID of the latest run
+        start_time: The start time string from task history
+        end_time: The calculated end time as datetime
+        duration: The duration string (e.g., "2d3h15m30s")
+    """
+
+    next_run: datetime
+    latest_run_id: str
+    start_time: str
+    end_time: datetime
+    duration: str
+
+
+# ---------------------------------------------------------------------------
+# Functions — Parsing / conversion utilities
+# ---------------------------------------------------------------------------
+
+
+def duration_to_timedelta(duration_string):
+    total_seconds = 0
+    if "d" in duration_string:
+        total_seconds += int(duration_string[: duration_string.find("d")]) * 86400
+        duration_string = duration_string[duration_string.find("d") + 1 :]
+    if "h" in duration_string:
+        total_seconds += int(duration_string[: duration_string.find("h")]) * 3600
+        duration_string = duration_string[duration_string.find("h") + 1 :]
+    if "m" in duration_string:
+        total_seconds += int(duration_string[: duration_string.find("m")]) * 60
+        duration_string = duration_string[duration_string.find("m") + 1 :]
+    if "s" in duration_string:
+        total_seconds += int(duration_string[: duration_string.find("s")])
+    return timedelta(seconds=total_seconds)
+
+
+def parse_bandwidth_value(bandwidth_str: str) -> float | None:
+    """Parse bandwidth value from Manager output string.
+
+    Args:
+        bandwidth_str: String containing bandwidth value (e.g., "22.313MiB/s/shard")
+
+    Returns:
+        Float value of bandwidth in MiB/s/shard, or None if parsing fails
+    """
+    bandwidth_match = re.search(r"(\d+\.\d+)", bandwidth_str)
+    if bandwidth_match:
+        return float(bandwidth_match.group(1))
+    else:
+        LOGGER.warning(f"Bandwidth value is non-numeric: {bandwidth_str.strip()}. Returning None.")
+        return None
 
 
 def parse_size_to_bytes(size_str: str) -> int:
@@ -72,51 +247,9 @@ def parse_size_to_bytes(size_str: str) -> int:
     return bytes_
 
 
-MANAGER_REPO_PATTERNS = {
-    "rhel": "https://downloads.scylladb.com/rpm/centos/scylladb-manager-{version}.repo",
-    "debian": "https://downloads.scylladb.com/deb/debian/scylladb-manager-{version}.list",
-}
-MANAGER_REPO_MASTER_LATEST = {
-    "rhel": "https://downloads.scylladb.com/manager/rpm/unstable/centos/master/latest/scylla-manager.repo",
-    "debian": "https://downloads.scylladb.com/manager/deb/unstable/unified-deb/master/latest/scylla-manager.list",
-}
-
-
-def get_persistent_snapshots():  # Snapshot sizes (dict keys) are in GB
-    with open("defaults/manager_persistent_snapshots.yaml", encoding="utf-8") as mgmt_snapshot_yaml:
-        persistent_manager_snapshots_dict = yaml.safe_load(mgmt_snapshot_yaml)
-    return persistent_manager_snapshots_dict
-
-
-def get_distro_name(distro_object: Distro) -> str:
-    if distro_object.is_debian_like:
-        return "debian"
-    if distro_object.is_rhel_like:
-        return "rhel"
-
-    raise ValueError(f"Unsupported distribution for installing manager: {distro_object}")
-
-
-def duration_to_timedelta(duration_string):
-    total_seconds = 0
-    if "d" in duration_string:
-        total_seconds += int(duration_string[: duration_string.find("d")]) * 86400
-        duration_string = duration_string[duration_string.find("d") + 1 :]
-    if "h" in duration_string:
-        total_seconds += int(duration_string[: duration_string.find("h")]) * 3600
-        duration_string = duration_string[duration_string.find("h") + 1 :]
-    if "m" in duration_string:
-        total_seconds += int(duration_string[: duration_string.find("m")]) * 60
-        duration_string = duration_string[duration_string.find("m") + 1 :]
-    if "s" in duration_string:
-        total_seconds += int(duration_string[: duration_string.find("s")])
-    return timedelta(seconds=total_seconds)
-
-
-def create_cron_list_from_timedelta(minutes=0, hours=0):
-    destined_time = datetime.now() + timedelta(hours=hours, minutes=minutes)
-    cron_list = [str(destined_time.minute), str(destined_time.hour), "*", "*", "*"]
-    return cron_list
+# ---------------------------------------------------------------------------
+# Functions — Time / scheduling helpers
+# ---------------------------------------------------------------------------
 
 
 def calculate_task_end_time(start_time: str, duration: str) -> datetime:
@@ -134,57 +267,24 @@ def calculate_task_end_time(start_time: str, duration: str) -> datetime:
     return base_time + delta
 
 
-class TaskRunDetails(BaseModel):
-    """Details of a Manager task run.
-
-    Attributes:
-        next_run: The datetime of the next scheduled run
-        latest_run_id: The ID of the latest run
-        start_time: The start time string from task history
-        end_time: The calculated end time as datetime
-        duration: The duration string (e.g., "2d3h15m30s")
-    """
-
-    next_run: datetime
-    latest_run_id: str
-    start_time: str
-    end_time: datetime
-    duration: str
+def create_cron_list_from_timedelta(minutes=0, hours=0):
+    destined_time = datetime.now() + timedelta(hours=hours, minutes=minutes)
+    cron_list = [str(destined_time.minute), str(destined_time.hour), "*", "*", "*"]
+    return cron_list
 
 
-def get_task_run_details(task: "ManagerTask", wait: bool = True, timeout: int = 1000, step: int = 10) -> TaskRunDetails:
-    """Get details of the latest task run.
+# ---------------------------------------------------------------------------
+# Functions — Repo / distro helpers
+# ---------------------------------------------------------------------------
 
-    Args:
-        task: The manager task object to get details from
-        wait: Whether to wait for task completion before retrieving details
-        timeout: Maximum time to wait for task completion (seconds)
-        step: Poll interval when waiting (seconds)
 
-    Returns:
-        TaskRunDetails object containing task run details
-    """
-    if wait:
-        task.wait_and_get_final_status(timeout=timeout, step=step)
+def get_distro_name(distro_object: Distro) -> str:
+    if distro_object.is_debian_like:
+        return "debian"
+    if distro_object.is_rhel_like:
+        return "rhel"
 
-    task_history = task.history
-    latest_run_id = task.latest_run_id
-    start_time = task.sctool.get_table_value(
-        parsed_table=task_history, column_name="start time", identifier=latest_run_id
-    )
-    next_run_time = datetime.strptime(task.next_run, "%d %b %y %H:%M:%S %Z")  # from `03 Feb 26 16:35:00 UTC`
-    duration = task.sctool.get_table_value(parsed_table=task_history, column_name="duration", identifier=latest_run_id)
-    end_time = calculate_task_end_time(duration=duration, start_time=start_time)
-
-    task_details = TaskRunDetails(
-        next_run=next_run_time,
-        latest_run_id=latest_run_id,
-        start_time=start_time,
-        end_time=end_time,
-        duration=duration,
-    )
-    LOGGER.debug("Task %s details: %s", task.id, task_details)
-    return task_details
+    raise ValueError(f"Unsupported distribution for installing manager: {distro_object}")
 
 
 def get_manager_repo(manager_version: str, distro: Distro) -> str:
@@ -227,135 +327,9 @@ def get_manager_scylla_backend(scylla_backend_version_name: str, distro: Distro)
     return find_scylla_repo(scylla_version=scylla_backend_version_name, dist_type=distro_name)
 
 
-def reconfigure_scylla_manager(manager_node, logger, values_to_update=(), values_to_remove=()):
-    with manager_node.remote_manager_yaml() as scylla_manager_yaml:
-        for value in values_to_update:
-            scylla_manager_yaml.update(value)
-        for value in values_to_remove:
-            del scylla_manager_yaml[value]
-        logger.info("The new Scylla Manager is:\n%s", scylla_manager_yaml)
-    manager_node.restart_manager_server()
-
-
-class ScyllaManagerError(Exception):
-    """
-    A custom exception for Manager related errors
-    """
-
-
-class HostSsl(Enum):
-    ON = "ON"
-    OFF = "OFF"
-
-    @classmethod
-    def from_str(cls, output_str):
-        if "SSL" in output_str:
-            return HostSsl.ON
-        return HostSsl.OFF
-
-
-class HostStatus(Enum):
-    UP = "UP"
-    DOWN = "DOWN"
-    TIMEOUT = "TIMEOUT"
-
-    @classmethod
-    def from_str(cls, output_str):
-        try:
-            output_str = output_str.upper()
-            if output_str == "-":
-                return cls.DOWN
-            return getattr(cls, output_str)
-        except AttributeError as err:
-            raise ScyllaManagerError("Could not recognize returned host status: {}".format(output_str)) from err
-
-
-class HostRestStatus(Enum):
-    UP = "UP"
-    DOWN = "DOWN"
-    TIMEOUT = "TIMEOUT"
-    UNAUTHORIZED = "UNAUTHORIZED"
-    HTTP = "HTTP"
-
-    @classmethod
-    def from_str(cls, output_str):
-        try:
-            output_str = output_str.upper()
-            if output_str == "-":
-                return cls.DOWN
-            return getattr(cls, output_str)
-        except AttributeError as err:
-            raise ScyllaManagerError("Could not recognize returned host rest status: {}".format(output_str)) from err
-
-
-class TaskStatus:
-    NEW = "NEW"
-    RUNNING = "RUNNING"
-    DONE = "DONE"
-    UNKNOWN = "UNKNOWN"
-    ERROR = "ERROR"
-    ERROR_FINAL = "ERROR (4/4)"
-    STOPPING = "STOPPING"
-    STOPPED = "STOPPED"
-    WAITING = "WAITING"
-    STARTING = "STARTING"
-    ABORTED = "ABORTED"
-    SKIPPED = "SKIPPED"
-
-    @classmethod
-    def from_str(cls, output_str) -> str:
-        try:
-            output_str = output_str.upper()
-            return getattr(cls, output_str)
-        except AttributeError as err:
-            raise ScyllaManagerError("Could not recognize returned task status: {}".format(output_str)) from err
-
-    @classmethod
-    def all_statuses(cls):
-        return set(getattr(cls, name) for name in dir(cls) if name.isupper())
-
-
-class AgentBackupParameters(BaseModel):
-    checkers: Optional[int] = 100
-    transfers: Optional[int] = 2
-    low_level_retries: Optional[int] = 20
-
-    model_config = ConfigDict(arbitrary_types_allowed=False)
-
-
-def get_backup_size(mgr_cluster, task_id):
-    """
-    Returns the generated backup size of a given Manager backup Task.
-    """
-    res = mgr_cluster.sctool.run(cmd=f"progress {task_id} -c {mgr_cluster.id}", parse_table_res=False)
-    match = BACKUP_SIZE_REGEX.search(res.stdout)
-    if match:
-        return match.group(1)
-    else:
-        raise ValueError(f"Backup size not found in the output in {res.stdout}")
-
-
-class ObjectStorageUploadMode(str, Enum):
-    AUTO = "auto"
-    RCLONE = "rclone"
-    NATIVE = "native"
-
-
-def parse_bandwidth_value(bandwidth_str: str) -> float | None:
-    """Parse bandwidth value from Manager output string.
-
-    Args:
-        bandwidth_str: String containing bandwidth value (e.g., "22.313MiB/s/shard")
-
-    Returns:
-        Float value of bandwidth in MiB/s/shard, or None if parsing fails
-    """
-    bandwidth_match = re.search(r"(\d+\.\d+)", bandwidth_str)
-    if bandwidth_match:
-        return float(bandwidth_match.group(1))
-    else:
-        LOGGER.warning(f"Bandwidth value is non-numeric: {bandwidth_str.strip()}. Returning None.")
-        return None
+# ---------------------------------------------------------------------------
+# Functions — Task / backup operations
+# ---------------------------------------------------------------------------
 
 
 def calculate_restore_metrics(
@@ -385,3 +359,71 @@ def calculate_restore_metrics(
     if load_and_stream_bw:
         results["l&s bandwidth"] = load_and_stream_bw
     return results
+
+
+def get_backup_size(mgr_cluster, task_id):
+    """
+    Returns the generated backup size of a given Manager backup Task.
+    """
+    res = mgr_cluster.sctool.run(cmd=f"progress {task_id} -c {mgr_cluster.id}", parse_table_res=False)
+    match = BACKUP_SIZE_REGEX.search(res.stdout)
+    if match:
+        return match.group(1)
+    else:
+        raise ValueError(f"Backup size not found in the output in {res.stdout}")
+
+
+def get_persistent_snapshots():  # Snapshot sizes (dict keys) are in GB
+    with open("defaults/manager_persistent_snapshots.yaml", encoding="utf-8") as mgmt_snapshot_yaml:
+        persistent_manager_snapshots_dict = yaml.safe_load(mgmt_snapshot_yaml)
+    return persistent_manager_snapshots_dict
+
+
+def get_task_run_details(task: "ManagerTask", wait: bool = True, timeout: int = 1000, step: int = 10) -> TaskRunDetails:
+    """Get details of the latest task run.
+
+    Args:
+        task: The manager task object to get details from
+        wait: Whether to wait for task completion before retrieving details
+        timeout: Maximum time to wait for task completion (seconds)
+        step: Poll interval when waiting (seconds)
+
+    Returns:
+        TaskRunDetails object containing task run details
+    """
+    if wait:
+        task.wait_and_get_final_status(timeout=timeout, step=step)
+
+    task_history = task.history
+    latest_run_id = task.latest_run_id
+    start_time = task.sctool.get_table_value(
+        parsed_table=task_history, column_name="start time", identifier=latest_run_id
+    )
+    next_run_time = datetime.strptime(task.next_run, "%d %b %y %H:%M:%S %Z")  # from `03 Feb 26 16:35:00 UTC`
+    duration = task.sctool.get_table_value(parsed_table=task_history, column_name="duration", identifier=latest_run_id)
+    end_time = calculate_task_end_time(duration=duration, start_time=start_time)
+
+    task_details = TaskRunDetails(
+        next_run=next_run_time,
+        latest_run_id=latest_run_id,
+        start_time=start_time,
+        end_time=end_time,
+        duration=duration,
+    )
+    LOGGER.debug("Task %s details: %s", task.id, task_details)
+    return task_details
+
+
+# ---------------------------------------------------------------------------
+# Functions — Manager configuration
+# ---------------------------------------------------------------------------
+
+
+def reconfigure_scylla_manager(manager_node, logger, values_to_update=(), values_to_remove=()):
+    with manager_node.remote_manager_yaml() as scylla_manager_yaml:
+        for value in values_to_update:
+            scylla_manager_yaml.update(value)
+        for value in values_to_remove:
+            del scylla_manager_yaml[value]
+        logger.info("The new Scylla Manager is:\n%s", scylla_manager_yaml)
+    manager_node.restart_manager_server()

--- a/sdcm/mgmt/operations.py
+++ b/sdcm/mgmt/operations.py
@@ -6,6 +6,7 @@ from functools import cached_property
 from pathlib import Path
 from textwrap import dedent
 from time import sleep
+from typing import TYPE_CHECKING
 
 import boto3
 import yaml
@@ -16,6 +17,7 @@ from sdcm.mgmt.cli import ScyllaManagerTool
 from sdcm.mgmt.common import ObjectStorageUploadMode
 from sdcm import mgmt
 from sdcm.exceptions import FilesNotCorrupted
+from sdcm.keystore import KeyStore
 from sdcm.remote import shell_script_cmd, LOCALRUNNER
 from sdcm.sct_events.system import InfoEvent
 from sdcm.test_config import TestConfig
@@ -23,10 +25,14 @@ from sdcm.tester import ClusterTester
 from sdcm.utils.azure_utils import AzureService
 from sdcm.utils.cluster_tools import flush_nodes, major_compaction_nodes, clear_snapshot_nodes
 from sdcm.utils.compaction_ops import CompactionOps
-from sdcm.utils.gce_utils import get_gce_storage_client
+from sdcm.utils.gce_region import GceRegion
+from sdcm.utils.gce_utils import create_gce_storage_bucket, get_gce_storage_client, gce_override_object_retention
 from sdcm.utils.loader_utils import LoaderUtilsMixin
 from sdcm.utils.time_utils import ExecutionTimer
 from sdcm.utils.version_utils import ComparableScyllaVersion
+
+if TYPE_CHECKING:
+    from google.cloud.storage import Bucket
 
 
 class ClusterOperations(ClusterTester):
@@ -223,6 +229,30 @@ class BucketOperations(ClusterTester):
         else:
             raise ValueError(f"Unsupported cluster backend - {cluster_backend}, should be either aws or gce")
 
+    @staticmethod
+    def create_worm_bucket(region: str, bucket_name: str) -> "Bucket":
+        bucket = create_gce_storage_bucket(name=bucket_name, region=region, object_lock_enabled=True)
+
+        # Grant the access to this bucket for sct-manager-backup service account
+        project_id = KeyStore().get_gcp_credentials()["project_id"]
+        sa_email = f"{GceRegion.SCT_BACKUP_SERVICE_ACCOUNT}@{project_id}.iam.gserviceaccount.com"
+
+        policy = bucket.get_iam_policy(requested_policy_version=3)
+        policy.bindings.append({"role": "roles/storage.objectAdmin", "members": {f"serviceAccount:{sa_email}"}})
+        bucket.set_iam_policy(policy)
+
+        return bucket
+
+    @staticmethod
+    def destroy_worm_bucket(bucket: "Bucket") -> None:
+        gce_override_object_retention(bucket_name=bucket.name, path="")
+
+        blobs = list(bucket.list_blobs())
+        for blob in blobs:
+            blob.delete()
+
+        bucket.delete()
+
 
 @dataclass
 class SnapshotData:
@@ -253,6 +283,8 @@ class SnapshotData:
 
 
 class SnapshotOperations(ClusterTester):
+    BACKUP_FILE_PREFIXES = ("backup/sst", "backup/meta", "backup/schema")
+
     def _get_total_loaders(self) -> int:
         """Get total number of loaders, handling both single-DC (int) and multi-DC (space-separated string or list) formats."""
         n_loaders = self.params.get("n_loaders")
@@ -293,50 +325,70 @@ class SnapshotOperations(ClusterTester):
         return snapshot_data
 
     @staticmethod
-    def _get_all_snapshot_files_s3(cluster_id, bucket_name, region_name):
+    def _get_all_snapshot_files_s3(bucket_name: str, region_name: str, prefixes: list[str]) -> set[str]:
         file_set = set()
         s3_client = boto3.client("s3", region_name=region_name)
         paginator = s3_client.get_paginator("list_objects")
-        pages = paginator.paginate(Bucket=bucket_name, Prefix=f"backup/sst/cluster/{cluster_id}")
-        for page in pages:
-            # No Contents key means that no snapshot file of the cluster exist,
-            # probably no backup ran before this function
-            if "Contents" in page:
-                content_list = page["Contents"]
-                file_set.update([item["Key"] for item in content_list])
+        for prefix in prefixes:
+            pages = paginator.paginate(Bucket=bucket_name, Prefix=prefix)
+            for page in pages:
+                # No Contents key means that no snapshot file of the cluster exist,
+                # probably no backup ran before this function
+                if "Contents" in page:
+                    file_set.update(item["Key"] for item in page["Contents"])
         return file_set
 
     @staticmethod
-    def _get_all_snapshot_files_gce(cluster_id, bucket_name):
+    def _get_all_snapshot_files_gce(bucket_name: str, prefixes: list[str]) -> set[str]:
         file_set = set()
         storage_client, _ = get_gce_storage_client()
-        blobs = storage_client.list_blobs(bucket_or_name=bucket_name, prefix=f"backup/sst/cluster/{cluster_id}")
-        for listing_object in blobs:
-            file_set.add(listing_object.name)
+        for prefix in prefixes:
+            blobs = storage_client.list_blobs(bucket_or_name=bucket_name, prefix=prefix)
+            for listing_object in blobs:
+                file_set.add(listing_object.name)
         # Unlike S3, if no files match the prefix, no error will occur
         return file_set
 
     @staticmethod
-    def _get_all_snapshot_files_azure(cluster_id, bucket_name):
+    def _get_all_snapshot_files_azure(bucket_name: str, prefixes: list[str]) -> set[str]:
         file_set = set()
         azure_service = AzureService()
         container_client = azure_service.blob.get_container_client(container=bucket_name)
-        dir_listing = container_client.list_blobs(name_starts_with=f"backup/sst/cluster/{cluster_id}")
-        for listing_object in dir_listing:
-            file_set.add(listing_object.name)
+        for prefix in prefixes:
+            dir_listing = container_client.list_blobs(name_starts_with=prefix)
+            for listing_object in dir_listing:
+                file_set.add(listing_object.name)
         return file_set
 
-    def get_all_snapshot_files(self, cluster_id):
+    def get_all_snapshot_files(
+        self,
+        cluster_id: str,
+        bucket_location: str | None = None,
+        only_sstables: bool = True,
+    ) -> set[str]:
+        """Return backup object paths in the bucket for the given cluster.
+
+        Args:
+            cluster_id: Scylla Manager cluster ID.
+            bucket_location: Bucket name; falls back to `backup_bucket_location` param.
+            only_sstables: If True (default), collect only SSTable files (`backup/sst`).
+                           If False, collect all types: `backup/sst`, `backup/meta`, `backup/schema`.
+
+        Returns:
+            Set of object path strings found in the bucket.
+        """
         region_name = next(iter(self.params.region_names), "")
-        bucket_name = self.params.get("backup_bucket_location")[0].format(region=region_name)
+        bucket_name = bucket_location or self.params.get("backup_bucket_location")[0].format(region=region_name)
+
+        file_type_prefixes = ("backup/sst",) if only_sstables else self.BACKUP_FILE_PREFIXES
+        prefixes = [f"{p}/cluster/{cluster_id}" for p in file_type_prefixes]
+
         if self.params.get("backup_bucket_backend") == "s3":
-            return self._get_all_snapshot_files_s3(
-                cluster_id=cluster_id, bucket_name=bucket_name, region_name=region_name
-            )
+            return self._get_all_snapshot_files_s3(bucket_name=bucket_name, region_name=region_name, prefixes=prefixes)
         elif self.params.get("backup_bucket_backend") == "gcs":
-            return self._get_all_snapshot_files_gce(cluster_id=cluster_id, bucket_name=bucket_name)
+            return self._get_all_snapshot_files_gce(bucket_name=bucket_name, prefixes=prefixes)
         elif self.params.get("backup_bucket_backend") == "azure":
-            return self._get_all_snapshot_files_azure(cluster_id=cluster_id, bucket_name=bucket_name)
+            return self._get_all_snapshot_files_azure(bucket_name=bucket_name, prefixes=prefixes)
         else:
             raise ValueError(f'"{self.params.get("backup_bucket_backend")}" not supported')
 

--- a/sdcm/utils/gce_utils.py
+++ b/sdcm/utils/gce_utils.py
@@ -174,6 +174,67 @@ def get_gce_storage_client() -> tuple[storage.Client, dict]:
     return storage.Client(credentials=credentials), info
 
 
+def create_gce_storage_bucket(name: str, region: str, object_lock_enabled: bool = False) -> storage.Bucket:
+    """Create a GCS bucket.
+
+    Args:
+        name: bucket name
+        region: GCS region (e.g., 'us-east1')
+        object_lock_enabled: if True, enables object retention (object lock) on the bucket.
+                             Requires uniform bucket-level access (set automatically).
+
+    Returns:
+        the created Bucket object
+    """
+    storage_client, _ = get_gce_storage_client()
+
+    bucket = storage_client.bucket(name)
+    if object_lock_enabled:
+        bucket.iam_configuration.uniform_bucket_level_access_enabled = True
+
+    storage_client.create_bucket(
+        bucket,
+        location=region,
+        enable_object_retention=object_lock_enabled,
+    )
+    LOGGER.info("Created GCS bucket gs://%s in %s (object_lock_enabled=%s)", name, region, object_lock_enabled)
+    return bucket
+
+
+def gce_override_object_retention(bucket_name: str, path: str) -> None:
+    """Override governance-mode object retention locks on blobs in a GCS bucket.
+
+    Processes all matching blobs individually — if one blob fails, the rest are
+    still attempted. Raises after all blobs have been processed if any failed.
+
+    Args:
+        bucket_name: the name of the GCS bucket
+        path: path prefix to match blobs (empty string means all blobs)
+    """
+    storage_client, _ = get_gce_storage_client()
+
+    if path.startswith("/"):
+        path = path[1:]
+
+    blobs = list(storage_client.list_blobs(bucket_or_name=bucket_name, prefix=path))
+    if not blobs:
+        LOGGER.warning("No blobs found in gs://%s/%s to unlock", bucket_name, path)
+        return
+
+    LOGGER.info("Overriding retention on %d blob(s) in gs://%s/%s", len(blobs), bucket_name, path)
+    failed = []
+    for blob in blobs:
+        try:
+            blob.retention.mode = None
+            blob.retention.retain_until_time = None
+            blob.patch(override_unlocked_retention=True)
+        except Exception as exc:  # noqa: BLE001
+            LOGGER.error("Failed to override retention on gs://%s/%s: %s", bucket_name, blob.name, exc)
+            failed.append((blob.name, exc))
+    if failed:
+        raise RuntimeError(f"Failed to override retention on {len(failed)}/{len(blobs)} blob(s) in gs://{bucket_name}")
+
+
 def get_gce_compute_disks_client() -> tuple[compute_v1.DisksClient, dict]:
     info = KeyStore().get_gcp_credentials()
     credentials = service_account.Credentials.from_service_account_info(info)


### PR DESCRIPTION
Closes https://scylladb.atlassian.net/browse/CLOUD-1939

## Summary

Implements SCT test coverage for the immutable/WORM backup feature in Scylla Manager on GCE.

The changes span three commits:

1. **refactor(mgmt/common.py)**: Reorganize file structure for clarity — consolidate constants, group enums/exceptions/data-model classes, add `BackupRetentionLockMode` enum (DISABLED / UNLOCKED / LOCKED).

2. **feature(manager): add lock-mode and retention-days to backup CLI** — Extend `create_backup_task()` in `sdcm/mgmt/cli.py` with `--retention-lock-mode` and `--retention-days` flags required by the WORM backup API.

3. **test(manager): add WORM backup test for GCE** — New `test_worm_backup` sub-test inside `test_backup_feature`:
   - Dynamically creates a GCS bucket with object retention enabled (governance mode)
   - Grants `roles/storage.objectAdmin` to the Manager backup service account
   - Waits for all DB nodes to access the bucket via `check-location` polling
   - Runs a backup task with `retention-lock-mode=unlocked` and `retention-days=1`
   - Verifies that backed-up snapshot files cannot be deleted (`google.api_core.exceptions.Forbidden`)
   - Cleans up the bucket best-effort in a `finally` block

## Test scope

- GCE backend only (guarded by `cluster_backend == "gce"` check in `test_backup_feature`)
- Part of the existing `test_backup_feature` suite

## Testing

- [x] [separate execution of test_worm_backup](https://jenkins.scylladb.com/job/scylla-staging/job/mikita/job/manager-master-clone/job/sct-feature-test-backup-gce/31/)
- [x] [test_worm_backup in scope of test_backup_feature](https://jenkins.scylladb.com/job/scylla-staging/job/mikita/job/manager-master-clone/job/sct-feature-test-backup-gce/36/) (the failure is not related to the added test)