### PR TITLE
fix(events/gce): publish *OnHostMaintenance as CRITICAL by default

### DIFF
--- a/sdcm/cluster_gce.py
+++ b/sdcm/cluster_gce.py
@@ -224,6 +224,8 @@ class GCENode(cluster.BaseNode):
                     case "compute.instances.preempted":
                         self.log.warning("Got spot termination notification from GCE")
                         SpotTerminationEvent(node=self, message="Instance was preempted.").publish()
+                    case "compute.instances.migrateOnHostMaintenance" | "compute.instances.terminateOnHostMaintenance":
+                        GceInstanceEvent(entry, severity=Severity.CRITICAL).publish()
                     case "compute.instances.automaticRestart" | "compute.instances.hostError":
                         GceInstanceEvent(entry).publish()
                     case _:

--- a/sdcm/sct_events/gce_events.py
+++ b/sdcm/sct_events/gce_events.py
@@ -21,5 +21,11 @@ class GceInstanceEvent(SctEvent):
         return super().msgfmt + ": {0.method} on node {0.node} at {0.date}: {0.message}"
 
 
-# lift cap to CRITICAL for migrateOnHostMaintenance, so critical_host_maintenance_migration() can escalate
-add_severity_limit_rules(["GceInstanceEvent.migrateOnHostMaintenance=CRITICAL"])
+# lift cap to CRITICAL for planned host-maintenance events (migrate + terminate) so the global
+# GceInstanceEvent cap doesn't downgrade them back to ERROR
+add_severity_limit_rules(
+    [
+        "GceInstanceEvent.migrateOnHostMaintenance=CRITICAL",
+        "GceInstanceEvent.terminateOnHostMaintenance=CRITICAL",
+    ]
+)

--- a/sdcm/sct_events/group_common_events.py
+++ b/sdcm/sct_events/group_common_events.py
@@ -19,7 +19,6 @@ from sdcm.cluster import TestConfig
 from sdcm.sct_events import Severity
 from sdcm.sct_events.database import DatabaseLogEvent
 from sdcm.sct_events.filters import DbEventsFilter, EventsSeverityChangerFilter, EventsFilter
-from sdcm.sct_events.gce_events import GceInstanceEvent
 from sdcm.sct_events.loaders import YcsbStressEvent
 from sdcm.sct_events.monitors import PrometheusAlertManagerEvent
 from sdcm.utils.issues import SkipPerIssues
@@ -568,18 +567,6 @@ def ignore_take_snapshot_failing():
                 extra_time_to_expiration=60,
             )
         )
-        yield
-
-
-@contextmanager
-def critical_host_maintenance_migration(extra_time_to_expiration: int = 360):
-    """Escalate GCE host-maintenance migration events to CRITICAL for the duration of the block."""
-    with EventsSeverityChangerFilter(
-        new_severity=Severity.CRITICAL,
-        event_class=GceInstanceEvent,
-        regex=r".*migrateOnHostMaintenance.*",
-        extra_time_to_expiration=extra_time_to_expiration,
-    ):
         yield
 
 

--- a/unit_tests/unit/test_gce_log_monitor.py
+++ b/unit_tests/unit/test_gce_log_monitor.py
@@ -46,8 +46,12 @@ class FakeGceLogClient(GceLoggingClient):
         auto_restart_entry["protoPayload"]["methodName"] = "compute.instances.automaticRestart"
         some_entry = copy.deepcopy(entry)
         some_entry["protoPayload"]["methodName"] = "compute.instances.some"
+        migrate_entry = copy.deepcopy(entry)
+        migrate_entry["protoPayload"]["methodName"] = "compute.instances.migrateOnHostMaintenance"
+        terminate_entry = copy.deepcopy(entry)
+        terminate_entry["protoPayload"]["methodName"] = "compute.instances.terminateOnHostMaintenance"
         print(host_error)
