### PR TITLE
fix(vector-store): retrieve VS version via HTTP API request

### DIFF
--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -1539,7 +1539,9 @@ class VectorStoreSetAWS(VectorStoreClusterMixin, AWSCluster):
                 self.log.error("Failed to reconfigure Vector Store node %s: %s", node.name, e)
                 raise
 
-    def _create_node(self, instance, ami_username, node_prefix, node_index, base_logdir, dc_idx, rack):
+    def _create_node(
+        self, instance, ami_username, node_prefix, node_index, base_logdir, dc_idx, rack, after_config=None
+    ):
         ec2_service = self._ec2_services[0 if self.params.get("simulated_regions") else dc_idx]
         credentials = self._credentials[0 if self.params.get("simulated_regions") else dc_idx]
         node = VectorStoreAWSNode(
@@ -1553,6 +1555,7 @@ class VectorStoreSetAWS(VectorStoreClusterMixin, AWSCluster):
             base_logdir=base_logdir,
             dc_idx=dc_idx,
             rack=rack,
+            after_config=after_config,
         )
         node.init()
         return node

--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -43,7 +43,6 @@ from sdcm.provision.network_configuration import (
 )
 from sdcm.provision.scylla_yaml import SeedProvider
 from sdcm.provision.helpers.cloud_init import wait_cloud_init_completes
-from sdcm.reporting.tooling_reporter import VectorStoreVersionReporter
 from sdcm.sct_provision.aws.cluster import PlacementGroup
 
 from sdcm.remote import LocalCmdRunner, shell_script_cmd, NETWORK_EXCEPTIONS
@@ -1482,12 +1481,6 @@ class VectorStoreAWSNode(VectorStoreNodeMixin, AWSNode):
             f"sudo chown {self.parent_cluster.params.get('ami_vector_store_user')}: /home/ubuntu/vector-store/.env",
             verbose=True,
         )
-        try:
-            VectorStoreVersionReporter(
-                self.remoter, "/opt/vector-store/vector-store", self.test_config.argus_client()
-            ).report()
-        except Exception:  # noqa: BLE001
-            LOGGER.warning("Error submitting vector store version, VS package won't show in Argus.", exc_info=True)
 
 
 class VectorStoreSetAWS(VectorStoreClusterMixin, AWSCluster):

--- a/sdcm/cluster_cloud.py
+++ b/sdcm/cluster_cloud.py
@@ -38,7 +38,7 @@ from sdcm.utils.cloud_api_utils import (
 )
 from sdcm.utils.gce_region import GceRegion
 from sdcm.utils.get_username import get_username
-from sdcm.utils.vector_store_utils import VectorStoreClusterMixin
+from sdcm.utils.vector_store_utils import VectorStoreClusterMixin, VectorStoreNodeMixin
 from sdcm.test_config import TestConfig
 from sdcm.remote import RemoteLibSSH2CmdRunner, shell_script_cmd
 from sdcm.provision.network_configuration import ssh_connection_ip_type
@@ -408,7 +408,7 @@ class CloudNode(cluster.BaseNode):
         )
 
 
-class CloudVSNode(CloudNode):
+class CloudVSNode(VectorStoreNodeMixin, CloudNode):
     """A Vector Search node running on Scylla Cloud"""
 
     def __init__(
@@ -822,9 +822,7 @@ class ScyllaCloudCluster(cluster.BaseScyllaCluster, cluster.BaseCluster):
         if self.vector_store_cluster and len(self.vector_store_cluster.nodes) > 0:
             try:
                 node = self.vector_store_cluster.nodes[0]
-                VectorStoreVersionReporter(
-                    node.remoter, "/home/ubuntu/vector-store/vector-store", self.test_config.argus_client()
-                ).report()
+                VectorStoreVersionReporter(node.get_vector_store_api_client(), self.test_config.argus_client()).report()
             except Exception:  # noqa: BLE001
                 LOGGER.warning("Error submitting vector store version, VS package won't show in Argus.", exc_info=True)
 

--- a/sdcm/cluster_docker.py
+++ b/sdcm/cluster_docker.py
@@ -28,7 +28,6 @@ from sdcm.provision.helpers.certificate import (
 )
 from sdcm.remote import LOCALRUNNER
 from sdcm.remote.docker_cmd_runner import DockerCmdRunner
-from sdcm.reporting.tooling_reporter import VectorStoreVersionReporter
 from sdcm.sct_events.database import DatabaseLogEvent
 from sdcm.sct_events.filters import DbEventsFilter
 from sdcm.utils.docker_utils import get_docker_bridge_gateway, Container, ContainerManager, DockerException
@@ -709,12 +708,6 @@ class VectorStoreSetDocker(VectorStoreClusterMixin, DockerCluster):
         if container is None:
             ContainerManager.run_container(node, "node")
             ContainerManager.wait_for_status(node, "node", status="running")
-        try:
-            VectorStoreVersionReporter(
-                node.remoter, "docker exec node /opt/vector-store/vector-store", self.test_config.argus_client()
-            ).report()
-        except Exception:  # noqa: BLE001
-            LOGGER.warning("Error submitting vector store version, VS package won't show in Argus.", exc_info=True)
         node.init()
         return node
 

--- a/sdcm/cluster_docker.py
+++ b/sdcm/cluster_docker.py
@@ -597,7 +597,7 @@ class CassandraDockerCluster(BaseCassandraCluster, DockerCluster):
             params=params,
         )
 
