### PR TITLE
fix(alternator): switch default to DNS routing instead of native load balancing

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -94,8 +94,8 @@ compaction_strategy: 'IncrementalCompactionStrategy'
 use_preinstalled_scylla: false
 
 alternator_enforce_authorization: false
-alternator_use_dns_routing: false
-alternator_loadbalancing: true
+alternator_use_dns_routing: true
+alternator_loadbalancing: false
 alternator_trust_all_certificates: true
 alternator_access_key_id: ''
 alternator_secret_access_key: ''

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -919,7 +919,7 @@ Set the write isolation for the alternator table, see https://github.com/scyllad
 
 If true, spawn a docker with a dns server for the ycsb loader to point to
 
-**default:** N/A
+**default:** True
 
 **type:** bool
 
@@ -928,7 +928,7 @@ If true, spawn a docker with a dns server for the ycsb loader to point to
 
 If true, enable native load balancing for alternator
 
-**default:** True
+**default:** N/A
 
 **type:** bool
 


### PR DESCRIPTION
Switch alternator default routing from native load balancing to DNS-based routing to work around a bug in the alternator Java client driver

Related
- Jira: https://scylladb.atlassian.net/browse/SCT-370
- Fix in alternator-client-java: https://github.com/scylladb/alternator-client-java/pull/89
- YCSB test case for validation: https://github.com/scylladb/YCSB/pull/36

### Testing
<!-- Add links to Argus/Jenkins of test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- 🟢 https://argus.scylladb.com/tests/scylla-cluster-tests/a9567187-dd87-4ad6-bee6-21925b431035

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
