### PR TITLE
fix(multidc-parallel-topology-schema-changes): select only nemesis with supports_high_disk_utilization

### DIFF
--- a/test-cases/longevity/longevity-multidc-parallel-topology-schema-changes-12h.yaml
+++ b/test-cases/longevity/longevity-multidc-parallel-topology-schema-changes-12h.yaml
@@ -67,7 +67,7 @@ simulated_racks: 0
 instance_type_db: 'i7i.xlarge'
 
 nemesis_class_name: ['SisyphusMonkey', 'SisyphusMonkey']
-nemesis_selector: ["topology_changes", "schema_changes and not disruptive"]
+nemesis_selector: ["topology_changes and supports_high_disk_utilization", "schema_changes and not disruptive and supports_high_disk_utilization"]
 nemesis_seed: [253, 328]
 nemesis_interval: 10
 nemesis_during_prepare: false


### PR DESCRIPTION
After 84ab956031011f1234d602cd6b90dbd521718c9c, the test has >50% disk utilization, so any nemesis that removes a node will cause the other node in rack to run out of space.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
