### PR TITLE
refactor(manager): simplify backup/restore test helpers and add schema restore to sanity

### DIFF
--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -89,14 +89,14 @@ class ManagerRestoreTests(ManagerTestFunctionsMixIn):
             snapshot_tag = random.choice(list(snapshot_dict.keys()))
             keyspace_name = snapshot_dict[snapshot_tag]["keyspace_name"]
 
-            self.restore_backup_with_task(
+            self.restore_with_manager_task(
                 mgr_cluster=mgr_cluster,
                 snapshot_tag=snapshot_tag,
                 timeout=180,
                 restore_schema=True,
                 location_list=location_list,
             )
-            self.restore_backup_with_task(
+            self.restore_with_manager_task(
                 mgr_cluster=mgr_cluster,
                 snapshot_tag=snapshot_tag,
                 timeout=expected_timeout,
@@ -116,11 +116,7 @@ class ManagerRestoreTests(ManagerTestFunctionsMixIn):
         mgr_cluster = self.db_cluster.get_cluster_manager(
             alternator_credentials=self.alternator.get_credentials(node=self.db_cluster.nodes[0])
         )
-        backup_task = mgr_cluster.create_backup_task(location_list=self.locations, method=self.backup_method)
-        backup_task_status = backup_task.wait_and_get_final_status(timeout=1500)
-        assert backup_task_status == TaskStatus.DONE, (
-            f"Backup task ended in {backup_task_status} instead of {TaskStatus.DONE}"
-        )
+        backup_task = self.backup_with_manager_task(mgr_cluster)
         soft_timeout = 36 * 60
         hard_timeout = 50 * 60
         with adaptive_timeout(Operations.MGMT_REPAIR, self.db_cluster.data_nodes[0], timeout=soft_timeout):
@@ -135,14 +131,11 @@ class ManagerBackupTests(ManagerRestoreTests):
     def test_backup_and_restore(self):
         self.log.info("starting test_backup_and_restore")
         mgr_cluster = self.db_cluster.get_cluster_manager()
-        backup_task = mgr_cluster.create_backup_task(location_list=self.locations, method=self.backup_method)
-        backup_task_status = backup_task.wait_and_get_final_status(timeout=1500)
-        assert backup_task_status == TaskStatus.DONE, (
-            f"Backup task ended in {backup_task_status} instead of {TaskStatus.DONE}"
-        )
+
+        backup_task = self.backup_with_manager_task(mgr_cluster)
 
         self.truncate_tables()
-        self.restore_backup_with_task(
+        self.restore_with_manager_task(
             mgr_cluster=mgr_cluster,
             snapshot_tag=backup_task.get_snapshot_tag(),
             restore_data=True,
@@ -155,15 +148,12 @@ class ManagerBackupTests(ManagerRestoreTests):
     def test_backup_and_restore_without_manager(self):
         self.log.info("starting test_backup_and_restore_without_manager")
         mgr_cluster = self.db_cluster.get_cluster_manager()
-        backup_task = mgr_cluster.create_backup_task(location_list=self.locations, method=self.backup_method)
-        backup_task_status = backup_task.wait_and_get_final_status(timeout=1500)
-        assert backup_task_status == TaskStatus.DONE, (
-            f"Backup task ended in {backup_task_status} instead of {TaskStatus.DONE}"
-        )
+
+        backup_task = self.backup_with_manager_task(mgr_cluster)
 
         ks_tables_map = self.get_ks_tables_map()
         self.truncate_tables(ks_tables_map=ks_tables_map)
-        self.restore_backup_without_manager(
+        self.restore_with_nodetool_refresh(
             mgr_cluster=mgr_cluster,
             snapshot_tag=backup_task.get_snapshot_tag(),
             ks_tables_map=ks_tables_map,
@@ -181,15 +171,11 @@ class ManagerBackupTests(ManagerRestoreTests):
         self.log.debug("tables list = {}".format(tables))
         # TODO: insert data to those tables
 
-        backup_task = mgr_cluster.create_backup_task(location_list=self.locations, method=self.backup_method)
-        backup_task_status = backup_task.wait_and_get_final_status(timeout=1500)
-        assert backup_task_status == TaskStatus.DONE, (
-            f"Backup task ended in {backup_task_status} instead of {TaskStatus.DONE}"
-        )
+        backup_task = self.backup_with_manager_task(mgr_cluster)
 
         ks_tables_map = self.get_ks_tables_map()
         self.truncate_tables(ks_tables_map=ks_tables_map)
-        self.restore_backup_without_manager(
+        self.restore_with_nodetool_refresh(
             mgr_cluster=mgr_cluster,
             snapshot_tag=backup_task.get_snapshot_tag(),
             ks_tables_map=ks_tables_map,
@@ -215,17 +201,13 @@ class ManagerBackupTests(ManagerRestoreTests):
         rate_limit_list = [f"{dc}:{random.randint(15, 25)}" for dc in self.get_all_dcs_names()]
         self.log.info("rate limit will be {}".format(rate_limit_list))
 
-        backup_task = mgr_cluster.create_backup_task(
-            location_list=self.locations, rate_limit_list=rate_limit_list, method=self.backup_method
-        )
-        task_status = backup_task.wait_and_get_final_status(timeout=18000)
-        assert task_status == TaskStatus.DONE, f"Backup task ended in {task_status} instead of {TaskStatus.DONE}"
-        self.log.info("backup task finished with status {}".format(task_status))
+        backup_task = self.backup_with_manager_task(mgr_cluster, timeout=18000, rate_limit_list=rate_limit_list)
+        self.log.info("backup task finished with status {}".format(backup_task.status))
         # TODO: verify that the rate limit is as set in the cmd
 
         ks_tables_map = self.get_ks_tables_map()
         self.truncate_tables(ks_tables_map=ks_tables_map)
-        self.restore_backup_without_manager(
+        self.restore_with_nodetool_refresh(
             mgr_cluster=mgr_cluster,
             snapshot_tag=backup_task.get_snapshot_tag(),
             ks_tables_map=ks_tables_map,
@@ -324,13 +306,7 @@ class ManagerBackupTests(ManagerRestoreTests):
 
         self.log.info("starting test_enospc_before_restore")
         mgr_cluster = self.db_cluster.get_cluster_manager()
-        backup_task = mgr_cluster.create_backup_task(
-            location_list=self.locations, keyspace_list=["keyspace1"], method=self.backup_method
-        )
-        backup_task_status = backup_task.wait_and_get_final_status(timeout=1500)
-        assert backup_task_status == TaskStatus.DONE, (
-            f"Backup task ended in {backup_task_status} instead of {TaskStatus.DONE}"
-        )
+        backup_task = self.backup_with_manager_task(mgr_cluster, keyspace_list=["keyspace1"])
         target_node = self.db_cluster.nodes[1]
         with ignore_no_space_errors(node=target_node), ignore_stream_mutation_fragments_errors():
             try:
@@ -406,26 +382,18 @@ class ManagerBackupTests(ManagerRestoreTests):
         mgr_cluster = self.db_cluster.get_cluster_manager(force_add=True)
 
         self.log.info("Run backup #1")
-        backup_task_1 = mgr_cluster.create_backup_task(location_list=self.locations, method=self.backup_method)
-        backup_task_1_status = backup_task_1.wait_and_get_final_status(timeout=3600)
-        assert backup_task_1_status == TaskStatus.DONE, (
-            f"Backup task ended in {backup_task_1_status} instead of {TaskStatus.DONE}"
-        )
+        backup_task_1 = self.backup_with_manager_task(mgr_cluster, timeout=3600)
         self.log.info(f"Backup task #1 duration - {backup_task_1.duration}")
 
         self.log.info("Run backup #2")
-        backup_task_2 = mgr_cluster.create_backup_task(location_list=self.locations, method=self.backup_method)
-        backup_task_2_status = backup_task_2.wait_and_get_final_status(timeout=60)
-        assert backup_task_2_status == TaskStatus.DONE, (
-            f"Backup task ended in {backup_task_2_status} instead of {TaskStatus.DONE}"
-        )
+        backup_task_2 = self.backup_with_manager_task(mgr_cluster, timeout=60)
         self.log.info(f"Backup task #2 duration - {backup_task_2.duration}")
 
         assert backup_task_2.duration < timedelta(seconds=15), "No-delta backup took more than 15 seconds"
 
         self.log.info("Verify restore from backup #2")
         self.truncate_tables()
-        self.restore_backup_with_task(
+        self.restore_with_manager_task(
             mgr_cluster=mgr_cluster,
             snapshot_tag=backup_task_2.get_snapshot_tag(),
             restore_data=True,
@@ -945,12 +913,8 @@ class ManagerHelperTests(ManagerTestFunctionsMixIn):
         self.run_and_verify_stress_in_threads(cs_cmds=cs_write_cmds, stop_on_failure=True)
 
         self.log.info("Run backup and wait for it to finish")
-        backup_task = mgr_cluster.create_backup_task(
-            location_list=location_list, rate_limit_list=["0"], method=self.backup_method
-        )
-        backup_task_status = backup_task.wait_and_get_final_status(timeout=200000)
-        assert backup_task_status == TaskStatus.DONE, (
-            f"Backup task ended in {backup_task_status} instead of {TaskStatus.DONE}"
+        backup_task = self.backup_with_manager_task(
+            mgr_cluster, timeout=200000, location_list=location_list, rate_limit_list=["0"]
         )
 
         if is_cloud_manager:
@@ -1247,13 +1211,7 @@ class ManagerRestoreBenchmarkTests(ManagerTestFunctionsMixIn):
         manager_tool = mgmt.get_scylla_manager_tool(manager_node=self.monitors.nodes[0])
         mgr_cluster = self.db_cluster.get_cluster_manager()
 
-        backup_task = mgr_cluster.create_backup_task(
-            location_list=self.locations, rate_limit_list=["0"], method=self.backup_method
-        )
-        backup_task_status = backup_task.wait_and_get_final_status(timeout=200000)
-        assert backup_task_status == TaskStatus.DONE, (
-            f"Backup task ended in {backup_task_status} instead of {TaskStatus.DONE}"
-        )
+        backup_task = self.backup_with_manager_task(mgr_cluster, timeout=200000, rate_limit_list=["0"])
         InfoEvent(message=f"The backup task has ended successfully. Backup run time: {backup_task.duration}").publish()
         self.manager_test_metrics.backup_time = backup_task.duration
 
@@ -1263,7 +1221,7 @@ class ManagerRestoreBenchmarkTests(ManagerTestFunctionsMixIn):
             self.db_cluster.nodes[0].run_cqlsh(f"TRUNCATE {ks_name}.standard1")
 
         extra_params = self.get_restore_extra_parameters()
-        task = self.restore_backup_with_task(
+        task = self.restore_with_manager_task(
             mgr_cluster=mgr_cluster,
             snapshot_tag=backup_task.get_snapshot_tag(),
             timeout=110000,
@@ -1316,7 +1274,7 @@ class ManagerRestoreBenchmarkTests(ManagerTestFunctionsMixIn):
             self.db_cluster.nodes[0].run_cqlsh(cmd="grant scylla_admin to scylla_manager")
 
         self.log.info("Restoring the schema")
-        self.restore_backup_with_task(
+        self.restore_with_manager_task(
             mgr_cluster=mgr_cluster,
             snapshot_tag=snapshot_data.tag,
             timeout=600,
@@ -1327,7 +1285,7 @@ class ManagerRestoreBenchmarkTests(ManagerTestFunctionsMixIn):
         if restore_outside_manager:
             self.log.info("Restoring the data outside the Manager")
             with ExecutionTimer() as timer:
-                self.restore_backup_without_manager(
+                self.restore_with_nodetool_refresh(
                     mgr_cluster=mgr_cluster,
                     snapshot_tag=snapshot_data.tag,
                     ks_tables_map=snapshot_data.ks_tables_map,
@@ -1338,7 +1296,7 @@ class ManagerRestoreBenchmarkTests(ManagerTestFunctionsMixIn):
         else:
             self.log.info("Restoring the data")
             extra_params = self.get_restore_extra_parameters()
-            task = self.restore_backup_with_task(
+            task = self.restore_with_manager_task(
                 mgr_cluster=mgr_cluster,
                 snapshot_tag=snapshot_data.tag,
                 restore_data=True,

--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -132,7 +132,7 @@ class ManagerRestoreTests(ManagerTestFunctionsMixIn):
 
 
 class ManagerBackupTests(ManagerRestoreTests):
-    def test_backup_and_restore(self, restore_with_task: bool = True, ks_names: list = None):
+    def test_backup_and_restore(self, restore_with_task: bool = True):
         self.log.info(f"starting test_backup_and_restore[restore_with_task={restore_with_task}]")
         mgr_cluster = self.db_cluster.get_cluster_manager()
         backup_task = mgr_cluster.create_backup_task(location_list=self.locations, method=self.backup_method)
@@ -146,7 +146,7 @@ class ManagerBackupTests(ManagerRestoreTests):
             ks_names=ks_names,
             restore_data_with_task=restore_with_task,
         )
-        self.run_verification_read_stress(ks_names)
+        self.run_verification_read_stress()
         mgr_cluster.delete()  # remove cluster at the end of the test
         self.log.info(f"finishing test_backup_and_restore[restore_with_task={restore_with_task}]")
 
@@ -955,7 +955,7 @@ class ManagerSanityTests(
     ManagerSuspendTests,
     ManagerEncryptionTests,
 ):
-    def test_manager_sanity(self, prepared_ks: bool = False, ks_names: list = None):
+    def test_manager_sanity(self, prepared_ks: bool = False):
         """
         Test steps:
         1) Generate load (unless keyspaces are pre-created via prepared_ks).
@@ -975,9 +975,9 @@ class ManagerSanityTests(
 
         if not is_multi_dc_cluster:
             with self.subTest("Backup and restore (via nodetool refresh, out of Manager) test"):
-                self.test_backup_and_restore(restore_with_task=False, ks_names=ks_names)
+                self.test_backup_and_restore(restore_with_task=False)
         with self.subTest("Backup and restore (via Manager task) test"):
-            self.test_backup_and_restore(restore_with_task=True, ks_names=ks_names)
+            self.test_backup_and_restore(restore_with_task=True)
         with self.subTest("Repair multiple keyspace types test"):
             self.test_repair_multiple_keyspace_types()
         with self.subTest("Manager cluster CRUD operations test"):
@@ -1003,13 +1003,12 @@ class ManagerSanityTests(
         self.log.info("starting test_manager_sanity_vnodes_tablets_cluster")
 
         ks_config = [("tablets_keyspace", True), ("vnodes_keyspace", False)]
-        ks_names = [i[0] for i in ks_config]
         for ks_name, tablets_enabled in ks_config:
             tablets_config = TabletsConfiguration(enabled=tablets_enabled)
             self.create_keyspace(ks_name, replication_factor=3, tablets_config=tablets_config)
             self.generate_load_and_wait_for_results(keyspace_name=ks_name)
 
-        self.test_manager_sanity(prepared_ks=True, ks_names=ks_names)
+        self.test_manager_sanity(prepared_ks=True)
 
         self.log.info("finishing test_manager_sanity_vnodes_tablets_cluster")
 

--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -133,11 +133,19 @@ class ManagerBackupTests(ManagerRestoreTests):
         mgr_cluster = self.db_cluster.get_cluster_manager()
 
         backup_task = self.backup_with_manager_task(mgr_cluster)
+        snapshot_tag = backup_task.get_snapshot_tag()
 
-        self.truncate_tables()
+        for ks in self.db_cluster.get_test_keyspaces():
+            self.db_cluster.nodes[0].run_cqlsh(f"DROP KEYSPACE IF EXISTS {ks}")
+
         self.restore_with_manager_task(
             mgr_cluster=mgr_cluster,
-            snapshot_tag=backup_task.get_snapshot_tag(),
+            snapshot_tag=snapshot_tag,
+            restore_schema=True,
+        )
+        self.restore_with_manager_task(
+            mgr_cluster=mgr_cluster,
+            snapshot_tag=snapshot_tag,
             restore_data=True,
         )
 

--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -132,36 +132,69 @@ class ManagerRestoreTests(ManagerTestFunctionsMixIn):
 
 
 class ManagerBackupTests(ManagerRestoreTests):
-    def test_backup_and_restore(self, restore_with_task: bool = True):
-        self.log.info(f"starting test_backup_and_restore[restore_with_task={restore_with_task}]")
+    def test_backup_and_restore(self):
+        self.log.info("starting test_backup_and_restore")
         mgr_cluster = self.db_cluster.get_cluster_manager()
         backup_task = mgr_cluster.create_backup_task(location_list=self.locations, method=self.backup_method)
         backup_task_status = backup_task.wait_and_get_final_status(timeout=1500)
         assert backup_task_status == TaskStatus.DONE, (
             f"Backup task ended in {backup_task_status} instead of {TaskStatus.DONE}"
         )
-        self.verify_backup_success(
+
+        self.truncate_tables()
+        self.restore_backup_with_task(
             mgr_cluster=mgr_cluster,
-            backup_task=backup_task,
-            ks_names=ks_names,
-            restore_data_with_task=restore_with_task,
+            snapshot_tag=backup_task.get_snapshot_tag(),
+            restore_data=True,
         )
+
         self.run_verification_read_stress()
         mgr_cluster.delete()  # remove cluster at the end of the test
-        self.log.info(f"finishing test_backup_and_restore[restore_with_task={restore_with_task}]")
+        self.log.info("finishing test_backup_and_restore")
+
+    def test_backup_and_restore_without_manager(self):
+        self.log.info("starting test_backup_and_restore_without_manager")
+        mgr_cluster = self.db_cluster.get_cluster_manager()
+        backup_task = mgr_cluster.create_backup_task(location_list=self.locations, method=self.backup_method)
+        backup_task_status = backup_task.wait_and_get_final_status(timeout=1500)
+        assert backup_task_status == TaskStatus.DONE, (
+            f"Backup task ended in {backup_task_status} instead of {TaskStatus.DONE}"
+        )
+
+        ks_tables_map = self.get_ks_tables_map()
+        self.truncate_tables(ks_tables_map=ks_tables_map)
+        self.restore_backup_without_manager(
+            mgr_cluster=mgr_cluster,
+            snapshot_tag=backup_task.get_snapshot_tag(),
+            ks_tables_map=ks_tables_map,
+        )
+
+        self.run_verification_read_stress()
+        mgr_cluster.delete()  # remove cluster at the end of the test
+        self.log.info("finishing test_backup_and_restore_without_manager")
 
     def test_backup_multiple_ks_tables(self):
         self.log.info("starting test_backup_multiple_ks_tables")
         mgr_cluster = self.db_cluster.get_cluster_manager()
+
         tables = self.create_ks_and_tables(10, 100)
         self.log.debug("tables list = {}".format(tables))
         # TODO: insert data to those tables
+
         backup_task = mgr_cluster.create_backup_task(location_list=self.locations, method=self.backup_method)
         backup_task_status = backup_task.wait_and_get_final_status(timeout=1500)
         assert backup_task_status == TaskStatus.DONE, (
             f"Backup task ended in {backup_task_status} instead of {TaskStatus.DONE}"
         )
-        self.verify_backup_success(mgr_cluster=mgr_cluster, backup_task=backup_task)
+
+        ks_tables_map = self.get_ks_tables_map()
+        self.truncate_tables(ks_tables_map=ks_tables_map)
+        self.restore_backup_without_manager(
+            mgr_cluster=mgr_cluster,
+            snapshot_tag=backup_task.get_snapshot_tag(),
+            ks_tables_map=ks_tables_map,
+        )
+
         self.log.info("finishing test_backup_multiple_ks_tables")
 
     def test_backup_location_with_path(self):
@@ -178,18 +211,26 @@ class ManagerBackupTests(ManagerRestoreTests):
     def test_backup_rate_limit(self):
         self.log.info("starting test_backup_rate_limit")
         mgr_cluster = self.db_cluster.get_cluster_manager()
+
         rate_limit_list = [f"{dc}:{random.randint(15, 25)}" for dc in self.get_all_dcs_names()]
         self.log.info("rate limit will be {}".format(rate_limit_list))
+
         backup_task = mgr_cluster.create_backup_task(
             location_list=self.locations, rate_limit_list=rate_limit_list, method=self.backup_method
         )
         task_status = backup_task.wait_and_get_final_status(timeout=18000)
-        assert task_status == TaskStatus.DONE, (
-            f"Task {backup_task.id} did not end successfully:\n{backup_task.detailed_progress}"
-        )
+        assert task_status == TaskStatus.DONE, f"Backup task ended in {task_status} instead of {TaskStatus.DONE}"
         self.log.info("backup task finished with status {}".format(task_status))
         # TODO: verify that the rate limit is as set in the cmd
-        self.verify_backup_success(mgr_cluster=mgr_cluster, backup_task=backup_task)
+
+        ks_tables_map = self.get_ks_tables_map()
+        self.truncate_tables(ks_tables_map=ks_tables_map)
+        self.restore_backup_without_manager(
+            mgr_cluster=mgr_cluster,
+            snapshot_tag=backup_task.get_snapshot_tag(),
+            ks_tables_map=ks_tables_map,
+        )
+
         self.log.info("finishing test_backup_rate_limit")
 
     def test_backup_purge_removes_orphan_files(self):
@@ -383,8 +424,12 @@ class ManagerBackupTests(ManagerRestoreTests):
         assert backup_task_2.duration < timedelta(seconds=15), "No-delta backup took more than 15 seconds"
 
         self.log.info("Verify restore from backup #2")
-        self.verify_backup_success(
-            mgr_cluster=mgr_cluster, backup_task=backup_task_2, restore_data_with_task=True, timeout=3600
+        self.truncate_tables()
+        self.restore_backup_with_task(
+            mgr_cluster=mgr_cluster,
+            snapshot_tag=backup_task_2.get_snapshot_tag(),
+            restore_data=True,
+            timeout=3600,
         )
 
         self.log.info("Run verification read stress")
@@ -975,9 +1020,9 @@ class ManagerSanityTests(
 
         if not is_multi_dc_cluster:
             with self.subTest("Backup and restore (via nodetool refresh, out of Manager) test"):
-                self.test_backup_and_restore(restore_with_task=False)
+                self.test_backup_and_restore_without_manager()
         with self.subTest("Backup and restore (via Manager task) test"):
-            self.test_backup_and_restore(restore_with_task=True)
+            self.test_backup_and_restore()
         with self.subTest("Repair multiple keyspace types test"):
             self.test_repair_multiple_keyspace_types()
         with self.subTest("Manager cluster CRUD operations test"):
@@ -1285,7 +1330,7 @@ class ManagerRestoreBenchmarkTests(ManagerTestFunctionsMixIn):
                 self.restore_backup_without_manager(
                     mgr_cluster=mgr_cluster,
                     snapshot_tag=snapshot_data.tag,
-                    ks_tables_list=snapshot_data.ks_tables_map,
+                    ks_tables_map=snapshot_data.ks_tables_map,
                     location=locations[0],
                     precreated_backup=True,
                 )

--- a/mgmt_upgrade_test.py
+++ b/mgmt_upgrade_test.py
@@ -213,17 +213,23 @@ class ManagerUpgradeTest(ManagerTestFunctionsMixIn, ClusterTester):
                 f"Task {stopped_backup_task.id} failed to continue after Manager upgrade"
             )
 
-        with self.subTest("Restoring an older version backup task with newer version of Manager"):
-            self.verify_backup_success(mgr_cluster=mgr_cluster, backup_task=backup_task, ks_names=["keyspace1"])
+        with self.subTest("Restoring an older version backup task with nodetool refresh"):
+            ks_tables_map = self.get_ks_tables_map(keyspace_filter=["keyspace1"])
+            self.truncate_tables(ks_tables_map=ks_tables_map)
+            self.restore_backup_without_manager(
+                mgr_cluster=mgr_cluster,
+                snapshot_tag=backup_task_snapshot,
+                ks_tables_map=ks_tables_map,
+            )
             self.run_verification_read_stress(ks_names=["keyspace1"])
 
-        with self.subTest("Restoring an older version backup task with newer version of Manager, using a restore task"):
-            self.verify_backup_success(
+        with self.subTest("Restoring an older version backup task with a Manager restore task"):
+            self.truncate_tables(ks_tables_map=ks_tables_map)
+            self.restore_backup_with_task(
                 mgr_cluster=mgr_cluster,
-                backup_task=backup_task,
-                restore_data_with_task=True,
+                snapshot_tag=backup_task_snapshot,
+                restore_data=True,
                 timeout=600,
-                ks_names=["keyspace1"],
             )
             self.run_verification_read_stress(ks_names=["keyspace1"])
 

--- a/mgmt_upgrade_test.py
+++ b/mgmt_upgrade_test.py
@@ -215,7 +215,7 @@ class ManagerUpgradeTest(ManagerTestFunctionsMixIn, ClusterTester):
 
         with self.subTest("Restoring an older version backup task with newer version of Manager"):
             self.verify_backup_success(mgr_cluster=mgr_cluster, backup_task=backup_task, ks_names=["keyspace1"])
-            self.run_verification_read_stress()
+            self.run_verification_read_stress(ks_names=["keyspace1"])
 
         with self.subTest("Restoring an older version backup task with newer version of Manager, using a restore task"):
             self.verify_backup_success(
@@ -225,7 +225,7 @@ class ManagerUpgradeTest(ManagerTestFunctionsMixIn, ClusterTester):
                 timeout=600,
                 ks_names=["keyspace1"],
             )
-            self.run_verification_read_stress()
+            self.run_verification_read_stress(ks_names=["keyspace1"])
 
         with self.subTest(
             "Executing the 'backup list' and 'backup files' commands on a older version backup"

--- a/mgmt_upgrade_test.py
+++ b/mgmt_upgrade_test.py
@@ -216,7 +216,7 @@ class ManagerUpgradeTest(ManagerTestFunctionsMixIn, ClusterTester):
         with self.subTest("Restoring an older version backup task with nodetool refresh"):
             ks_tables_map = self.get_ks_tables_map(keyspace_filter=["keyspace1"])
             self.truncate_tables(ks_tables_map=ks_tables_map)
-            self.restore_backup_without_manager(
+            self.restore_with_nodetool_refresh(
                 mgr_cluster=mgr_cluster,
                 snapshot_tag=backup_task_snapshot,
                 ks_tables_map=ks_tables_map,
@@ -225,7 +225,7 @@ class ManagerUpgradeTest(ManagerTestFunctionsMixIn, ClusterTester):
 
         with self.subTest("Restoring an older version backup task with a Manager restore task"):
             self.truncate_tables(ks_tables_map=ks_tables_map)
-            self.restore_backup_with_task(
+            self.restore_with_manager_task(
                 mgr_cluster=mgr_cluster,
                 snapshot_tag=backup_task_snapshot,
                 restore_data=True,

--- a/sdcm/mgmt/operations.py
+++ b/sdcm/mgmt/operations.py
@@ -589,6 +589,38 @@ class DatabaseOperations(ClusterTester):
             target_node = self.db_cluster.nodes[2]
             self.delete_keyspace_directory(db_node=target_node, keyspace_name="keyspace1")
 
+    def get_ks_tables_map(self, keyspace_filter: list[str] | None = None) -> dict[str, list[str]]:
+        """Discover non-system keyspaces and their tables, excluding materialized views.
+
+        Args:
+            keyspace_filter: If provided, only include these keyspaces
+        """
+        ks_cf_list = self.db_cluster.get_non_system_ks_cf_list(
+            db_node=self.db_cluster.nodes[0],
+            filter_out_mv=True,
+            filter_by_keyspace=keyspace_filter,
+        )
+        ks_tables_map: dict[str, list[str]] = {}
+        for ks_cf in ks_cf_list:
+            ks, table = ks_cf.split(".", maxsplit=1)
+            ks_tables_map.setdefault(ks, []).append(table)
+        self.log.debug(f"ks_tables_map: {ks_tables_map}")
+        if not ks_tables_map:
+            raise ValueError("No non-system tables were found")
+        return ks_tables_map
+
+    def truncate_tables(self, ks_tables_map: dict[str, list[str]] | None = None) -> None:
+        """Truncate all tables in the given keyspace-tables map.
+
+        If ks_tables_map is not provided, it is fetched automatically via get_ks_tables_map().
+        """
+        if ks_tables_map is None:
+            ks_tables_map = self.get_ks_tables_map()
+        for ks, tables in ks_tables_map.items():
+            for table_name in tables:
+                self.log.info(f"Truncating {ks}.{table_name}")
+                self.db_cluster.nodes[0].run_cqlsh(f"TRUNCATE {ks}.{table_name}")
+
 
 class StressLoadOperations(ClusterTester, LoaderUtilsMixin):
     def _get_total_loaders(self) -> int:
@@ -753,51 +785,6 @@ class ManagerTestFunctionsMixIn(
         else:
             return None
 
-    def verify_backup_success(
-        self,
-        mgr_cluster,
-        backup_task,
-        ks_names: list = None,
-        truncate=True,
-        restore_data_with_task=False,
-        timeout=None,
-    ):
-        snapshot_tag = backup_task.get_snapshot_tag()
-        ks_tables_map: dict[str, list[str]] = {}
-
-        ks_cf_list = self.db_cluster.get_non_system_ks_cf_list(
-            db_node=self.db_cluster.nodes[0],
-            filter_out_mv=True,
-            filter_by_keyspace=ks_names,
-        )
-        for ks_cf in ks_cf_list:
-            ks, table = ks_cf.split(".", maxsplit=1)
-            ks_tables_map.setdefault(ks, []).append(table)
-        self.log.debug(f"ks_tables_map: {ks_tables_map}")
-        if not ks_tables_map:
-            raise ValueError("No non-system tables were found for backup restore verification")
-
-        if truncate:
-            for ks, tables in ks_tables_map.items():
-                for table_name in tables:
-                    self.log.info(f"running truncate on {ks}.{table_name}")
-                    self.db_cluster.nodes[0].run_cqlsh(f"TRUNCATE {ks}.{table_name}")
-
-        if restore_data_with_task:
-            self.restore_backup_with_task(
-                mgr_cluster=mgr_cluster,
-                snapshot_tag=snapshot_tag,
-                timeout=timeout,
-                restore_data=True,
-            )
-            return
-
-        self.restore_backup_without_manager(
-            mgr_cluster=mgr_cluster,
-            snapshot_tag=snapshot_tag,
-            ks_tables_list=ks_tables_map,
-        )
-
     def verify_alternator_backup_success(self, mgr_cluster, backup_task, delete_tables: list = None, timeout=None):
         for table_name in delete_tables:
             self.log.info(f"running delete on {table_name}")
@@ -810,7 +797,7 @@ class ManagerTestFunctionsMixIn(
         )
 
     def restore_backup_without_manager(
-        self, mgr_cluster, snapshot_tag, ks_tables_list, location=None, precreated_backup=False
+        self, mgr_cluster, snapshot_tag, ks_tables_map, location=None, precreated_backup=False
     ):
         """Restore backup without Scylla Manager but using the `nodetool refresh` operation
         (https://opensource.docs.scylladb.com/stable/operating-scylla/nodetool-commands/refresh.html).
@@ -849,7 +836,7 @@ class ManagerTestFunctionsMixIn(
             # If the backup was not created with the cluster under test (precreated backup), get node_id from
             # sctool backup files output, otherwise, use node_ids of cluster under test
             backed_up_node_id = backed_up_node_ids[index] if precreated_backup else node.host_id
-            for keyspace, tables in ks_tables_list.items():
+            for keyspace, tables in ks_tables_map.items():
                 keyspace_path = node_data_path / keyspace
                 for table in tables:
                     table_id = self.get_table_id(node=node, table_name=table, keyspace_name=keyspace)
@@ -870,7 +857,7 @@ class ManagerTestFunctionsMixIn(
         self,
         mgr_cluster,
         snapshot_tag,
-        timeout,
+        timeout=1500,
         restore_schema=False,
         restore_data=False,
         location_list=None,

--- a/sdcm/mgmt/operations.py
+++ b/sdcm/mgmt/operations.py
@@ -26,7 +26,6 @@ from sdcm.utils.compaction_ops import CompactionOps
 from sdcm.utils.gce_utils import get_gce_storage_client
 from sdcm.utils.loader_utils import LoaderUtilsMixin
 from sdcm.utils.time_utils import ExecutionTimer
-from sdcm.utils.version_utils import ComparableScyllaVersion
 
 
 class ClusterOperations(ClusterTester):
@@ -892,10 +891,6 @@ class ManagerTestFunctionsMixIn(
         InfoEvent(
             message=f"The restore task has ended successfully. Restore run time: {restore_task.duration}."
         ).publish()
-
-        should_restart = restore_schema and ComparableScyllaVersion(self.db_cluster.nodes[0].scylla_version) <= "2024.1"
-        if should_restart:
-            self.db_cluster.restart_scylla()
 
         return restore_task
 

--- a/sdcm/mgmt/operations.py
+++ b/sdcm/mgmt/operations.py
@@ -648,16 +648,18 @@ class StressLoadOperations(ClusterTester, LoaderUtilsMixin):
         time.sleep(15)
         return stress_thread
 
-    def run_verification_read_stress(self, ks_names=None):
+    def run_verification_read_stress(self, ks_names: list[str] | None = None):
         stress_queue = []
         stress_cmd = self.params.get("stress_read_cmd")
-        keyspace_num = self.params.get("keyspace_num")
+
+        if ks_names is None:
+            ks_names = self.db_cluster.get_test_keyspaces()
+        assert ks_names, "No keyspaces provided for data verification"
+
         InfoEvent(message="Starting read stress for data verification").publish()
         stress_start_time = datetime.now()
-        if ks_names:
-            self.assemble_and_run_all_stress_cmd_by_ks_names(stress_queue, stress_cmd, ks_names)
-        else:
-            self.assemble_and_run_all_stress_cmd(stress_queue, stress_cmd, keyspace_num)
+        self.log.debug(f"Running read stress for keyspaces: {ks_names}")
+        self.assemble_and_run_all_stress_cmd_by_ks_names(stress_queue, stress_cmd, ks_names)
         for stress in stress_queue:
             self.verify_stress_thread(stress)
         stress_run_time = datetime.now() - stress_start_time

--- a/sdcm/mgmt/operations.py
+++ b/sdcm/mgmt/operations.py
@@ -789,14 +789,14 @@ class ManagerTestFunctionsMixIn(
         for table_name in delete_tables:
             self.log.info(f"running delete on {table_name}")
             self.alternator.delete_table(self.db_cluster.nodes[0], table_name=table_name, wait_until_table_removed=True)
-        self.restore_backup_with_task(
+        self.restore_with_manager_task(
             mgr_cluster=mgr_cluster, snapshot_tag=backup_task.get_snapshot_tag(), timeout=timeout, restore_schema=True
         )
-        self.restore_backup_with_task(
+        self.restore_with_manager_task(
             mgr_cluster=mgr_cluster, snapshot_tag=backup_task.get_snapshot_tag(), timeout=timeout, restore_data=True
         )
 
-    def restore_backup_without_manager(
+    def restore_with_nodetool_refresh(
         self, mgr_cluster, snapshot_tag, ks_tables_map, location=None, precreated_backup=False
     ):
         """Restore backup without Scylla Manager but using the `nodetool refresh` operation
@@ -853,7 +853,16 @@ class ManagerTestFunctionsMixIn(
                         node.run_nodetool(f"refresh {keyspace} {table} {nodetool_refresh_extra_flags}")
                     self.log.info(f"[Node {index}][{keyspace}.{table}] Nodetool refresh took {timer.duration}")
 
-    def restore_backup_with_task(
+    def backup_with_manager_task(self, mgr_cluster, timeout=1500, **kwargs):
+        """Create a backup task, wait for completion, assert success, and return the task."""
+        location_list = kwargs.pop("location_list", self.locations)
+        method = kwargs.pop("method", self.backup_method)
+        backup_task = mgr_cluster.create_backup_task(location_list=location_list, method=method, **kwargs)
+        task_status = backup_task.wait_and_get_final_status(timeout=timeout)
+        assert task_status == TaskStatus.DONE, f"Backup task ended in {task_status} instead of {TaskStatus.DONE}"
+        return backup_task
+
+    def restore_with_manager_task(
         self,
         mgr_cluster,
         snapshot_tag,


### PR DESCRIPTION
Closes https://scylladb.atlassian.net/browse/CLOUD-1699

## Summary

Refactor the manager backup/restore test infrastructure to remove duplication, clarify method naming, and extend `test_backup_and_restore` to exercise the full schema+data restore path (previously only data restore was tested).

## Changes

### Remove dead compatibility code
- Remove post-schema-restore restart logic (Scylla <= 2024.1 is no longer supported)

### Simplify `run_verification_read_stress`
- Auto-detect non-system keyspaces via `db_cluster.get_test_keyspaces()` instead of threading `ks_names` through callers
- Remove the dead `assemble_and_run_all_stress_cmd` fallback path

### Remove `verify_backup_success` monolith
- Extract `get_ks_tables_map()` and `truncate_tables()` as standalone reusable helpers
- Callers now explicitly choose their restore method and handle truncation directly, removing hidden branching logic (`restore_data_with_task` flag)

### Rename methods for clarity
- `restore_backup_with_task` → `restore_with_manager_task`
- `restore_backup_without_manager` → `restore_with_nodetool_refresh`

### Extract `backup_with_manager_task` helper
- Encapsulates the repeated create → wait → assert DONE pattern
- Converts 9 eligible call sites, removing ~55 lines of boilerplate

### Extend `test_backup_and_restore` with schema restoration
- Replace truncate + data-only restore with the full flow: drop keyspaces → restore schema → restore data → verify
- This test is called from `test_manager_sanity`, so schema restore is now part of the sanity suite

## Files Changed

| File | Change |
|------|--------|
| `sdcm/mgmt/operations.py` | Remove `verify_backup_success`, extract helpers, add `backup_with_manager_task`, rename methods, remove restart logic |
| `mgmt_cli_test.py` | Convert all callers to new API, extend `test_backup_and_restore` |
| `mgmt_upgrade_test.py` | Update callers to renamed methods |

## Testing

- [x] [ubuntu24-vnodes-tablets-enterprise-sanity-test](https://jenkins.scylladb.com/job/scylla-staging/job/mikita/job/manager-master-clone/job/ubuntu24-vnodes-tablets-enterprise-sanity-test/6/)
- [x] [ubuntu24-sanity-test](https://jenkins.scylladb.com/job/scylla-staging/job/mikita/job/manager-master-clone/job/ubuntu24-sanity-test/20/)
- [x] [ubuntu24-upgrade-test](https://jenkins.scylladb.com/job/scylla-staging/job/mikita/job/manager-master-clone/job/ubuntu24-upgrade-test/12/)