### PR TITLE
fix: handle comma-separated availability_zone in GCE provisioner

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4404,9 +4404,9 @@ class BaseCluster:
                     for idx in range(num):
                         nodes_per_az[idx % azs] += 1
                     for az_index in range(azs):
-                        # NOTE: OCI pre-provisioner places VMs using per-node round-robin
+                        # NOTE: OCI and GCE pre-provisioners place VMs using per-node round-robin
                         #       so rack must be 'None' to let the 'add_nodes' derive it from the 'node_index'.
-                        if self.params.get("simulated_racks") or self.params.get("cluster_backend") == "oci":
+                        if self.params.get("simulated_racks") or self.params.get("cluster_backend") in ("oci", "gce"):
                             rack = None
                         else:
                             rack = az_index
@@ -4419,7 +4419,7 @@ class BaseCluster:
                 for idx in range(n_nodes):
                     nodes_per_az[idx % azs] += 1
                 for az_index in range(azs):
-                    if self.params.get("simulated_racks") or self.params.get("cluster_backend") == "oci":
+                    if self.params.get("simulated_racks") or self.params.get("cluster_backend") in ("oci", "gce"):
                         rack = None
                     else:
                         rack = az_index

--- a/sdcm/cluster_gce.py
+++ b/sdcm/cluster_gce.py
@@ -38,6 +38,7 @@ from sdcm.utils.gce_utils import (
     SECONDARY_NIC_ROUTING_SERVICE,
     SECONDARY_NIC_ROUTING_SERVICE_UNIT,
     GceLoggingClient,
+    gce_instance_zone,
     get_gce_compute_disks_client,
     get_alternative_zones,
     wait_for_extended_operation,
@@ -287,7 +288,7 @@ class GCENode(cluster.BaseNode):
 
     @property
     def zone(self):
-        return self._instance.zone.split("/")[-1]
+        return gce_instance_zone(self._instance)
 
     def set_hostname(self):
         self.log.debug("Hostname for node %s left as is", self.name)
@@ -433,7 +434,7 @@ class GCECluster(cluster.BaseCluster):
         # Use provisioner's zones to ensure consistency - provisioners already resolved random_zone() if needed
         self._gce_zone_names: list[str] = [provisioner.availability_zone for provisioner in provisioners]
         # Keep this print out for debugging purposes: validate that zones are correctly set
-        LOGGER.debug("GCE zones used: %s", self._gce_zone_names)
+        LOGGER.debug("GCE zones used: %s", [provisioner.availability_zones for provisioner in provisioners])
         self._gce_n_local_ssd = int(gce_n_local_ssd) if gce_n_local_ssd else 0
         self._add_disks = add_disks
         # the full node prefix will contain unique uuid, so use this for search of existing nodes
@@ -476,20 +477,28 @@ class GCECluster(cluster.BaseCluster):
             return bool(value)
         return False
 
-    def _create_instances(self, count, dc_idx=0, instance_type=None):
+    def _create_instances(self, node_indexes: list[int], dc_idx=0, rack=None, instance_type=None):
+        """Provision instances for the given node indexes, placing them in the zone of `rack`.
+
+        `rack` is handed to the provisioner as the definition's rack index, which selects the zone -
+        the GCE equivalent of picking the AZ subnet on AWS. When it is None the provisioner falls
+        back to the node index, so placement stays keyed on the node rather than on the batch.
+        """
+        count = len(node_indexes)
         region = self._definition_builder.regions[dc_idx]
         pricing_model = PricingModel.SPOT if "spot" in self.instance_provision else PricingModel.ON_DEMAND
         definitions = []
-        for node_index in range(self._node_index + 1, self._node_index + count + 1):
-            definitions.append(
-                self._definition_builder.build_instance_definition(
-                    region=region,
-                    node_type=self.node_type,
-                    index=node_index,
-                    dc_idx=dc_idx,
-                    instance_type=instance_type,
-                )
+        for node_index in node_indexes:
+            definition = self._definition_builder.build_instance_definition(
+                region=region,
+                node_type=self.node_type,
+                index=node_index,
+                dc_idx=dc_idx,
+                instance_type=instance_type,
             )
+            if rack is not None:
+                definition.rack_index = rack
+            definitions.append(definition)
         try:
             return provision_instances_with_fallback(
                 self.provisioners[dc_idx],
@@ -501,6 +510,14 @@ class GCECluster(cluster.BaseCluster):
             if isinstance(exc, ProvisionError) and not _is_zone_exhausted(exc):
                 raise
             if not self.is_az_fallback_enabled:
+                raise
+            if len(self.provisioners[dc_idx].availability_zones) > 1:
+                # Replacing a multi-AZ provisioner with a single-zone one would collapse the
+                # cluster into one zone; there is also no way to tell which zone was exhausted.
+                self.log.warning(
+                    "AZ fallback is not supported for a multi-AZ configuration (%s), not retrying",
+                    self.provisioners[dc_idx].availability_zones,
+                )
                 raise
             if count > 1:
                 self.log.warning(
@@ -565,28 +582,27 @@ class GCECluster(cluster.BaseCluster):
     def _destroy_instance(self, name: str, dc_idx: int):
         target_node = self._get_instances_by_name(dc_idx=dc_idx, name=name)
         operation = self._gce_service.delete(
-            instance=target_node, project=self.project, zone=self.provisioners[dc_idx].availability_zone
+            instance=target_node, project=self.project, zone=gce_instance_zone(target_node)
         )
         wait_for_extended_operation(operation, "Wait for instance deletion")
 
     def _get_instances_by_prefix(self, dc_idx: int = 0):
-        instances_by_zone = self._gce_service.list(
-            project=self.project, zone=self.provisioners[dc_idx].availability_zone
-        )
-        return [node for node in instances_by_zone if node.name.startswith(self._node_prefix)]
+        instances = []
+        for zone in self.provisioners[dc_idx].availability_zones:
+            instances.extend(self._gce_service.list(project=self.project, zone=zone))
+        return [node for node in instances if node.name.startswith(self._node_prefix)]
 
     def _get_instances_by_name(self, name: str, dc_idx: int = 0):
-        """Search for an instance by name in the zone where the provisioner created it.
+        """Search for an instance by name in every zone of the DC's region.
 
-        Uses the provisioner's zone to ensure we search in the same zone where instances
-        are created, avoiding mismatches when availability_zone is not specified and
-        random_zone() is used independently.
+        A multi-AZ cluster has its nodes spread over several zones of one region, so the search
+        cannot be pinned to a single zone - the provisioner's own zone is just the first of them.
         """
-        zone = self.provisioners[dc_idx].availability_zone
+        region = self.provisioners[dc_idx].region
         all_instances = self._gce_service.aggregated_list(project=self.project)
         for zone_key, response in all_instances:
             # zone_key format is "zones/zone-name"
-            if response.instances and zone in zone_key:
+            if response.instances and zone_key.split("/")[-1].startswith(f"{region}-"):
                 for instance in response.instances:
                     if instance.name == name:
                         return instance
@@ -612,15 +628,13 @@ class GCECluster(cluster.BaseCluster):
             raise CreateGCENodeError(f"Instance {name} is not in RUNNING state: {instance.status}")
         return instance
 
-    def _get_instances(self, dc_idx: int) -> list[compute_v1.Instance]:
+    def _get_instances(self, dc_idx: int, az_idx: int | None = None) -> list[compute_v1.Instance]:
         test_id = self.test_config.test_id()
         if not test_id:
             raise ValueError("test_id should be configured for using reuse_cluster")
 
         instances_by_tags = list_instances_gce(tags_dict={"TestId": test_id, "NodeType": self.node_type})
-        # Use provisioner's zone to extract region, ensuring consistency with where instances are created
-        provisioner_zone = self.provisioners[dc_idx].availability_zone
-        region = provisioner_zone[:-2]  # Remove zone suffix (e.g., "us-east1-b" -> "us-east1")
+        region = self.provisioners[dc_idx].region
         # Use ssh_connection_ip_type from params if _node_public_ips is not yet set (during __init__)
         # If _node_public_ips exists, use it; otherwise fallback to ssh_connection_ip_type
         if hasattr(self, "_node_public_ips"):
@@ -636,12 +650,43 @@ class GCECluster(cluster.BaseCluster):
         existing_node_names = {node.name for node in self.nodes}
         instances = [instance for instance in instances if instance.name not in existing_node_names]
 
+        if az_idx is not None and instances:
+            instances = self._instances_in_az(instances, az_idx, dc_idx)
+
         def sort_by_index(instance):
             metadata = gce_meta_to_dict(instance.metadata)
             return metadata.get("NodeIndex", 0)
 
         instances = sorted(instances, key=sort_by_index)
         return instances
+
+    def _instances_in_az(
+        self, instances: list[compute_v1.Instance], az_idx: int, dc_idx: int
+    ) -> list[compute_v1.Instance]:
+        """Keep only the instances that live in the zone of rack `az_idx` of the given DC.
+
+        The rack order comes from the DC's own provisioner rather than the raw `availability_zone`
+        param, so it reflects the zones actually in use once `GceAZResolver` has resolved them.
+
+        Bucketing itself goes by the zone each instance is actually in, so an instance is found
+        under the zone it really occupies rather than the one it was meant to occupy.
+        """
+        rack_letters = [zone.rsplit("-", 1)[-1] for zone in self.provisioners[dc_idx].availability_zones]
+        if len(rack_letters) < 2:
+            # A single rack owns every instance of the DC, wherever runtime AZ fallback put it
+            return instances
+
+        by_zone_letter = {}
+        for instance in instances:
+            by_zone_letter.setdefault(gce_instance_zone(instance).rsplit("-", 1)[-1], []).append(instance)
+
+        # Rack N is the Nth configured zone whether or not that zone currently holds anything:
+        # skipping the empty ones would shift every later rack onto a zone that is not its own.
+        # Zones outside the configured set (nothing places there today) get positions after them.
+        ordered_letters = rack_letters + sorted(letter for letter in by_zone_letter if letter not in rack_letters)
+        if az_idx >= len(ordered_letters):
+            return []
+        return by_zone_letter.get(ordered_letters[az_idx], [])
 
     def _create_node(self, instance, node_index, dc_idx, rack, after_config=None):
         try:
@@ -680,33 +725,27 @@ class GCECluster(cluster.BaseCluster):
         self.log.info("Adding nodes to cluster")
         nodes = []
         instance_dc = 0 if self.params.get("simulated_regions") else dc_idx
-        if self.test_config.REUSE_CLUSTER:
-            instances = self._get_instances(instance_dc)
-            if not instances:
-                raise RuntimeError("No nodes found for testId %s " % (self.test_config.test_id(),))
-        elif instances := self._get_instances(instance_dc):
-            if len(instances) < count:
-                raise ProvisionError(
-                    f"Found only {len(instances)} pre-provisioned instance(s) but {count} were requested "
-                    f"for dc_idx={instance_dc}. The pre-provisioning step may have partially failed."
-                )
-            self.log.info("Found provisioned instances = %s", instances)
-        else:
-            self.log.info("Found no provisioned instances. Provision them.")
-            provisioned_vms = self._create_instances(count, instance_dc, instance_type=instance_type)
-            # The provisioner returns VmInstance objects, but GCENode expects compute_v1.Instance.
-            # Fetch the native GCE instances by name with retry to ensure they are in RUNNING state.
-            instances = []
-            for vm in provisioned_vms:
-                gce_instance = self._get_instance_with_retry(name=vm.name, dc_idx=instance_dc)
-                instances.append(gce_instance)
+        # With simulated racks every instance goes to the same zone; only the node labels differ
+        instance_rack = 0 if self.params.get("simulated_racks") else rack
+        rack_distribution = self._rack_distribution(count, instance_rack)
+        self.log.info("rack distribution: %s", {rack_idx: len(indexes) for rack_idx, indexes in rack_distribution})
 
-        self.log.debug("instances: %s", instances)
-        if instances:
-            self.log.debug("GCE instance extra info: %s", instances[0])
-        for node_index, instance in enumerate(instances, start=self._node_index + 1):
-            # in case rack is not specified, spread nodes to different racks
-            node_rack = node_index % self.racks_count if rack is None else rack
+        placed = []
+        for rack_idx, node_indexes in rack_distribution:
+            instances = self._create_or_find_instances(
+                node_indexes=node_indexes, dc_idx=instance_dc, az_idx=rack_idx, instance_type=instance_type
+            )
+            # Requesting N instances may find more than N leftover pre-provisioned ones; take N
+            placed.extend(zip(node_indexes, instances))
+        placed.sort(key=lambda item: item[0])
+
+        self.log.debug("instances: %s", [instance for _, instance in placed])
+        if placed:
+            self.log.debug("GCE instance extra info: %s", placed[0][1])
+        for node_index, instance in placed:
+            # in case rack is not specified, spread nodes to different racks - the same node index
+            # based rule the provisioner uses to pick the zone, so rack and zone stay in sync
+            node_rack = (node_index - 1) % self.racks_count if rack is None else rack
             node = self._create_node(instance, node_index, dc_idx, rack=node_rack, after_config=after_config)
             nodes.append(node)
             self.nodes.append(node)
@@ -716,6 +755,57 @@ class GCECluster(cluster.BaseCluster):
         self._node_index += count
         self.log.info("added nodes: %s", nodes)
         return nodes
+
+    def _rack_distribution(self, count: int, rack: int | None) -> list[tuple[int, list[int]]]:
+        """Split the next `count` node indexes into `(rack_idx, node_indexes)` groups.
+
+        With an explicit rack every node goes to it. With rack=None nodes are spread over the racks
+        by node index, so which rack - and therefore which zone - a node ends up in depends only on
+        the node itself, not on how many nodes happen to be provisioned together.
+        """
+        node_indexes = list(range(self._node_index + 1, self._node_index + count + 1))
+        if rack is not None:
+            return [(rack, node_indexes)]
+        groups: Dict[int, list[int]] = {}
+        for node_index in node_indexes:
+            groups.setdefault((node_index - 1) % self.racks_count, []).append(node_index)
+        return sorted(groups.items())
+
+    def _create_or_find_instances(
+        self, node_indexes: list[int], dc_idx: int, az_idx: int, instance_type=None
+    ) -> list[compute_v1.Instance]:
+        """Return instances for the given node indexes, all placed in the zone of rack `az_idx`.
+
+        Pre-provisioned instances of that zone are reused when present, otherwise the nodes are
+        provisioned inline.
+        """
+        count = len(node_indexes)
+        if self.test_config.REUSE_CLUSTER:
+            instances = self._get_instances(dc_idx, az_idx)
+            if not instances:
+                raise RuntimeError("No nodes found for testId %s " % (self.test_config.test_id(),))
+            if len(instances) < count:
+                raise ProvisionError(
+                    f"Found only {len(instances)} instance(s) to reuse but {count} were requested "
+                    f"for dc_idx={dc_idx}, az_idx={az_idx}"
+                )
+            return instances
+        if instances := self._get_instances(dc_idx, az_idx):
+            if len(instances) < count:
+                raise ProvisionError(
+                    f"Found only {len(instances)} pre-provisioned instance(s) but {count} were requested "
+                    f"for dc_idx={dc_idx}, az_idx={az_idx}. The pre-provisioning step may have partially failed."
+                )
+            self.log.info("Found provisioned instances = %s", instances)
+            return instances
+
+        self.log.info("Found no provisioned instances. Provision them.")
+        provisioned_vms = self._create_instances(
+            node_indexes=node_indexes, dc_idx=dc_idx, rack=az_idx, instance_type=instance_type
+        )
+        # The provisioner returns VmInstance objects, but GCENode expects compute_v1.Instance.
+        # Fetch the native GCE instances by name with retry to ensure they are in RUNNING state.
+        return [self._get_instance_with_retry(name=vm.name, dc_idx=dc_idx) for vm in provisioned_vms]
 
 
 class ScyllaGCECluster(cluster.BaseScyllaCluster, GCECluster):

--- a/sdcm/cluster_gce.py
+++ b/sdcm/cluster_gce.py
@@ -68,6 +68,21 @@ class CreateGCENodeError(Exception):
     pass
 
 
+def gce_instance_node_index(instance: compute_v1.Instance) -> int:
+    """Node index an instance was created for, taken from its GCE metadata.
+
+    GCE metadata values are strings, so they have to be converted before sorting: sorted as text,
+    node 10 comes before node 4, while callers pair the resulting order with numeric node indexes.
+    An instance without a usable NodeIndex sorts first.
+    """
+    node_index = gce_meta_to_dict(instance.metadata).get("NodeIndex")
+    try:
+        return int(node_index)
+    except TypeError, ValueError:
+        LOGGER.warning("Instance %s has no usable NodeIndex metadata: %s", instance.name, node_index)
+        return 0
+
+
 class GCENode(cluster.BaseNode):
     """
     Wraps GCE instances, so that we can also control the instance through SSH.
@@ -653,12 +668,7 @@ class GCECluster(cluster.BaseCluster):
         if az_idx is not None and instances:
             instances = self._instances_in_az(instances, az_idx, dc_idx)
 
-        def sort_by_index(instance):
-            metadata = gce_meta_to_dict(instance.metadata)
-            return metadata.get("NodeIndex", 0)
-
-        instances = sorted(instances, key=sort_by_index)
-        return instances
+        return sorted(instances, key=gce_instance_node_index)
 
     def _instances_in_az(
         self, instances: list[compute_v1.Instance], az_idx: int, dc_idx: int

--- a/sdcm/cluster_k8s/gke.py
+++ b/sdcm/cluster_k8s/gke.py
@@ -651,7 +651,9 @@ class MonitorSetGKE(MonitorSetGCE):
         pass
 
     # NOTE: setting and filtering of the "monitorid" tag is needed for the multi-tenant setup.
-    def _get_instances(self, dc_idx):
+    def _get_instances(self, dc_idx, az_idx=None):
+        # az_idx is accepted for signature compatibility with GCECluster: a GKE monitor set is
+        # always confined to a single zone, so there is nothing to filter by rack.
         if not self.monitor_id:
             raise ValueError("'monitor_id' must exist")
         instances_by_nodetype = list_instances_gce(tags_dict={"MonitorId": self.monitor_id, "NodeType": self.node_type})

--- a/sdcm/cluster_k8s/gke.py
+++ b/sdcm/cluster_k8s/gke.py
@@ -24,7 +24,7 @@ from google.cloud import compute_v1
 
 from sdcm import sct_abs_path, cluster
 from sdcm.wait import exponential_retry
-from sdcm.utils.common import list_instances_gce, gce_meta_to_dict
+from sdcm.utils.common import list_instances_gce
 from sdcm.utils.k8s import ApiCallRateLimiter, TokenUpdateThread
 from sdcm.utils.gce_utils import (
     GcloudContainerMixin,
@@ -37,7 +37,7 @@ from sdcm.utils.gce_utils import (
 from sdcm.utils.ci_tools import get_test_name
 from sdcm.nemesis.utils.node_allocator import mark_new_nodes_as_running_nemesis
 from sdcm.cluster_k8s import KubernetesCluster, ScyllaPodCluster, BaseScyllaPodContainer, CloudK8sNodePool
-from sdcm.cluster_gce import MonitorSetGCE
+from sdcm.cluster_gce import MonitorSetGCE, gce_instance_node_index
 from sdcm.provision.network_configuration import ssh_connection_ip_type
 from sdcm.keystore import KeyStore
 from sdcm.remote import LOCALRUNNER
@@ -674,9 +674,4 @@ class MonitorSetGKE(MonitorSetGCE):
                 if node_zone.id == node_nodetype.id:
                     instances.append(node_zone)
 
-        def sort_by_index(node):
-            metadata = gce_meta_to_dict(node.metadata)
-            return metadata.get("NodeIndex", 0)
-
-        instances = sorted(instances, key=sort_by_index)
-        return instances
+        return sorted(instances, key=gce_instance_node_index)

--- a/sdcm/provision/gce/provisioner.py
+++ b/sdcm/provision/gce/provisioner.py
@@ -50,46 +50,66 @@ class GceProvisioner(Provisioner):
         Args:
             test_id: Test ID for tagging resources
             region: GCE region (e.g., 'us-east1')
-            availability_zone: GCE zone letter (e.g., 'b') or None for random
+            availability_zone: GCE zone letter (e.g., 'b'), or comma-separated
+                letters (e.g., 'a,b,c') to distribute nodes across AZs.
+                If None/empty, a random zone is selected.
             network_name: VPC network name (from gce_network SCT parameter)
             **config: Additional configuration options
         """
-        # If availability_zone is None or empty, use random_zone
-        # This matches the logic in GCECluster.__init__
-        if not availability_zone:
-            availability_zone = random_zone(region)
+        # Parse availability zones
+        if not availability_zone or not availability_zone.strip():
+            zone_letters = [random_zone(region)]
+        elif "," in availability_zone:
+            zone_letters = [az.strip() for az in availability_zone.split(",") if az.strip()]
+            if not zone_letters:
+                zone_letters = [random_zone(region)]
+        else:
+            zone_letters = [availability_zone.strip()]
 
-        # Construct full zone name (region + zone)
-        zone = f"{region}-{availability_zone}"
-        super().__init__(test_id, region, zone)
+        # Primary zone (first one) used for base class
+        primary_zone = f"{region}-{zone_letters[0]}"
+        super().__init__(test_id, region, primary_zone)
 
         # Get GCE credentials
         credentials = KeyStore().get_gcp_credentials()
         self.project_id = credentials["project_id"]
 
-        # Initialize providers
-        self._disk_provider = DiskProvider(self.project_id, zone)
+        # Create a VM provider per zone for distributing nodes across AZs
+        self._zone_names = [f"{region}-{letter}" for letter in zone_letters]
         self._network_provider = NetworkProvider(self.project_id, network_name)
-        self._vm_provider = VirtualMachineProvider(
-            self.project_id,
-            zone,
-            test_id,
-            self._disk_provider,
-            self._network_provider,
-        )
+        self._vm_providers: Dict[str, VirtualMachineProvider] = {}
+        for zone in self._zone_names:
+            disk_provider = DiskProvider(self.project_id, zone)
+            self._vm_providers[zone] = VirtualMachineProvider(
+                self.project_id,
+                zone,
+                test_id,
+                disk_provider,
+                self._network_provider,
+            )
+
+        # Primary zone providers for backward compatibility
+        self._disk_provider = DiskProvider(self.project_id, primary_zone)
+        self._vm_provider = self._vm_providers[primary_zone]
 
         # Cache for instances
         self._cache: Dict[str, VmInstance] = {}
 
-        # Populate cache with existing instances
-        for gce_instance in self._vm_provider.list():
-            try:
-                vm_instance = self._gce_instance_to_vm_instance(gce_instance)
-                self._cache[vm_instance.name] = vm_instance
-            except Exception as exc:  # noqa: BLE001
-                LOGGER.warning("Failed to cache instance %s: %s", gce_instance.name, exc)
+        # Populate cache with existing instances from all zones
+        for vm_provider in self._vm_providers.values():
+            for gce_instance in vm_provider.list():
+                try:
+                    vm_instance = self._gce_instance_to_vm_instance(gce_instance)
+                    self._cache[vm_instance.name] = vm_instance
+                except Exception as exc:  # noqa: BLE001
+                    LOGGER.warning("Failed to cache instance %s: %s", gce_instance.name, exc)
 
-        LOGGER.debug("Initialized GceProvisioner for test_id=%s, region=%s, zone=%s", test_id, region, zone)
+        LOGGER.debug(
+            "Initialized GceProvisioner for test_id=%s, region=%s, zones=%s",
+            test_id,
+            region,
+            self._zone_names,
+        )
 
     def __str__(self):
         return f"{self.__class__.__name__}(region={self.region}, zone={self.availability_zone})"
@@ -172,7 +192,8 @@ class GceProvisioner(Provisioner):
         """
         Create a set of instances specified by a list of InstanceDefinition.
 
-        Instances are created in parallel for better performance.
+        Instances are distributed across configured availability zones in
+        round-robin fashion. Within each zone, instances are created in parallel.
 
         Args:
             definitions: List of instance definitions
@@ -193,19 +214,30 @@ class GceProvisioner(Provisioner):
                 vms_to_create.append(definition)
                 user_data_list.append(user_data)
 
-        # Create instances in parallel
         provisioned = list(cached)
         if vms_to_create:
-            gce_instances = self._vm_provider.get_or_create(
-                definitions=vms_to_create,
-                pricing_model=pricing_model,
-                user_data_list=user_data_list,
-                startup_script_list=[""] * len(vms_to_create),
-            )
-            for gce_instance in gce_instances:
-                vm_instance = self._gce_instance_to_vm_instance(gce_instance)
-                self._cache[vm_instance.name] = vm_instance
-                provisioned.append(vm_instance)
+            # Group definitions by zone (round-robin assignment)
+            zone_groups: Dict[str, tuple] = {zone: ([], []) for zone in self._zone_names}
+            for idx, (definition, user_data) in enumerate(zip(vms_to_create, user_data_list)):
+                zone = self._zone_names[idx % len(self._zone_names)]
+                zone_groups[zone][0].append(definition)
+                zone_groups[zone][1].append(user_data)
+
+            # Create instances in each zone
+            for zone, (zone_definitions, zone_user_data) in zone_groups.items():
+                if not zone_definitions:
+                    continue
+                LOGGER.info("Creating %d instance(s) in zone %s", len(zone_definitions), zone)
+                gce_instances = self._vm_providers[zone].get_or_create(
+                    definitions=zone_definitions,
+                    pricing_model=pricing_model,
+                    user_data_list=zone_user_data,
+                    startup_script_list=[""] * len(zone_definitions),
+                )
+                for gce_instance in gce_instances:
+                    vm_instance = self._gce_instance_to_vm_instance(gce_instance)
+                    self._cache[vm_instance.name] = vm_instance
+                    provisioned.append(vm_instance)
 
         return provisioned
 

--- a/sdcm/provision/gce/provisioner.py
+++ b/sdcm/provision/gce/provisioner.py
@@ -33,8 +33,9 @@ from sdcm.provision.provisioner import (
 from sdcm.provision.gce.disk_provider import DiskProvider
 from sdcm.provision.gce.network_provider import NetworkProvider
 from sdcm.provision.gce.instance_provider import VirtualMachineProvider
+from sdcm.provision.gce.utils import normalize_instance_name
 from sdcm.provision.user_data import UserDataBuilder
-from sdcm.utils.gce_utils import get_gce_compute_instances_client, random_zone
+from sdcm.utils.gce_utils import gce_instance_zone, get_gce_compute_instances_client, random_zone
 from sdcm.keystore import KeyStore
 from sdcm.remote import RemoteCmdRunnerBase
 
@@ -51,46 +52,75 @@ class GceProvisioner(Provisioner):
         Args:
             test_id: Test ID for tagging resources
             region: GCE region (e.g., 'us-east1')
-            availability_zone: GCE zone letter (e.g., 'b') or None for random
+            availability_zone: GCE zone letter (e.g., 'b'), or comma-separated
+                letters (e.g., 'a,b,c') to distribute nodes across AZs.
+                If None/empty, a random zone is selected.
             network_name: VPC network name (from gce_network SCT parameter)
             **config: Additional configuration options
         """
-        # If availability_zone is None or empty, use random_zone
-        # This matches the logic in GCECluster.__init__
-        if not availability_zone:
-            availability_zone = random_zone(region)
+        # Nodes are spread over every configured zone; which zone a node lands in is derived from its
+        # rack - see `_zone_for_definition` - the same contract AWS implements with per-AZ subnets.
+        self._zone_names = [f"{region}-{letter}" for letter in self._parse_zone_letters(region, availability_zone)]
 
-        # Construct full zone name (region + zone)
-        zone = f"{region}-{availability_zone}"
-        super().__init__(test_id, region, zone)
+        # The first zone is this provisioner's own AZ, used wherever a single zone is expected.
+        super().__init__(test_id, region, self._zone_names[0])
 
         # Get GCE credentials
         credentials = KeyStore().get_gcp_credentials()
         self.project_id = credentials["project_id"]
 
-        # Initialize providers
-        self._disk_provider = DiskProvider(self.project_id, zone)
+        # One VM provider per zone: the GCE API is zone-scoped, so every instance operation has to be
+        # issued against the zone the instance actually lives in.
         self._network_provider = NetworkProvider(self.project_id, network_name)
-        self._vm_provider = VirtualMachineProvider(
+        self._vm_providers: Dict[str, VirtualMachineProvider] = {
+            zone: self._make_vm_provider(zone) for zone in self._zone_names
+        }
+
+        # Cache for instances, and the zone each of them was found in
+        self._cache: Dict[str, VmInstance] = {}
+        self._instance_zones: Dict[str, str] = {}
+
+        # Populate cache with existing instances from all zones
+        for vm_provider in self._vm_providers.values():
+            for gce_instance in vm_provider.list():
+                try:
+                    vm_instance = self._gce_instance_to_vm_instance(gce_instance)
+                    self._cache[vm_instance.name] = vm_instance
+                except Exception as exc:  # noqa: BLE001
+                    LOGGER.warning("Failed to cache instance %s: %s", gce_instance.name, exc)
+
+        LOGGER.debug(
+            "Initialized GceProvisioner for test_id=%s, region=%s, zones=%s",
+            test_id,
+            region,
+            self._zone_names,
+        )
+
+    @staticmethod
+    def _cache_key(name: str) -> str:
+        """Key an instance is tracked under: the name GCE gives it, which is the normalized one.
+
+        A definition name can differ from it - anything outside [a-z0-9-] is replaced on creation,
+        and a `user_prefix` may well carry a dot - so looking a definition up by its own name would
+        never find the instance that was just created for it.
+        """
+        return normalize_instance_name(name)
+
+    def _make_vm_provider(self, zone: str) -> VirtualMachineProvider:
+        """Build a VM provider bound to one zone."""
+        return VirtualMachineProvider(
             self.project_id,
             zone,
-            test_id,
-            self._disk_provider,
+            self.test_id,
+            DiskProvider(self.project_id, zone),
             self._network_provider,
         )
 
-        # Cache for instances
-        self._cache: Dict[str, VmInstance] = {}
-
-        # Populate cache with existing instances
-        for gce_instance in self._vm_provider.list():
-            try:
-                vm_instance = self._gce_instance_to_vm_instance(gce_instance)
-                self._cache[vm_instance.name] = vm_instance
-            except Exception as exc:  # noqa: BLE001
-                LOGGER.warning("Failed to cache instance %s: %s", gce_instance.name, exc)
-
-        LOGGER.debug("Initialized GceProvisioner for test_id=%s, region=%s, zone=%s", test_id, region, zone)
+    @staticmethod
+    def _parse_zone_letters(region: str, availability_zone: str) -> List[str]:
+        """Zone letters to use: 'a,b,c' -> ['a', 'b', 'c']; when unset, one randomly picked zone."""
+        letters = [letter.strip() for letter in (availability_zone or "").split(",") if letter.strip()]
+        return letters or [random_zone(region)]
 
     def __str__(self):
         return f"{self.__class__.__name__}(region={self.region}, zone={self.availability_zone})"
@@ -99,6 +129,51 @@ class GceProvisioner(Provisioner):
     def zone(self) -> str:
         """Get the full zone name."""
         return self.availability_zone
+
+    @property
+    def availability_zones(self) -> List[str]:
+        """Full names of every zone this provisioner places instances in."""
+        return list(self._zone_names)
+
+    def _zone_for_definition(self, definition: InstanceDefinition) -> str:
+        """Zone an instance belongs to: its rack index, falling back to its node index.
+
+        Placement is keyed on the node's identity and never on its position in the batch being
+        provisioned, so a node lands in the same zone whether the cluster is created in one call or
+        grown a node at a time, and a retry after a partial failure does not move the nodes around.
+        """
+        if len(self._zone_names) == 1:
+            return self._zone_names[0]
+        if definition.rack_index is not None:
+            return self._zone_names[definition.rack_index % len(self._zone_names)]
+        try:
+            node_index = int(definition.tags.get("NodeIndex", 1))
+        except TypeError, ValueError:
+            LOGGER.warning(
+                "Could not determine NodeIndex of instance %s, using zone %s", definition.name, self._zone_names[0]
+            )
+            return self._zone_names[0]
+        return self._zone_names[(node_index - 1) % len(self._zone_names)]
+
+    def _provider_for_instance(self, name: str) -> VirtualMachineProvider:
+        """VM provider bound to the zone the instance lives in.
+
+        An instance can sit outside the configured zones - runtime AZ fallback relocates one on a
+        capacity error - so a provider for its own zone is created on demand. Sending the operation
+        to the primary zone instead would either fail silently or hit the wrong instance.
+        """
+        zone = self._instance_zones.get(self._cache_key(name))
+        if zone is None:
+            LOGGER.warning(
+                "Zone of instance %s is unknown, issuing the operation against %s", name, self.availability_zone
+            )
+            return self._vm_providers[self.availability_zone]
+        if zone not in self._vm_providers:
+            LOGGER.warning(
+                "Instance %s lives in zone %s, outside the configured zones %s", name, zone, self._zone_names
+            )
+            self._vm_providers[zone] = self._make_vm_provider(zone)
+        return self._vm_providers[zone]
 
     @classmethod
     def discover_regions(cls, test_id: str, **config) -> List["GceProvisioner"]:
@@ -110,7 +185,13 @@ class GceProvisioner(Provisioner):
             **config: Additional configuration
 
         Returns:
-            List of GceProvisioner instances, one per region
+            List of GceProvisioner instances, one per zone holding resources of the test
+
+        Note:
+            This is a discovery/cleanup path, so each provisioner is built for a single zone: the
+            zones of a multi-AZ cluster come back as separate single-zone provisioners rather than
+            one provisioner covering them all. Every zone is still reachable, but a caller that
+            expects one provisioner to span the whole cluster has to iterate all of them.
         """
         # Get GCE credentials
         credentials = KeyStore().get_gcp_credentials()
@@ -173,42 +254,59 @@ class GceProvisioner(Provisioner):
         """
         Create a set of instances specified by a list of InstanceDefinition.
 
-        Instances are created in parallel for better performance.
+        Each instance goes to the zone its rack maps to (`_zone_for_definition`). Instances sharing a
+        zone are created in one call, in parallel.
 
         Args:
             definitions: List of instance definitions
             pricing_model: Pricing model (spot or on-demand)
 
         Returns:
-            List of VmInstance objects
+            List of VmInstance objects, in the same order as `definitions`
         """
         # Separate cached from new, prepare user data
-        cached, vms_to_create, user_data_list = [], [], []
+        vms_to_create, user_data_list = [], []
         for definition in definitions:
-            if definition.name in self._cache:
-                cached.append(self._cache[definition.name])
-            else:
-                user_data = ""
-                if definition.user_data:
-                    user_data = UserDataBuilder(user_data_objects=definition.user_data).build_user_data_yaml()
-                vms_to_create.append(definition)
-                user_data_list.append(user_data)
+            if self._cache_key(definition.name) in self._cache:
+                continue
+            user_data = ""
+            if definition.user_data:
+                user_data = UserDataBuilder(user_data_objects=definition.user_data).build_user_data_yaml()
+            vms_to_create.append(definition)
+            user_data_list.append(user_data)
 
-        # Create instances in parallel
-        provisioned = list(cached)
         if vms_to_create:
-            gce_instances = self._vm_provider.get_or_create(
-                definitions=vms_to_create,
-                pricing_model=pricing_model,
-                user_data_list=user_data_list,
-                startup_script_list=[""] * len(vms_to_create),
-            )
-            for gce_instance in gce_instances:
-                vm_instance = self._gce_instance_to_vm_instance(gce_instance)
-                self._cache[vm_instance.name] = vm_instance
-                provisioned.append(vm_instance)
+            # Group definitions by the zone they belong to
+            zone_groups: Dict[str, List[tuple[InstanceDefinition, str]]] = {}
+            for definition, user_data in zip(vms_to_create, user_data_list):
+                zone_groups.setdefault(self._zone_for_definition(definition), []).append((definition, user_data))
 
-        return provisioned
+            # Create instances in each zone
+            for zone, group in zone_groups.items():
+                zone_definitions = [definition for definition, _ in group]
+                LOGGER.info(
+                    "Creating %d instance(s) in zone %s: %s",
+                    len(zone_definitions),
+                    zone,
+                    [definition.name for definition in zone_definitions],
+                )
+                gce_instances = self._vm_providers[zone].get_or_create(
+                    definitions=zone_definitions,
+                    pricing_model=pricing_model,
+                    user_data_list=[user_data for _, user_data in group],
+                    startup_script_list=[""] * len(zone_definitions),
+                )
+                for gce_instance in gce_instances:
+                    vm_instance = self._gce_instance_to_vm_instance(gce_instance)
+                    self._cache[vm_instance.name] = vm_instance
+
+        # Callers zip the result with the definitions they passed in, so keep the requested order and
+        # never return a short list - a missing instance would silently shift every pairing after it.
+        if missing := [
+            definition.name for definition in definitions if self._cache_key(definition.name) not in self._cache
+        ]:
+            raise ProvisionError(f"Provisioning did not return {len(missing)} requested instance(s): {missing}")
+        return [self._cache[self._cache_key(definition.name)] for definition in definitions]
 
     def terminate_instance(self, name: str, wait: bool = False) -> None:
         """
@@ -218,7 +316,9 @@ class GceProvisioner(Provisioner):
             name: Instance name
             wait: Whether to wait for termination to complete
         """
-        self._vm_provider.delete(name, wait=wait)
+        name = self._cache_key(name)
+        self._provider_for_instance(name).delete(name, wait=wait)
+        self._instance_zones.pop(name, None)
         if name in self._cache:
             del self._cache[name]
 
@@ -231,7 +331,8 @@ class GceProvisioner(Provisioner):
             wait: Whether to wait for reboot to complete
             hard: Whether to perform a hard reboot
         """
-        self._vm_provider.reboot(name, wait=wait, hard=hard)
+        name = self._cache_key(name)
+        self._provider_for_instance(name).reboot(name, wait=wait, hard=hard)
         # Invalidate cache
         if name in self._cache:
             del self._cache[name]
@@ -255,7 +356,7 @@ class GceProvisioner(Provisioner):
         Args:
             wait: Whether to wait for each deletion to complete
         """
-        LOGGER.info("Cleaning up instances for test %s in zone %s", self.test_id, self.zone)
+        LOGGER.info("Cleaning up instances for test %s in zones %s", self.test_id, self._zone_names)
 
         # Delete all cached instances concurrently (deletion is slow; serial wait=True would take minutes).
         instance_names = list(self._cache.keys())
@@ -270,7 +371,9 @@ class GceProvisioner(Provisioner):
 
         # Clear cache
         self._cache.clear()
-        self._vm_provider.clear_cache()
+        self._instance_zones.clear()
+        for vm_provider in self._vm_providers.values():
+            vm_provider.clear_cache()
 
         LOGGER.info("Cleanup completed for test %s", self.test_id)
 
@@ -282,7 +385,8 @@ class GceProvisioner(Provisioner):
             name: Instance name
             tags: Tags to add
         """
-        self._vm_provider.add_tags(name, tags)
+        name = self._cache_key(name)
+        self._provider_for_instance(name).add_tags(name, tags)
 
         # Update cache
         if name in self._cache:
@@ -299,6 +403,7 @@ class GceProvisioner(Provisioner):
         Returns:
             Result object with command output
         """
+        name = self._cache_key(name)
         if name not in self._cache:
             raise ProvisionError(f"Instance {name} not found in cache")
 
@@ -382,6 +487,10 @@ class GceProvisioner(Provisioner):
             creation_time = datetime.fromisoformat(gce_instance.creation_timestamp.replace("Z", "+00:00"))
         elif "creation_time" in tags:
             creation_time = datetime.fromisoformat(tags.pop("creation_time")).replace(tzinfo=timezone.utc)
+
+        # Remember where the instance lives: every GCE instance operation is zone-scoped
+        if gce_instance.zone:
+            self._instance_zones[gce_instance.name] = gce_instance_zone(gce_instance)
 
         return VmInstance(
             name=gce_instance.name,

--- a/sdcm/provision/gce/zone_resolver.py
+++ b/sdcm/provision/gce/zone_resolver.py
@@ -101,7 +101,9 @@ class GceAZResolver:
         If `pre_filter_unavailable_availability_zones` is False, returns without
         modifying params. Multi-AZ configs ("b,c,d") have invalid zones replaced with
         valid alternatives in the same region.
-        Raises `NoValidAvailabilityZoneError` when no zone letter is valid in every region.
+        Raises `NoValidAvailabilityZoneError` when no zone letter is valid in every region, or
+        when fewer zones are valid than the configuration asks for - the zone count sets
+        `racks_count`, so returning fewer would silently change the cluster topology.
         """
         if not self._params.get("pre_filter_unavailable_availability_zones"):
             LOGGER.info("Upfront zone filter disabled; skipping GceAZResolver.resolve()")
@@ -141,6 +143,20 @@ class GceAZResolver:
                 break
             if letter not in resolved:
                 resolved.append(letter)
+
+        if len(resolved) < len(configured_letters):
+            # `availability_zone: 'b,c,d'` asks for three racks, one per zone. Handing back two
+            # would silently build a two-rack cluster - `racks_count` is derived from this very
+            # parameter - so the test would run a topology it never asked for. Dropping a rack is
+            # the job's decision, not the resolver's. `get_region_fallback_candidates` already
+            # holds a region to the configured zone count; `resolve` is held to the same rule.
+            raise NoValidAvailabilityZoneError(
+                f"availability_zone '{','.join(configured_letters)}' requests "
+                f"{len(configured_letters)} zone(s), but only {len(resolved)} "
+                f"('{','.join(resolved)}') support all required machine types {machine_types} "
+                f"in every region of {region_names}. Reduce availability_zone, drop a region, "
+                f"or use machine types available in more zones."
+            )
 
         new_value = ",".join(resolved)
         original_value = self._params.get("availability_zone")

--- a/sdcm/utils/gce_utils.py
+++ b/sdcm/utils/gce_utils.py
@@ -394,6 +394,15 @@ class GceZoneResolver:
         return {mt: self.get_zones_for_machine_type(region, mt) for mt in machine_types}
 
 
+def gce_instance_zone(instance: compute_v1.Instance) -> str:
+    """Full zone name of an instance (e.g. 'us-east1-b').
+
+    GCE reports it as a URL - "projects/<project>/zones/<zone>" - and every instance operation
+    needs the bare zone name.
+    """
+    return str(instance.zone).split("/")[-1]
+
+
 def gce_public_addresses(instance: compute_v1.Instance) -> list[str]:
     addresses = []
 

--- a/unit_tests/unit/provisioner/test_gce_provisioner_az_distribution.py
+++ b/unit_tests/unit/provisioner/test_gce_provisioner_az_distribution.py
@@ -1,0 +1,173 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2026 ScyllaDB
+
+"""Tests for GCE provisioner multi-AZ distribution."""
+
+from unittest.mock import patch, MagicMock
+
+import pytest
+from google.cloud import compute_v1
+
+from sdcm.provision.gce.provisioner import GceProvisioner
+from sdcm.provision.provisioner import InstanceDefinition, PricingModel
+from sdcm.keystore import SSHKey
+
+
+FAKE_SSH_KEY = SSHKey(
+    name="test_key",
+    public_key=b"ssh-rsa AAAA fake\n",
+    private_key=b"fake-private\n",
+)
+
+
+def _make_definition(name: str) -> InstanceDefinition:
+    return InstanceDefinition(
+        name=name,
+        image_id="projects/scylla-images/global/images/test-image",
+        type="n2-highmem-8",
+        user_name="scylla-test",
+        ssh_key=FAKE_SSH_KEY,
+        root_disk_size=50,
+        root_disk_type="pd-ssd",
+    )
+
+
+def _make_fake_instance(name: str, zone: str) -> compute_v1.Instance:
+    instance = MagicMock(spec=compute_v1.Instance)
+    instance.name = name
+    instance.zone = f"projects/test-project/zones/{zone}"
+    instance.status = "RUNNING"
+    instance.network_interfaces = [
+        MagicMock(
+            network_i_p="10.0.0.1",
+            access_configs=[MagicMock(nat_i_p="35.0.0.1")],
+        )
+    ]
+    instance.metadata = MagicMock(
+        items=[
+            MagicMock(key="ssh_user", value="scylla-test"),
+            MagicMock(key="ssh_key", value="test_key"),
+        ]
+    )
+    instance.labels = {"sct_test_id": "test-123"}
+    instance.creation_timestamp = "2026-01-01T00:00:00.000-00:00"
+    instance.machine_type = "zones/us-east1-a/machineTypes/n2-highmem-8"
+    instance.scheduling = MagicMock(provisioning_model="STANDARD")
+    instance.disks = []
+    return instance
+
+
+@pytest.fixture
+def mock_gce_deps():
+    """Mock all GCE dependencies to avoid real API calls."""
+    with (
+        patch("sdcm.provision.gce.provisioner.KeyStore") as mock_keystore_cls,
+        patch("sdcm.provision.gce.provisioner.get_gce_compute_instances_client") as mock_client,
+        patch("sdcm.provision.gce.provisioner.DiskProvider"),
+        patch("sdcm.provision.gce.provisioner.NetworkProvider"),
+        patch("sdcm.provision.gce.provisioner.VirtualMachineProvider") as mock_vm_provider_cls,
+    ):
+        mock_keystore_cls.return_value.get_gcp_credentials.return_value = {"project_id": "test-project"}
+        mock_client.return_value = (MagicMock(), {"project_id": "test-project"})
+        mock_vm_provider_cls.return_value.list.return_value = []
+
+        yield {
+            "vm_provider_cls": mock_vm_provider_cls,
+        }
+
+
+def test_6_nodes_across_3_azs_distributes_2_per_az(mock_gce_deps):
+    """With AZ='a,b,c' and 6 nodes, each AZ gets exactly 2 nodes."""
+    vm_provider_cls = mock_gce_deps["vm_provider_cls"]
+
+    created_per_zone = {}
+
+    def make_provider(project_id, zone, test_id, disk_provider, network_provider):
+        provider = MagicMock()
+        provider.list.return_value = []
+
+        def track_create(definitions, pricing_model, user_data_list, startup_script_list):
+            created_per_zone[zone] = definitions
+            return [_make_fake_instance(d.name, zone) for d in definitions]
+
+        provider.get_or_create.side_effect = track_create
+        return provider
+
+    vm_provider_cls.side_effect = make_provider
+
+    provisioner = GceProvisioner(
+        test_id="test-123",
+        region="us-east1",
+        availability_zone="a,b,c",
+        network_name="qa-vpc",
+    )
+
+    definitions = [_make_definition(f"node-{i}") for i in range(6)]
+    provisioner.get_or_create_instances(definitions, PricingModel.ON_DEMAND)
+
+    assert len(created_per_zone) == 3
+    assert len(created_per_zone["us-east1-a"]) == 2
+    assert len(created_per_zone["us-east1-b"]) == 2
+    assert len(created_per_zone["us-east1-c"]) == 2
+
+    # Round-robin: node-0->a, node-1->b, node-2->c, node-3->a, node-4->b, node-5->c
+    assert [d.name for d in created_per_zone["us-east1-a"]] == ["node-0", "node-3"]
+    assert [d.name for d in created_per_zone["us-east1-b"]] == ["node-1", "node-4"]
+    assert [d.name for d in created_per_zone["us-east1-c"]] == ["node-2", "node-5"]
+
+
+@patch("sdcm.provision.gce.provisioner.random_zone", return_value="c")
+def test_empty_az_uses_random_zone(mock_random_zone, mock_gce_deps):
+    """When availability_zone is empty, a random zone is selected."""
+    provisioner = GceProvisioner(
+        test_id="test-123",
+        region="us-east1",
+        availability_zone="",
+        network_name="qa-vpc",
+    )
+
+    assert provisioner._zone_names == ["us-east1-c"]
+    mock_random_zone.assert_called_once_with("us-east1")
+
+
+def test_single_az_all_nodes_in_one_zone(mock_gce_deps):
+    """With AZ='b', all nodes are created in that single zone."""
+    vm_provider_cls = mock_gce_deps["vm_provider_cls"]
+
+    created_per_zone = {}
+
+    def make_provider(project_id, zone, test_id, disk_provider, network_provider):
+        provider = MagicMock()
+        provider.list.return_value = []
+
+        def track_create(definitions, pricing_model, user_data_list, startup_script_list):
+            created_per_zone[zone] = definitions
+            return [_make_fake_instance(d.name, zone) for d in definitions]
+
+        provider.get_or_create.side_effect = track_create
+        return provider
+
+    vm_provider_cls.side_effect = make_provider
+
+    provisioner = GceProvisioner(
+        test_id="test-123",
+        region="us-east1",
+        availability_zone="b",
+        network_name="qa-vpc",
+    )
+
+    definitions = [_make_definition(f"node-{i}") for i in range(3)]
+    provisioner.get_or_create_instances(definitions, PricingModel.ON_DEMAND)
+
+    assert len(created_per_zone) == 1
+    assert len(created_per_zone["us-east1-b"]) == 3

--- a/unit_tests/unit/provisioner/test_gce_provisioner_az_distribution.py
+++ b/unit_tests/unit/provisioner/test_gce_provisioner_az_distribution.py
@@ -1,0 +1,314 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2026 ScyllaDB
+
+"""Tests for GCE provisioner multi-AZ placement.
+
+A comma separated `availability_zone` ('a,b,c') means the nodes are spread evenly over those
+zones, one rack per zone. Which zone a node goes to is derived from the node itself - its rack
+index, or its node index - never from its position in the batch being provisioned.
+"""
+
+from unittest.mock import patch, MagicMock
+
+import pytest
+from google.cloud import compute_v1
+
+from sdcm.provision.gce.provisioner import GceProvisioner
+from sdcm.provision.gce.utils import normalize_instance_name
+from sdcm.provision.provisioner import InstanceDefinition, PricingModel, ProvisionError
+from sdcm.keystore import SSHKey
+
+
+FAKE_SSH_KEY = SSHKey(
+    name="test_key",
+    public_key=b"ssh-rsa AAAA fake\n",
+    private_key=b"fake-private\n",
+)
+
+
+def _make_definition(node_index: int, rack_index: int | None = None) -> InstanceDefinition:
+    return InstanceDefinition(
+        name=f"node-{node_index}",
+        image_id="projects/scylla-images/global/images/test-image",
+        type="n2-highmem-8",
+        user_name="scylla-test",
+        ssh_key=FAKE_SSH_KEY,
+        root_disk_size=50,
+        root_disk_type="pd-ssd",
+        tags={"NodeIndex": str(node_index)},
+        rack_index=rack_index,
+    )
+
+
+def _make_fake_instance(name: str, zone: str) -> compute_v1.Instance:
+    instance = MagicMock(spec=compute_v1.Instance)
+    instance.name = name
+    instance.zone = f"projects/test-project/zones/{zone}"
+    instance.status = "RUNNING"
+    instance.network_interfaces = [
+        MagicMock(
+            network_i_p="10.0.0.1",
+            access_configs=[MagicMock(nat_i_p="35.0.0.1")],
+        )
+    ]
+    instance.metadata = MagicMock(
+        items=[
+            MagicMock(key="ssh_user", value="scylla-test"),
+            MagicMock(key="ssh_key", value="test_key"),
+        ]
+    )
+    instance.labels = {"sct_test_id": "test-123"}
+    instance.creation_timestamp = "2026-01-01T00:00:00.000-00:00"
+    instance.machine_type = "zones/us-east1-a/machineTypes/n2-highmem-8"
+    instance.scheduling = MagicMock(provisioning_model="STANDARD")
+    instance.disks = []
+    return instance
+
+
+@pytest.fixture
+def gce_providers():
+    """Mock GCE dependencies and expose the per-zone VM provider mocks by zone name."""
+    providers = {}
+    created_per_zone = {}
+
+    def make_provider(project_id, zone, test_id, disk_provider, network_provider):
+        provider = MagicMock()
+        provider.list.return_value = []
+
+        def track_create(definitions, pricing_model, user_data_list, startup_script_list):
+            created_per_zone.setdefault(zone, []).extend(definition.name for definition in definitions)
+            # GCE creates the instance under the normalized name, not the definition name
+            return [_make_fake_instance(normalize_instance_name(definition.name), zone) for definition in definitions]
+
+        provider.get_or_create.side_effect = track_create
+        providers[zone] = provider
+        return provider
+
+    with (
+        patch("sdcm.provision.gce.provisioner.KeyStore") as mock_keystore_cls,
+        patch("sdcm.provision.gce.provisioner.get_gce_compute_instances_client") as mock_client,
+        patch("sdcm.provision.gce.provisioner.DiskProvider"),
+        patch("sdcm.provision.gce.provisioner.NetworkProvider"),
+        patch("sdcm.provision.gce.provisioner.VirtualMachineProvider") as mock_vm_provider_cls,
+    ):
+        mock_keystore_cls.return_value.get_gcp_credentials.return_value = {"project_id": "test-project"}
+        mock_client.return_value = (MagicMock(), {"project_id": "test-project"})
+        mock_vm_provider_cls.side_effect = make_provider
+
+        yield {"providers": providers, "created_per_zone": created_per_zone}
+
+
+def _provisioner(availability_zone: str) -> GceProvisioner:
+    return GceProvisioner(
+        test_id="test-123",
+        region="us-east1",
+        availability_zone=availability_zone,
+        network_name="qa-vpc",
+    )
+
+
+def test_nodes_are_placed_by_node_index(gce_providers):
+    """With AZ='a,b,c' and 6 nodes, each zone gets the nodes whose index maps to it."""
+    provisioner = _provisioner("a,b,c")
+
+    provisioner.get_or_create_instances([_make_definition(idx) for idx in range(1, 7)], PricingModel.ON_DEMAND)
+
+    assert gce_providers["created_per_zone"] == {
+        "us-east1-a": ["node-1", "node-4"],
+        "us-east1-b": ["node-2", "node-5"],
+        "us-east1-c": ["node-3", "node-6"],
+    }
+
+
+def test_placement_is_stable_when_nodes_are_provisioned_one_at_a_time(gce_providers):
+    """Growing a cluster a node at a time must place each node in the zone of its index.
+
+    This is what a nemesis grow does: a batch position based rule would send every added node to
+    the first zone.
+    """
+    provisioner = _provisioner("a,b,c")
+
+    for node_index in range(1, 7):
+        provisioner.get_or_create_instances([_make_definition(node_index)], PricingModel.ON_DEMAND)
+
+    assert gce_providers["created_per_zone"] == {
+        "us-east1-a": ["node-1", "node-4"],
+        "us-east1-b": ["node-2", "node-5"],
+        "us-east1-c": ["node-3", "node-6"],
+    }
+
+
+def test_placement_is_unchanged_when_some_nodes_already_exist(gce_providers):
+    """A retry after a partial failure must not move the remaining nodes to other zones."""
+    provisioner = _provisioner("a,b,c")
+    definitions = [_make_definition(idx) for idx in range(1, 7)]
+
+    # first attempt created nodes 1 and 2 only
+    provisioner.get_or_create_instances(definitions[:2], PricingModel.ON_DEMAND)
+    provisioner.get_or_create_instances(definitions, PricingModel.ON_DEMAND)
+
+    assert gce_providers["created_per_zone"] == {
+        "us-east1-a": ["node-1", "node-4"],
+        "us-east1-b": ["node-2", "node-5"],
+        "us-east1-c": ["node-3", "node-6"],
+    }
+
+
+def test_rack_index_selects_the_zone(gce_providers):
+    """An explicit rack index wins over the node index - it is how the cluster picks the AZ."""
+    provisioner = _provisioner("a,b,c")
+
+    provisioner.get_or_create_instances(
+        [_make_definition(idx, rack_index=2) for idx in range(1, 4)], PricingModel.ON_DEMAND
+    )
+
+    assert gce_providers["created_per_zone"] == {"us-east1-c": ["node-1", "node-2", "node-3"]}
+
+
+def test_instances_are_returned_in_the_requested_order(gce_providers):
+    """Callers zip the result with the definitions they passed in, so the order must be kept."""
+    provisioner = _provisioner("a,b,c")
+    definitions = [_make_definition(idx) for idx in range(1, 7)]
+
+    instances = provisioner.get_or_create_instances(definitions, PricingModel.ON_DEMAND)
+
+    assert [instance.name for instance in instances] == [definition.name for definition in definitions]
+
+
+def test_partial_creation_raises_instead_of_returning_a_short_list(gce_providers):
+    """A missing instance must not be swallowed: callers pair the result with their definitions."""
+    provisioner = _provisioner("a,b,c")
+    definitions = [_make_definition(idx) for idx in range(1, 4)]
+    zone_b = gce_providers["providers"]["us-east1-b"]
+    zone_b.get_or_create.side_effect = lambda definitions, **kwargs: []
+
+    with pytest.raises(ProvisionError, match="node-2"):
+        provisioner.get_or_create_instances(definitions, PricingModel.ON_DEMAND)
+
+
+def test_operations_on_an_out_of_zone_instance_go_to_its_own_zone(gce_providers):
+    """AZ fallback can leave an instance outside the configured zones; it must still be reachable."""
+    provisioner = _provisioner("a,b")
+    provisioner._cache["moved-node"] = MagicMock()
+    provisioner._instance_zones["moved-node"] = "us-east1-f"
+
+    provisioner.terminate_instance("moved-node", wait=True)
+
+    assert "us-east1-f" in gce_providers["providers"], "no provider was created for the instance's own zone"
+    gce_providers["providers"]["us-east1-f"].delete.assert_called_once_with("moved-node", wait=True)
+    for zone in ("us-east1-a", "us-east1-b"):
+        gce_providers["providers"][zone].delete.assert_not_called()
+
+
+def test_definition_name_that_gce_renames_is_still_matched_to_its_instance(gce_providers):
+    """GCE replaces anything outside [a-z0-9-] on creation - a user_prefix may well carry a dot."""
+    provisioner = _provisioner("a,b")
+    definition = _make_definition(1)
+    definition.name = "user.name-db-node-1"
+
+    instances = provisioner.get_or_create_instances([definition], PricingModel.ON_DEMAND)
+    assert [instance.name for instance in instances] == ["user-name-db-node-1"]
+
+    # asking again must find the instance instead of trying to create it a second time
+    provisioner.get_or_create_instances([definition], PricingModel.ON_DEMAND)
+    assert gce_providers["created_per_zone"] == {"us-east1-a": ["user.name-db-node-1"]}
+
+
+def test_terminate_uses_the_zone_of_the_instance(gce_providers):
+    """A node living in the second zone must not be deleted through the first zone's provider."""
+    provisioner = _provisioner("a,b,c")
+    provisioner.get_or_create_instances([_make_definition(2)], PricingModel.ON_DEMAND)
+
+    provisioner.terminate_instance("node-2", wait=True)
+
+    gce_providers["providers"]["us-east1-b"].delete.assert_called_once_with("node-2", wait=True)
+    gce_providers["providers"]["us-east1-a"].delete.assert_not_called()
+
+
+def test_reboot_and_tagging_use_the_zone_of_the_instance(gce_providers):
+    provisioner = _provisioner("a,b,c")
+    provisioner.get_or_create_instances([_make_definition(3)], PricingModel.ON_DEMAND)
+
+    provisioner.reboot_instance("node-3", wait=False)
+    provisioner.add_instance_tags("node-3", {"keep": "alive"})
+
+    gce_providers["providers"]["us-east1-c"].reboot.assert_called_once_with("node-3", wait=False, hard=False)
+    gce_providers["providers"]["us-east1-c"].add_tags.assert_called_once_with("node-3", {"keep": "alive"})
+
+
+def test_cleanup_deletes_instances_in_every_zone(gce_providers):
+    """Cleanup must reach the nodes of all zones, or they leak."""
+    provisioner = _provisioner("a,b,c")
+    provisioner.get_or_create_instances([_make_definition(idx) for idx in range(1, 7)], PricingModel.ON_DEMAND)
+
+    provisioner.cleanup(wait=True)
+
+    deleted_per_zone = {
+        zone: sorted(call.args[0] for call in provider.delete.call_args_list)
+        for zone, provider in gce_providers["providers"].items()
+    }
+    assert deleted_per_zone == {
+        "us-east1-a": ["node-1", "node-4"],
+        "us-east1-b": ["node-2", "node-5"],
+        "us-east1-c": ["node-3", "node-6"],
+    }
+    for provider in gce_providers["providers"].values():
+        provider.clear_cache.assert_called_once()
+
+
+def test_existing_instances_are_cached_with_their_own_zone(gce_providers):
+    """Instances discovered at startup must keep the zone they were found in."""
+
+    def list_for_zone(zone):
+        return lambda: [_make_fake_instance(f"node-in-{zone}", zone)]
+
+    with patch("sdcm.provision.gce.provisioner.VirtualMachineProvider") as mock_vm_provider_cls:
+        providers = {}
+
+        def make_provider(project_id, zone, test_id, disk_provider, network_provider):
+            provider = MagicMock()
+            provider.list.side_effect = list_for_zone(zone)
+            providers[zone] = provider
+            return provider
+
+        mock_vm_provider_cls.side_effect = make_provider
+        provisioner = _provisioner("a,b")
+
+        provisioner.terminate_instance("node-in-us-east1-b")
+
+        providers["us-east1-b"].delete.assert_called_once_with("node-in-us-east1-b", wait=False)
+        providers["us-east1-a"].delete.assert_not_called()
+
+
+def test_single_az_places_every_node_in_that_zone(gce_providers):
+    provisioner = _provisioner("b")
+
+    provisioner.get_or_create_instances([_make_definition(idx) for idx in range(1, 4)], PricingModel.ON_DEMAND)
+
+    assert gce_providers["created_per_zone"] == {"us-east1-b": ["node-1", "node-2", "node-3"]}
+    assert provisioner.availability_zones == ["us-east1-b"]
+
+
+@pytest.mark.parametrize("availability_zone", ["a, b , c", "a,,b,c,"], ids=["spaces", "empty-parts"])
+def test_zone_letters_are_normalized(gce_providers, availability_zone):
+    assert _provisioner(availability_zone).availability_zones == ["us-east1-a", "us-east1-b", "us-east1-c"]
+
+
+@patch("sdcm.provision.gce.provisioner.random_zone", return_value="c")
+def test_empty_az_uses_random_zone(mock_random_zone, gce_providers):
+    """When availability_zone is empty, a random zone is selected."""
+    provisioner = _provisioner("")
+
+    assert provisioner.availability_zones == ["us-east1-c"]
+    assert provisioner.availability_zone == "us-east1-c"
+    mock_random_zone.assert_called_once_with("us-east1")

--- a/unit_tests/unit/provisioner/test_gce_zone_resolver.py
+++ b/unit_tests/unit/provisioner/test_gce_zone_resolver.py
@@ -174,6 +174,40 @@ def test_resolve_multi_region_multi_az_drops_unsupported_and_fills(mock_multi_re
     assert set(result) == {"b", "c", "d"}
 
 
+def test_resolve_raises_when_regions_cannot_supply_the_configured_zone_count(mock_multi_region):
+    """'b,c,d' asks for three racks; two zones would silently build a two-rack cluster."""
+    mock_multi_region["us-east1"] = ["us-east1-b", "us-east1-c", "us-east1-d"]
+    mock_multi_region["us-west1"] = ["us-west1-b", "us-west1-c"]
+    params = _make_params(gce_datacenter="us-east1 us-west1", availability_zone="b,c,d")
+
+    with pytest.raises(NoValidAvailabilityZoneError, match="requests 3 zone.*only 2"):
+        GceAZResolver(params).resolve()
+
+    # the caller must see the value it configured, not a silently narrowed one
+    assert params["availability_zone"] == "b,c,d"
+
+
+def test_resolve_raises_when_a_single_region_cannot_supply_the_configured_zone_count(mock_gce_zone_resolver):
+    """The shortfall is about the count, not about how many regions are configured."""
+    _, resolver_instance = mock_gce_zone_resolver
+    resolver_instance.get_common_zones.return_value = ["us-east1-b", "us-east1-c"]
+    params = _make_params(availability_zone="b,c,d")
+
+    with pytest.raises(NoValidAvailabilityZoneError, match="requests 3 zone.*only 2"):
+        GceAZResolver(params).resolve()
+
+
+def test_resolve_does_not_raise_when_the_zone_count_is_preserved(mock_gce_zone_resolver):
+    """Substituting an unsupported zone is fine - only a shortfall in the count is fatal."""
+    _, resolver_instance = mock_gce_zone_resolver
+    resolver_instance.get_common_zones.return_value = ["us-east1-c", "us-east1-d"]
+    params = _make_params(availability_zone="b,c")
+
+    GceAZResolver(params).resolve()
+
+    assert sorted(params["availability_zone"].split(",")) == ["c", "d"]
+
+
 @pytest.fixture(name="mock_discovery_resolver")
 def mock_discovery_resolver_fixture():
     class _DiscoveryStub:

--- a/unit_tests/unit/test_cluster_gce.py
+++ b/unit_tests/unit/test_cluster_gce.py
@@ -1,0 +1,146 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2026 ScyllaDB
+
+"""Tests for GCE cluster multi-AZ node placement."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from sdcm.cluster_gce import GCECluster
+
+
+def _instance(name: str, zone: str) -> MagicMock:
+    instance = MagicMock()
+    instance.name = name
+    instance.zone = f"projects/test-project/zones/{zone}"
+    return instance
+
+
+def _cluster(zone_letters: list[str], region: str = "us-east1") -> MagicMock:
+    cluster = MagicMock(spec=GCECluster)
+    cluster.log = MagicMock()
+    cluster.params = MagicMock()
+    cluster.params.get.side_effect = lambda key, *a, **kw: {"availability_zone": ",".join(zone_letters)}.get(key)
+    provisioner = MagicMock()
+    provisioner.region = region
+    provisioner.availability_zones = [f"{region}-{letter}" for letter in zone_letters]
+    cluster.provisioners = [provisioner]
+    return cluster
+
+
+@pytest.mark.parametrize(
+    "az_idx,expected",
+    [
+        pytest.param(0, ["db-1", "db-4"], id="rack-0"),
+        pytest.param(1, ["db-2", "db-5"], id="rack-1"),
+        pytest.param(2, ["db-3", "db-6"], id="rack-2"),
+    ],
+)
+def test_instances_in_az_buckets_by_configured_zone_order(az_idx, expected):
+    """Each rack must see only the instances living in its own zone."""
+    cluster = _cluster(["a", "b", "c"])
+    instances = [
+        _instance("db-1", "us-east1-a"),
+        _instance("db-2", "us-east1-b"),
+        _instance("db-3", "us-east1-c"),
+        _instance("db-4", "us-east1-a"),
+        _instance("db-5", "us-east1-b"),
+        _instance("db-6", "us-east1-c"),
+    ]
+
+    found = GCECluster._instances_in_az(cluster, instances, az_idx, 0)
+
+    assert [instance.name for instance in found] == expected
+
+
+def test_instances_in_az_keeps_rack_positions_when_an_earlier_zone_is_empty():
+    """A rack must never be handed another zone's instances just because its own zone is empty.
+
+    Compacting the zone order would give rack 0 the zone-b instances and rack 1 the zone-c ones,
+    labelling every node with a rack it does not live in - and leaving rack 2 to re-create the
+    instances the other racks already took.
+    """
+    cluster = _cluster(["a", "b", "c"])
+    instances = [
+        _instance("db-2", "us-east1-b"),
+        _instance("db-5", "us-east1-b"),
+        _instance("db-3", "us-east1-c"),
+        _instance("db-6", "us-east1-c"),
+    ]
+
+    assert GCECluster._instances_in_az(cluster, instances, 0, 0) == []
+    assert [i.name for i in GCECluster._instances_in_az(cluster, instances, 1, 0)] == ["db-2", "db-5"]
+    assert [i.name for i in GCECluster._instances_in_az(cluster, instances, 2, 0)] == ["db-3", "db-6"]
+
+
+def test_instances_in_az_puts_unconfigured_zones_after_the_configured_racks():
+    """A zone outside the configured set gets its own position and never displaces a rack."""
+    cluster = _cluster(["a", "b"])
+    instances = [_instance("db-1", "us-east1-a"), _instance("db-2", "us-east1-d")]
+
+    assert [i.name for i in GCECluster._instances_in_az(cluster, instances, 0, 0)] == ["db-1"]
+    assert GCECluster._instances_in_az(cluster, instances, 1, 0) == []
+    assert [i.name for i in GCECluster._instances_in_az(cluster, instances, 2, 0)] == ["db-2"]
+
+
+def test_instances_in_az_returns_nothing_for_a_zone_without_instances():
+    cluster = _cluster(["a", "b", "c"])
+
+    assert GCECluster._instances_in_az(cluster, [_instance("db-1", "us-east1-a")], 2, 0) == []
+
+
+@pytest.mark.parametrize("zone_letters", [["a"], ["c"]], ids=["configured-az", "resolved-az"])
+def test_instances_in_az_is_a_no_op_for_a_single_rack(zone_letters):
+    """With one rack there is nothing to split: every instance of the DC belongs to it."""
+    cluster = _cluster(zone_letters)
+    instances = [_instance("db-1", "us-east1-a"), _instance("db-2", "us-east1-b")]
+
+    assert GCECluster._instances_in_az(cluster, instances, 0, 0) == instances
+
+
+def test_instances_in_az_follows_the_provisioner_not_the_raw_param():
+    """The rack order must come from the DC's provisioner, which holds the resolved zones."""
+    cluster = _cluster(["b", "c"])
+    # the raw param still names the pre-resolve zones
+    cluster.params.get.side_effect = lambda key, *a, **kw: {"availability_zone": "a,b"}.get(key)
+    instances = [_instance("db-1", "us-east1-b"), _instance("db-2", "us-east1-c")]
+
+    assert [i.name for i in GCECluster._instances_in_az(cluster, instances, 0, 0)] == ["db-1"]
+    assert [i.name for i in GCECluster._instances_in_az(cluster, instances, 1, 0)] == ["db-2"]
+
+
+def test_get_instances_by_name_searches_every_zone_of_the_region():
+    """A multi-AZ cluster spreads nodes over zones, so the search cannot be pinned to one zone."""
+    cluster = _cluster(["a", "b", "c"])
+    wanted = _instance("db-3", "us-east1-c")
+    cluster._gce_service = MagicMock()
+    cluster._gce_service.aggregated_list.return_value = [
+        ("zones/us-east1-a", MagicMock(instances=[_instance("db-1", "us-east1-a")])),
+        ("zones/us-east1-c", MagicMock(instances=[wanted])),
+        ("zones/us-west1-c", MagicMock(instances=[_instance("db-3", "us-west1-c")])),
+    ]
+    cluster.project = "test-project"
+
+    assert GCECluster._get_instances_by_name(cluster, name="db-3", dc_idx=0) is wanted
+
+
+def test_get_instances_by_name_ignores_other_regions():
+    cluster = _cluster(["a"], region="us-east1")
+    cluster._gce_service = MagicMock()
+    cluster._gce_service.aggregated_list.return_value = [
+        ("zones/us-east10-a", MagicMock(instances=[_instance("db-1", "us-east10-a")])),
+    ]
+    cluster.project = "test-project"
+
+    assert GCECluster._get_instances_by_name(cluster, name="db-1", dc_idx=0) is None

--- a/unit_tests/unit/test_cluster_gce.py
+++ b/unit_tests/unit/test_cluster_gce.py
@@ -16,8 +16,9 @@
 from unittest.mock import MagicMock
 
 import pytest
+from google.cloud.compute_v1.types import Items, Metadata
 
-from sdcm.cluster_gce import GCECluster
+from sdcm.cluster_gce import GCECluster, gce_instance_node_index
 
 
 def _instance(name: str, zone: str) -> MagicMock:
@@ -144,3 +145,32 @@ def test_get_instances_by_name_ignores_other_regions():
     cluster.project = "test-project"
 
     assert GCECluster._get_instances_by_name(cluster, name="db-1", dc_idx=0) is None
+
+
+def _instance_with_index(name: str, node_index: str | None) -> MagicMock:
+    instance = _instance(name, "us-east1-a")
+    items = [] if node_index is None else [Items(key="NodeIndex", value=node_index)]
+    instance.metadata = Metadata(items=items)
+    return instance
+
+
+def test_instances_are_sorted_by_numeric_node_index():
+    """NodeIndex is a string in GCE metadata: sorted as text, node 10 would come before node 4."""
+    instances = [_instance_with_index(f"db-{index}", str(index)) for index in (10, 2, 4, 1, 7)]
+
+    assert sorted(instances, key=gce_instance_node_index) == [
+        instances[3],
+        instances[1],
+        instances[2],
+        instances[4],
+        instances[0],
+    ]
+
+
+@pytest.mark.parametrize("node_index", [pytest.param(None, id="missing"), pytest.param("not-a-number", id="garbage")])
+def test_instance_without_usable_node_index_sorts_first(node_index):
+    """A missing or unparsable NodeIndex must not blow up the comparison against numeric ones."""
+    broken = _instance_with_index("db-broken", node_index)
+    numbered = _instance_with_index("db-1", "1")
+
+    assert sorted([numbered, broken], key=gce_instance_node_index) == [broken, numbered]

--- a/unit_tests/unit/test_partial_provision_guard.py
+++ b/unit_tests/unit/test_partial_provision_guard.py
@@ -44,25 +44,8 @@ def _make_gce_cluster(instance_count, requested_count, is_reuse=False):
     """
     fake_instances = [MagicMock(name=f"instance-{i}") for i in range(instance_count)]
 
-    cluster = MagicMock(spec=GCECluster)
-    cluster.log = MagicMock()
-    cluster.params = MagicMock()
-    cluster.params.get.side_effect = lambda key, *a, **kw: {
-        "simulated_regions": False,
-    }.get(key)
-    cluster._node_index = 0
-    cluster.nodes = []
-    cluster.racks_count = 1
-
-    test_config = MagicMock()
-    test_config.REUSE_CLUSTER = is_reuse
-    test_config.test_id.return_value = "test-id-123"
-    cluster.test_config = test_config
-
-    cluster._get_instances = MagicMock(return_value=fake_instances)
-    cluster._create_node = MagicMock(
-        side_effect=lambda inst, idx, dc, rack, after_config=None: MagicMock(name=f"node-{idx}")
-    )
+    cluster = _gce_cluster_mock(is_reuse=is_reuse)
+    cluster._get_instances = MagicMock(side_effect=lambda dc_idx, az_idx=None: fake_instances)
 
     # Call the real add_nodes with self=cluster
     return GCECluster.add_nodes.__wrapped__(
@@ -71,6 +54,35 @@ def _make_gce_cluster(instance_count, requested_count, is_reuse=False):
         dc_idx=0,
         rack=0,
     )
+
+
+def _gce_cluster_mock(is_reuse=False, racks_count=1):
+    """Mocked GCECluster keeping the real rack placement and find-or-create logic."""
+    cluster = MagicMock(spec=GCECluster)
+    cluster.log = MagicMock()
+    cluster.params = MagicMock()
+    cluster.params.get.side_effect = lambda key, *a, **kw: {
+        "simulated_regions": False,
+    }.get(key)
+    cluster._node_index = 0
+    cluster.nodes = []
+    cluster.racks_count = racks_count
+
+    test_config = MagicMock()
+    test_config.REUSE_CLUSTER = is_reuse
+    test_config.test_id.return_value = "test-id-123"
+    cluster.test_config = test_config
+
+    cluster._rack_distribution = MagicMock(
+        side_effect=lambda count, rack: GCECluster._rack_distribution(cluster, count, rack)
+    )
+    cluster._create_or_find_instances = MagicMock(
+        side_effect=lambda **kwargs: GCECluster._create_or_find_instances(cluster, **kwargs)
+    )
+    cluster._create_node = MagicMock(
+        side_effect=lambda inst, idx, dc, rack, after_config=None: MagicMock(name=f"node-{idx}")
+    )
+    return cluster
 
 
 def test_gce_add_nodes_partial_provision_raises_error():
@@ -91,35 +103,75 @@ def test_gce_add_nodes_more_instances_than_requested_succeeds():
     assert len(result) >= 3
 
 
+def test_gce_reuse_cluster_with_fewer_instances_raises():
+    """Reusing a cluster that lost nodes must fail loudly, not add fewer nodes than requested."""
+    cluster = _gce_cluster_mock(is_reuse=True)
+    cluster._get_instances = MagicMock(side_effect=lambda dc_idx, az_idx=None: [MagicMock(name="instance-0")])
+
+    with pytest.raises(ProvisionError, match="Found only 1 instance.*but 3 were requested"):
+        GCECluster.add_nodes.__wrapped__(cluster, count=3, dc_idx=0, rack=0)
+
+
 def test_gce_add_nodes_no_instances_provisions_inline():
     """add_nodes should fall through to inline provisioning when no instances are found."""
-    cluster = MagicMock(spec=GCECluster)
-    cluster.log = MagicMock()
-    cluster.params = MagicMock()
-    cluster.params.get.side_effect = lambda key, *a, **kw: {
-        "simulated_regions": False,
-    }.get(key)
-    cluster._node_index = 0
-    cluster.nodes = []
-    cluster.racks_count = 1
-
-    test_config = MagicMock()
-    test_config.REUSE_CLUSTER = False
-    cluster.test_config = test_config
+    cluster = _gce_cluster_mock()
 
     # _get_instances returns empty list -> falls through to _create_instances
-    cluster._get_instances = MagicMock(return_value=[])
+    cluster._get_instances = MagicMock(side_effect=lambda dc_idx, az_idx=None: [])
 
     fake_vms = [MagicMock(name=f"vm-{i}") for i in range(3)]
     cluster._create_instances = MagicMock(return_value=fake_vms)
     cluster._get_instance_with_retry = MagicMock(side_effect=lambda name, dc_idx: MagicMock(name=name))
-    cluster._create_node = MagicMock(
-        side_effect=lambda inst, idx, dc, rack, after_config=None: MagicMock(name=f"node-{idx}")
-    )
 
     result = GCECluster.add_nodes.__wrapped__(cluster, count=3, dc_idx=0, rack=0)
-    cluster._create_instances.assert_called_once_with(3, 0, instance_type=None)
+    cluster._create_instances.assert_called_once_with(node_indexes=[1, 2, 3], dc_idx=0, rack=0, instance_type=None)
     assert len(result) == 3
+
+
+def test_gce_add_nodes_spreads_racks_by_node_index():
+    """rack=None must place each node in the rack its node index maps to."""
+    cluster = _gce_cluster_mock(racks_count=3)
+    cluster._get_instances = MagicMock(side_effect=lambda dc_idx, az_idx=None: [])
+    cluster._create_instances = MagicMock(
+        side_effect=lambda node_indexes, **kwargs: [MagicMock(name=f"vm-{idx}") for idx in node_indexes]
+    )
+    cluster._get_instance_with_retry = MagicMock(side_effect=lambda name, dc_idx: MagicMock(name=name))
+
+    GCECluster.add_nodes.__wrapped__(cluster, count=6, dc_idx=0, rack=None)
+
+    # every rack gets its own provisioning call, with the node indexes belonging to it
+    placement = {call.kwargs["rack"]: call.kwargs["node_indexes"] for call in cluster._create_instances.call_args_list}
+    assert placement == {0: [1, 4], 1: [2, 5], 2: [3, 6]}
+    # node labels agree with where the nodes were placed
+    assert [call.kwargs["rack"] for call in cluster._create_node.call_args_list] == [0, 1, 2, 0, 1, 2]
+
+
+def test_gce_add_nodes_explicit_rack_places_all_nodes_in_it():
+    """An explicit rack must be used for every node of the call, as the AZ to provision in."""
+    cluster = _gce_cluster_mock(racks_count=3)
+    cluster._get_instances = MagicMock(side_effect=lambda dc_idx, az_idx=None: [])
+    cluster._create_instances = MagicMock(
+        side_effect=lambda node_indexes, **kwargs: [MagicMock(name=f"vm-{idx}") for idx in node_indexes]
+    )
+    cluster._get_instance_with_retry = MagicMock(side_effect=lambda name, dc_idx: MagicMock(name=name))
+
+    GCECluster.add_nodes.__wrapped__(cluster, count=2, dc_idx=0, rack=2)
+
+    cluster._create_instances.assert_called_once_with(node_indexes=[1, 2], dc_idx=0, rack=2, instance_type=None)
+    assert [call.kwargs["rack"] for call in cluster._create_node.call_args_list] == [2, 2]
+
+
+def test_gce_add_nodes_finds_pre_provisioned_instances_per_rack():
+    """Pre-provisioned instances must be looked up in the zone bucket of each rack."""
+    cluster = _gce_cluster_mock(racks_count=3)
+    per_az = {az_idx: [MagicMock(name=f"instance-az{az_idx}")] for az_idx in range(3)}
+    cluster._get_instances = MagicMock(side_effect=lambda dc_idx, az_idx=None: per_az[az_idx])
+
+    nodes = GCECluster.add_nodes.__wrapped__(cluster, count=3, dc_idx=0, rack=None)
+
+    assert [call.kwargs["az_idx"] for call in cluster._create_or_find_instances.call_args_list] == [0, 1, 2]
+    cluster._create_instances.assert_not_called()
+    assert len(nodes) == 3
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
`GceAZResolver.resolve()` can set `availability_zone` to a comma-separated string like `'a,b,c'`, which means *spread the nodes over those zones, one rack per zone*. The GCE provisioner used the value as-is to build the zone name (`'us-central1-a,b,c'`), which is invalid, and the GCE cluster ignored racks altogether.

GCE now follows the same contract AWS implements with per-AZ subnets: **the rack selects the zone**, and instances are looked up by the zone they actually live in.

Failed test: https://jenkins.scylladb.com/job/scylla-2026.2/job/vnodes/job/tier1/job/longevity-multidc-schema-topology-changes-12h-test/3/

### Provisioner (`sdcm/provision/gce/provisioner.py`)
- The zone of an instance is derived from its **rack index**, falling back to its node index — never from its position in the batch being provisioned. A node lands in the same zone whether the cluster is created in one call or grown a node at a time, and a retry after a partial failure does not move nodes around.
- One VM provider per zone. Every instance operation — terminate, reboot, tagging, cleanup — is issued against the zone the instance lives in. Previously they all went to the first zone, so cleanup of a multi-AZ cluster silently left the nodes of the other zones running.
- An instance sitting outside the configured zones (runtime AZ fallback relocates one on a capacity error) gets a provider for its own zone, with a warning, rather than having the operation sent to the primary zone.
- Instances are tracked under the name GCE gives them (anything outside `[a-z0-9-]` replaced), so a definition whose name gets rewritten — e.g. a `user_prefix` carrying a dot — still matches the instance created for it.
- `get_or_create_instances()` returns instances in the order they were requested, and raises `ProvisionError` if creation comes back short, instead of returning a list that would shift every pairing a caller makes with its definitions.
- Zone letters are parsed defensively: empty tokens and whitespace (`'a, ,b,'`) are dropped; an empty value still picks a random zone.

### Cluster (`sdcm/cluster_gce.py`)
- `add_nodes` splits the requested nodes into per-rack groups and provisions each group in the zone of its rack, mirroring `cluster_aws.add_nodes`.
- `_create_instances` takes the node indexes to create and hands the rack to the provisioner as the definition's rack index, like `cluster_oci`.
- Node rack labels use the same node-index-based rule as zone selection, so rack and zone stay in sync.
- Pre-provisioned instances are bucketed by the zone they really occupy, and rack N addresses the Nth zone of that DC's provisioner whether or not that zone holds anything — compacting the order would hand a rack the instances of another zone. Single-rack clusters keep finding every instance of the DC regardless of zone.
- Reusing a cluster errors when a rack holds fewer instances than requested, instead of quietly adding fewer nodes than asked for.
- Instance lookup by name covers every zone of the region instead of one zone, and instance deletion uses the instance's own zone.
- AZ fallback is skipped for a multi-AZ configuration: it would replace the provisioner with a single-zone one and collapse the cluster into one zone.

### Zone resolver (`sdcm/provision/gce/zone_resolver.py`)
- `resolve()` now raises `NoValidAvailabilityZoneError` when fewer zones are valid than the configuration asks for. `availability_zone: 'b,c,d'` requests three racks; silently returning `'b,c'` would build a two-rack cluster (`racks_count` is derived from this parameter), running a topology the test never asked for. Dropping a rack is the job's decision, not the resolver's.

### Side effect
GCE joins OCI in getting `rack=None` for initial provisioning, so `add_nodes` derives racks from node indexes, matching how the pre-provisioner placed the VMs. As a result GCE loaders and monitors now get real rack labels instead of always `0`, which is what makes `rack_aware_loader` meaningful on GCE.

Single-AZ and empty-AZ (random selection) behavior is preserved.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] [longevity-multidc-schema-topology-changes-12h](https://argus.scylladb.com/tests/scylla-cluster-tests/1b8d727f-1b10-4d44-a614-994b0ba66dd6) - failed with:
```
google.api_core.exceptions.ServiceUnavailable: 503 SERVICE UNAVAILABLE ZONE_RESOURCE_POOL_EXHAUSTED_WITH_DETAILS:
The zone 'projects/sct-project-1/zones/us-central1-b' does not have enough resources available to fulfill the request.  'NULL:0/NULL:0/NULL:0 (state:STOCKOUT, sub-state:STOCKOUT, resource type:compute)'.
```
- Unit tests: `unit_tests/unit/provisioner/test_gce_provisioner_az_distribution.py` (placement stability, lifecycle routing per zone, return ordering, partial-creation failure, cleanup across zones, name normalization, single/empty AZ), `unit_tests/unit/test_cluster_gce.py`, `unit_tests/unit/test_partial_provision_guard.py`, `unit_tests/unit/provisioner/test_gce_zone_resolver.py`

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)

