### PR TITLE
fix(claude): use repo collaborators endpoint for membership fallback

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -29,14 +29,17 @@ jobs:
             *)
               # author_association occasionally misclassifies org members as CONTRIBUTOR.
               # Fall back to a live org membership check to avoid false rejections.
-              STATUS=$(gh api "orgs/scylladb/members/$AUTHOR_LOGIN" \
+              # Use the repo collaborators endpoint — works with the repo-scoped
+              # GITHUB_TOKEN (unlike orgs/members which requires org membership
+              # on the caller side and returns 302 for the Actions bot).
+              STATUS=$(gh api "repos/scylladb/scylla-cluster-tests/collaborators/$AUTHOR_LOGIN" \
                 --silent -i 2>&1 | head -1 | awk '{print $2}')
               if [ "$STATUS" = "204" ]; then
                 echo "is_member=true" >> "$GITHUB_OUTPUT"
-                echo "✅ $AUTHOR_LOGIN is a scylladb org member (live check)"
+                echo "✅ $AUTHOR_LOGIN is a repo collaborator (live check)"
               else
                 echo "is_member=false" >> "$GITHUB_OUTPUT"
-                echo "❌ $AUTHOR_LOGIN ($AUTHOR_ASSOC) is not a scylladb org member — skipping"
+                echo "❌ $AUTHOR_LOGIN ($AUTHOR_ASSOC) is not a repo collaborator — skipping"
               fi
               ;;
           esac

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -187,6 +187,8 @@ To re-run the review on an existing PR, push an empty commit to the PR branch:
 git commit --allow-empty -m "re-trigger Claude review" && git push
 ```
 
+The review comment is posted directly on the PR by the `claude[bot]` user.
+
 ## How to find equivalent AMIs across regions or architectures?
 
 Use the `find-ami-equivalent` command to find equivalent AWS AMIs in different regions or architectures based on image tags:


### PR DESCRIPTION
## Problem

The live org membership check in the Claude Code Review workflow always fails because `GET /orgs/{org}/members/{user}` returns **302** (redirect) when the caller is not an org member — which the `GITHUB_TOKEN` Actions bot never is.

Confirmed in run [26473127240](https://github.com/scylladb/scylla-cluster-tests/actions/runs/26473127240): `fruch` got `author_association: CONTRIBUTOR` (known GitHub misclassification bug for org members), fell through to the live check, which also returned non-204, so the entire review was skipped.

## Fix

Switch the fallback to `GET /repos/{owner}/{repo}/collaborators/{user}`, which:
- Works with the repo-scoped `GITHUB_TOKEN`
- Returns 204 for any org member with repo access
- Returns 404 for external contributors

## Note on testing

`pull_request_target` always runs the workflow from **master**, so this fix only takes effect after merging. Merge this, then open another small PR to confirm the review fires correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified in the FAQ that the code review comment is posted directly on the pull request by the automated reviewer.
* **Chores**
  * Improved the CI workflow's membership check for PR authors to more accurately determine collaborator status.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/scylladb/scylla-cluster-tests/pull/14795?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->