### PR TITLE
audit: allow SCT to configure rule-based auditing

### DIFF
--- a/configurations/nemesis/ToggleAuditRulesNemesisSyslog.yaml
+++ b/configurations/nemesis/ToggleAuditRulesNemesisSyslog.yaml
@@ -1,0 +1,3 @@
+nemesis_class_name: "SisyphusMonkey"
+nemesis_selector: 'ToggleAuditRulesNemesisSyslog'
+user_prefix: 'longevity-5gb-1h-ToggleAuditRulesNemesisSyslog'

--- a/configurations/toggle-audit-rules-nemesis.yaml
+++ b/configurations/toggle-audit-rules-nemesis.yaml
@@ -1,0 +1,2 @@
+nemesis_class_name: "SisyphusMonkey"
+nemesis_selector: 'ToggleAuditRulesNemesisSyslog'

--- a/data_dir/nemesis.yml
+++ b/data_dir/nemesis.yml
@@ -1749,6 +1749,23 @@ ToggleAuditNemesisSyslog:
   topology_changes: false
   xcloud: false
   zero_node_changes: false
+ToggleAuditRulesNemesisSyslog:
+  config_changes: true
+  delete_rows: false
+  disruptive: true
+  enospc: false
+  free_tier_set: true
+  kubernetes: false
+  limited: false
+  manager_operation: false
+  modify_table: false
+  networking: false
+  schema_changes: true
+  sla: false
+  supports_high_disk_utilization: true
+  topology_changes: false
+  xcloud: false
+  zero_node_changes: false
 ToggleCDCMonkey:
   config_changes: true
   delete_rows: false

--- a/data_dir/nemesis_classes.yml
+++ b/data_dir/nemesis_classes.yml
@@ -101,6 +101,7 @@
 - TerminateKubernetesHostThenDecommissionAndAddScyllaNode
 - TerminateKubernetesHostThenReplaceScyllaNode
 - ToggleAuditNemesisSyslog
+- ToggleAuditRulesNemesisSyslog
 - ToggleCDCMonkey
 - ToggleGcModeMonkey
 - ToggleLdapConfiguration

--- a/docs/docker-backend-nemesis.md
+++ b/docs/docker-backend-nemesis.md
@@ -81,6 +81,7 @@
 | TerminateKubernetesHostThenDecommissionAndAddScyllaNode | Skipped | Not a k8s backend
 | TerminateKubernetesHostThenReplaceScyllaNode | Skipped | Not a k8s backend
 | ToggleAuditNemesisSyslog | Pass | Should be executed on enterprise
+| ToggleAuditRulesNemesisSyslog | Pass | Should be executed on enterprise
 | ToggleCDCMonkey | Pass |
 | ToggleGcModeMonkey | Pass |
 | ToggleLdapConfiguration | Pass | Should be executed on enterprise

--- a/docs/docker-backend-nemesis.md
+++ b/docs/docker-backend-nemesis.md
@@ -48,7 +48,7 @@
 | NodeToolCleanupMonkey | Pass |
 | OperatorNodeReplace | Skipped | Should be skipped for docker backend
 | OperatorNodetoolFlushAndReshard | Pass |
-| PauseLdapNemesis | Pass | Should be executed on enterprise
+| PauseLdapNemesis | Pass |
 | RandomInterruptionNetworkMonkey | Pass |
 | RebuildStreamingErrMonkey | Skipped | Backend doesn't support hard reboot
 | RefreshBigMonkey | Pass |
@@ -80,11 +80,11 @@
 | TerminateAndRemoveNodeMonkey | Fail | [scylla-cluster-tests/issues/7331](https://github.com/scylladb/scylla-cluster-tests/issues/7331)
 | TerminateKubernetesHostThenDecommissionAndAddScyllaNode | Skipped | Not a k8s backend
 | TerminateKubernetesHostThenReplaceScyllaNode | Skipped | Not a k8s backend
-| ToggleAuditNemesisSyslog | Pass | Should be executed on enterprise
-| ToggleAuditRulesNemesisSyslog | Pass | Should be executed on enterprise
+| ToggleAuditNemesisSyslog | Pass |
+| ToggleAuditRulesNemesisSyslog | Pass |
 | ToggleCDCMonkey | Pass |
 | ToggleGcModeMonkey | Pass |
-| ToggleLdapConfiguration | Pass | Should be executed on enterprise
+| ToggleLdapConfiguration | Pass |
 | ToggleTableIcsMonkey | Pass |
 | TopPartitions | Pass |
 | TruncateLargeParititionMonkey | Pass |

--- a/jenkins-pipelines/oss/features/audit/longevity-100gb-4h-audit-rules-nemesis.jenkinsfile
+++ b/jenkins-pipelines/oss/features/audit/longevity-100gb-4h-audit-rules-nemesis.jenkinsfile
@@ -1,0 +1,12 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    region: 'eu-west-1',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: '''["test-cases/longevity/longevity-100gb-4h.yaml", "configurations/toggle-audit-rules-nemesis.yaml"]'''
+
+)

