### PR TITLE
fix(apt-keys): make gpg --recv-keys recover from keyserver stalls

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2414,9 +2414,10 @@ class BaseNode(AutoSshContainerMixin):
                 # Try each HKP keyserver
                 for keyserver in hkp_keyservers:
                     result = self.remoter.sudo(
-                        f"gpg --homedir /tmp --no-default-keyring --keyring {temp_keyring} --keyserver {keyserver} --keyserver-options timeout=10 --recv-keys {apt_key}",
+                        f"timeout 30 gpg --homedir /tmp --no-default-keyring --keyring {temp_keyring} --keyserver {keyserver} --keyserver-options timeout=10 --recv-keys {apt_key}",
                         retry=1,
                         ignore_status=True,
+                        timeout=120,
                     )
                     if result.ok:
                         LOGGER.debug("Fetched GPG key %s from %s", apt_key, keyserver)
@@ -2432,6 +2433,7 @@ class BaseNode(AutoSshContainerMixin):
                         ),
                         retry=1,
                         ignore_status=True,
+                        timeout=120,
                     )
                     if result.ok:
                         LOGGER.debug("Fetched GPG key %s from HTTPS fallback", apt_key)

--- a/unit_tests/unit/test_fetch_apt_keys.py
+++ b/unit_tests/unit/test_fetch_apt_keys.py
@@ -30,9 +30,10 @@ def _make_result(ok):
 
 def _gpg_recv_call(temp_keyring, keyserver, apt_key):
     return mock.call(
-        f"gpg --homedir /tmp --no-default-keyring --keyring {temp_keyring} --keyserver {keyserver} --keyserver-options timeout=10 --recv-keys {apt_key}",
+        f"timeout 30 gpg --homedir /tmp --no-default-keyring --keyring {temp_keyring} --keyserver {keyserver} --keyserver-options timeout=10 --recv-keys {apt_key}",
         retry=1,
         ignore_status=True,
+        timeout=120,
     )
 
 
@@ -44,6 +45,7 @@ def _https_fallback_call(temp_keyring, apt_key):
         ),
         retry=1,
         ignore_status=True,
+        timeout=120,
     )
 
 


### PR DESCRIPTION
`gpg --keyserver-options timeout=10` only caps the dirmngr connect, not the overall HKP transaction. A silent stall can block `remoter.sudo` forever, so the HKP/HTTPS fallback chain (added in PR #14537) never kicks in.

Wrap each gpg call with `timeout 30` and pass `timeout=120` to `remoter.sudo` in fetch_apt_keys as an additional SSH-layer guard.

Ref: SCT-290

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] provision tests

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added execution time limits to GPG key retrieval operations to prevent indefinite hangs during package manager setup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/scylladb/scylla-cluster-tests/pull/14777?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->