### PR TITLE
fix(claude): bypass OIDC federation for pull_request_target trigger

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -63,6 +63,13 @@ jobs:
         uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251  # v1.0.133
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # pass github_token to bypass OIDC federation — the action's federation
+          # server rejects OIDC tokens from pull_request_target events (not in its
+          # allowlist). Passing github_token directly skips the exchange and uses
+          # the workflow token instead. Comments appear from github-actions[bot]
+          # rather than claude[bot], but review content is identical.
+          # Ref: https://github.com/anthropics/claude-code-action/issues/1348
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'


### PR DESCRIPTION
## Problem

Every run of the Claude Code Review workflow fails with:

```
App token exchange failed: 401 Unauthorized - Invalid OIDC token
```

The action's OIDC federation server (at `api.anthropic.com/api/github/github-app-token-exchange`) rejects tokens generated by `pull_request_target` events — this trigger is not in its supported allowlist. The issue is documented upstream at [anthropics/claude-code-action#1348](https://github.com/anthropics/claude-code-action/issues/1348).

## Fix

Pass `github_token: ${{ secrets.GITHUB_TOKEN }}` to the action, which short-circuits the OIDC exchange entirely and uses the workflow token directly.

**Trade-off:** Review comments appear from `github-actions[bot]` instead of `claude[bot]`. The review content is identical — only the posting identity changes.

## Previous fix PRs in this chain

- #14789 — initial setup (pull_request_target, membership gate, API key)
- #14795 — fix repo collaborators endpoint
- #14797 — fix token scope for membership check (AUTO_BACKPORT_TOKEN)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow to enable code review automation during pull requests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/scylladb/scylla-cluster-tests/pull/14799?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->