### PR TITLE
ci(claude): enable PR review for all scylladb org members including forks

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,16 +1,11 @@
 name: Claude Code Review
 
 on:
-  # Disabled: automatic PR review is not needed for now.
-  # To re-enable, restore the pull_request trigger below.
-  # pull_request:
-  #   types: [opened, synchronize, ready_for_review, reopened]
-  workflow_dispatch:
+  pull_request_target:
+    types: [opened, synchronize, ready_for_review, reopened]
 
 jobs:
   claude-review:
-    # Skip fork PRs — secrets are unavailable for pull_request from forks.
-    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -19,17 +14,49 @@ jobs:
       id-token: write
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
+      - name: Check PR author org membership
+        id: membership
+        env:
+          AUTHOR_LOGIN: ${{ github.event.pull_request.user.login }}
+          AUTHOR_ASSOC: ${{ github.event.pull_request.author_association }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          case "$AUTHOR_ASSOC" in
+            OWNER|MEMBER|COLLABORATOR)
+              echo "is_member=true" >> "$GITHUB_OUTPUT"
+              echo "✅ $AUTHOR_LOGIN has association $AUTHOR_ASSOC — proceeding"
+              ;;
+            *)
+              # author_association occasionally misclassifies org members as CONTRIBUTOR.
+              # Fall back to a live org membership check to avoid false rejections.
+              STATUS=$(gh api "orgs/scylladb/members/$AUTHOR_LOGIN" \
+                --silent -i 2>&1 | head -1 | awk '{print $2}')
+              if [ "$STATUS" = "204" ]; then
+                echo "is_member=true" >> "$GITHUB_OUTPUT"
+                echo "✅ $AUTHOR_LOGIN is a scylladb org member (live check)"
+              else
+                echo "is_member=false" >> "$GITHUB_OUTPUT"
+                echo "❌ $AUTHOR_LOGIN ($AUTHOR_ASSOC) is not a scylladb org member — skipping"
+              fi
+              ;;
+          esac
+
+      - name: Checkout base repository
+        if: steps.membership.outputs.is_member == 'true'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
+          # Always checkout the BASE branch, never the fork's HEAD.
+          # pull_request_target runs with base-repo secrets; executing untrusted
+          # fork code here would expose them ("pwn request" attack vector).
           ref: ${{ github.event.pull_request.base.sha }}
           fetch-depth: 1
 
       - name: Run Claude Code Review
+        if: steps.membership.outputs.is_member == 'true'
         id: claude-review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251  # v1.0.133
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -109,16 +109,16 @@ jobs:
 
       - name: Checkout repository
         if: steps.membership.outputs.is_member == 'true'
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         if: steps.membership.outputs.is_member == 'true'
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251  # v1.0.133
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
           # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
           # prompt: 'Update the pull request description to include a summary of changes.'

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -172,6 +172,21 @@ SCT_PERF_GRADUAL_THREADS={"read": [450, 400, 450], "write": 400, "mixed": 1900}
 SCT_PERF_GRADUAL_THROTTLE_STEPS={"read": ['700000', 'unthrottled', 'unthrottled'], "mixed": ['50000', '150000', '300000', '450000', 'unthrottled'], "write": ['200000', '300000', 'unthrottled']}
 ```
 
+## How does the Claude AI code review work?
+
+The Claude Code Review workflow runs automatically on every PR opened by a scylladb org member.
+It uses the `pull_request_target` trigger, which means:
+
+- The workflow always executes code from the **base branch (master)**, not the PR branch — this is a GitHub security requirement that prevents secrets from being exposed to fork code
+- Because of this, changes to the workflow file only take effect **after they are merged to master**
+- The review is restricted to scylladb org members and collaborators; PRs from external contributors are silently skipped
+
+To re-run the review on an existing PR, push an empty commit to the PR branch:
+
+```bash
+git commit --allow-empty -m "re-trigger Claude review" && git push
+```
+
 ## How to find equivalent AMIs across regions or architectures?
 
 Use the `find-ami-equivalent` command to find equivalent AWS AMIs in different regions or architectures based on image tags:


### PR DESCRIPTION
## Summary

- Switch `claude-code-review.yml` trigger from `workflow_dispatch` to `pull_request_target` so Claude automatically reviews every PR, including from forks
- Replace `CLAUDE_CODE_OAUTH_TOKEN` with `ANTHROPIC_API_KEY` in both `claude.yml` and `claude-code-review.yml`
- Add a two-layer org membership gate that restricts the review to scylladb org members and collaborators

## Security design

`pull_request_target` runs with base-repo secrets but the workflow code is always from the base branch — forks can't modify the CI. The known "pwn request" attack vector (checking out and executing fork code) is blocked because checkout is pinned to `base.sha`.

**Membership gate** (two layers per [GitHub Security Lab guidance](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/)):
1. Fast-path: `author_association` in `OWNER | MEMBER | COLLABORATOR`
2. Fallback: live `GET /orgs/scylladb/members/{login}` API call — handles the [known GitHub bug](https://github.com/actions/github-script/issues/643) where org members occasionally receive `CONTRIBUTOR` association

## Setup required

Add `ANTHROPIC_API_KEY` as a repository secret:
```bash
gh secret set ANTHROPIC_API_KEY --repo scylladb/scylla-cluster-tests
```

## Test plan

- [ ] This PR itself triggers `claude-code-review.yml` via `pull_request_target` — check the Actions tab to confirm the review runs and posts a comment
- [ ] Confirm the membership check step shows `✅` for the PR author
- [ ] Verify Claude posts a review comment on this PR
- [ ] Confirm a PR from a non-org member would be skipped (membership step outputs `is_member=false`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled CI workflow to run on pull-request events, added step-level gating that verifies PR author membership before sensitive steps run, removed the previous fork-repo guard, narrowed workflow permissions, and pinned action versions; migrated the automated review to a new credential input.
* **Documentation**
  * Added FAQ explaining how the automated review is triggered, which branch it runs against, membership gating, and how to re-trigger a review.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/scylladb/scylla-cluster-tests/pull/14789?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->