### PR TITLE
ci(oci): add OCI test config wrapper for long-150gb-asymmetric-cluster

### DIFF
--- a/configurations/oci/longevity-150GB-12h-autorization-LimitedMonkey.yaml
+++ b/configurations/oci/longevity-150GB-12h-autorization-LimitedMonkey.yaml
@@ -1,0 +1,12 @@
+# NOTE: it is config-wrapper for the test-cases/longevity/longevity-150GB-12h-autorization-LimitedMonkey.yaml
+
+user_prefix: 'long-150gb-12h-oci'
+
+simulated_racks: 0
+availability_zone: "a,b,c" # use real AZs to balance limited DenseIO shapes usage
+
+# NOTE: set minimal possible DenseIO shape size, it is twice bigger than the 'i4i.2xlarge' used in AWS test
+oci_instance_type_db: "VM.DenseIO.E5.Flex:8" # <shape-name>:<ocpus>:<ram>:<nvmes>
+instance_provision: 'on_demand' # DenseIO shapes cannot be 'spot'
+
+oci_instance_type_loader:  "VM.Standard3.Flex:8:32" # <shape-name>:<ocpus>:<ram>:<nvmes>

--- a/jenkins-pipelines/oss/raft/longevity-150gb-asymmetric-cluster-12h-oci.jenkinsfile
+++ b/jenkins-pipelines/oss/raft/longevity-150gb-asymmetric-cluster-12h-oci.jenkinsfile
@@ -1,0 +1,12 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'oci',
+    region: 'us-ashburn-1',
+    instance_provision: 'on_demand', // DenseIO OCI shapes cannot be 'spot'
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: '''["test-cases/longevity/longevity-150GB-12h-autorization-LimitedMonkey.yaml", "configurations/db-nodes-shards-random.yaml", "configurations/raft/enable_raft_experimental.yaml", "configurations/auth_cassandra.yaml", "configurations/oci/longevity-150GB-12h-autorization-LimitedMonkey.yaml"]'''
+)

--- a/test-cases/longevity/longevity-150GB-12h-autorization-LimitedMonkey.yaml
+++ b/test-cases/longevity/longevity-150GB-12h-autorization-LimitedMonkey.yaml
@@ -16,7 +16,7 @@ nemesis_seed: '026'
 nemesis_interval: 30
 nemesis_during_prepare: false
 
-user_prefix: 'longevity-50gb-12h'
+user_prefix: 'longevity-150gb-12h'
 
 space_node_threshold: 644245094
 


### PR DESCRIPTION
### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [scylla-staging/valerii/vp-longevity-150gb-asymmetric-cluster-12h-oci#2](https://argus.scylladb.com/tests/scylla-cluster-tests/95633045-7e0e-42ef-bdf0-0d1536522931)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)