### PR TITLE
fix(claude): switch to sonnet model for higher rate limits

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -70,6 +70,7 @@ jobs:
           # rather than claude[bot], but review content is identical.
           # Ref: https://github.com/anthropics/claude-code-action/issues/1348
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          claude_args: '--model claude-sonnet-4-6'
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'


### PR DESCRIPTION
Opus 4.7 has a 10,000 TPM limit which this repo's review prompts exceed (confirmed in [run 26474036409](https://github.com/scylladb/scylla-cluster-tests/actions/runs/26474036409)).

Switch to `claude-sonnet-4-6` via `claude_args: '--model claude-sonnet-4-6'` — significantly higher rate limits, still excellent for code review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal code review automation configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/scylladb/scylla-cluster-tests/pull/14801?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->