### PR TITLE
ci(perf): apply `pre_release` filter only if ScyllaDB is non-master

### DIFF
--- a/vars/perfRegressionParallelPipelinebyRegion.groovy
+++ b/vars/perfRegressionParallelPipelinebyRegion.groovy
@@ -420,7 +420,7 @@ def call(Map pipelineParams) {
                                         }
                                         // NOTE: Check that Scylla version matches specified 'pre-release' parts.
                                         //       Semver structure: <major> "." <minor> "." <patch> "-" <pre-release> "+" <build>
-                                        if (entry.pre_release && !entry.pre_release.any { pr -> version.contains("-${pr}") }) {
+                                        if (!scylla_version?.startsWith("master") && entry.pre_release && !entry.pre_release.any { pr -> version.contains("-${pr}") }) {
                                             println("Skipping job $job_name because $version version doesn't match specified pre-releases: ${entry.pre_release}")
                                             continue
                                         }


### PR DESCRIPTION
### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pre-release filtering logic to correctly apply filters based on version type, ensuring accurate release processing and proper handling of version selection workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/scylladb/scylla-cluster-tests/pull/14793?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->