### PR TITLE
fix(claude): checkout PR branch and restrict to read-only tools

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -47,17 +47,17 @@ jobs:
               ;;
           esac
 
-      - name: Checkout base repository
+      - name: Checkout PR branch for review
         if: steps.membership.outputs.is_member == 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
-          # Always checkout the BASE branch, never the fork's HEAD.
-          # pull_request_target runs with base-repo secrets; executing untrusted
-          # fork code here would expose them ("pwn request" attack vector).
-          # The code-review plugin fetches the PR diff via `gh pr diff` (Bash)
-          # rather than relying on a local checkout of the PR branch.
-          ref: ${{ github.event.pull_request.base.sha }}
-          fetch-depth: 1
+          # Check out the PR's actual code so Claude can read the files being
+          # reviewed. The security risk of pull_request_target (secrets exposed
+          # to fork code) applies only when untrusted code is *executed* — we
+          # prevent that by restricting Claude to read-only tools (Read + safe
+          # git/gh subcommands only; no Write, Edit, or arbitrary Bash).
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
 
       - name: Run Claude Code Review
         if: steps.membership.outputs.is_member == 'true'
@@ -72,7 +72,9 @@ jobs:
           # rather than claude[bot], but review content is identical.
           # Ref: https://github.com/anthropics/claude-code-action/issues/1348
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          claude_args: '--model claude-sonnet-4-6 --allowedTools Bash,Read'
+          claude_args: >-
+            --model claude-sonnet-4-6
+            --allowedTools Read,Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git blame:*),Bash(gh pr view:*),Bash(gh pr diff:*)
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -54,6 +54,8 @@ jobs:
           # Always checkout the BASE branch, never the fork's HEAD.
           # pull_request_target runs with base-repo secrets; executing untrusted
           # fork code here would expose them ("pwn request" attack vector).
+          # The code-review plugin fetches the PR diff via `gh pr diff` (Bash)
+          # rather than relying on a local checkout of the PR branch.
           ref: ${{ github.event.pull_request.base.sha }}
           fetch-depth: 1
 
@@ -70,10 +72,11 @@ jobs:
           # rather than claude[bot], but review content is identical.
           # Ref: https://github.com/anthropics/claude-code-action/issues/1348
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          claude_args: '--model claude-sonnet-4-6'
+          claude_args: '--model claude-sonnet-4-6 --allowedTools Bash,Read'
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
           allowed_bots: 'claude,renovate[bot]'
+          show_full_output: 'true'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -13,10 +13,13 @@ on:
 
 jobs:
   claude-review:
-    # Deduplicate: pull_request_target fires for every PR including same-repo ones.
-    # Skip it when pull_request already covers the same PR (same-repo only).
+    # Route by PR origin:
+    # - Same-repo PR: pull_request fires with secrets from the PR branch (testable)
+    # - Fork PR:      pull_request_target fires with secrets from master
+    # Each PR type triggers exactly one run; the other event is skipped.
     if: |
-      github.event_name == 'pull_request' ||
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.head.repo.full_name == github.repository) ||
       (github.event_name == 'pull_request_target' &&
        github.event.pull_request.head.repo.full_name != github.repository)
     runs-on: ubuntu-latest

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,11 +1,24 @@
 name: Claude Code Review
 
 on:
+  pull_request:
+    # Runs from the PR branch — secrets available for same-repo PRs.
+    # This is the testable path: workflow changes take effect immediately
+    # without needing to merge to master first.
+    types: [opened, synchronize, ready_for_review, reopened]
   pull_request_target:
+    # Runs from master — secrets available even for fork PRs.
+    # Used only for fork PRs; same-repo PRs are handled by pull_request above.
     types: [opened, synchronize, ready_for_review, reopened]
 
 jobs:
   claude-review:
+    # Deduplicate: pull_request_target fires for every PR including same-repo ones.
+    # Skip it when pull_request already covers the same PR (same-repo only).
+    if: |
+      github.event_name == 'pull_request' ||
+      (github.event_name == 'pull_request_target' &&
+       github.event.pull_request.head.repo.full_name != github.repository)
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -60,17 +60,26 @@ jobs:
               ;;
           esac
 
-      - name: Checkout PR branch for review
+      - name: Checkout base branch
         if: steps.membership.outputs.is_member == 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
-          # Check out the PR's actual code so Claude can read the files being
-          # reviewed. The security risk of pull_request_target (secrets exposed
-          # to fork code) applies only when untrusted code is *executed* — we
-          # prevent that by restricting Claude to read-only tools (Read + safe
-          # git/gh subcommands only; no Write, Edit, or arbitrary Bash).
+          ref: ${{ github.event.pull_request.base.sha }}
+          fetch-depth: 1
+
+      - name: Checkout PR code into subdirectory
+        if: steps.membership.outputs.is_member == 'true'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          # PR head goes into a subdirectory, not the workspace root.
+          # persist-credentials: false ensures the GITHUB_TOKEN is not written
+          # into the subdirectory's git config, preventing fork code from
+          # accessing it. Claude reads the PR files via --add-dir below.
+          # Ref: https://github.com/anthropics/claude-code-action/blob/main/docs/security.md
           ref: ${{ github.event.pull_request.head.sha }}
+          path: pr-code
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Run Claude Code Review
         if: steps.membership.outputs.is_member == 'true'
@@ -87,6 +96,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_args: >-
             --model claude-sonnet-4-6
+            --add-dir pr-code
             --allowedTools Read,Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git blame:*),Bash(gh pr view:*),Bash(gh pr diff:*)
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'


### PR DESCRIPTION
## Root cause (two issues)

**1. Wrong checkout** — we were checking out `base.sha` (the base branch tip). Claude was reading the base branch files, not the PR's actual changes. The plugin had no diff to review.

**2. Tool permission denials** — the plugin needs `Bash` to run `git diff` and `Read` to access files. Both were being denied (6 denials observed in [run 26528341484](https://github.com/scylladb/scylla-cluster-tests/actions/runs/26528341484)). Claude ran 18 turns and spent $2.59 producing zero comments.

## Fix

- Switch checkout to `head.sha` with `fetch-depth: 0` so Claude reads the actual PR code
- Restrict `Bash` to a read-only allowlist: `git diff/log/show/blame` and `gh pr view/diff` — no `Write`, `Edit`, or arbitrary shell execution

## Security

The `pull_request_target` pwn-request risk applies only when fork code is **executed**. Checking out the fork's code for **reading** is safe as long as Claude cannot run arbitrary shell commands from the working tree — which the restricted `allowedTools` enforces.

`show_full_output: true` is temporarily enabled to confirm the fix is working; can be removed once reviews are confirmed.