--- a/jenkins-pipelines/oss/nemesis/longevity-5gb-1h-ToggleAuditRulesNemesisSyslog-aws.jenkinsfile
+++ b/jenkins-pipelines/oss/nemesis/longevity-5gb-1h-ToggleAuditRulesNemesisSyslog-aws.jenkinsfile
@@ -1,0 +1,11 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: "aws",
+    region: "eu-west-1",
+    test_name: "longevity_test.LongevityTest.test_custom_time",
+    test_config: "['configurations/nemesis/longevity-5gb-1h-nemesis.yaml', 'configurations/nemesis/ToggleAuditRulesNemesisSyslog.yaml', 'configurations/toggle-audit-rules-nemesis.yaml']"
+)

--- a/jenkins-pipelines/oss/nemesis/longevity-5gb-1h-ToggleAuditRulesNemesisSyslog-azure.jenkinsfile
+++ b/jenkins-pipelines/oss/nemesis/longevity-5gb-1h-ToggleAuditRulesNemesisSyslog-azure.jenkinsfile
@@ -1,0 +1,11 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: "azure",
+    azure_region_name: "eastus",
+    test_name: "longevity_test.LongevityTest.test_custom_time",
+    test_config: "['configurations/nemesis/longevity-5gb-1h-nemesis.yaml', 'configurations/nemesis/ToggleAuditRulesNemesisSyslog.yaml', 'configurations/toggle-audit-rules-nemesis.yaml']"
+)

--- a/jenkins-pipelines/oss/nemesis/longevity-5gb-1h-ToggleAuditRulesNemesisSyslog-docker.jenkinsfile
+++ b/jenkins-pipelines/oss/nemesis/longevity-5gb-1h-ToggleAuditRulesNemesisSyslog-docker.jenkinsfile
@@ -1,0 +1,11 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: "docker",
+    region: "eu-west-1",
+    test_name: "longevity_test.LongevityTest.test_custom_time",
+    test_config: "['configurations/nemesis/longevity-5gb-1h-nemesis.yaml', 'configurations/nemesis/ToggleAuditRulesNemesisSyslog.yaml', 'configurations/nemesis/additional_configs/docker_backend.yaml', 'configurations/toggle-audit-rules-nemesis.yaml']"
+)

--- a/jenkins-pipelines/oss/nemesis/longevity-5gb-1h-ToggleAuditRulesNemesisSyslog-gce.jenkinsfile
+++ b/jenkins-pipelines/oss/nemesis/longevity-5gb-1h-ToggleAuditRulesNemesisSyslog-gce.jenkinsfile
@@ -1,0 +1,11 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: "gce",
+    gce_datacenter: "us-east1",
+    test_name: "longevity_test.LongevityTest.test_custom_time",
+    test_config: "['configurations/nemesis/longevity-5gb-1h-nemesis.yaml', 'configurations/nemesis/ToggleAuditRulesNemesisSyslog.yaml', 'configurations/toggle-audit-rules-nemesis.yaml']"
+)

--- a/jenkins-pipelines/oss/nemesis/longevity-5gb-1h-ToggleAuditRulesNemesisSyslog-oci.jenkinsfile
+++ b/jenkins-pipelines/oss/nemesis/longevity-5gb-1h-ToggleAuditRulesNemesisSyslog-oci.jenkinsfile
@@ -1,0 +1,11 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: "oci",
+    oci_region_name: "us-ashburn-1",
+    test_name: "longevity_test.LongevityTest.test_custom_time",
+    test_config: "['configurations/nemesis/longevity-5gb-1h-nemesis.yaml', 'configurations/nemesis/ToggleAuditRulesNemesisSyslog.yaml', 'configurations/toggle-audit-rules-nemesis.yaml']"
+)

--- a/sdcm/audit.py
+++ b/sdcm/audit.py
@@ -14,7 +14,7 @@ import logging
 import re
 from dataclasses import dataclass
 from datetime import datetime, date
