### PR TITLE
lwt: disable tablets for latte schema in LWT longevity test

### DIFF
--- a/configurations/tablets_disabled.yaml
+++ b/configurations/tablets_disabled.yaml
@@ -1,3 +1,8 @@
 append_scylla_yaml:
   enable_tablets: false
   tablets_mode_for_new_keyspaces: 'disabled'
+
+latte_schema_parameters:
+  tablets: "false"
+  enable_tablets: "false"
+  use_tablets: "false"

--- a/jenkins-pipelines/oss/vnodes/tier2/longevity-lwt-24h-gce-vnodes.jenkinsfile
+++ b/jenkins-pipelines/oss/vnodes/tier2/longevity-lwt-24h-gce-vnodes.jenkinsfile
@@ -8,5 +8,4 @@ longevityPipeline(
     region: 'us-east1',
     test_name: 'longevity_lwt_test.LWTLongevityTest.test_lwt_longevity',
     test_config: '''["test-cases/longevity/longevity-lwt-basic-24h.yaml", "configurations/tablets_disabled.yaml"]'''
-
 )


### PR DESCRIPTION
Add lwt_load_rn_tablets_disable.yaml configuration that sets latte_schema_parameters tablets to false, and include it in the longevity-lwt-24h-gce-vnodes pipeline config list.

This ensures the latte load schema explicitly disables tablets when running LWT longevity tests on vnodes, preventing tablet-related issues during LWT workloads.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated tablet configuration parameters in test environment settings.
  * Refined build pipeline formatting for consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/scylladb/scylla-cluster-tests/pull/14767?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->