-    def _create_node(self, node_index, container=None):
+    def _create_node(self, node_index, container=None, after_config=None):
         node = CassandraDockerNode(
             parent_cluster=self,
             container=container,
@@ -605,6 +605,7 @@ class CassandraDockerCluster(BaseCassandraCluster, DockerCluster):
             base_logdir=self.logdir,
             node_prefix=self.node_prefix,
             node_index=node_index,
+            after_config=after_config,
         )
 
         if container is None:

--- a/sdcm/reporting/tooling_reporter.py
+++ b/sdcm/reporting/tooling_reporter.py
@@ -7,6 +7,7 @@ from argus.client.sct.client import ArgusSCTClient
 from argus.client.sct.types import Package
 
 from sdcm.remote.base import CommandRunner
+from sdcm.utils.vector_store_client import VectorStoreClient
 
 LOGGER = logging.getLogger(__name__)
 
@@ -368,10 +369,11 @@ class YcsbVersionReporter(ToolReporterBase):
 class VectorStoreVersionReporter(ToolReporterBase):
     TOOL_NAME = "vector-store"
 
-    def _collect_version_info(self):
-        output = self.runner.sudo(f"{self.command_prefix} --version")
-        LOGGER.info("%s: Collected vector-store output:\n%s", self, output.stdout)
+    def __init__(self, vector_store_client: VectorStoreClient, argus_client: ArgusSCTClient = None) -> None:
+        super().__init__(runner=None, command_prefix=None, argus_client=argus_client)
+        self.vector_store_client = vector_store_client
 
-        name, version, *_ = output.stdout.split(" ")
-        LOGGER.info("%s: Collected %s version:\n%s", self, name, version)
-        self.version = version
+    def _collect_version_info(self):
+        info = self.vector_store_client.get_info()
+        LOGGER.info("%s: Collected vector-store info: %s", self, info)
+        self.version = info.get("version", "#FAILED_CHECK_LOGS")

--- a/sdcm/utils/vector_store_utils.py
+++ b/sdcm/utils/vector_store_utils.py
@@ -11,9 +11,13 @@
 #
 # Copyright (c) 2025 ScyllaDB
 
+import logging
 from functools import cached_property
 
+from sdcm.reporting.tooling_reporter import VectorStoreVersionReporter
 from sdcm.utils.vector_store_client import VectorStoreClient
+
+LOGGER = logging.getLogger(__name__)
 
 
 class VectorStoreNodeMixin:
@@ -96,3 +100,15 @@ class VectorStoreClusterMixin:
             if not node.wait_for_vector_store_ready(timeout=timeout):
                 raise RuntimeError(f"Vector Store node {node.name} failed to become ready within {timeout} seconds")
         self.log.info("All Vector Store nodes are ready")
+        self._report_vector_store_version()
+
+    def _report_vector_store_version(self) -> None:
+        """Submit Vector Store version to Argus."""
+        if not self.nodes:
+            return
+        try:
+            VectorStoreVersionReporter(
+                self.nodes[0].get_vector_store_api_client(), self.test_config.argus_client()
+            ).report()
+        except Exception:  # noqa: BLE001
+            LOGGER.warning("Error submitting vector store version, VS package won't show in Argus.", exc_info=True)