-from typing import Literal, Optional, List
+from typing import Any, List, Literal, Optional
 
 from cassandra.util import uuid_from_time, datetime_from_uuid1
 
@@ -39,6 +39,7 @@ class AuditConfiguration:
     categories: List[AuditCategory]
     tables: List[str]
     keyspaces: List[str]
+    rules: Optional[List[dict[str, Any]]] = None
 
     @classmethod
     def from_scylla_yaml(cls, scylla_yaml):
@@ -46,7 +47,8 @@ class AuditConfiguration:
         categories = scylla_yaml.audit_categories.split(",") if scylla_yaml.audit_categories else []
         tables = scylla_yaml.audit_tables.split(",") if scylla_yaml.audit_tables else []
         keyspaces = scylla_yaml.audit_keyspaces.split(",") if scylla_yaml.audit_keyspaces else []
-        return cls(store=store, categories=categories, tables=tables, keyspaces=keyspaces)
+        rules = getattr(scylla_yaml, "audit_rules", None)
+        return cls(store=store, categories=categories, tables=tables, keyspaces=keyspaces, rules=rules)
 
 
 @dataclass
@@ -219,14 +221,17 @@ class Audit:
         for node in self._cluster.nodes:
             LOGGER.debug("Configuring audit on node %s", node.name)
             with node.remote_scylla_yaml() as scylla_yaml:
-                scylla_yaml.update(
-                    {
-                        "audit": audit_configuration.store,
-                        "audit_categories": ",".join(audit_configuration.categories),
-                        "audit_tables": ",".join(audit_configuration.tables),
-                        "audit_keyspaces": ",".join(audit_configuration.keyspaces),
-                    }
-                )
+                scylla_yaml_options: dict[str, Any] = {
+                    "audit": audit_configuration.store,
+                    "audit_categories": ",".join(audit_configuration.categories),
+                    "audit_tables": ",".join(audit_configuration.tables),
+                    "audit_keyspaces": ",".join(audit_configuration.keyspaces),
+                }
+                if audit_configuration.rules is not None:
+                    scylla_yaml_options["audit_rules"] = audit_configuration.rules
+                elif getattr(scylla_yaml, "audit_rules", None) is not None:
+                    scylla_yaml_options["audit_rules"] = []
+                scylla_yaml.update(scylla_yaml_options)
         self._cluster.restart_scylla()
         LOGGER.debug("Audit configuration completed")
         self._configuration = audit_configuration
@@ -253,5 +258,13 @@ class Audit:
         return self._configuration.store != "none"
 
     def disable(self):
-        self.configure(AuditConfiguration(store="none", categories=[], tables=[], keyspaces=[]))
+        self.configure(
+            AuditConfiguration(
+                store="none",
+                categories=[],
+                tables=[],
+                keyspaces=[],
+                rules=[] if self._configuration.rules is not None else None,
+            )
+        )
         LOGGER.info("Audit has been disabled on all nodes")

--- a/sdcm/nemesis/__init__.py
+++ b/sdcm/nemesis/__init__.py
@@ -5401,7 +5401,14 @@ class NemesisRunner:
     def disrupt_toggle_audit_syslog(self):
         self._disrupt_toggle_audit(store="syslog")
 