-        return [host_error, auto_restart_entry, some_entry]
+        return [host_error, auto_restart_entry, some_entry, migrate_entry, terminate_entry]
 
 
 class FakeGceNode(GCENode):
@@ -84,4 +88,13 @@ class TestGceErrorLog(FakeEventsMixin):
         assert (
             "compute.instances.some on node longevity-10gb-3h-master-db-node-fac7b27a-0-6 "
             "at 2022-06-30" in warning_events
+        )
+        critical_events = "\n".join(events_by_category.get("CRITICAL", []))
+        assert (
+            "compute.instances.migrateOnHostMaintenance on node "
+            "longevity-10gb-3h-master-db-node-fac7b27a-0-6 at 2022-06-30" in critical_events
+        )
+        assert (
+            "compute.instances.terminateOnHostMaintenance on node "
+            "longevity-10gb-3h-master-db-node-fac7b27a-0-6 at 2022-06-30" in critical_events
         )

--- a/unit_tests/unit/test_sct_events_filters.py
+++ b/unit_tests/unit/test_sct_events_filters.py
@@ -15,10 +15,8 @@ import re
 import pickle
 
 from sdcm.sct_events import Severity
-from sdcm.sct_events.base import max_severity
 from sdcm.sct_events.filters import DbEventsFilter, EventsFilter, EventsSeverityChangerFilter
 from sdcm.sct_events.database import DatabaseLogEvent
-from sdcm.sct_events.gce_events import GceInstanceEvent
 
 
 def test_db_events_filter_just_type():
@@ -153,38 +151,3 @@ def test_events_severity_changer_filter():
     assert event.severity == Severity.ERROR
     db_events_filter.eval_filter(event)
     assert event.severity == Severity.NORMAL
-
-
-def _make_gce_instance_event(method: str, severity: Severity = Severity.WARNING) -> GceInstanceEvent:
-    log_entry = {
-        "timestamp": "2026-05-04T12:34:56.000Z",
-        "protoPayload": {
-            "resourceName": "projects/proj/zones/us-east1-b/instances/test-node",
-            "methodName": f"compute.instances.{method}",
-            "status": {"message": f"synthetic {method} event"},
-        },
-    }
-    return GceInstanceEvent(log_entry, severity=severity)
-
-
-def test_critical_host_maintenance_migration_escalates_migrate_on_host_maintenance():
-    severity_filter = EventsSeverityChangerFilter(
-        new_severity=Severity.CRITICAL,
-        event_class=GceInstanceEvent,
-        regex=r".*migrateOnHostMaintenance.*",
-    )
-    event = _make_gce_instance_event(method="migrateOnHostMaintenance", severity=Severity.WARNING)
-    severity_filter.eval_filter(event)
-    assert event.severity == Severity.CRITICAL
-
-
-def test_critical_host_maintenance_migration_outside_context_keeps_warning():
-    event = _make_gce_instance_event(method="migrateOnHostMaintenance", severity=Severity.WARNING)
-    assert event.severity == Severity.WARNING
-
-
-def test_gce_instance_event_severity_cap_per_method():
-    migrate_event = _make_gce_instance_event(method="migrateOnHostMaintenance", severity=Severity.WARNING)
-    restart_event = _make_gce_instance_event(method="automaticRestart", severity=Severity.ERROR)
-    assert max_severity(migrate_event) == Severity.CRITICAL
-    assert max_severity(restart_event) == Severity.ERROR

