### PR TITLE
Stop nemesis before teardown diagnostics to prevent hang

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -3728,10 +3728,8 @@ class ClusterTester(unittest.TestCase):
         with silence(parent=self, name="Kill Stress Threads"):
             self.kill_stress_thread()
 
-        # Stopping nemesis, using timeout of 30 minutes, since replace/decommission node can take time
         if self.db_cluster:
             self.get_nemesis_report(self.db_cluster)
-            self.stop_nemesis(self.db_cluster)
             self.stop_resources_stop_tasks_threads(self.db_cluster)
             self.get_backtraces(self.db_cluster)
 
@@ -3980,6 +3978,10 @@ class ClusterTester(unittest.TestCase):
 
     def tearDown(self):
         self.teardown_started = True
+        # Stop nemesis first — if still running, it keeps disrupting nodes and
+        # diagnostic commands (gather_failure_statistics, validators) hang indefinitely.
+        if self.db_cluster:
+            self.stop_nemesis(self.db_cluster)
         with silence(parent=self, name="Enabling teardown filters"):
             enable_teardown_filters()
         with silence(parent=self, name="Sending test end event"):


### PR DESCRIPTION
gather_failure_statistics() can hang indefinitely when nemesis is still running during tearDown - nodetool commands block on nodes being actively disrupted, and stop_nemesis() in stop_resources() is never reached.

Move stop_nemesis() to early in tearDown, before any diagnostic operations

Fixes SCT-391

### Testing
https://jenkins.scylladb.com/job/scylla-staging/job/eugene_test_folder/job/teardown_test/3/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test teardown reliability by stopping the external fault injector immediately after the final test snapshot. This ensures diagnostics and final test-state capture happen while the injector is still active.
  * Avoided redundant shutdown during later cleanup so diagnostic collection and failure statistics run consistently and without interference during final analysis.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/scylladb/scylla-cluster-tests/pull/14806?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->