### PR TITLE
feature(longevity): add 12h utilization config and nemesis exclusions for vnode-to-tablet migration

### DIFF
--- a/configurations/nemesis/exclude-vnode-to-tablet-migration-limitations.yaml
+++ b/configurations/nemesis/exclude-vnode-to-tablet-migration-limitations.yaml
@@ -1,0 +1,60 @@
+# Nemesis exclusions for vnode-to-tablet migration tests.
+#
+# These nemeses are excluded because they violate limitations of the
+# migrate-to-tablets procedure, as documented at:
+# https://github.com/scylladb/scylladb/blob/master/docs/operating-scylla/procedures/config-change/migrate-vnodes-to-tablets.rst
+#
+# Limitation: "No schema changes" — do not create, alter, or drop tables in migrating keyspace
+# Limitation: "No topology changes" — do not add, remove, decommission, or replace nodes
+# Limitation: "No TRUNCATE" on tables in migrating keyspace
+# Limitation: Only CQL base tables — no MV, secondary indexes, CDC, or Alternator tables
+
+nemesis_class_name: 'SisyphusMonkey'
+nemesis_selector: >-
+  not AddDropColumnMonkey
+  and not ToggleTableIcsMonkey
+  and not ToggleGcModeMonkey
+  and not ToggleCDCMonkey
+  and not NoCorruptRepairMonkey
+  and not EnableDisableTableEncryptionAwsKmsProviderWithRotationMonkey
+  and not EnableDisableTableEncryptionAwsKmsProviderWithoutRotationMonkey
+  and not ToggleAuditNemesisSyslog
+  and not AddRemoveMvNemesis
+  and not ModifyTableCommentMonkey
+  and not ModifyTableGcGraceTimeMonkey
+  and not ModifyTableCachingMonkey
+  and not ModifyTableBloomFilterFpChanceMonkey
+  and not ModifyTableCompactionMonkey
+  and not ModifyTableCompressionMonkey
+  and not ModifyTableCrcCheckChanceMonkey
+  and not ModifyTableDclocalReadRepairChanceMonkey
+  and not ModifyTableDefaultTimeToLiveMonkey
+  and not ModifyTableMaxIndexIntervalMonkey
+  and not ModifyTableMinIndexIntervalMonkey
+  and not ModifyTableMemtableFlushPeriodInMsMonkey
+  and not ModifyTableReadRepairChanceMonkey
+  and not ModifyTableSpeculativeRetryMonkey
+  and not ModifyTableTwcsWindowSizeMonkey
+  and not DecommissionMonkey
+  and not DecommissionSeedNode
+  and not AbortDecommissionMonkey
+  and not TerminateAndRemoveNodeMonkey
+  and not NodeTerminateAndReplace
+  and not DecommissionStreamingErrMonkey
+  and not GrowShrinkClusterNemesis
+  and not AddRemoveRackNemesis
+  and not AddRemoveDcNemesis
+  and not BootstrapStreamingErrorNemesis
+  and not GrowShrinkZeroTokenNode
+  and not DrainKubernetesNodeThenReplaceScyllaNode
+  and not TerminateKubernetesHostThenReplaceScyllaNode
+  and not DrainKubernetesNodeThenDecommissionAndAddScyllaNode
+  and not TerminateKubernetesHostThenDecommissionAndAddScyllaNode
+  and not OperatorNodeReplace
+  and not IsolateNodeWithProcessSignalNemesis
+  and not IsolateNodeWithIptableRuleNemesis
+  and not TruncateMonkey
+  and not TruncateLargeParititionMonkey
+  and not KillMVBuildingCoordinator
+  and not CreateIndexNemesis
+  and not CDCStressorMonkey

--- a/jenkins-pipelines/oss/longevity/longevity-vnode-to-tablet-migration.jenkinsfile
+++ b/jenkins-pipelines/oss/longevity/longevity-vnode-to-tablet-migration.jenkinsfile
@@ -8,6 +8,6 @@ longevityPipeline(
     region: 'eu-west-1',
     availability_zone: 'c',
     test_name: 'vnode_to_tablet_migration_test.VnodeToTabletMigrationTest.test_vnode_to_tablet_migration',
-    test_config: """['test-cases/longevity/longevity-100gb-4h-cql-stress.yaml', 'configurations/tablets_disabled.yaml']""",
+    test_config: """['test-cases/longevity/longevity-50-percent-utilization-4h.yaml', 'configurations/tablets_disabled.yaml', 'configurations/nemesis/exclude-vnode-to-tablet-migration-limitations.yaml']""",
     instance_provision_fallback_on_demand: true
 )

