### PR TITLE
fix(claude-review): post single top-level PR comment with attribution

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -101,11 +101,12 @@ jobs:
           claude_args: >-
             --model claude-sonnet-4-6
             --add-dir pr-code
-            --allowedTools Read,Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git blame:*),Bash(gh pr view:*),Bash(gh pr diff:*)
+            --allowedTools Read,Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git blame:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*)
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review --comment https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
           allowed_bots: 'claude,renovate[bot]'
+          classify_inline_comments: 'false'
           show_full_output: 'true'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options

--- a/skills/code-review/workflows/review-a-pr.md
+++ b/skills/code-review/workflows/review-a-pr.md
@@ -75,12 +75,50 @@ Step-by-step process for reviewing a pull request on the SCT repository.
 
 **Entry criteria**: All checks complete.
 
-1. **Group findings by severity**:
-   - 🔴 **Blocking**: Override breaks, runtime errors, data loss risks
-   - 🟡 **Should fix**: Convention violations, missing tests, missing defaults
-   - 🟢 **Suggestion**: Style improvements, optional optimizations
-2. **Be specific**: Include file names, line numbers, and concrete fix suggestions
-3. **Be concise**: One sentence per issue, with a code suggestion when applicable
-4. **Acknowledge good patterns**: Note well-structured code, good test coverage, or clever solutions
+### Output Format
 
-**Exit criteria**: Review feedback posted with clear severity levels and actionable suggestions.
+Post a **single top-level PR comment** using `gh pr comment`. Do NOT post inline review comments or use the GitHub review API.
+
+**Comment structure:**
+
+```markdown
+## 🤖 Claude Code Review
+
+**PR**: #<number> — <title>
+**Status**: <LGTM ✅ | Issues Found ⚠️ | Blocking Issues 🚫>
+
+### Summary
+
+<1-2 sentence summary of what the PR does>
+
+### Findings
+
+<If no issues: "No issues found. The change looks correct and follows SCT conventions.">
+
+<If issues found, group by severity:>
+
+#### 🔴 Blocking
+- **<file>:<line>** — <description>. Fix: <suggestion>
+
+#### 🟡 Should Fix
+- **<file>:<line>** — <description>. Fix: <suggestion>
+
+#### 🟢 Suggestions
+- **<file>:<line>** — <description>
+
+### Good Patterns
+<Note any well-structured code, good test coverage, or clever solutions. Omit section if nothing notable.>
+
+---
+<sub>🔗 [Action run](https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID) · Automated review by Claude Code</sub>
+```
+
+### Posting Rules
+
+1. **Never post inline comments** — all findings go in the single top-level comment
+2. **Never use `gh api` to create review comments** — only use `gh pr comment`
+3. **Always include the action run link** using `$GITHUB_REPOSITORY` and `$GITHUB_RUN_ID` env vars
+4. **Use the exact command**: `gh pr comment <PR_NUMBER> --body "<body>"`
+5. **If the PR has no issues**, still post the comment with "LGTM ✅" status
+
+**Exit criteria**: Single top-level comment posted with all findings, attribution header, and action link footer.


### PR DESCRIPTION
## Summary
- Switch from inline review comments to a single top-level PR comment
- Add `🤖 Claude Code Review` header and action run link footer for attribution
- Add `gh pr comment` to allowed tools
- Disable `classify_inline_comments` (no longer needed)

## Why
The previous approach posted inline review comments that:
1. Lacked attribution (no way to tell it was Claude)
2. Had no link to the GitHub Action run for debugging
3. Sometimes posted after the PR was already merged (race condition with ~5min review time)

A single top-level comment is easier to read, clearly attributed, and links to the action run.

## Backends Affected
None - CI workflow only.