--- a/unit_tests/unit/test_cluster.py
+++ b/unit_tests/unit/test_cluster.py
@@ -22,7 +22,7 @@ from datetime import datetime, timezone
 import pytest
 from invoke import Result
 
-from sdcm.cluster import BaseMonitorSet, BaseNode
+from sdcm.cluster import BaseCluster, BaseMonitorSet, BaseNode
 from sdcm.db_log_reader import DbLogReader
 from sdcm.sct_events.database import SYSTEM_ERROR_EVENTS_PATTERNS
 from sdcm.sct_events.filters import DbEventsFilter
@@ -977,3 +977,61 @@ def test_base_node_subclass_constructs_with_forwarded_kwargs(cls, monkeypatch):
         monkeypatch.setattr(target, unittest.mock.MagicMock())
 
     cls(**_build_init_kwargs(cls))
+
+
+def _cluster_classes_overriding_create_node() -> list[type]:
+    """Return all `BaseCluster` subclasses from the `sdcm` package that override `_create_node`."""
+    for module_name in _BACKEND_MODULES:
+        importlib.import_module(module_name)
+
+    all_subclasses = set()
+    stack = list(BaseCluster.__subclasses__())
+    while stack:
+        cls = stack.pop()
+        if cls not in all_subclasses:
+            all_subclasses.add(cls)
+            stack.extend(cls.__subclasses__())
+
+    production = [
+        cls for cls in all_subclasses if cls.__module__.startswith("sdcm.") and "_create_node" in cls.__dict__
+    ]
+    return sorted(production, key=lambda c: c.__name__)
+
+
+def _parent_create_node_kwargs(cls: type) -> dict | None:
+    """Build kwargs from the closest ancestor's `_create_node` signature, or None if no ancestor defines it."""
+    for ancestor in cls.__mro__[1:]:
+        if "_create_node" not in ancestor.__dict__:
+            continue
+
+        signature = inspect.signature(ancestor._create_node)
+        return {
+            name: (
+                param.default if param.default is not inspect.Parameter.empty else unittest.mock.MagicMock(name=name)
+            )
+            for name, param in signature.parameters.items()
+            if name != "self"
+        }
+    return None
+
+
+@pytest.mark.parametrize("cls", _cluster_classes_overriding_create_node(), ids=lambda cls: cls.__name__)
+def test_cluster_create_node_accepts_parent_kwargs(cls):
+    """Verify every `_create_node` override accepts the kwargs its parent's `add_nodes` forwards.
+
+    Bypasses cluster `__init__` via `__new__` — Python validates kwargs at the call
+    boundary before the body runs, so any TypeError about unexpected/missing/duplicate
+    kwargs surfaces a signature mismatch. Other exceptions come from the body running
+    against the bare cluster, which is unrelated to what we're checking.
+    """
+    kwargs = _parent_create_node_kwargs(cls)
+    if kwargs is None:
+        pytest.skip(f"{cls.__name__} has no ancestor with `_create_node`")
+
+    try:
+        cls._create_node(cls.__new__(cls), **kwargs)
+    except TypeError as exc:
+        if any(phrase in str(exc) for phrase in ("unexpected keyword argument", "got multiple values", "missing ")):
+            raise
+    except Exception:  # noqa: BLE001
+        pass


### PR DESCRIPTION
So far the CLI call `runner.sudo(<binary> --version)` was used to retrieve the VS version, including sudo, which is likely not required (at least for the current state of VS service implementation)
This change switches reading version from CLI to dedicated API endpoint that VS service exposes. This is a better approach as it is platform/backend-agnostic.

Additionally, the change follow-up to PR https://github.com/scylladb/scylla-cluster-tests/pull/14687 / [SCT-357](https://scylladb.atlassian.net/browse/SCT-357), which patched Node objects `__init__` overrides,
but missed few cluster-level `_create_node` overrides with the same problem.
The fix updates missed VectorStoreSetAWS and CassandraDockerCluster cluster abstractions, their _create_node methods, to accept and forward after_config param.

Fixes: SCT-55
Refs: SCT-357

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :green_circle: [pr-provision-test with VS node on AWS](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/pr-provision-test/314/)
- [x] :green_circle: [pr-provision-test with VS node on Docker](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/pr-provision-test/317/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)


[SCT-357]: https://scylladb.atlassian.net/browse/SCT-357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