-    def _disrupt_toggle_audit(self, store: "AuditStore"):
+    def disrupt_toggle_audit_rules_syslog(self):
+        with self.target_node.remote_scylla_yaml() as scylla_yaml:
+            configured_audit = scylla_yaml.audit or "none"
+        if configured_audit != "none":
+            raise UnsupportedNemesis("ToggleAuditRulesNemesisSyslog requires audit to be initially disabled")
+        self._disrupt_toggle_audit(store="syslog", use_audit_rules=True)
+
+    def _disrupt_toggle_audit(self, store: "AuditStore", use_audit_rules: bool = False):  # noqa: PLR0914
         """
         Enable audit log with all categories and user keyspaces (if audit already enabled, disable it and finish the Nemesis),
         verify audit log content,
@@ -5418,6 +5425,10 @@ class NemesisRunner:
             raise UnsupportedNemesis(
                 "Audit feature log format was changed in Scylla 2025.2 and later. Use old sct-branch for Scylla < 2025.2"
             )
+        if use_audit_rules and (
+            ComparableScyllaVersion(self.target_node.scylla_version) < ComparableScyllaVersion("2026.2.0-dev")
+        ):
+            raise UnsupportedNemesis("audit_rules are supported by Scylla 2026.2.0-dev and later")
 
         audit = Audit(self.cluster)
 
@@ -5428,19 +5439,34 @@ class NemesisRunner:
 
         audit_keyspace = "audit_keyspace"
         keyspaces_for_audit = [audit_keyspace]
-        InfoEvent(f"Enabling full audit for keyspaces: {keyspaces_for_audit}").publish()
+        audit_categories = ["DCL", "DDL", "AUTH", "ADMIN", "DML", "QUERY"]
+        audit_rules = None
+        if use_audit_rules:
+            audit_rules = [
+                {
+                    "sinks": [store],
+                    "categories": audit_categories,
+                    "qualified_table_names": [f"{audit_keyspace}.*"],
+                    "roles": ["*"],
+                }
+            ]
+            audit_categories = []
+            keyspaces_for_audit = []
+        InfoEvent(f"Enabling full audit for keyspaces: {[audit_keyspace]}").publish()
         audit_config = AuditConfiguration(
             store=store,
-            categories=["DCL", "DDL", "AUTH", "ADMIN", "DML", "QUERY"],
+            categories=audit_categories,
             keyspaces=keyspaces_for_audit,
             tables=[],
+            rules=audit_rules,
         )
         try:
             with self.action_log_scope(
-                f"Enable {store} audit on categories: {audit_config.categories} in {keyspaces_for_audit} keyspace"
+                f"Enable {store} audit on categories: {audit_config.categories or audit_rules} "
+                f"in {[audit_keyspace]} keyspace"
             ):
                 audit.configure(audit_config)
-            keyspace_name = keyspaces_for_audit[0]
+            keyspace_name = audit_keyspace
             errors = []
             audit_start = datetime.datetime.now() - datetime.timedelta(seconds=5)
             InfoEvent(message="Writing/Reading data from audited keyspace").publish()
@@ -5481,15 +5507,23 @@ class NemesisRunner:
                     LOGGER.error("QUERY audit log row: %s", row)
         except Exception as ex:
             LOGGER.error("Exception while testing full audit: %s", ex)
-            audit_config.categories = ["DCL", "DDL", "AUTH", "ADMIN"]
-            with self.action_log_scope(f"Reconfiguring audit with {audit_config.categories} categories"):
+            reduced_audit_categories = ["DCL", "DDL", "AUTH", "ADMIN"]
+            if use_audit_rules:
+                audit_config.rules[0]["categories"] = reduced_audit_categories
+            else:
+                audit_config.categories = reduced_audit_categories
+            with self.action_log_scope(f"Reconfiguring audit with {reduced_audit_categories} categories"):
                 audit.configure(audit_config)
             raise
 
         InfoEvent("Reducing audit categories and setting back audited keyspaces").publish()
 
-        audit_config.categories = ["DCL", "DDL", "AUTH", "ADMIN"]
-        with self.action_log_scope(f"Reconfiguring audit with {audit_config.categories} categories"):
+        reduced_audit_categories = ["DCL", "DDL", "AUTH", "ADMIN"]
+        if use_audit_rules:
+            audit_config.rules[0]["categories"] = reduced_audit_categories
+        else:
+            audit_config.categories = reduced_audit_categories
+        with self.action_log_scope(f"Reconfiguring audit with {reduced_audit_categories} categories"):
             audit.configure(audit_config)
         table_name = "audit_cf"
         audit_start = datetime.datetime.now() - datetime.timedelta(seconds=5)

--- a/sdcm/nemesis/monkey/__init__.py
+++ b/sdcm/nemesis/monkey/__init__.py
@@ -920,6 +920,17 @@ class ToggleAuditNemesisSyslog(NemesisBaseClass):
         self.runner.disrupt_toggle_audit_syslog()
 
 
+class ToggleAuditRulesNemesisSyslog(NemesisBaseClass):
+    disruptive = True
+    schema_changes = True
+    config_changes = True
+    free_tier_set = True
+    additional_configs = ["configurations/toggle-audit-rules-nemesis.yaml"]
+
+    def disrupt(self):
+        self.runner.disrupt_toggle_audit_rules_syslog()
+
+
 @target_data_nodes
 class BootstrapStreamingErrorNemesis(NemesisBaseClass):
     disruptive = True

--- a/sdcm/provision/scylla_yaml/scylla_yaml.py
+++ b/sdcm/provision/scylla_yaml/scylla_yaml.py
@@ -370,6 +370,7 @@ class ScyllaYaml(BaseModel):
     audit_categories: str = None  # None
     audit_tables: str = None  # None
     audit_keyspaces: str = None  # None
+    audit_rules: list = None  # None
 
     compaction_collection_items_count_warning_threshold: int = None  # None
 

--- a/unit_tests/unit/test_audit.py
+++ b/unit_tests/unit/test_audit.py
@@ -1,27 +1,133 @@
+from contextlib import contextmanager
 from datetime import datetime
-from pathlib import Path
+
+import pytest
+
+from sdcm.audit import Audit, AuditConfiguration, get_audit_log_rows
+from sdcm.provision.scylla_yaml import ScyllaYaml
+from unit_tests.lib.fake_cluster import DummyDbCluster, DummyNode
 
 
-from sdcm.audit import get_audit_log_rows
-from sdcm.cluster import BaseNode
+class AuditConfigNode:
+    name = "dummy-node"
+
+    def __init__(self):
+        self.scylla_yaml = ScyllaYaml(audit="none")
+
+    @contextmanager
+    def remote_scylla_yaml(self):
+        yield self.scylla_yaml
 
 
-class DummyAuditNode(BaseNode):
-    def __init__(self, system_log: Path, **kwargs):
-        super().__init__(**kwargs)
-        self._system_log_path = system_log
+class AuditCluster(DummyDbCluster):
+    def __init__(self, node):
+        super().__init__([node])
+        self.restarted = False
 
-    @property
-    def system_log(self):
-        return str(self._system_log_path)
+    def restart_scylla(self, nodes=None, random_order=False):
+        self.restarted = True
 
 
-def test_get_audit_log_rows_can_be_filtered_by_time(test_data_dir):
-    node = DummyAuditNode(
-        system_log=test_data_dir / "test_audit.log",
+@pytest.fixture
+def audit_rules():
+    return [
+        {
+            "sinks": ["syslog"],
+            "categories": ["DML"],
+            "qualified_table_names": ["audit_keyspace.*"],
+            "roles": ["*"],
+        }
+    ]
+
+
+@pytest.fixture
+def audit_node():
+    return AuditConfigNode()
+
+
+@pytest.fixture
+def audit_cluster(audit_node):
+    return AuditCluster(audit_node)
+
+
+@pytest.fixture
+def audit_with_rules(audit_cluster, audit_rules):
+    audit_cluster.nodes[0].scylla_yaml.update(
+        {
+            "audit": "syslog",
+            "audit_categories": "",
+            "audit_tables": "",
+            "audit_keyspaces": "",
+            "audit_rules": audit_rules,
+        }
+    )
+    return Audit(audit_cluster)
+
+
+def get_node_scylla_yaml(cluster):
+    return cluster.nodes[0].scylla_yaml.model_dump(exclude_defaults=True, exclude_unset=True, exclude_none=True)
+
+
+def get_audit_log_node(test_data_dir, log_name):
+    node = DummyNode(
         name="dummy-node",
         parent_cluster=None,
     )
+    node.system_log = str(test_data_dir / log_name)
+    return node
+
+
+def test_configure_audit_rules_keeps_sink_enabled(audit_cluster, audit_rules, events):
+    audit = Audit(audit_cluster)
+
+    audit.configure(AuditConfiguration(store="syslog", categories=[], tables=[], keyspaces=[], rules=audit_rules))
+
+    assert get_node_scylla_yaml(audit_cluster) == {
+        "audit": "syslog",
+        "audit_categories": "",
+        "audit_tables": "",
+        "audit_keyspaces": "",
+        "audit_rules": audit_rules,
+    }
+    assert audit_cluster.restarted
+    assert audit.is_enabled()
+
+
+def test_empty_audit_rules_do_not_disable_legacy_sink(audit_cluster):
+    audit_cluster.nodes[0].scylla_yaml.update({"audit": "syslog", "audit_rules": []})
+    audit = Audit(audit_cluster)
+
+    assert audit.is_enabled()
+
+
+def test_configure_legacy_audit_clears_existing_rules(audit_cluster, audit_with_rules, events):
+    audit_with_rules.configure(AuditConfiguration(store="syslog", categories=["DML"], tables=[], keyspaces=["ks"]))
+
+    assert get_node_scylla_yaml(audit_cluster) == {
+        "audit": "syslog",
+        "audit_categories": "DML",
+        "audit_tables": "",
+        "audit_keyspaces": "ks",
+        "audit_rules": [],
+    }
+
+
+def test_disable_audit_rules_clears_rules(audit_cluster, audit_with_rules, events):
+    audit_with_rules.disable()
+
+    assert get_node_scylla_yaml(audit_cluster) == {
+        "audit": "none",
+        "audit_categories": "",
+        "audit_tables": "",
+        "audit_keyspaces": "",
+        "audit_rules": [],
+    }
+    assert audit_cluster.restarted
+    assert not audit_with_rules.is_enabled()
+
+
+def test_get_audit_log_rows_can_be_filtered_by_time(test_data_dir):
+    node = get_audit_log_node(test_data_dir, "test_audit.log")
     # no date filter provided
     rows = get_audit_log_rows(node, from_datetime=None)
     assert len(list(rows)) == 69
@@ -35,11 +141,7 @@ def test_get_audit_log_rows_can_be_filtered_by_time(test_data_dir):
 
 
 def test_get_audit_log_rows_can_be_filtered_by_time_comma_separated(test_data_dir):
-    node = DummyAuditNode(
-        system_log=test_data_dir / "test_audit_comma_sep.log",
-        name="dummy-node",
-        parent_cluster=None,
-    )
+    node = get_audit_log_node(test_data_dir, "test_audit_comma_sep.log")
     # no date filter provided
     rows = get_audit_log_rows(node, from_datetime=None)
     assert len(list(rows)) == 211
@@ -53,11 +155,7 @@ def test_get_audit_log_rows_can_be_filtered_by_time_comma_separated(test_data_di
 
 
 def test_get_audit_log_rows_can_be_filtered_by_category(test_data_dir):
-    node = DummyAuditNode(
-        system_log=test_data_dir / "test_audit.log",
-        name="dummy-node",
-        parent_cluster=None,
-    )
+    node = get_audit_log_node(test_data_dir, "test_audit.log")
     # no date filter provided
     rows = get_audit_log_rows(node, from_datetime=None, category="DML")
     rows = list(rows)
@@ -73,11 +171,7 @@ def test_get_audit_log_rows_can_be_filtered_by_category(test_data_dir):
 
 
 def test_get_audit_log_rows_can_be_filtered_by_operation(test_data_dir):
-    node = DummyAuditNode(
-        system_log=test_data_dir / "test_audit.log",
-        name="dummy-node",
-        parent_cluster=None,
-    )
+    node = get_audit_log_node(test_data_dir, "test_audit.log")
     # no date filter provided
     rows = get_audit_log_rows(node, from_datetime=None, operation='USE "audit_keyspace"')
     rows = list(rows)

--- a/unit_tests/unit/test_scylla_yaml.py
+++ b/unit_tests/unit/test_scylla_yaml.py
@@ -171,6 +171,7 @@ def test_scylla_yaml():
             "audit": None,
             "audit_categories": None,
             "audit_keyspaces": None,
+            "audit_rules": None,
             "audit_tables": None,
             "auth_superuser_name": None,
             "auth_superuser_salted_password": None,
@@ -473,6 +474,23 @@ def test_update_with_dict_object(test_data_dir):
     assert yaml1.enable_sstables_md_format == append_scylla_args_dict["enable_sstables_md_format"]
 
     assert yaml1.force_schema_commit_log == append_scylla_args_dict["force_schema_commit_log"]
+
+
+def test_update_with_extra_audit_rules():
+    audit_rules = [
+        {
+            "sinks": ["syslog"],
+            "categories": ["DML"],
+            "qualified_table_names": ["audit_keyspace.*"],
+            "roles": ["*"],
+        }
+    ]
+    yaml1 = ScyllaYaml()
+
+    yaml1.update({"audit_rules": audit_rules})
+
+    dumped_yaml = yaml1.model_dump(exclude_defaults=True, exclude_unset=True, exclude_none=True)
+    assert dumped_yaml["audit_rules"] == audit_rules
 
 
 def test_copy():


### PR DESCRIPTION
This patch series adds SCT tests for granular audit (SCYLLADB-1083).
The implementation is based on pre-existing audit tests.

### Testing
- https://jenkins.scylladb.com/job/scylla-staging/job/andrzej-jackowski/job/longevity-100gb-4h-test/5/

### PR pre-checks (self review)
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)

Fixes: SCYLLADB-1443

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a chaos test to toggle rule-based audit in syslog mode, plus runtime support and new configuration entries; added CI pipelines for AWS, Azure, Docker, GCE and OCI.
* **Documentation**
  * Updated Docker backend docs to adjust nemesis test expectations.
* **Tests**
  * Expanded unit tests covering audit rules, legacy audit behavior, and disable/restart workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/scylladb/scylla-cluster-tests/pull/14734?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->