### PR TITLE
fix(tester): prevent FileExistsError in collect_ssl_conf during tearDown

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -761,7 +761,7 @@ class ClusterTester(unittest.TestCase):
             self.log.warning("Error submitting gemini results to argus", exc_info=True)
 
     def collect_ssl_conf(self):
-        shutil.copytree(Path(get_data_dir_path("ssl_conf")), Path(self.logdir) / "ssl_conf")
+        shutil.copytree(Path(get_data_dir_path("ssl_conf")), Path(self.logdir) / "ssl_conf", dirs_exist_ok=True)
 
     def _init_data_validation(self):
         if data_validation := self.params.get("data_validation"):


### PR DESCRIPTION
Use dirs_exist_ok=True in shutil.copytree to avoid FileExistsError when ssl_conf directory already exists in the logdir. This occurs intermittently when tearDown is triggered after a setup failure that already created the directory.

Failed test: https://argus.scylladb.com/tests/scylla-cluster-tests/be385907-ab32-4319-a125-b42bd749f9c4
```
16:13:16  entries = [<DirEntry 'client'>]
16:13:16  src = PosixPath('/home/ubuntu/scylla-cluster-tests/data_dir/ssl_conf')
16:13:16  dst = PosixPath('/home/ubuntu/sct-results/20260526-130116-644988/ssl_conf')
16:13:16  symlinks = False, ignore = None
16:13:16  copy_function = <function copy2 at 0x7fb000a862a0>
16:13:16  ignore_dangling_symlinks = False, dirs_exist_ok = False
16:13:16  
16:13:16      def _copytree(entries, src, dst, symlinks, ignore, copy_function,
16:13:16                    ignore_dangling_symlinks, dirs_exist_ok=False):
16:13:16          if ignore is not None:
16:13:16              ignored_names = ignore(os.fspath(src), [x.name for x in entries])
16:13:16          else:
16:13:16              ignored_names = ()
16:13:16      
16:13:16  >       os.makedirs(dst, exist_ok=dirs_exist_ok)
16:13:16  E       FileExistsError: [Errno 17] File exists: '/home/ubuntu/sct-results/20260526-130116-644988/ssl_conf'
```

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SSL configuration collection in test logs to handle cases where the destination directory already exists, preventing potential errors during test execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/scylladb/scylla-cluster-tests/pull/14783?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->