### PR TITLE
fix(log-collector): include system_tablets.log in schema-logs artifact upload

### DIFF
--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -2047,6 +2047,7 @@ class SchemaLogCollector(BaseSCTLogCollector):
         FileLog(name="system_schema_tables.log", search_locally=True),
         FileLog(name="system_truncated.log", search_locally=True),
         FileLog(name="schema_with_internals.log", search_locally=True),
+        FileLog(name="system_tablets.log", search_locally=True),
     ]
     cluster_log_type = "schema-logs"
     cluster_dir_prefix = "schema-logs"


### PR DESCRIPTION
## Summary

- Adds `system_tablets.log` to `SchemaLogCollector.log_entities` so the file is uploaded to test artifacts

## Problem

PR #13426 added the CQL dump of `system.tablets` to `save_schema()` in `tester.py`, but missed adding the corresponding `FileLog` entry to `SchemaLogCollector` in `logcollector.py`. The file was created on the runner but never uploaded to S3/Argus.

## Fix

One-line addition to `sdcm/logcollector.py`.

Fixes SCT-401