### PR TITLE
improvement(provision/aws): AZ capacity fallbacks improvements

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -81,7 +81,8 @@ from sdcm.cluster_k8s.eks import MonitorSetEKS
 from sdcm.cluster_cloud import ScyllaCloudCluster
 from sdcm.cql_stress_cassandra_stress_thread import CqlStressCassandraStressThread
 from sdcm.mgmt import get_scylla_manager_tool
-from sdcm.provision.aws.az_resolver import AZResolver
+from sdcm.provision.aws.az_resolver import AZResolver, is_az_fallback_enabled
+from sdcm.provision.aws.capacity_errors import ProvisioningCapacityExhausted, is_capacity_error
 from sdcm.provision.aws.capacity_reservation import SCTCapacityReservation
 from sdcm.kafka.kafka_cluster import LocalKafkaCluster
 from sdcm.provision.aws.emr_provisioner import EmrClusterProvisioner, ensure_emr_roles
@@ -1869,6 +1870,34 @@ class ClusterTester(unittest.TestCase):
             self.monitors = NoMonitorSet()
 
     def get_cluster_aws(self, loader_info, db_info, monitor_info):
+        AZResolver(self.params).resolve()
+
+        # capacity reservation handles its own AZ fallback internally
+        cr_enabled = SCTCapacityReservation.is_capacity_reservation_enabled(self.params)
+        fallback_enabled = is_az_fallback_enabled(self.params) and not cr_enabled
+
+        self._populate_aws_info_dicts(loader_info, db_info, monitor_info)
+
+        original_az = self.params.get("availability_zone")
+        if fallback_enabled and (az_candidates := AZResolver(self.params).get_fallback_candidates()):
+            candidates = az_candidates
+        else:
+            candidates = [original_az.split(",") if original_az else []]
+
+        region_exhausted, last_error = self._provision_legacy_with_az_fallback(
+            loader_info, db_info, monitor_info, candidates, last_error=None
+        )
+        if not region_exhausted:
+            return
+
+        self.params["availability_zone"] = original_az
+        tried = ", ".join("+".join(c) for c in candidates)
+        raise CriticalTestFailure(
+            f"Failed creating AWS clusters in all {len(candidates)} AZ candidate(s) [{tried}]: {last_error}"
+        ) from last_error
+
+    def _populate_aws_info_dicts(self, loader_info: dict, db_info: dict, monitor_info: dict) -> None:
+        """Fill missing AWS info values for the current region."""
         regions = self.params.get("region_name").split()
 
         if loader_info["n_nodes"] is None:
@@ -1898,14 +1927,69 @@ class ClusterTester(unittest.TestCase):
 
         init_db_info_from_params(db_info, params=self.params, regions=regions)
         init_monitoring_info_from_params(monitor_info, params=self.params, regions=regions)
-        user_prefix = self.params.get("user_prefix")
 
-        user_credentials = self.params.get("user_credentials_path")
+    def _provision_legacy_with_az_fallback(
+        self,
+        loader_info: dict,
+        db_info: dict,
+        monitor_info: dict,
+        candidates: list[list[str]],
+        last_error: Exception | None,
+    ) -> tuple[bool, Exception | None]:
+        """Try AZ candidates in the current region.
 
+        Return `(False, last_error)` on success, or `(True, last_error)` if all
+        candidates fail with capacity errors.
+        """
+        for attempt_idx, candidate in enumerate(candidates, start=1):
+            if candidate:
+                self.params["availability_zone"] = ",".join(candidate)
+
+            if attempt_idx > 1:
+                self.log.warning(
+                    "Capacity error in previous AZ; retrying in '%s' (attempt %d/%d)",
+                    self.params["availability_zone"],
+                    attempt_idx,
+                    len(candidates),
+                )
+                self._cleanup_legacy_partial_aws_clusters()
+
+            try:
+                self._provision_legacy_aws_clusters(loader_info, db_info, monitor_info)
+                return False, last_error
+            except (botocore.exceptions.ClientError, ProvisioningCapacityExhausted) as exc:
+                if isinstance(exc, botocore.exceptions.ClientError) and not is_capacity_error(exc):
+                    raise
+                last_error = exc
+                self.log.warning(
+                    "Provision failed with capacity error in AZ '%s': %s",
+                    self.params.get("availability_zone"),
+                    exc,
+                )
+
+        return True, last_error
+
+    def _cleanup_legacy_partial_aws_clusters(self) -> None:
+        """Destroy partially created AWS clusters before retrying provisioning."""
+        for attr in ("db_cluster", "cs_db_cluster", "loaders", "monitors"):
+            cluster = getattr(self, attr, None)
+            if cluster is None or isinstance(cluster, NoMonitorSet):
+                continue
+            with contextlib.suppress(Exception):
+                cluster.destroy()
+            setattr(self, attr, None)
+
+        self.credentials = []
+
+    def _provision_legacy_aws_clusters(self, loader_info, db_info, monitor_info):
+        """Provision AWS clusters using the current region and availability zone.
+
+        Used by `get_cluster_aws` to retry provisioning with different AZs.
+        """
         regions = self.params.get("region_name").split()
         services = get_ec2_services(regions)
