### PR TITLE
cluster: filter out paxos tables from non-system table list by default

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4877,7 +4877,7 @@ class BaseCluster:
         filter_empty_tables=True,
         filter_by_keyspace: list = None,
         filter_func: Callable[..., bool] = None,
-        filter_out_paxos_tables: bool = False,
+        filter_out_paxos_tables: bool = True,
     ) -> List[str]:
         return self.get_any_ks_cf_list(
             db_node,


### PR DESCRIPTION
Change the default value of filter_out_paxos_tables from False to True in get_non_system_ks_cf_list(). LWT paxos tables (system_cluster_paxos.*) are internal bookkeeping tables that should not be included in general non-system table listings used by nemesis, validations, and other operations. Filtering them out by default prevents unexpected interactions with these internal tables during test workflows.

Fixes: SCT-403

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Modified default behavior for cluster operations to exclude paxos-related tables in system keyspace listing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/scylladb/scylla-cluster-tests/pull/14768?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->