### PR TITLE
Backport: YCSB improvements to branch-2026.1

### DIFF
--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -989,7 +989,7 @@ the aws_secret_access_key that would be used for alternator
 
 ## **alternator_loadbalancing** / SCT_ALTERNATOR_LOADBALANCING
 
-If true, enable client-side load balancing across alternator nodes
+If true, enable native load balancing for alternator
 
 **default:** N/A
 
@@ -998,7 +998,7 @@ If true, enable client-side load balancing across alternator nodes
 
 ## **alternator_trust_all_certificates** / SCT_ALTERNATOR_TRUST_ALL_CERTIFICATES
 
-If true, trust all TLS certificates when connecting to alternator (useful for self-signed certs)
+If true, trust all TLS certificates for alternator connections (for testing with self-signed certs)
 
 **default:** True
 

--- a/sdcm/reporting/tooling_reporter.py
+++ b/sdcm/reporting/tooling_reporter.py
@@ -309,3 +309,69 @@ class GeminiGoCqlDriverVersionReporter(ToolReporterBase):
 
     def _collect_version_info(self) -> None:
         pass
+
+
+class YcsbAwsSdkVersionReporter(ToolReporterBase):
+    TOOL_NAME = "ycsb-aws-sdk"
+
+    def __init__(self, version: str, argus_client: ArgusSCTClient = None) -> None:
+        super().__init__(None, "", argus_client)
+        self.version = version
+
+    def _collect_version_info(self) -> None:
+        pass
+
+
+class YcsbScyllaDriverVersionReporter(ToolReporterBase):
+    TOOL_NAME = "ycsb-scylla-driver"
+
+    def __init__(self, version: str, argus_client: ArgusSCTClient = None) -> None:
+        super().__init__(None, "", argus_client)
+        self.version = version
+
+    def _collect_version_info(self) -> None:
+        pass
+
+
+class YcsbVersionReporter(ToolReporterBase):
+    """Reports YCSB version used in SCT."""
+
+    TOOL_NAME = "ycsb"
+    _YCSB_HOME = "/usr/local/share/scylla-ycsb"
+
+    def __init__(
+        self,
+        runner: CommandRunner,
+        command_prefix: str = None,
+        argus_client: ArgusSCTClient = None,
+        stress_cmd: str = "",
+    ) -> None:
+        super().__init__(runner, command_prefix, argus_client)
+        self.stress_cmd = stress_cmd
+
+    def _collect_version_info(self) -> None:
+        output = self.runner.run(f"{self._YCSB_HOME}/bin/ycsb.sh --version")
+        LOGGER.debug("%s: Collected ycsb version output:\n%s", self, output.stdout)
+        version_info = json.loads(output.stdout.strip())
+
+        self.version = version_info.get("version", "#FAILED_CHECK_LOGS")
+        self.date = version_info.get("build_date")
+        self.revision_id = version_info.get("git_hash")
+
+        if "dynamodb" in self.stress_cmd and (aws_sdk_version := version_info.get("aws_sdk_version")):
+            YcsbAwsSdkVersionReporter(version=aws_sdk_version, argus_client=self.argus_client).report()
+
+        if "scylla" in self.stress_cmd and (scylla_driver_version := version_info.get("scylla_driver_version")):
+            YcsbScyllaDriverVersionReporter(version=scylla_driver_version, argus_client=self.argus_client).report()
+
+
+class VectorStoreVersionReporter(ToolReporterBase):
+    TOOL_NAME = "vector-store"
+
+    def _collect_version_info(self):
+        output = self.runner.sudo(f"{self.command_prefix} --version")
+        LOGGER.info("%s: Collected vector-store output:\n%s", self, output.stdout)
+
+        name, version, *_ = output.stdout.split(" ")
+        LOGGER.info("%s: Collected %s version:\n%s", self, name, version)
+        self.version = version

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -960,13 +960,13 @@ class SCTConfiguration(dict):
             name="alternator_loadbalancing",
             env="SCT_ALTERNATOR_LOADBALANCING",
             type=boolean,