-
-        AZResolver(self.params).resolve()
+        user_prefix = self.params.get("user_prefix")
+        user_credentials = self.params.get("user_credentials_path")
 
         for _ in regions:
             self.credentials.append(UserRemoteCredentials(key_file=user_credentials))
@@ -1914,47 +1998,9 @@ class ClusterTester(unittest.TestCase):
         for idx, ami_id in enumerate(ami_ids):
             wait_ami_available(services[idx].meta.client, ami_id)
 
-        def _get_all_zones_common_params() -> list[dict]:
-            all_zones_common_params = []
-            aws_region = AwsRegion(region_name=regions[0])
-            availability_zones = [
-                zone[-1]
-                for zone in aws_region.get_availability_zones_for_instance_type(self.params.get("instance_type_db"))
-            ]
-            for zone in availability_zones:
-                all_zones_common_params.append(
-                    get_common_params(
-                        params=self.params,
-                        regions=regions,
-                        credentials=self.credentials,
-                        services=services,
-                        availability_zone=zone,
-                    )
-                )
-            return all_zones_common_params
-
         common_params = get_common_params(
             params=self.params, regions=regions, credentials=self.credentials, services=services
         )
-
-        def _create_auto_zone_scylla_aws_cluster():
-            capacity_errors = []
-            for cl_zone_params in _get_all_zones_common_params():
-                cl_zone_params.update(_get_instance_params())
-                try:
-                    return ScyllaAWSCluster(
-                        ec2_ami_id=self.params.get("ami_id_db_scylla").split(),
-                        ec2_ami_username=self.params.get("ami_db_scylla_user"),
-                        **cl_zone_params,
-                    )
-                except botocore.exceptions.ClientError as error:
-                    capacity_error_keywards = ["Unsupported", "InsufficientInstanceCapacity"]
-                    if any(capacity_error in str(error) for capacity_error in capacity_error_keywards):
-                        self.log.warning("Failed creating a Scylla AWS cluster: %s", error)
-                        capacity_errors.append(error)
-                    else:
-                        raise
-            raise CriticalTestFailure(f"Failed creating a Scylla AWS cluster: {capacity_errors}")
 
         def _get_instance_params() -> dict:
             return dict(
@@ -1967,8 +2013,6 @@ class ClusterTester(unittest.TestCase):
             cl_params = _get_instance_params()
             cl_params.update(common_params)
             if db_type == "scylla":
-                if self.params.get("aws_fallback_to_next_availability_zone"):
-                    return _create_auto_zone_scylla_aws_cluster()
                 return ScyllaAWSCluster(
                     ec2_ami_id=self.params.get("ami_id_db_scylla").split(),
                     ec2_ami_username=self.params.get("ami_db_scylla_user"),

--- a/test-cases/artifacts/amazon2023.yaml
+++ b/test-cases/artifacts/amazon2023.yaml
@@ -15,6 +15,5 @@ scylla_linux_distro: 'centos'
 test_duration: 60
 use_preinstalled_scylla: false
 user_prefix: 'artifacts-al2023'
-aws_fallback_to_next_availability_zone: true
 
 user_credentials_path: '~/.ssh/scylla_test_id_ed25519'

--- a/test-cases/artifacts/ami.yaml
+++ b/test-cases/artifacts/ami.yaml
@@ -12,4 +12,3 @@ region_name: 'us-east-1'
 scylla_linux_distro: 'centos'
 test_duration: 60
 user_prefix: 'artifacts-ami'
-aws_fallback_to_next_availability_zone: true

--- a/test-cases/artifacts/centos9.yaml
+++ b/test-cases/artifacts/centos9.yaml
@@ -15,6 +15,5 @@ scylla_linux_distro: 'centos'
 test_duration: 60
 user_prefix: 'artifacts-centos9'
 use_preinstalled_scylla: false
-aws_fallback_to_next_availability_zone: true
 
 user_credentials_path: '~/.ssh/scylla_test_id_ed25519'

--- a/test-cases/artifacts/oel76.yaml
+++ b/test-cases/artifacts/oel76.yaml
@@ -15,4 +15,3 @@ scylla_linux_distro: 'centos'
 test_duration: 60
 use_preinstalled_scylla: false
 user_prefix: 'artifacts-oel76'
-aws_fallback_to_next_availability_zone: true

--- a/test-cases/artifacts/oel8.yaml
+++ b/test-cases/artifacts/oel8.yaml
@@ -15,4 +15,3 @@ scylla_linux_distro: 'centos'
 test_duration: 60
 use_preinstalled_scylla: false
 user_prefix: 'artifacts-oel8'
-aws_fallback_to_next_availability_zone: true

--- a/test-cases/artifacts/oel9.yaml
+++ b/test-cases/artifacts/oel9.yaml
@@ -15,4 +15,3 @@ scylla_linux_distro: 'centos'
 test_duration: 60
 use_preinstalled_scylla: false
 user_prefix: 'artifacts-oel9'
-aws_fallback_to_next_availability_zone: true

--- a/test-cases/artifacts/ubuntu2004-fips.yaml
+++ b/test-cases/artifacts/ubuntu2004-fips.yaml
@@ -19,4 +19,3 @@ server_encrypt: true
 internode_encryption: 'all'
 test_duration: 60
 user_prefix: 'artifacts-ubuntu2004-fips'
-aws_fallback_to_next_availability_zone: true

--- a/test-cases/artifacts/ubuntu2204.yaml
+++ b/test-cases/artifacts/ubuntu2204.yaml
@@ -15,4 +15,3 @@ scylla_linux_distro: 'ubuntu-jammy'
 test_duration: 60
 user_prefix: 'artifacts-ubuntu2204'
 use_preinstalled_scylla: false
-aws_fallback_to_next_availability_zone: true

--- a/test-cases/artifacts/ubuntu2404.yaml
+++ b/test-cases/artifacts/ubuntu2404.yaml
@@ -15,6 +15,5 @@ scylla_linux_distro: 'ubuntu-noble'
 test_duration: 60
 user_prefix: 'artifacts-ubuntu2404'
 use_preinstalled_scylla: false
-aws_fallback_to_next_availability_zone: true
 
 user_credentials_path: '~/.ssh/scylla_test_id_ed25519'

--- a/test-cases/artifacts/ubuntu2604.yaml
+++ b/test-cases/artifacts/ubuntu2604.yaml
@@ -15,6 +15,5 @@ scylla_linux_distro: 'ubuntu-resolute'
 test_duration: 60
 user_prefix: 'artifacts-ubuntu2604'
 use_preinstalled_scylla: false
-aws_fallback_to_next_availability_zone: true
 
 user_credentials_path: '~/.ssh/scylla_test_id_ed25519'

--- a/unit_tests/unit/provisioner/test_az_fallback.py
+++ b/unit_tests/unit/provisioner/test_az_fallback.py
@@ -17,9 +17,11 @@ from unittest.mock import MagicMock, patch
 import pytest
 from botocore.exceptions import ClientError
 
+from sdcm.cluster import NoMonitorSet
 from sdcm.cluster_aws import AWSCluster
 from sdcm.provision.aws.capacity_errors import ProvisioningCapacityExhausted
 from sdcm.sct_provision.aws.layout import SCTProvisionAWSLayout
+from sdcm.tester import ClusterTester
 
 
 class _DotDict(dict):
@@ -28,7 +30,14 @@ class _DotDict(dict):
     __delattr__ = dict.__delitem__
 
 
-def _make_params(**overrides):
+def _capacity_error() -> ClientError:
+    return ClientError(
+        error_response={"Error": {"Code": "InsufficientInstanceCapacity", "Message": "Insufficient capacity."}},
+        operation_name="RunInstances",
+    )
+
+
+def _make_layout_params(**overrides):
     params = _DotDict(
         {
             "cluster_backend": "aws",
@@ -71,16 +80,9 @@ def patched_capacity_reservation_fixture():
         yield mock_cr
 
 
-def _capacity_error() -> ClientError:
-    return ClientError(
-        error_response={"Error": {"Code": "InsufficientInstanceCapacity", "Message": "Insufficient capacity."}},
-        operation_name="RunInstances",
-    )
-
-
 def test_provision_retries_on_capacity_error(patched_aws_region, patched_capacity_reservation):  # noqa: ARG001
     """Core fallback flow: capacity error -> cleanup -> cache clear -> retry next AZ -> success."""
-    params = _make_params()
+    params = _make_layout_params()
     layout = SCTProvisionAWSLayout(params)
     seen_azs: list[str] = []
 
@@ -103,7 +105,7 @@ def test_provision_retries_on_capacity_error(patched_aws_region, patched_capacit
 
 def test_provision_non_capacity_error_propagates(patched_aws_region, patched_capacity_reservation):  # noqa: ARG001
     """Non-capacity errors (e.g. AuthFailure) must not trigger AZ retry."""
-    layout = SCTProvisionAWSLayout(_make_params())
+    layout = SCTProvisionAWSLayout(_make_layout_params())
     other_error = ClientError({"Error": {"Code": "AuthFailure", "Message": "Not authorized"}}, "RunInstances")
     with patch.object(layout, "_do_provision", side_effect=other_error):
         with patch.object(layout, "_cleanup_partial_provision") as mock_cleanup:
@@ -115,7 +117,7 @@ def test_provision_non_capacity_error_propagates(patched_aws_region, patched_cap
 def test_provision_retries_on_spot_capacity_exhausted(patched_aws_region, patched_capacity_reservation):  # noqa: ARG001
     """Spot path raises ProvisioningCapacityExhausted (no ClientError) when capacity is unavailable;
     AZ fallback must treat it the same as an on-demand capacity ClientError."""
-    params = _make_params(instance_provision="spot")
+    params = _make_layout_params(instance_provision="spot")
     layout = SCTProvisionAWSLayout(params)
     seen_azs: list[str] = []
 
@@ -139,7 +141,7 @@ def test_provision_retries_on_spot_capacity_exhausted(patched_aws_region, patche
 def test_provision_capacity_reservation_enabled_skips_layout_fallback(patched_aws_region, patched_capacity_reservation):  # noqa: ARG001
     """CR owns AZ iteration; layout-level retry would double-fallback and orphan reservations."""
     patched_capacity_reservation.is_capacity_reservation_enabled.return_value = True
-    layout = SCTProvisionAWSLayout(_make_params(use_capacity_reservation=True, instance_provision="on_demand"))
+    layout = SCTProvisionAWSLayout(_make_layout_params(use_capacity_reservation=True, instance_provision="on_demand"))
     with patch.object(layout, "_do_provision", side_effect=_capacity_error()) as mock_do:
         with pytest.raises(ClientError):
             layout.provision()
@@ -156,7 +158,7 @@ def _fake_instance(instance_id: str, region: str) -> SimpleNamespace:
 
 def test_cleanup_partial_provision_groups_terminations_by_region():
     """Partial instances from different regions must be terminated against each region's client."""
-    layout = SCTProvisionAWSLayout(_make_params(region_name="us-east-1 eu-west-1"))
+    layout = SCTProvisionAWSLayout(_make_layout_params(region_name="us-east-1 eu-west-1"))
     layout.__dict__["db_cluster"] = SimpleNamespace(
         _provisioned_instances=[_fake_instance("i-aaa", "us-east-1"), _fake_instance("i-bbb", "eu-west-1")]
     )
@@ -219,3 +221,118 @@ def test_get_instances_returns_empty_when_az_idx_out_of_bounds(patched_ec2_for_g
     }
     result = AWSCluster._get_instances(_fake_aws_cluster(availability_zone="a"), dc_idx=0, az_idx=5)
     assert result == []
+
+
+def _make_tester_params(**overrides) -> _DotDict:
+    return _DotDict(
+        {
+            "region_name": "us-east-1",
+            "availability_zone": "a",
+            "n_db_nodes": 1,
+            **overrides,
+        }
+    )
+
+
+def _make_tester_stub(params: dict) -> SimpleNamespace:
+    """Build a stub with only the attributes the legacy-fallback helpers touch."""
+    return SimpleNamespace(
+        params=params, log=MagicMock(), db_cluster=None, cs_db_cluster=None, loaders=None, monitors=None, credentials=[]
+    )
+
+
+def _raise_or_none(queue):
+    item = queue.pop(0)
+    if isinstance(item, BaseException):
+        raise item
+    return item
+
+
+def test_cleanup_destroys_existing_clusters_and_clears_credentials():
+    stub = _make_tester_stub(_make_tester_params())
+    db_cluster, loaders, monitors = MagicMock(), MagicMock(), MagicMock()
+    stub.db_cluster = db_cluster
+    stub.loaders = loaders
+    stub.monitors = monitors
+    stub.credentials = [MagicMock(), MagicMock()]
+
+    ClusterTester._cleanup_legacy_partial_aws_clusters(stub)
+
+    db_cluster.destroy.assert_called_once()
+    loaders.destroy.assert_called_once()
+    monitors.destroy.assert_called_once()
+    assert stub.db_cluster is None
+    assert stub.loaders is None
+    assert stub.monitors is None
+    assert stub.credentials == []
+
+
+def test_cleanup_skips_no_monitor_set_and_swallows_destroy_errors():
+    """`NoMonitorSet` has no instances to terminate; `destroy()` failures must not propagate."""
+    stub = _make_tester_stub(_make_tester_params())
+    stub.monitors = NoMonitorSet()
+    broken = MagicMock()
+    broken.destroy.side_effect = RuntimeError("boom")
+    stub.db_cluster = broken
+
+    ClusterTester._cleanup_legacy_partial_aws_clusters(stub)
+
+    broken.destroy.assert_called_once()
+    assert stub.db_cluster is None
+    assert isinstance(stub.monitors, NoMonitorSet)
+
+
+@pytest.mark.parametrize(
+    ("first_exc", "expected_calls", "expected_cleanup_calls", "expected_final_az"),
+    [
+        pytest.param(None, 1, 0, "a", id="success_first_attempt"),
+        pytest.param(_capacity_error(), 2, 1, "b", id="capacity_error_then_retry"),
+        pytest.param(ProvisioningCapacityExhausted("spot empty"), 2, 1, "b", id="spot_exhaustion_then_retry"),
+    ],
+)
+def test_provision_legacy_with_az_fallback_succeeds(
+    first_exc, expected_calls, expected_cleanup_calls, expected_final_az
+):
+    """Both on-demand capacity errors (ClientError) and spot exhaustion (ProvisioningCapacityExhausted)
+    trigger AZ retry; clean first attempts skip cleanup entirely."""
+    stub = _make_tester_stub(_make_tester_params(availability_zone="a"))
+    calls = [first_exc, None]
+    stub._provision_legacy_aws_clusters = MagicMock(side_effect=lambda *_a, **_k: _raise_or_none(calls))
+    stub._cleanup_legacy_partial_aws_clusters = MagicMock()
+
+    region_exhausted, _ = ClusterTester._provision_legacy_with_az_fallback(
+        stub, loader_info={}, db_info={}, monitor_info={}, candidates=[["a"], ["b"]], last_error=None
+    )
+
+    assert region_exhausted is False
+    assert stub._provision_legacy_aws_clusters.call_count == expected_calls
+    assert stub._cleanup_legacy_partial_aws_clusters.call_count == expected_cleanup_calls
+    assert stub.params["availability_zone"] == expected_final_az
+
+
+def test_provision_legacy_with_az_fallback_returns_region_exhausted_when_all_candidates_fail():
+    stub = _make_tester_stub(_make_tester_params(availability_zone="a"))
+    error = _capacity_error()
+    stub._provision_legacy_aws_clusters = MagicMock(side_effect=error)
+    stub._cleanup_legacy_partial_aws_clusters = MagicMock()
+
+    region_exhausted, last_error = ClusterTester._provision_legacy_with_az_fallback(
+        stub, loader_info={}, db_info={}, monitor_info={}, candidates=[["a"], ["b"]], last_error=None
+    )
+
+    assert region_exhausted is True
+    assert last_error is error
+    assert stub._provision_legacy_aws_clusters.call_count == 2
+
+
+def test_provision_legacy_with_az_fallback_non_capacity_error_propagates():
+    stub = _make_tester_stub(_make_tester_params(availability_zone="a"))
+    other_error = ClientError({"Error": {"Code": "AuthFailure", "Message": "denied"}}, "RunInstances")
+    stub._provision_legacy_aws_clusters = MagicMock(side_effect=other_error)
+    stub._cleanup_legacy_partial_aws_clusters = MagicMock()
+
+    with pytest.raises(ClientError):
+        ClusterTester._provision_legacy_with_az_fallback(
+            stub, loader_info={}, db_info={}, monitor_info={}, candidates=[["a"], ["b"]], last_error=None
+        )
+    assert stub._provision_legacy_aws_clusters.call_count == 1


### PR DESCRIPTION
Phases 4-5 implementation of the plan: [docs/plans/infrastructure/aws-capacity-az-fallback.md](https://github.com/scylladb/scylla-cluster-tests/blob/da3ffd7d51b90b15f10b922b029cc8c6f92dc41b/docs/plans/infrastructure/aws-capacity-az-fallback.md)

AWS provision fallbacks improvements:
- AZ fallback logic is extended to cover loaders and monitors in the legacy path (partial clusters are cleanud up between retries).
- Redundant `aws_fallback_to_next_availability_zone: true` override is dropped from artifact configs as the backend-agnostic `fallback_to_next_availability_zone` defaults to true (yet the deprecated name is kept for compatibility reasons).

Refs: SCT-302
Refs: SCT-303

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] unit tests
- [x] :green_circle: [artifacts-ami-arm test](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/artifacts/job/artifacts-ami-arm-test/16/) (triggers AZ fallback path)
```
22:53:04  < t:2026-05-20 20:53:02,518 f:tester.py       l:2002 c:ArtifactsTest        p:WARNING > Provision failed with capacity error in AZ 'a': An error occurred (InsufficientInstanceCapacity) when calling the RunInstances operation (reached max retries: 4): We currently do not have sufficient i8g.4xlarge capacity in the Availability Zone you requested (eu-west-1a).
...
22:53:04  < t:2026-05-20 20:53:02,519 f:tester.py       l:1987 c:ArtifactsTest        p:WARNING > Capacity error in previous AZ; retrying in 'b' (attempt 2/3)
...
22:53:46  < t:2026-05-20 20:53:45,202 f:cloud_init.py   l:33   c:sdcm.provision.helpers.cloud_init p:INFO  > Waiting for cloud-init to complete on node artifacts-ami-jenkins-db-node-e1b24a80-1...
```
- [x] :green_circle: [artifacts-debian12 testh](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/artifacts/job/artifacts-debian12-test/10/) (happy patch - no capacity shortage)
- [x] :green_circle:  [longevity-multi-dc-rack-aware test](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/longevity-multi-dc-rack-aware-test/9/) (this is a happy path, as was not able to trigger fallback due capacity was more than enough on the provider side)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
