### PR TITLE
fix(claude): switch claude.yml to sonnet model for higher rate limits

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -119,6 +119,7 @@ jobs:
         uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251  # v1.0.133
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_args: '--model claude-sonnet-4-6'
 
           # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
           # prompt: 'Update the pull request description to include a summary of changes.'


### PR DESCRIPTION
The org is hitting the 10,000 TPM limit on `claude-opus-4-7` (confirmed in runs [26474353130](https://github.com/scylladb/scylla-cluster-tests/actions/runs/26474353130) and [26474450546](https://github.com/scylladb/scylla-cluster-tests/actions/runs/26474450546)).

`claude-code-review.yml` was already switched to Sonnet in #14801. This PR does the same for `claude.yml` (the `@claude` comment workflow).

**Also:** the no-comment issue on #14802 was because the PR had an empty commit — no diff means the code review plugin has nothing to post. This PR has a real diff so it will also serve as the smoke test once merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to specify model version for automated code analysis.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/scylladb/scylla-cluster-tests/pull/14803?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->