--- a/test-cases/longevity/longevity-50-percent-utilization-4h.yaml
+++ b/test-cases/longevity/longevity-50-percent-utilization-4h.yaml
@@ -1,0 +1,86 @@
+# LONGEVITY TEST: FIFTY PERCENT UTILIZATION 4H
+#
+# Purpose:
+#   Validates ScyllaDB stability under a 4-hour sustained cassandra-stress mixed
+#   workload targeting approximately 60-70 percent disk utilization on each node
+#   (i8g.xlarge — 1.9 TB NVMe).
+#   - Exercises ICS compaction under heavy sequential write and mixed read/write load
+#   - Encrypted client and inter-node communication (TLS)
+#
+# Cluster:
+#   - 6 DB nodes (i8g.xlarge — ARM64/Graviton), 3 simulated racks, 2 loaders
+#   - Replication factor: 3, ICS compaction
+#   - Nemesis: SisyphusMonkey (general chaos)
+#
+# Workload (cassandra-stress, 4h):
+#   - Prepare: 2x write streams, 120M rows each, 512B x 10 columns (~60-70% disk fill)
+#   - Stress: 2x mixed streams (read/write), 240min each, same schema
+#
+# Encryption: server + client TLS enabled
+
+test_duration: 600
+
+n_db_nodes: 6
+n_loaders: 2
+seeds_num: 3
+simulated_racks: 3
+
+round_robin: true
+
+instance_type_db: 'i8g.xlarge'
+append_scylla_setup_args: ' --no-ec2-check '
+
+nemesis_class_name: 'SisyphusMonkey'
+nemesis_interval: 15
+
+user_prefix: 'longevity-50-percent-utilization-4h'
+space_node_threshold: 64424
+
+pre_create_schema: true
+sstable_size: 100
+
+server_encrypt: true
+client_encrypt: true
+
+hinted_handoff: 'enabled'
+parallel_node_operations: true
+
+nemesis_during_prepare: false
+
+prepare_write_cmd:
+  - >-
+    cassandra-stress write cl=QUORUM n=120000000
+    -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=IncrementalCompactionStrategy)'
+    -mode cql3 native
+    -rate threads=80
+    -pop seq=1..120000000
+    -col 'n=FIXED(5) size=FIXED(512)'
+    -log interval=5
+  - >-
+    cassandra-stress write cl=QUORUM n=120000000
+    -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=IncrementalCompactionStrategy)'
+    -mode cql3 native
+    -rate threads=80
+    -pop seq=120000001..240000000
+    -col 'n=FIXED(5) size=FIXED(512)'
+    -log interval=5
+
+stress_cmd:
+  - >-
+    cassandra-stress mixed cl=QUORUM duration=180m
+    -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=IncrementalCompactionStrategy)'
+    -mode cql3 native
+    -rate threads=80
+    -pop seq=1..120000000
+    -col 'n=FIXED(5) size=FIXED(512)'
+    -log interval=5
+  - >-
+    cassandra-stress mixed cl=QUORUM duration=180m
+    -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=IncrementalCompactionStrategy)'
+    -mode cql3 native
+    -rate threads=80
+    -pop seq=120000001..240000000
+    -col 'n=FIXED(5) size=FIXED(512)'
+    -log interval=5
+
+use_hdrhistogram: true

--- a/vnode_to_tablet_migration_test.py
+++ b/vnode_to_tablet_migration_test.py
@@ -14,12 +14,15 @@
 # Copyright (c) 2026 ScyllaDB
 
 import re
+import time
 from enum import StrEnum
 
 from longevity_test import LongevityTest
+from sdcm.cluster import DB_LOG_PATTERN_RESHARDING_FINISH, DB_LOG_PATTERN_RESHARDING_START
 from sdcm.sct_events.system import InfoEvent
+from sdcm.utils.decorators import latency_calculator_decorator
 from sdcm.utils.tablets.common import wait_no_tablets_migration_running
