### PR TITLE
sdcm: add filter for hints_manager segment data corruption errors

### DIFF
--- a/sdcm/sct_events/group_common_events.py
+++ b/sdcm/sct_events/group_common_events.py
@@ -605,6 +605,20 @@ def ignore_ipv6_failure_to_assign():
         yield
 
 
+@contextmanager
+def ignore_hints_sending_errors():
+    with ExitStack() as stack:
+        stack.enter_context(
+            EventsSeverityChangerFilter(
+                new_severity=Severity.WARNING,
+                event_class=DatabaseLogEvent,
+                regex=r".*hints_manager - hint_sender.*send_one_file: Segment error.*Segment data corruption.*",
+                extra_time_to_expiration=30,
+            )
+        )
+        yield
+
+
 NODE_UNAVAILABLE_CONTEXTS: list[Callable[[], ContextManager]] = [
     ignore_raft_topology_cmd_failing,
     ignore_raft_transport_failing,
@@ -612,6 +626,7 @@ NODE_UNAVAILABLE_CONTEXTS: list[Callable[[], ContextManager]] = [
     ignore_stream_mutation_fragments_errors,
     ignore_compaction_stopped_exceptions,
     ignore_ignore_runtime_errors,
+    ignore_hints_sending_errors,
 ]
 
 


### PR DESCRIPTION
Add ignore_hints_sending_errors() context manager that downgrades hints_manager hint segment corruption errors from ERROR to WARNING.

local regexp testing
Fixes SCYLLADB-923

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
