### PR TITLE
feature(sct_event): decrease severity of runtime_error when it is ignored

### DIFF
--- a/sdcm/sct_events/group_common_events.py
+++ b/sdcm/sct_events/group_common_events.py
@@ -298,6 +298,20 @@ def ignore_compaction_stopped_exceptions():
 
 
 @contextmanager
+def ignore_ignore_runtime_errors():
+    # These are actually INFO logs, but they get caught by RUNTIME_ERROR filter
+    with ExitStack() as stack:
+        stack.enter_context(
+            EventsSeverityChangerFilter(
+                new_severity=Severity.INFO,
+                event_class=DatabaseLogEvent,
+                regex=r".*ignoring error response: std::runtime_error.*",
+            )
+        )
+        yield
+
+
+@contextmanager
 def ignore_large_collection_warning():
     with ExitStack() as stack:
         stack.enter_context(DbEventsFilter(db_event=DatabaseLogEvent.WARNING, line="Writing large collection"))
@@ -597,6 +611,7 @@ NODE_UNAVAILABLE_CONTEXTS: list[Callable[[], ContextManager]] = [
     ignore_ycsb_connection_refused,
     ignore_stream_mutation_fragments_errors,
     ignore_compaction_stopped_exceptions,
+    ignore_ignore_runtime_errors,
 ]
 
 


### PR DESCRIPTION
During an operation like restart, a node may log that it ignored a runtime_error, but this is treated as an RUNTIME_ERROR by that regex, so it needs to be downgraded in this case.

Example:
> (DatabaseLogEvent Severity.ERROR) period_type=one-time event_id=d34dab97-f082-49da-8a71-99f572a97fa9: type=RUNTIME_ERROR regex=std::runtime_error line_number=34425 node=elasticity-test-nemesis-master-db-node-ad36b2ce-1
2026-05-16T20:02:22.139 elasticity-test-nemesis-master-db-node-ad36b2ce-1  !INFO | scylla[28793]  [shard 0:strm] rpc - client 10.12.11.40:7000: **ignoring error response**: std::runtime_error: Got stream_blob_cmd::error from peer 848946c4-463d-4af8-a305-bb0d129a02ff

Fixes: SCT-365

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
