### PR TITLE
fix(azure): delay vm creation after nic creation

### DIFF
--- a/sdcm/provision/azure/network_interface_provider.py
+++ b/sdcm/provision/azure/network_interface_provider.py
@@ -12,6 +12,7 @@
 # Copyright (c) 2022 ScyllaDB
 
 import logging
+import time
 from dataclasses import dataclass, field
 
 from typing import Dict, List
@@ -85,6 +86,8 @@ class NetworkInterfaceProvider:
             LOGGER.info("Provisioned nic %s in the %s resource group", nic.name, self._resource_group_name)
             self._cache[nic_name] = nic
             nics.append(nic)
+        if pollers:
+            time.sleep(5)  # wait for nic to be fully propagated before returning (SCT-373)
         return nics
 
     def delete(self, nic: NetworkInterface):


### PR DESCRIPTION
In several tests we could observe first db node provision hanged. My suspection is that NIC creation was not fully propagated and VM fails to properly attach it.
Fix is by adding 5s delay (should be enough, as second db node that is triggered 1 s after first one works ok).

fixes: https://scylladb.atlassian.net/browse/SCT-373

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] - azure provision test

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