-            help="If true, enable client-side load balancing across alternator nodes",
+            help="If true, enable native load balancing for alternator",
         ),
         dict(
             name="alternator_trust_all_certificates",
             env="SCT_ALTERNATOR_TRUST_ALL_CERTIFICATES",
             type=boolean,
-            help="If true, trust all TLS certificates when connecting to alternator (useful for self-signed certs)",
+            help="If true, trust all TLS certificates for alternator connections (for testing with self-signed certs)",
         ),
         dict(
             name="region_aware_loader",

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -1237,6 +1237,8 @@ class FileFollowerThread:
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.stop()
+        if self.future:
+            self.future.result(timeout=30)
 
     def run(self):
         raise NotImplementedError()

--- a/sdcm/ycsb_thread.py
+++ b/sdcm/ycsb_thread.py
@@ -22,8 +22,9 @@ from functools import cached_property
 from textwrap import dedent
 
 from sdcm.prometheus import nemesis_metrics_obj
-from sdcm.sct_events.loaders import YcsbStressEvent
 from sdcm.remote import FailuresWatcher
+from sdcm.reporting.tooling_reporter import YcsbVersionReporter
+from sdcm.sct_events.loaders import YcsbStressEvent
 from sdcm.utils import alternator
 from sdcm.utils.common import FileFollowerThread
 from sdcm.utils.docker_remote import RemoteDocker
@@ -154,7 +155,7 @@ class YcsbStressThread(DockerBasedStressThread):
     def _hdr_files_directory_on_loaders_node(self, loader_idx, cpu_idx):
         return f"{self._hdr_main_dir_on_loaders_node()}/{loader_idx}/{cpu_idx}"
 
-    def copy_template(self, cmd_runner, loader_name, memo={}):  # noqa: B006
+    def copy_template(self, cmd_runner, loader_name, loader=None, memo={}):  # noqa: B006
         if loader_name in memo:
             return None
         web_protocol = "http"
@@ -210,6 +211,11 @@ class YcsbStressThread(DockerBasedStressThread):
 
             with tempfile.NamedTemporaryFile(mode="w+", encoding="utf-8") as tmp_file:
                 tmp_file.write(dynamodb_teample)
+                alternator_port = self.params.get("alternator_port")
+                native_loading = self.params.get("alternator_loadbalancing")
+                trustAllCerts = self.params.get("alternator_trust_all_certificates")  # noqa: N806
+                access_key = self.params.get("alternator_access_key_id")
+                secret_key = self.params.get("alternator_secret_access_key")
                 tmp_file.write(
                     dedent(f"""
                     dynamodb.debug = false
@@ -416,8 +422,16 @@ class YcsbStressThread(DockerBasedStressThread):
             )
             cmd_runner_name = str(loader)
 
-        self.copy_template(cmd_runner, loader.name)
+        self.copy_template(cmd_runner, loader.name, loader=loader)
         stress_cmd = self.build_stress_cmd(loader_idx, cpu_idx)
+
+        try:
+            reporter = YcsbVersionReporter(
+                cmd_runner, "", loader.parent_cluster.test_config.argus_client(), stress_cmd=self.stress_cmd
+            )
+            reporter.report()
+        except Exception:  # noqa: BLE001
+            LOGGER.info("Failed to collect ycsb version information", exc_info=True)
 
         if not os.path.exists(loader.logdir):
             os.makedirs(loader.logdir, exist_ok=True)

--- a/sdcm/ycsb_thread.py
+++ b/sdcm/ycsb_thread.py
@@ -63,7 +63,10 @@ class YcsbStatsPublisher(FileFollowerThread):
     def handle_verify_metric(self, line):
         verify_status_regex = re.compile(r"Return\((?P<status>.*?)\)=(?P<value>\d*)")
         verify_regex = re.compile(r"\[VERIFY:(.*?)\]")
-        verify_content = verify_regex.findall(line)[0]
+        found = verify_regex.findall(line)
+        if not found:
+            return
+        verify_content = found[0]
 
         for status_match in verify_status_regex.finditer(verify_content):
             stat = status_match.groupdict()
@@ -108,6 +111,13 @@ class YcsbStatsPublisher(FileFollowerThread):
                                     except ValueError:
                                         value = float(0)  # noqa: PLW2901
                                 self.set_metric(operation, key, float(value))
+
+                    # [VERIFY: Return(OK/UNEXPECTED_STATE/ERROR)=N] lines are final summary lines
+                    # that do NOT match the stats regex (no Count/Max/Min/Avg fields), so
+                    # handle_verify_metric would never be called for them from inside the
+                    # stats regex loop above. Handle them separately here.
+                    if "[VERIFY:" in line and "Return(" in line:
+                        self.handle_verify_metric(line)
 
                 except Exception:
                     LOGGER.exception("fail to send metric")
@@ -200,6 +210,27 @@ class YcsbStressThread(DockerBasedStressThread):
 
             with tempfile.NamedTemporaryFile(mode="w+", encoding="utf-8") as tmp_file:
                 tmp_file.write(dynamodb_teample)
+                tmp_file.write(
+                    dedent(f"""
+                    dynamodb.debug = false
+                    dynamodb.alternator.port = {alternator_port}
+                    dynamodb.alternator.loadbalancing = {native_loading}
+                    dynamodb.virtualThreads = true
+                    dynamodb.alternator.trustAllCertificates = {trustAllCerts}
+                    dynamodb.awsAccessKey = {access_key}
+                    dynamodb.awsSecretKey = {secret_key}
+                """)
+                )
+                # Only write datacenter/rack when non-empty. Java's Properties.getProperty()
+                # returns "" for empty values (not null), so `datacenter != null` would be
+                # true for "", creating DatacenterScope.of("") which routes to a non-existent
+                # datacenter and causes all operations to fail.
+                loader_datacenter = getattr(loader, "datacenter", "")
+                loader_rack = getattr(loader, "rack", "")
+                if loader_datacenter:
+                    tmp_file.write(f"dynamodb.alternator.datacenter = {loader_datacenter}\n")
+                if loader_rack:
+                    tmp_file.write(f"dynamodb.alternator.rack = {loader_rack}\n")
                 tmp_file.flush()
                 cmd_runner.send_files(tmp_file.name, os.path.join("/tmp", "dynamodb.properties"))
 

--- a/sdcm/ycsb_thread.py
+++ b/sdcm/ycsb_thread.py
@@ -155,7 +155,8 @@ class YcsbStressThread(DockerBasedStressThread):
     def _hdr_files_directory_on_loaders_node(self, loader_idx, cpu_idx):
         return f"{self._hdr_main_dir_on_loaders_node()}/{loader_idx}/{cpu_idx}"
 
-    def copy_template(self, cmd_runner, loader_name, loader=None, memo={}):  # noqa: B006
+    def copy_template(self, cmd_runner, loader, memo={}):  # noqa: B006
+        loader_name = loader.name
         if loader_name in memo:
             return None
         web_protocol = "http"
@@ -175,7 +176,6 @@ class YcsbStressThread(DockerBasedStressThread):
             dynamodb_teample = dedent(
                 """
                 measurementtype=hdrhistogram
-                dynamodb.awsCredentialsFile = /tmp/aws_dummy_credentials_file
                 dynamodb.endpoint = {0}://{1}:{2}
                 dynamodb.connectMax = 2500
                 requestdistribution = uniform
@@ -198,24 +198,45 @@ class YcsbStressThread(DockerBasedStressThread):
                     dynamodb.primaryKey = {alternator.consts.HASH_KEY_NAME}
                     dynamodb.primaryKeyType = {alternator.enums.YCSBSchemaTypes.HASH_SCHEMA.value}
                 """)
+            access_key = self.params.get("alternator_access_key_id")
             if self.params.get("alternator_enforce_authorization"):
-                aws_credentials_content = dedent(f"""
-                    accessKey = {self.params.get("alternator_access_key_id")}
-                    secretKey = {alternator.api.Alternator.get_salted_hash(node=self.node_list[0], username=self.params.get("alternator_access_key_id"))}
-                """)
+                secret_key = alternator.api.Alternator.get_salted_hash(node=self.node_list[0], username=access_key)
             else:
-                aws_credentials_content = dedent(f"""
-                    accessKey = {self.params.get("alternator_access_key_id")}
-                    secretKey = {self.params.get("alternator_secret_access_key")}
-                """)
+                secret_key = self.params.get("alternator_secret_access_key")
+
+            dns_loadbalancing = self.params.get("alternator_use_dns_routing")
+            native_loading = self.params.get("alternator_loadbalancing")
+            if dns_loadbalancing:
+                native_loading = False
+
+            if dns_loadbalancing == False and native_loading == False:  # noqa: E712
+                LOGGER.error(
+                    "Both 'alternator_use_dns_routing' and 'alternator_loadbalancing' options are set to False, "
+                    "alternator must use some form of load balancing to distribute the load between the nodes in the cluster "
+                    ", or alternator will not be able to start as it will look for DEFAULT AWS address"
+                )
+                raise ValueError(
+                    "One of the 'alternator_use_dns_routing' or 'alternator_loadbalancing' options must be set to True"
+                )
+
+            alternator_port = self.params.get("alternator_port")
+            trustAllCerts = self.params.get("alternator_trust_all_certificates")  # noqa: N806
+
+            if not alternator_port:
+                alternator_port = -1
+            if not trustAllCerts:
+                trustAllCerts = True
+
+            # This is a workaround to make AWS SDK v2 Happy
+            # as it will fail if the credentials are not provided,
+            # even if the alternator is running in a mode that does not require authentication.
+            if access_key is None or access_key == "":
+                access_key = "test"
+            if secret_key is None or secret_key == "":
+                secret_key = "test"
 
             with tempfile.NamedTemporaryFile(mode="w+", encoding="utf-8") as tmp_file:
                 tmp_file.write(dynamodb_teample)
-                alternator_port = self.params.get("alternator_port")
-                native_loading = self.params.get("alternator_loadbalancing")
-                trustAllCerts = self.params.get("alternator_trust_all_certificates")  # noqa: N806
-                access_key = self.params.get("alternator_access_key_id")
-                secret_key = self.params.get("alternator_secret_access_key")
                 tmp_file.write(
                     dedent(f"""
                     dynamodb.debug = false
@@ -225,6 +246,8 @@ class YcsbStressThread(DockerBasedStressThread):
                     dynamodb.alternator.trustAllCertificates = {trustAllCerts}
                     dynamodb.awsAccessKey = {access_key}
                     dynamodb.awsSecretKey = {secret_key}
+                    aws.accessKeyId = {access_key}
+                    aws.secretKey = {secret_key}
                 """)
                 )
                 # Only write datacenter/rack when non-empty. Java's Properties.getProperty()
@@ -239,11 +262,6 @@ class YcsbStressThread(DockerBasedStressThread):
                     tmp_file.write(f"dynamodb.alternator.rack = {loader_rack}\n")
                 tmp_file.flush()
                 cmd_runner.send_files(tmp_file.name, os.path.join("/tmp", "dynamodb.properties"))
-
-            with tempfile.NamedTemporaryFile(mode="w+", encoding="utf-8") as tmp_file:
-                tmp_file.write(aws_credentials_content)
-                tmp_file.flush()
-                cmd_runner.send_files(tmp_file.name, os.path.join("/tmp", "aws_dummy_credentials_file"))
             if is_kubernetes:
                 if web_protocol == "https":
                     if ca_bundle_path := getattr(self.node_list[0], "alternator_ca_bundle_path", None):
@@ -422,7 +440,7 @@ class YcsbStressThread(DockerBasedStressThread):
             )
             cmd_runner_name = str(loader)
 
-        self.copy_template(cmd_runner, loader.name, loader=loader)
+        self.copy_template(cmd_runner, loader)
         stress_cmd = self.build_stress_cmd(loader_idx, cpu_idx)
 
         try:

--- a/unit_tests/test_tooling_ycsb_reporter_parsing.py
+++ b/unit_tests/test_tooling_ycsb_reporter_parsing.py
@@ -1,0 +1,248 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2026 ScyllaDB
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from sdcm.reporting.tooling_reporter import (
+    YcsbVersionReporter,
+    YcsbAwsSdkVersionReporter,
+    YcsbScyllaDriverVersionReporter,
+)
+
+
+SAMPLE_VERSION_JSON = json.dumps(
+    {
+        "version": "1.3.0-SNAPSHOT",
+        "git_hash": "4c50691",
+        "git_tag": "",
+        "build_date": "2026-02-26T22:28:26+0100",
+        "aws_sdk_version": "2.0.0",
+        "scylla_driver_version": "3.10.2",
+    }
+)
+
+
+@pytest.fixture
+def make_runner():
+    def _make(stdout: str) -> MagicMock:
+        mock_runner = MagicMock()
+        mock_output = MagicMock()
+        mock_output.stdout = stdout
+        mock_runner.run.return_value = mock_output
+        return mock_runner
+
+    return _make
+
+
+def test_version_parsed_from_json(make_runner):
+    runner = make_runner(SAMPLE_VERSION_JSON)
+    reporter = YcsbVersionReporter(runner=runner, command_prefix="", argus_client=None)
+
+    reporter._collect_version_info()
+
+    assert reporter.version == "1.3.0-SNAPSHOT"
+
+
+def test_build_date_parsed_from_json(make_runner):
+    runner = make_runner(SAMPLE_VERSION_JSON)
+    reporter = YcsbVersionReporter(runner=runner, command_prefix="", argus_client=None)
+
+    reporter._collect_version_info()
+
+    assert reporter.date == "2026-02-26T22:28:26+0100"
+
+
+def test_git_hash_used_as_revision_id(make_runner):
+    runner = make_runner(SAMPLE_VERSION_JSON)
+    reporter = YcsbVersionReporter(runner=runner, command_prefix="", argus_client=None)
+
+    reporter._collect_version_info()
+
+    assert reporter.revision_id == "4c50691"
+
+
+def test_version_command_targets_ycsb_binary(make_runner):
+    runner = make_runner(SAMPLE_VERSION_JSON)
+    reporter = YcsbVersionReporter(runner=runner, command_prefix="", argus_client=None)
+
+    reporter._collect_version_info()
+
+    runner.run.assert_called_once()
+    (cmd,) = runner.run.call_args.args
+    assert f"{YcsbVersionReporter._YCSB_HOME}/bin/ycsb" in cmd
+    assert "--version" in cmd
+
+
+def test_missing_version_key_falls_back_to_marker(make_runner):
+    runner = make_runner(json.dumps({"git_hash": "abc", "build_date": "2026-01-01"}))
+    reporter = YcsbVersionReporter(runner=runner, command_prefix="", argus_client=None)
+
+    reporter._collect_version_info()
+
+    assert reporter.version == "#FAILED_CHECK_LOGS"
+
+
+def test_dynamodb_workload_reports_aws_sdk_version(make_runner):
+    runner = make_runner(SAMPLE_VERSION_JSON)
+    reporter = YcsbVersionReporter(
+        runner=runner,
+        command_prefix="",
+        argus_client=None,
+        stress_cmd="bin/ycsb run dynamodb -P workloads/workloada -threads 5",
+    )
+
+    with patch.object(YcsbAwsSdkVersionReporter, "report") as mock_report:
+        reporter._collect_version_info()
+
+    mock_report.assert_called_once()
+
+
+def test_dynamodb_aws_sdk_reporter_receives_correct_version(make_runner):
+    runner = make_runner(SAMPLE_VERSION_JSON)
+    reporter = YcsbVersionReporter(
+        runner=runner,
+        command_prefix="",
+        argus_client=None,
+        stress_cmd="bin/ycsb run dynamodb -P workloads/workloada",
+    )
+
+    created_reporters = []
+    original_init = YcsbAwsSdkVersionReporter.__init__
+
+    def capture_init(self, *args, **kwargs):
+        original_init(self, *args, **kwargs)
+        created_reporters.append(self)
+
+    with (
+        patch.object(YcsbAwsSdkVersionReporter, "__init__", capture_init),
+        patch.object(YcsbAwsSdkVersionReporter, "report"),
+    ):
+        reporter._collect_version_info()
+
+    assert len(created_reporters) == 1
+    assert created_reporters[0].version == "2.0.0"
+
+
+def test_scylla_workload_reports_scylla_driver_version(make_runner):
+    runner = make_runner(SAMPLE_VERSION_JSON)
+    reporter = YcsbVersionReporter(
+        runner=runner,
+        command_prefix="",
+        argus_client=None,
+        stress_cmd="bin/ycsb run scylla -P workloads/workloada -threads 5",
+    )
+
+    with patch.object(YcsbScyllaDriverVersionReporter, "report") as mock_report:
+        reporter._collect_version_info()
+
+    mock_report.assert_called_once()
+
+
+def test_scylla_driver_reporter_receives_correct_version(make_runner):
+    runner = make_runner(SAMPLE_VERSION_JSON)
+    reporter = YcsbVersionReporter(
+        runner=runner,
+        command_prefix="",
+        argus_client=None,
+        stress_cmd="bin/ycsb run scylla -P workloads/workloada",
+    )
+
+    created_reporters = []
+    original_init = YcsbScyllaDriverVersionReporter.__init__
+
+    def capture_init(self, *args, **kwargs):
+        original_init(self, *args, **kwargs)
+        created_reporters.append(self)
+
+    with (
+        patch.object(YcsbScyllaDriverVersionReporter, "__init__", capture_init),
+        patch.object(YcsbScyllaDriverVersionReporter, "report"),
+    ):
+        reporter._collect_version_info()
+
+    assert len(created_reporters) == 1
+    assert created_reporters[0].version == "3.10.2"
+
+
+def test_unrecognized_workload_reports_no_sub_reporters(make_runner):
+    runner = make_runner(SAMPLE_VERSION_JSON)
+    reporter = YcsbVersionReporter(
+        runner=runner,
+        command_prefix="",
+        argus_client=None,
+        stress_cmd="bin/ycsb run mongodb -P workloads/workloada",
+    )
+
+    with (
+        patch.object(YcsbAwsSdkVersionReporter, "report") as aws_report,
+        patch.object(YcsbScyllaDriverVersionReporter, "report") as scylla_report,
+    ):
+        reporter._collect_version_info()
+
+    aws_report.assert_not_called()
+    scylla_report.assert_not_called()
+
+
+def test_dynamodb_workload_without_aws_sdk_key_does_not_crash(make_runner):
+    runner = make_runner(json.dumps({"version": "1.0.0", "git_hash": "abc", "build_date": "2026-01-01"}))
+    reporter = YcsbVersionReporter(
+        runner=runner,
+        command_prefix="",
+        argus_client=None,
+        stress_cmd="bin/ycsb run dynamodb -P workloads/workloada",
+    )
+
+    reporter._collect_version_info()
+
+    assert reporter.version == "1.0.0"
+
+
+def test_scylla_workload_without_driver_version_key_does_not_crash(make_runner):
+    runner = make_runner(json.dumps({"version": "1.0.0", "git_hash": "abc", "build_date": "2026-01-01"}))
+    reporter = YcsbVersionReporter(
+        runner=runner,
+        command_prefix="",
+        argus_client=None,
+        stress_cmd="bin/ycsb run scylla -P workloads/workloada",
+    )
+
+    reporter._collect_version_info()
+
+    assert reporter.version == "1.0.0"
+
+
+def test_aws_sdk_reporter_stores_version():
+    reporter = YcsbAwsSdkVersionReporter(version="2.0.0")
+
+    assert reporter.version == "2.0.0"
+
+
+def test_scylla_driver_reporter_stores_version():
+    reporter = YcsbScyllaDriverVersionReporter(version="3.10.2")
+
+    assert reporter.version == "3.10.2"
+
+
+def test_tool_name_is_ycsb():
+    assert YcsbVersionReporter.TOOL_NAME == "ycsb"
+
+
+def test_aws_sdk_reporter_tool_name():
+    assert YcsbAwsSdkVersionReporter.TOOL_NAME == "ycsb-aws-sdk"
+
+
+def test_scylla_driver_reporter_tool_name():
+    assert YcsbScyllaDriverVersionReporter.TOOL_NAME == "ycsb-scylla-driver"

--- a/unit_tests/test_ycsb_thread.py
+++ b/unit_tests/test_ycsb_thread.py
@@ -116,7 +116,7 @@ def test_01_dynamodb_api(request, docker_scylla, prom_address, params):
 
     cmd = (
         "bin/ycsb run dynamodb -P workloads/workloada -threads 5 -p recordcount=1000000 "
-        "-p fieldcount=10 -p fieldlength=1024 -p operationcount=200200300 -s"
+        "-p fieldcount=10 -p fieldlength=1024 -p operationcount=200200300 -p status.interval=2 -s"
     )
     ycsb_thread = YcsbStressThread(
         loader_set, cmd, node_list=[docker_scylla], timeout=5, params=params, cluster_tester=MagicMock()
@@ -137,7 +137,7 @@ def test_01_dynamodb_api(request, docker_scylla, prom_address, params):
         assert "sct_ycsb_update_gauge" in output
 
         matches = regex.findall(output)
-        assert all(float(i) > 0 for i in matches), output
+        assert any(float(i) > 0 for i in matches), output
 
     check_metrics()
 
@@ -218,7 +218,7 @@ def test_03_cql(request, docker_scylla, prom_address, params):
 
     cmd = (
         "bin/ycsb load scylla -P workloads/workloada -threads 5 -p recordcount=1000000 "
-        "-p fieldcount=10 -p fieldlength=1024 -p operationcount=200200300 -s"
+        "-p fieldcount=10 -p fieldlength=1024 -p operationcount=200200300 -p status.interval=2 -s"
     )
     ycsb_thread = YcsbStressThread(
         loader_set,
@@ -239,12 +239,11 @@ def test_03_cql(request, docker_scylla, prom_address, params):
     @timeout(timeout=60)
     def check_metrics():
         output = requests.get("http://{}/metrics".format(prom_address)).text
-        regex = re.compile(r"^sct_ycsb_read_gauge.*?([0-9\.]*?)$", re.MULTILINE)
-        assert "sct_ycsb_read_gauge" in output
-        assert "sct_ycsb_update_gauge" in output
+        regex = re.compile(r"^sct_ycsb_insert_gauge.*?([0-9\.]*?)$", re.MULTILINE)
+        assert "sct_ycsb_insert_gauge" in output
 
         matches = regex.findall(output)
-        assert all(float(i) > 0 for i in matches), output
+        assert any(float(i) > 0 for i in matches), output
 
     check_metrics()
     results, _ = ycsb_thread.parse_results()


### PR DESCRIPTION
Fixes  - Unable to load credentials from any of the providers in the chain AwsCredentialsProviderChain

Fix datacenter/rack handling in YCSB dynamodb properties file: only write datacenter/rack properties when non-empty. Java's Properties.getProperty() returns "" (not null) for empty values, causing DatacenterScope.of("") to route all operations to a non-existent datacenter and fail.
- Fix race condition and integration test failures in YcsbStressThread.
- Add new SCT config params for alternator datacenter/rack support (defaults/test_default.yaml, sdcm/sct_config.py).

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- 🔴 https://argus.scylladb.com/tests/scylla-cluster-tests/b107921e-1fd8-493f-a3cb-6193f45ac0ab - Test identifying the issue
- 🟢 https://argus.scylladb.com/tests/scylla-cluster-tests/e288cfb9-e917-422e-9aa3-388f1bc3afea (With Fixes)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