--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -52,7 +52,6 @@ from sdcm.sct_events.database import (
 )
 from sdcm.sct_events.filters import DbEventsFilter
 from sdcm.sct_events.group_common_events import (
-    critical_host_maintenance_migration,
     decorate_with_context,
     ignore_abort_requested_errors,
     ignore_upgrade_schema_errors,
@@ -866,13 +865,12 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
         with ignore_upgrade_schema_errors():
             step = "Step5 - Upgrade rest of the Nodes "
             self.actions_log.info(step)
-            with critical_host_maintenance_migration():
-                for i in indexes[1:]:
-                    self.db_cluster.node_to_upgrade = self.db_cluster.nodes[i]
-                    self.upgrade_node(self.db_cluster.node_to_upgrade)
-                    self.db_cluster.node_to_upgrade.check_node_health()
-                    self.fill_and_verify_db_data("after upgraded %s" % self.db_cluster.node_to_upgrade.name)
-                    self.search_for_idx_token_error_after_upgrade(node=self.db_cluster.node_to_upgrade, step=step)
+            for i in indexes[1:]:
+                self.db_cluster.node_to_upgrade = self.db_cluster.nodes[i]
+                self.upgrade_node(self.db_cluster.node_to_upgrade)
+                self.db_cluster.node_to_upgrade.check_node_health()
+                self.fill_and_verify_db_data("after upgraded %s" % self.db_cluster.node_to_upgrade.name)
+                self.search_for_idx_token_error_after_upgrade(node=self.db_cluster.node_to_upgrade, step=step)
         self.actions_log.info("Step5.1 - run raft topology upgrade procedure")
         self.run_raft_topology_upgrade_procedure()
         InfoEvent(message="Step5.2 - check limited voters feature").publish()
@@ -1137,9 +1135,8 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
 
         # Upgrade all nodes
         self.actions_log.info("Upgrade nodes")
-        with critical_host_maintenance_migration():
-            for node_to_upgrade in nodes_to_upgrade:
-                self._start_and_wait_for_node_upgrade(node_to_upgrade, step=next(step))
+        for node_to_upgrade in nodes_to_upgrade:
+            self._start_and_wait_for_node_upgrade(node_to_upgrade, step=next(step))
         self.actions_log.info("All nodes were upgraded successfully")
 
         self.actions_log.info("Run raft topology upgrade procedure")


### PR DESCRIPTION
Make GCE host-maintenance migration CRITICAL for all tests and remove the `critical_host_maintenance_migration` upgrade tests specific context manager.

Closes: SCT-385

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] local run with simulated maintenance event
- when `GceInstanceEvent.terminateOnHostMaintenance` event is triggered (for all instance types except for e2*)
```
gcloud compute instances simulate-maintenance-event pr-provision-test-dmitriy-db-node-4afd80ff-0-1 --zone us-east1-b --project sct-project-1
...
# CRITICAL event is published

< t:2026-05-27 11:42:06,522 f:file_logger.py  l:108  c:sdcm.sct_events.file_logger p:CRITICAL > 2026-05-27 09:42:06.521: (GceInstanceEvent Severity.CRITICAL) period_type=one-time event_id=b8ba12ce-2b13-4887-88b5-517e6dce0f4f: compute.instances.terminateOnHostMaintenance on node pr-provision-test-dmitriy-db-node-6f1407b3-0-1 at 2026-05-27 11:41:47.868757+02:00: Instance terminated during Compute Engine maintenance.
```
- when `GceInstanceEvent.migrateOnHostMaintenance` event is triggered (for e2* instance types)
```
gcloud compute instances simulate-maintenance-event pr-provision-test-dmitriy-loader-node-155a077a-0-1 --zone us-east1-b --project sct-project-1
...
# CRITICAL event is published
< t:2026-05-26 20:27:00,022 f:file_logger.py  l:108  c:sdcm.sct_events.file_logger p:CRITICAL > 2026-05-26 18:27:00.017: (GceInstanceEvent Severity.CRITICAL) period_type=one-time event_id=12a1a1f4-76be-4530-bcc7-6e53caed18c2: compute.instances.migrateOnHostMaintenance on node pr-provision-test-dmitriy-loader-node-072027b2-0-1 at 2026-05-26 20:24:52.681116+02:00: Instance migrated during Compute Engine maintenance.
```

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
