### PR TITLE
fix(claude-review): add --comment flag and full PR URL to post findings

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -73,7 +73,7 @@ jobs:
           claude_args: '--model claude-sonnet-4-6'
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          prompt: '/code-review:code-review --comment https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
           allowed_bots: 'claude,renovate[bot]'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options


### PR DESCRIPTION
## Summary
- Adds the `--comment` flag to the code-review plugin prompt so findings are posted as PR comments
- Fixes the PR URL to include the full `https://github.com/` prefix

Without these changes, the Claude code review workflow runs successfully but never posts its findings back to the PR.

## Backends Affected
None - CI workflow only.

## Manual Testing Required
- [ ] Open a test PR and verify the workflow posts review comments