### PR TITLE
fix(azure-provision): add 15-minute timeout to VM provisioning poller

### DIFF
--- a/sdcm/provision/azure/virtual_machine_provider.py
+++ b/sdcm/provision/azure/virtual_machine_provider.py
@@ -148,7 +148,7 @@ class VirtualMachineProvider:
                 error_to_raise = err
         for definition, poller in pollers:
             try:
-                poller.wait()
+                poller.wait(timeout=900)
                 v_m = self._azure_service.compute.virtual_machines.get(
                     self._resource_group_name, definition.name, expand="instanceView"
                 )

--- a/unit_tests/unit/provisioner/fake_azure_service.py
+++ b/unit_tests/unit/provisioner/fake_azure_service.py
@@ -43,7 +43,7 @@ class WaitableObject:
     def __init__(self, error: AzureError = None):
         self.error = error
 
-    def wait(self):
+    def wait(self, timeout=None):
         if self.error:
             raise self.error
 


### PR DESCRIPTION
## Summary

- Add `timeout=900` (15 minutes) to `poller.wait()` in Azure VM provisioning to prevent indefinite hangs

## Root Cause

The ScyllaDB Azure image has two issues causing VMs to take 6+ minutes before the Azure guest agent reports "Ready":

1. **`rootdelay=300`** in kernel cmdline — kernel waits 5 minutes before mounting root, even though NVMe is ready in <3s (added for MS marketplace certification in fd72489a835eb422b8d0796a8ea4c292afb7a5dc)
2. **`walinuxagent` masked** — only unmasked at end of cloud-init `modules:final` (~375s into boot)

Without a timeout, `poller.wait()` blocks indefinitely if Azure ARM never transitions out of "Creating" state, causing entire test runs to hang during `provision-resources`.

## Evidence

Serial console from build #972 (db-node-5):
```
[    2.9s] Waiting 300 sec before mounting root device...
[  333s]   Root mounted (after rootdelay expired)
[  375s]   systemctl unmask walinuxagent  ← agent finally starts
```

## Fix

Add `timeout=900` to `poller.wait()`. 15 minutes gives ample headroom for the 6-minute minimum boot time plus any variance, while preventing indefinite hangs.

## Related

- **SCT-373**: longevity-10gb-3h-azure-test hanging during provision-resources
- **SMI-284**: Filed to reduce `rootdelay=300` in the image (the proper long-term fix)

## Backends Affected
- [ ] AWS
- [ ] GCE
- [x] Azure
- [ ] Docker