-from sdcm.wait import wait_for
+from sdcm.wait import wait_for, wait_for_log_lines
 
 
 class NodeMigrationStatus(StrEnum):
@@ -34,10 +37,14 @@ def get_nodetool_migrate_to_tablets_status(node, keyspace: str) -> dict[str, Nod
     migration status for all nodes in the cluster.
 
     Example output:
+        Keyspace: ks
+        Status: migrating_to_tablets
+
         Nodes:
         Host ID                              Status
         dc1c5a03-8878-49da-a6f3-bd27d6a2d85d uses vnodes
         b1428349-2154-41c9-a5c1-dd33c71bd571 migrating to tablets
+        017dd39a-3d06-4c8a-8ac4-379f9e595607 uses vnodes
 
     Returns: dict of host_id -> NodeMigrationStatus.
     """
@@ -54,42 +61,47 @@ def get_nodetool_migrate_to_tablets_status(node, keyspace: str) -> dict[str, Nod
 class VnodeToTabletMigrationTest(LongevityTest):
     """Test vnode to tablet migration scenarios."""
 
-    def test_vnode_to_tablet_migration(self):
+    def restart_node_after_migration(self, node) -> None:
+        """Restart a node after migrate-to-tablets upgrade, waiting for resharding to complete.
+
+        After the upgrade the node reshards all data on startup. For large datasets
+        (hundreds of GB) this can take 15+ minutes. This method monitors the scylla
+        log for resharding start/finish and logs the elapsed duration so slow reshards
+        are visible in test output.
+
+        Args:
+            node: The DB node to restart.
         """
-        Test vnode to tablet migration procedure:
+        reshard_timeout = 3600
+        self.log.info(
+            "Restarting node %s after migrate-to-tablets upgrade (reshard_timeout=%ds)", node.name, reshard_timeout
+        )
+        node.run_nodetool("drain")
+        node.stop_scylla(verify_down=True)
 
-        1. Fill the database with data via prepare_write_cmd.
-        2. Launch main stress load (stress_cmd) in the background — runs concurrently with migration.
-        3. Start migration for all user keyspaces:
-               nodetool migrate-to-tablets start <ks>  (once per keyspace)
-        4. Rolling restart - for each node in order:
-               nodetool migrate-to-tablets upgrade      (cluster-wide, run on each node)
-               drain + stop + start node
-        5. Finalize migration for all user keyspaces:
-               nodetool migrate-to-tablets finalize <ks>  (once per keyspace)
-        6. Wait for all tablet topology operations to quiesce.
-        7. Verify migrated keyspaces use tablets via system.tablets metrics.
-        8. Wait for main stress load to finish.
+        with wait_for_log_lines(
+            node=node,
+            start_line_patterns=[DB_LOG_PATTERN_RESHARDING_START],
+            end_line_patterns=[DB_LOG_PATTERN_RESHARDING_FINISH],
+            start_timeout=600,
+            end_timeout=reshard_timeout,
+            error_msg_ctx=f"Resharding on {node.name} after tablet migration",
+        ):
+            node.start_scylla(verify_up=False, timeout=reshard_timeout * 2)
+
+        node.wait_db_up(timeout=reshard_timeout)
+        self.db_cluster.wait_for_nodes_up_and_normal(nodes=[node], timeout=reshard_timeout)
+        node.wait_node_fully_start(timeout=reshard_timeout)
+
+    def _perform_migration_steps(self) -> None:
+        """Execute the full vnode-to-tablet migration procedure.
+
+        1. Start migration for all user keyspaces.
+        2. Rolling restart — for each node: run migrate-to-tablets upgrade, drain/stop/start.
+        3. Finalize migration for all user keyspaces.
+        4. Wait for all tablet topology operations to quiesce.
+        5. Verify migrated keyspaces use tablets via system.tablets.
         """
-        self.db_cluster.add_nemesis(nemesis=self.get_nemesis_class(), tester_obj=self)
-
-        prepare_write_cmd = self.params.get("prepare_write_cmd")
-
-        InfoEvent(message="Step 1 - Filling database with data before migration").publish()
-        self.run_pre_create_keyspace()
-        self.run_pre_create_schema()
-        self.run_prepare_write_cmd()
-
-        if not prepare_write_cmd or not self.params.get("nemesis_during_prepare"):
-            self.db_cluster.start_nemesis()
-
-        keyspace_num = self.params.get("keyspace_num")
-
-        InfoEvent(message="Step 2 - Starting main stress load concurrently with migration").publish()
-        stress_queue = []
-        stress_cmd = self.params.get("stress_cmd")
-        self.assemble_and_run_all_stress_cmd(stress_queue, stress_cmd, keyspace_num)
-
         coordinator_node = self.db_cluster.data_nodes[0]
         keyspaces = self.db_cluster.get_test_keyspaces()
         if not keyspaces:
@@ -98,7 +110,7 @@ class VnodeToTabletMigrationTest(LongevityTest):
             )
         self.log.info("User keyspaces to migrate to tablets: %s", keyspaces)
 
-        InfoEvent(message=f"Step 3 - Starting tablet migration for keyspaces: {keyspaces}").publish()
+        InfoEvent(message=f"Starting tablet migration for keyspaces: {keyspaces}").publish()
         for ks in keyspaces:
             coordinator_node.run_nodetool(f"migrate-to-tablets start {ks}")
             migration_status = get_nodetool_migrate_to_tablets_status(coordinator_node, ks)
@@ -107,7 +119,7 @@ class VnodeToTabletMigrationTest(LongevityTest):
                     f"[ks={ks}] Expected {NodeMigrationStatus.USES_VNODES!r} for {node.host_id}, got {migration_status[node.host_id]!r}"
                 )
 
-        InfoEvent(message="Step 4 - Rolling restart with migrate-to-tablets upgrade").publish()
+        InfoEvent(message="Rolling restart with migrate-to-tablets upgrade").publish()
         for node in self.db_cluster.data_nodes:
             wait_for(
                 func=lambda n=node: not n.running_nemesis,
@@ -124,12 +136,7 @@ class VnodeToTabletMigrationTest(LongevityTest):
                     assert migration_status[node.host_id] == NodeMigrationStatus.MIGRATING, (
                         f"[ks={ks}] Expected {NodeMigrationStatus.MIGRATING!r} for {node.host_id}, got {migration_status[node.host_id]!r}"
                     )
-                node.run_nodetool("drain")
-                self.log.info("Restarting node %s after prepare-node", node.name)
-                node.stop_scylla(verify_down=True)
-                node.start_scylla(verify_up=True)
-                self.db_cluster.wait_for_nodes_up_and_normal(nodes=[node])
-                node.wait_node_fully_start()
+                self.restart_node_after_migration(node)
                 self.log.info("Node %s is back up and normal after restart", node.name)
 
             self.log.info("Waiting for node %s status to change to 'uses tablets'", node.name)
@@ -143,15 +150,18 @@ class VnodeToTabletMigrationTest(LongevityTest):
                     throw_exc=True,
                 )
 
-        InfoEvent(message="Step 5 - Finalizing tablet migration").publish()
+            self.log.info("Waiting 300 seconds for cluster to stabilize before migrating next node")
+            time.sleep(300)
+
+        InfoEvent(message="Finalizing tablet migration").publish()
         for ks in keyspaces:
             coordinator_node.run_nodetool(f"migrate-to-tablets finalize {ks}")
 
-        InfoEvent(message="Step 6 - Waiting for tablet migration to fully complete").publish()
+        InfoEvent(message="Waiting for tablet migration to fully complete").publish()
         for migration_node in self.db_cluster.data_nodes:
             wait_no_tablets_migration_running(migration_node, timeout=7200)
 
-        InfoEvent(message="Step 7 - Verifying migrated keyspaces have tablets in system.tablets").publish()
+        InfoEvent(message="Verifying migrated keyspaces have tablets in system.tablets").publish()
         with self.db_cluster.cql_connection_patient(coordinator_node, connect_timeout=600) as session:
             result = session.execute("SELECT keyspace_name FROM system.tablets")
             tablet_keyspaces = {row.keyspace_name for row in result}
@@ -159,6 +169,92 @@ class VnodeToTabletMigrationTest(LongevityTest):
         for ks in keyspaces:
             assert ks in tablet_keyspaces, f"Keyspace {ks} not found in system.tablets after migration"
 
-        InfoEvent(message="Step 8 - Waiting for main stress load to finish").publish()
+    @latency_calculator_decorator(
+        legend="Pre-migration baseline (vnodes)",
+        cycle_name="pre_migration",
+        workload_type="mixed",
+    )
+    def run_pre_migration_benchmark(self):
+        """Run stress on vnodes to establish a performance baseline before migration.
+
+        The latency_calculator_decorator collects HDR histogram data for this time window
+        and reports P90/P99 latencies and throughput to Argus.
+        """
+        stress_queue = []
+        for cmd in self.params.get("stress_cmd"):
+            stress_queue.append(self.run_stress_thread(stress_cmd=cmd, duration=60))
         for stress in stress_queue:
             self.verify_stress_thread(stress)
+        return stress_queue
+
+    @latency_calculator_decorator(
+        legend="During vnode-to-tablet migration",
+        cycle_name="during_migration",
+        workload_type="mixed",
+    )
+    def run_migration(self):
+        """Run stress concurrently with migration and measure the performance impact.
+
+        Stress starts first so the cluster is under load throughout the migration.
+        The latency_calculator_decorator captures the full migration window in HDR.
+        """
+        stress_queue = []
+        self.assemble_and_run_all_stress_cmd(
+            stress_queue, self.params.get("stress_cmd"), self.params.get("keyspace_num")
+        )
+        self._perform_migration_steps()
+        for stress in stress_queue:
+            self.verify_stress_thread(stress)
+        return stress_queue
+
+    @latency_calculator_decorator(
+        legend="Post-migration (tablets)",
+        cycle_name="post_migration",
+        workload_type="mixed",
+    )
+    def run_post_migration_benchmark(self):
+        """Run stress on tablets after migration to compare with the pre-migration baseline.
+
+        The latency_calculator_decorator collects HDR histogram data for this time window
+        and reports P90/P99 latencies and throughput to Argus.
+        """
+        stress_queue = []
+        for cmd in self.params.get("stress_cmd"):
+            stress_queue.append(self.run_stress_thread(stress_cmd=cmd, duration=60))
+        for stress in stress_queue:
+            self.verify_stress_thread(stress)
+        return stress_queue
+
+    def test_vnode_to_tablet_migration(self):
+        """
+        Test vnode to tablet migration procedure with performance measurement.
+
+        1. Fill the database with data via prepare_write_cmd.
+        2. Run pre-migration benchmark: stress on vnodes to establish a baseline.
+        3. Run migration with concurrent stress:
+               nodetool migrate-to-tablets start <ks>  (once per keyspace)
+               rolling restart with migrate-to-tablets upgrade per node
+               nodetool migrate-to-tablets finalize <ks>  (once per keyspace)
+               wait for all tablet topology operations to quiesce
+               verify migrated keyspaces use tablets via system.tablets
+        4. Run post-migration benchmark: stress on tablets to compare with baseline.
+
+        Each phase (pre, during, post) is wrapped with latency_calculator_decorator
+        which records HDR histograms and publishes P90/P99 latency and throughput
+        tables to Argus for before/during/after comparison.
+        """
+        self.db_cluster.add_nemesis(nemesis=self.get_nemesis_class(), tester_obj=self)
+
+        prepare_write_cmd = self.params.get("prepare_write_cmd")
+
+        InfoEvent(message="Filling database with data before migration").publish()
+        self.run_pre_create_keyspace()
+        self.run_pre_create_schema()
+        self.run_prepare_write_cmd()
+
+        if not prepare_write_cmd or not self.params.get("nemesis_during_prepare"):
+            self.db_cluster.start_nemesis()
+
+        self.run_pre_migration_benchmark()
+        self.run_migration()
+        self.run_post_migration_benchmark()


### PR DESCRIPTION
Split the vnode-to-tablet migration test configuration into a reusable 50-percent utilization longevity config and a separate nemesis exclusion overlay. The overlay excludes nemeses that violate migration limitations documented in the ScyllaDB migrate-vnodes-to-tablets procedure:
- No schema changes (ALTER/CREATE/DROP TABLE)
- No topology changes (decommission, replace, add/remove nodes)
- No TRUNCATE on migrating tables
- No MV/SI/CDC operations (only CQL base tables supported)

Also improve the migration test with proper resharding log monitoring via wait_for_log_lines, node stabilization delays between migrations, and java cassandra-stress for node downtime resilience.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
