### PR TITLE
fix(oci): properly propagate the rack index. part2

### DIFF
--- a/sdcm/cluster_oci.py
+++ b/sdcm/cluster_oci.py
@@ -358,8 +358,9 @@ class OciCluster(cluster.BaseCluster):
 
         self.log.debug("instances: %s", instances)
         for node_index, instance in enumerate(instances, start=self._node_index + 1):
-            # in case rack is not specified, spread nodes to different racks
-            node_rack = node_index % self.racks_count if rack is None else rack
+            # NOTE: In case rack is not specified, spread nodes to different racks using
+            #       the 0-based formula to stay consistent with AZ selection in '_get_availability_domain'.
+            node_rack = (node_index - 1) % self.racks_count if rack is None else rack
             node = self._create_node(instance, node_index, dc_idx, rack=node_rack, after_config=after_config)
             nodes.append(node)
             self.nodes.append(node)

--- a/unit_tests/unit/test_cluster_oci.py
+++ b/unit_tests/unit/test_cluster_oci.py
@@ -2,7 +2,9 @@
 
 from unittest.mock import Mock, patch
 
-from sdcm.cluster_oci import OciNode
+import pytest
+
+from sdcm.cluster_oci import OciCluster, OciNode
 
 
 MOCK_CREDENTIALS = Mock(key_file="/tmp/test_key")
@@ -129,3 +131,85 @@ def test_create_node_certificate_includes_short_and_fqdn_dns_names(mock_create_c
     dns_names = mock_create_cert.call_args.kwargs["dns_names"]
     assert "db-node-short" in dns_names
     assert "db-node-short.subnet.vcn.oraclevcn.com" in dns_names
+
+
+# --- OciCluster.add_nodes rack assignment tests ---
+
+
+@pytest.fixture()
+def oci_cluster_for_rack_tests():
+    """Real OciCluster instance with patched init and mocked external dependencies."""
+    with patch.object(OciCluster, "__init__", lambda self: None):
+        cluster = OciCluster()
+    cluster._node_index = 0
+    cluster.racks_count = 3
+    cluster.nodes = []
+    cluster.log = Mock()
+    cluster.params = Mock()
+    cluster.params.get = Mock(return_value=0)  # simulated_regions=0
+    cluster.instance_provision = "on_demand"
+    # needed by @mark_new_nodes_as_running_nemesis decorator
+    cluster.test_config = Mock()
+    cluster.test_config.tester_obj = Mock(return_value=Mock(spec=[]))
+    # mock external boundaries (provisioning and node creation)
+    cluster._create_instances = Mock(
+        side_effect=lambda count, *args, **kwargs: [_mock_cloud_instance() for _ in range(count)]
+    )
+    cluster._create_node = Mock(
+        side_effect=lambda instance, node_index, dc_idx, rack, after_config: Mock(
+            name=f"node-{node_index}",
+            rack=rack,
+            enable_auto_bootstrap=False,
+        )
+    )
+    return cluster
+
+
+def test_add_nodes_rack_none_assigns_zero_based_indices(oci_cluster_for_rack_tests):
+    """Rack indices must be 0-based to match AZ selection in _get_availability_domain."""
+    oci_cluster_for_rack_tests.add_nodes(count=6, rack=None)
+
+    actual_racks = [call.kwargs["rack"] for call in oci_cluster_for_rack_tests._create_node.call_args_list]
+    assert actual_racks == [0, 1, 2, 0, 1, 2]
+
+
+def test_add_nodes_explicit_rack_uses_value_for_all_nodes(oci_cluster_for_rack_tests):
+    """When rack is explicitly specified, all nodes get that rack value."""
+    oci_cluster_for_rack_tests.add_nodes(count=3, rack=2)
+
+    actual_racks = [call.kwargs["rack"] for call in oci_cluster_for_rack_tests._create_node.call_args_list]
+    assert actual_racks == [2, 2, 2]
+
+
+def test_add_nodes_propagates_explicit_rack_to_create_instances(oci_cluster_for_rack_tests):
+    """Explicit rack must be forwarded to _create_instances for AZ placement."""
+    oci_cluster_for_rack_tests.add_nodes(count=1, rack=1)
+
+    oci_cluster_for_rack_tests._create_instances.assert_called_once_with(1, 0, instance_type=None, rack=1)
+
+
+def test_add_nodes_propagates_none_rack_to_create_instances(oci_cluster_for_rack_tests):
+    """rack=None must be forwarded so _create_instances falls back to NodeIndex-based AZ."""
+    oci_cluster_for_rack_tests.add_nodes(count=1, rack=None)
+
+    oci_cluster_for_rack_tests._create_instances.assert_called_once_with(1, 0, instance_type=None, rack=None)
+
+
+@pytest.mark.parametrize(
+    "node_index_start,count,expected_racks",
+    [
+        pytest.param(0, 3, [0, 1, 2], id="offset-0"),
+        pytest.param(3, 3, [0, 1, 2], id="offset-3"),
+        pytest.param(6, 3, [0, 1, 2], id="offset-6"),
+    ],
+)
+def test_add_nodes_rack_none_consistent_across_node_index_offsets(
+    oci_cluster_for_rack_tests, node_index_start, count, expected_racks
+):
+    """Rack round-robin must produce 0,1,2 regardless of _node_index offset."""
+    oci_cluster_for_rack_tests._node_index = node_index_start
+
+    oci_cluster_for_rack_tests.add_nodes(count=count, rack=None)
+
+    actual_racks = [call.kwargs["rack"] for call in oci_cluster_for_rack_tests._create_node.call_args_list]
+    assert actual_racks == expected_racks


### PR DESCRIPTION
Previous PR (https://github.com/scylladb/scylla-cluster-tests/pull/14564) fixed the improper rack distribution in OCI partially.
Align the order of racks that get picked up with the `_get_availability_domain` method.

Fixes: #SCT-389

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added test coverage for cluster rack assignment, verifying round‑robin distribution across racks (including different start offsets), explicit rack specification, and that the chosen rack is applied when creating nodes.

* **Documentation**
  * Clarified rack selection notes to explain 0‑based rack spreading behavior and its relation to availability‑domain selection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/scylladb/scylla-cluster-tests/pull/14788?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->