### PR TITLE
fix(perf-tests): reduce cassandra-stress JVM heap size for elasticity test

### DIFF
--- a/test-cases/performance/perf-regression-latency-650gb-elasticity.yaml
+++ b/test-cases/performance/perf-regression-latency-650gb-elasticity.yaml
@@ -34,7 +34,9 @@ email_recipients: ["scylla-perf-results@scylladb.com"]
 use_prepared_loaders: false
 use_hdrhistogram: true
 
-cs_extra_jvm_opts: '-XX:+UseZGC -XX:+ZGenerational -Xms8g -Xmx8g -XX:+AlwaysPreTouch'
+# Using 4g heap instead of 8g: loaders have 16GB RAM and during elasticity double-load step
+# two c-s processes run on the same loader, so 8g each causes OOM.
+cs_extra_jvm_opts: '-XX:+UseZGC -XX:+ZGenerational -Xms4g -Xmx4g -XX:+AlwaysPreTouch'
 email_subject_postfix: 'elasticity test'
 nemesis_double_load_during_grow_shrink_duration: 30
 parallel_node_operations: true


### PR DESCRIPTION
Reduced cs_extra_jvm_opts heap allocation from 8g to 4g (-Xms4g -Xmx4g) in perf-regression-latency-650gb-elasticity.yaml. The loader instance used in this test has 16GB of RAM. During the elasticity phase, two cassandra-stress commands run on the same loader simultaneously, and with 8GB heap each (16GB total), one of them fails with OOM. Reducing to 4GB per process leaves sufficient memory for both processes and OS.

 Fixes: https://scylladb.atlassian.net/browse/SCT-412

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [scylla-enterprise-perf-regression-latency-650gb-elasticity](https://argus.scylladb.com/tests/scylla-cluster-tests/81680385-de2f-49be-a609-3f931e49b2c4)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
