### PR TITLE
fix(ldap): move are_ldap_users_on_scylla runtime state to TestConfig singleton

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4504,7 +4504,7 @@ class BaseCluster:
             node.destroy()
 
     def get_db_auth(self):
-        if self.params.get("use_ldap") and self.params.get("are_ldap_users_on_scylla"):
+        if self.params.get("use_ldap") and TestConfig().LDAP_USERS_ON_SCYLLA:
             user = LDAP_USERS[0]
             password = LDAP_PASSWORD
         else:

--- a/sdcm/test_config.py
+++ b/sdcm/test_config.py
@@ -57,6 +57,7 @@ class TestConfig(metaclass=Singleton):
     SYSLOGNG_ADDRESS = None
     VECTOR_ADDRESS = None
     LDAP_ADDRESS = None
+    LDAP_USERS_ON_SCYLLA: bool = False
     DECODING_QUEUE = None
 
     _test_id = None

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -769,7 +769,7 @@ class ClusterTester(unittest.TestCase):
         return None
 
     def _init_ldap(self):
-        self.params["are_ldap_users_on_scylla"] = False
+        self.test_config.LDAP_USERS_ON_SCYLLA = False
 
         match self.params.get("ldap_server_type"):
             case LdapServerType.MS_AD:
@@ -795,7 +795,7 @@ class ClusterTester(unittest.TestCase):
         for user in LDAP_USERS:
             node.run_cqlsh(f"CREATE ROLE '{user}' WITH login=true")
         node.run_cqlsh(f"ALTER ROLE '{LDAP_USERS[0]}' with SUPERUSER=true and password='{LDAP_PASSWORD}'")
-        self.params["are_ldap_users_on_scylla"] = True
+        self.test_config.LDAP_USERS_ON_SCYLLA = True
 
     def configure_ldap(self, node, use_ssl=False):
         self.test_config.configure_ldap(node=node, use_ssl=use_ssl)


### PR DESCRIPTION
## Summary

Fixes SCT-382: `_init_ldap()` fails with `ValueError: Unknown configuration key 'are_ldap_users_on_scylla'` after Pydantic migration.

## Root Cause

`_init_ldap()` and `_setup_ldap_roles()` in `sdcm/tester.py` were using `self.params["are_ldap_users_on_scylla"]` to track whether LDAP users had been created in Scylla. After the Pydantic migration, `SCTConfiguration.__setitem__` validates key existence and rejects unknown keys — and `are_ldap_users_on_scylla` was removed from the schema.

## Fix

This flag is **runtime state** (has `_setup_ldap_roles()` been called?), not a configuration option. It belongs in the `TestConfig` singleton, not `SCTConfiguration`.

- Add `LDAP_USERS_ON_SCYLLA: bool = False` to `TestConfig`
- Replace `self.params["are_ldap_users_on_scylla"]` writes with `self.test_config.LDAP_USERS_ON_SCYLLA`
- Replace `self.params.get("are_ldap_users_on_scylla")` read in `cluster.py` with `TestConfig().LDAP_USERS_ON_SCYLLA`

## Testing

- [x] 🟡 [rolling-upgrade-ubuntu22.04-ldap-authorization-test #4](https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/oss/job/rolling-upgrade/job/rolling-upgrade-ubuntu22.04-ldap-authorization-test/4/) - now failing on a coredump as the rest of the rolling upgrades cases