### PR TITLE
fix(claude): use AUTO_BACKPORT_TOKEN for org membership fallback check

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -30,8 +30,10 @@ jobs:
               echo "✅ $AUTHOR_LOGIN has association $AUTHOR_ASSOC — proceeding"
               ;;
             *)
-              # author_association returns CONTRIBUTOR instead of MEMBER for some
-              # org members due to a known GitHub bug. Fall back to a live check.
+              # author_association only returns MEMBER when the user's org
+              # membership is public. GitHub defaults membership to private, so
+              # most org members appear as CONTRIBUTOR here. Fall back to a live
+              # API call with a read:org token to check actual membership.
               # See: https://github.com/orgs/community/discussions/18690
               STATUS=$(gh api "orgs/scylladb/members/$AUTHOR_LOGIN" \
                 --silent -i 2>&1 | head -1 | awk '{print $2}')

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -19,7 +19,10 @@ jobs:
         env:
           AUTHOR_LOGIN: ${{ github.event.pull_request.user.login }}
           AUTHOR_ASSOC: ${{ github.event.pull_request.author_association }}
-          GH_TOKEN: ${{ github.token }}
+          # AUTO_BACKPORT_TOKEN has read:org scope — required to call the org
+          # membership API. GITHUB_TOKEN (Actions bot) is not an org member and
+          # cannot reliably check membership via any GitHub endpoint.
+          GH_TOKEN: ${{ secrets.AUTO_BACKPORT_TOKEN }}
         run: |
           case "$AUTHOR_ASSOC" in
             OWNER|MEMBER|COLLABORATOR)
@@ -27,19 +30,17 @@ jobs:
               echo "✅ $AUTHOR_LOGIN has association $AUTHOR_ASSOC — proceeding"
               ;;
             *)
-              # author_association occasionally misclassifies org members as CONTRIBUTOR.
-              # Fall back to a live org membership check to avoid false rejections.
-              # Use the repo collaborators endpoint — works with the repo-scoped
-              # GITHUB_TOKEN (unlike orgs/members which requires org membership
-              # on the caller side and returns 302 for the Actions bot).
-              STATUS=$(gh api "repos/scylladb/scylla-cluster-tests/collaborators/$AUTHOR_LOGIN" \
+              # author_association returns CONTRIBUTOR instead of MEMBER for some
+              # org members due to a known GitHub bug. Fall back to a live check.
+              # See: https://github.com/orgs/community/discussions/18690
+              STATUS=$(gh api "orgs/scylladb/members/$AUTHOR_LOGIN" \
                 --silent -i 2>&1 | head -1 | awk '{print $2}')
               if [ "$STATUS" = "204" ]; then
                 echo "is_member=true" >> "$GITHUB_OUTPUT"
-                echo "✅ $AUTHOR_LOGIN is a repo collaborator (live check)"
+                echo "✅ $AUTHOR_LOGIN is a scylladb org member (live check)"
               else
                 echo "is_member=false" >> "$GITHUB_OUTPUT"
-                echo "❌ $AUTHOR_LOGIN ($AUTHOR_ASSOC) is not a repo collaborator — skipping"
+                echo "❌ $AUTHOR_LOGIN ($AUTHOR_ASSOC) is not a scylladb org member — skipping"
               fi
               ;;
           esac


### PR DESCRIPTION
## Problem

The membership fallback in the Claude Code Review workflow always fails. The root cause is that **`GITHUB_TOKEN` (the Actions bot) is not an org member** and cannot reliably call any GitHub membership API:

- `GET /orgs/{org}/members/{user}` → returns **302** (redirect for non-org callers)
- `GET /repos/{owner}/{repo}/collaborators/{user}` → returns **404** (requires caller to be a collaborator)

Confirmed in runs [26473127240](https://github.com/scylladb/scylla-cluster-tests/actions/runs/26473127240) and [26473327950](https://github.com/scylladb/scylla-cluster-tests/actions/runs/26473327950): `fruch` gets `author_association: CONTRIBUTOR` due to a [known GitHub bug](https://github.com/orgs/community/discussions/18690), falls through to the live check, which also fails → review skipped.

## Fix

Switch the `GH_TOKEN` in the membership step to `AUTO_BACKPORT_TOKEN`, which already has `read:org` scope. This is the same pattern used by `build-docker-image.yaml` and `update-git-blame-ignore-revs.yaml` for team membership checks.

Also reverts the collaborators endpoint back to `orgs/members` now that the token has the correct scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

This pull request contains no user-facing changes. The updates are internal to the CI/CD infrastructure and do not affect the functionality or user experience of the application.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/scylladb/scylla-cluster-tests/pull/14797?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->