### PR TITLE
improvement(provision/aws): mid-test capacity guard for dynamically added nodes

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -217,6 +217,8 @@ fallback_to_next_availability_zone: true
 
 pre_filter_unavailable_availability_zones: true
 
+pre_flight_capacity_probe: false
+
 enable_argus: true
 
 enable_kernel_panic_checker: true

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -4060,6 +4060,15 @@ Filter availability zones upfront to only those that support all required instan
 **type:** bool
 
 
+## **pre_flight_capacity_probe** / SCT_PRE_FLIGHT_CAPACITY_PROBE
+
+Before provisioning, probe capacity by launching and terminating one on-demand instance per dynamic type (`instance_type_db_target`, `nemesis_grow_shrink_instance_type`) in the chosen AZ. On capacity errors, raise to trigger AZ/region fallback. Costs ~1 min per type. AWS-only.
+
+**default:** N/A
+
+**type:** bool
+
+
 ## **num_nodes_to_rollback** / SCT_NUM_NODES_TO_ROLLBACK
 
 Number of nodes to upgrade and rollback in test_generic_cluster_upgrade

--- a/sdcm/provision/aws/az_resolver.py
+++ b/sdcm/provision/aws/az_resolver.py
@@ -14,9 +14,20 @@
 import logging
 from typing import Callable
 
+import boto3
+from botocore.exceptions import ClientError
+
+from sdcm.provision.aws.capacity_errors import ProvisioningCapacityExhausted, is_capacity_error
+from sdcm.test_config import TestConfig
 from sdcm.utils.aws_region import AwsRegion
 
 LOGGER = logging.getLogger(__name__)
+
+# instance types added mid-test; AZ fallback at provisioning time is unsafe for them
+_DYNAMIC_ADD_TYPE_PARAMS: tuple[str, ...] = (
+    "instance_type_db_target",
+    "nemesis_grow_shrink_instance_type",
+)
 
 
 def _node_count_positive(value) -> bool:
@@ -254,3 +265,123 @@ class AZResolver:
     def _configured_az_letters(self) -> list[str]:
         raw = self._params.get("availability_zone") or ""
         return [letter.strip() for letter in raw.split(",") if letter.strip()]
+
+    def probe_capacity_for_types(self, types: list[str], az: str) -> dict[str, bool]:
+        """Confirm AWS has on-demand capacity for each `type` in `az`.
+
+        Launches and immediately terminates one on-demand instance per type. Returns
+        `{type: True}` on success and `{type: False}` for capacity-class errors per
+        `is_capacity_error`. Re-raises any non-capacity ClientError. Probe instances
+        always terminate in `finally` so a probe failure cannot leak a running
+        instance.
+        """
+        if not types:
+            return {}
+
+        region_names = self._region_names()
+        if not region_names:
+            raise RuntimeError("Pre-flight capacity probe: no region configured")
+        region = region_names[0]
+        region_az = az if az.startswith(region) else f"{region}{az[-1]}"
+
+        aws_region = AwsRegion(region_name=region)
+        subnet = aws_region.sct_subnet(region_az=region_az, subnet_index=0)
+        if subnet is None:
+            raise RuntimeError(
+                f"Pre-flight capacity probe: no SCT subnet found in {region_az}; "
+                f"run `hydra prepare-aws-region --region {region}` to enable"
+            )
+        security_group = aws_region.sct_security_group
+        if security_group is None:
+            raise RuntimeError(f"Pre-flight capacity probe: no SCT security group in {region}")
+
+        ec2_client = boto3.client("ec2", region_name=region)
+        ssm_client = boto3.client("ssm", region_name=region)
+
+        results = {}
+        for instance_type in types:
+            ami_id = _get_amazon_linux_ami_for_type(ec2_client, ssm_client, instance_type)
+            tags = TestConfig.common_tags(self._params) | {
+                "Purpose": "capacity-probe",
+                "Name": f"capacity-probe-{instance_type}-{region_az}",
+                "keep_alive": "false",
+            }
+            instance_ids = []
+            try:
+                response = ec2_client.run_instances(
+                    ImageId=ami_id,
+                    InstanceType=instance_type,
+                    MinCount=1,
+                    MaxCount=1,
+                    SubnetId=subnet.subnet_id,
+                    SecurityGroupIds=[security_group.group_id],
+                    TagSpecifications=[
+                        {
+                            "ResourceType": "instance",
+                            "Tags": [{"Key": k, "Value": str(v)} for k, v in tags.items()],
+                        }
+                    ],
+                )
+                instance_ids = [i["InstanceId"] for i in response.get("Instances", [])]
+                results[instance_type] = True
+                LOGGER.info("Pre-flight probe: capacity available for %s in %s", instance_type, region_az)
+            except ClientError as exc:
+                if is_capacity_error(exc):
+                    LOGGER.warning("Pre-flight probe: no capacity for %s in %s: %s", instance_type, region_az, exc)
+                    results[instance_type] = False
+                else:
+                    LOGGER.warning(
+                        "Pre-flight probe: skipping %s in %s due to non-capacity error (%s): %s",
+                        instance_type,
+                        region_az,
+                        exc.response.get("Error", {}).get("Code"),
+                        exc,
+                    )
+                    results[instance_type] = True
+            finally:
+                if instance_ids:
+                    try:
+                        ec2_client.terminate_instances(InstanceIds=instance_ids)
+                    except Exception as exc:  # noqa: BLE001
+                        LOGGER.warning(
+                            "Pre-flight probe: failed to terminate %s in %s: %s", instance_ids, region_az, exc
+                        )
+        return results
+
+
+def _get_amazon_linux_ami_for_type(ec2_client, ssm_client, instance_type: str) -> str:
+    """Return the latest Amazon Linux 2 AMI matching `instance_type`'s architecture."""
+    info = ec2_client.describe_instance_types(InstanceTypes=[instance_type])
+    arch = info["InstanceTypes"][0]["ProcessorInfo"]["SupportedArchitectures"][0]
+    ssm_arch = "arm64" if arch == "arm64" else "x86_64"
+    ssm_path = f"/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-{ssm_arch}-gp2"
+    return ssm_client.get_parameter(Name=ssm_path)["Parameter"]["Value"]
+
+
+def run_pre_flight_capacity_probe(params) -> None:
+    """Probe each configured AZ for capacity of every dynamically-added instance type."""
+    if not params.get("pre_flight_capacity_probe"):
+        return
+
+    types = [t for key in _DYNAMIC_ADD_TYPE_PARAMS if (t := params.get(key))]
+    if not types:
+        return
+
+    az_letters = [az.strip() for az in (params.get("availability_zone") or "").split(",") if az.strip()]
+    if not az_letters:
+        return
+
+    LOGGER.info(
+        "pre_flight_capacity_probe enabled — probing types %s in AZs %s (~1 min per type per AZ)",
+        types,
+        az_letters,
+    )
+
+    resolver = AZResolver(params)
+    failures = []
+    for letter in az_letters:
+        results = resolver.probe_capacity_for_types(types=types, az=letter)
+        failures.extend(f"{instance_type}@{letter}" for instance_type, ok in results.items() if not ok)
+
+    if failures:
+        raise ProvisioningCapacityExhausted(f"Pre-flight capacity probe failed for: {failures}")

--- a/sdcm/provision/aws/capacity_reservation.py
+++ b/sdcm/provision/aws/capacity_reservation.py
@@ -54,7 +54,20 @@ class SCTCapacityReservation:
         else:
             cluster_max_size += nemesis_node_count
 
+        def _to_int_sum(value) -> int:
+            if isinstance(value, list):
+                return sum(int(n) for n in value)
+            return int(value or 0)
+
         instance_counts[params.get("instance_type_db")] += cluster_max_size
+
+        if instance_type_db_target := params.get("instance_type_db_target"):
+            instance_counts[instance_type_db_target] += _to_int_sum(params.get("n_db_nodes"))
+        if (instance_type_db_oracle := params.get("instance_type_db_oracle")) and params.get("db_type") in (
+            "mixed_scylla",
+            "mixed_cassandra",
+        ):
+            instance_counts[instance_type_db_oracle] += _to_int_sum(params.get("n_test_oracle_db_nodes"))
         instance_counts[params.get("instance_type_loader")] += params.get("n_loaders")
         # don't reserve capacity for monitor - as usually it's not a problem to spin it
         duration = params.get("test_duration")

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1999,6 +1999,11 @@ class SCTConfiguration(BaseModel):
         "Replaces invalid AZs with valid alternatives in the same region before any provisioning attempt. "
         "Supported backends: AWS, GCE.",
     )
+    pre_flight_capacity_probe: Boolean = SctField(
+        description="Before provisioning, probe capacity by launching and terminating one on-demand instance per dynamic type "
+        "(`instance_type_db_target`, `nemesis_grow_shrink_instance_type`) in the chosen AZ. On capacity errors, raise to "
+        "trigger AZ/region fallback. Costs ~1 min per type. AWS-only.",
+    )
     num_nodes_to_rollback: int = SctField(
         description="Number of nodes to upgrade and rollback in test_generic_cluster_upgrade",
     )

--- a/sdcm/sct_provision/aws/layout.py
+++ b/sdcm/sct_provision/aws/layout.py
@@ -16,7 +16,7 @@ from functools import cached_property
 
 from botocore.exceptions import ClientError
 
-from sdcm.provision.aws.az_resolver import AZResolver, is_az_fallback_enabled
+from sdcm.provision.aws.az_resolver import AZResolver, is_az_fallback_enabled, run_pre_flight_capacity_probe
 from sdcm.provision.aws.capacity_errors import ProvisioningCapacityExhausted, is_capacity_error
 from sdcm.provision.aws.capacity_reservation import SCTCapacityReservation
 from sdcm.provision.aws.dedicated_host import SCTDedicatedHosts
@@ -93,6 +93,10 @@ class SCTProvisionAWSLayout(SCTProvisionLayout, cluster_backend="aws"):
 
     def _do_provision(self):
         use_scylla_cloud = self._params.get("cluster_backend") == "xcloud" or self._params.get("xcloud_provider")
+
+        # raises ProvisioningCapacityExhausted on probe failure; the surrounding
+        # AZ fallback loop in `provision()` retries the next candidate.
+        run_pre_flight_capacity_probe(self._params)
 
         if self.placement_group:
             self.placement_group.provision()

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -81,7 +81,7 @@ from sdcm.cluster_k8s.eks import MonitorSetEKS
 from sdcm.cluster_cloud import ScyllaCloudCluster
 from sdcm.cql_stress_cassandra_stress_thread import CqlStressCassandraStressThread
 from sdcm.mgmt import get_scylla_manager_tool
-from sdcm.provision.aws.az_resolver import AZResolver, is_az_fallback_enabled
+from sdcm.provision.aws.az_resolver import AZResolver, is_az_fallback_enabled, run_pre_flight_capacity_probe
 from sdcm.provision.aws.capacity_errors import ProvisioningCapacityExhausted, is_capacity_error
 from sdcm.provision.aws.capacity_reservation import SCTCapacityReservation
 from sdcm.kafka.kafka_cluster import LocalKafkaCluster
@@ -1987,6 +1987,8 @@ class ClusterTester(unittest.TestCase):
 
         Used by `get_cluster_aws` to retry provisioning with different AZs.
         """
+        run_pre_flight_capacity_probe(self.params)
+
         regions = self.params.get("region_name").split()
         services = get_ec2_services(regions)
         user_prefix = self.params.get("user_prefix")

--- a/unit_tests/unit/provisioner/test_az_resolver.py
+++ b/unit_tests/unit/provisioner/test_az_resolver.py
@@ -11,16 +11,19 @@
 #
 # Copyright (c) 2026 ScyllaDB
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
+from botocore.exceptions import ClientError
 
 from sdcm.provision.aws.az_resolver import (
     AZResolver,
     NoValidAvailabilityZoneError,
     _node_count_positive,
     is_az_fallback_enabled,
+    run_pre_flight_capacity_probe,
 )
+from sdcm.provision.aws.capacity_errors import ProvisioningCapacityExhausted
 
 
 class _DotDict(dict):
@@ -317,3 +320,113 @@ def test_get_fallback_candidates_enumerates_alternatives_when_upfront_filter_dis
     region_instance.get_common_availability_zones.return_value = ["us-east-1a", "us-east-1b"]
     params = _make_params(availability_zone="c", pre_filter_unavailable_availability_zones=False)
     assert AZResolver(params).get_fallback_candidates() == [["a"], ["b"]]
+
+
+def _capacity_error() -> ClientError:
+    return ClientError({"Error": {"Code": "InsufficientInstanceCapacity", "Message": "no capacity"}}, "RunInstances")
+
+
+def _non_capacity_error() -> ClientError:
+    return ClientError({"Error": {"Code": "UnauthorizedOperation", "Message": "not allowed"}}, "RunInstances")
+
+
+@pytest.fixture(name="mock_probe_aws")
+def mock_probe_aws_fixture():
+    """Patch boto3 clients and AwsRegion used by `probe_capacity_for_types`.
+    Yields the ec2 mock so tests can configure run_instances / terminate_instances.
+    """
+    ec2 = MagicMock()
+    ec2.describe_instance_types.return_value = {
+        "InstanceTypes": [{"ProcessorInfo": {"SupportedArchitectures": ["x86_64"]}}]
+    }
+    ssm = MagicMock()
+    ssm.get_parameter.return_value = {"Parameter": {"Value": "ami-deadbeef"}}
+
+    clients = {"ec2": ec2, "ssm": ssm}
+
+    region_obj = MagicMock()
+    region_obj.sct_subnet.return_value = MagicMock(subnet_id="subnet-abc")
+    region_obj.sct_security_group = MagicMock(group_id="sg-xyz")
+
+    with (
+        patch("sdcm.provision.aws.az_resolver.boto3.client", side_effect=lambda svc, **_: clients[svc]),
+        patch("sdcm.provision.aws.az_resolver.AwsRegion", return_value=region_obj),
+        patch("sdcm.provision.aws.az_resolver.TestConfig.common_tags", return_value={"RunByUser": "tester"}),
+    ):
+        yield ec2
+
+
+def test_probe_capacity_returns_true_on_successful_launch(mock_probe_aws):
+    mock_probe_aws.run_instances.return_value = {"Instances": [{"InstanceId": "i-1"}]}
+    params = _make_params(test_id="t-1", instance_type_db_target="m6g.large")
+
+    results = AZResolver(params).probe_capacity_for_types(types=["m6g.large"], az="a")
+
+    assert results == {"m6g.large": True}
+    mock_probe_aws.terminate_instances.assert_called_once_with(InstanceIds=["i-1"])
+
+
+def test_probe_capacity_returns_false_on_capacity_error(mock_probe_aws):
+    mock_probe_aws.run_instances.side_effect = _capacity_error()
+    resolver = AZResolver(_make_params(test_id="t-1"))
+
+    assert resolver.probe_capacity_for_types(types=["m6g.large"], az="a") == {"m6g.large": False}
+
+    mock_probe_aws.terminate_instances.assert_not_called()
+
+
+def test_probe_capacity_passes_through_non_capacity_error(mock_probe_aws):
+    """SCP denies, IAM gaps, etc. must not fail the test — the probe degrades to a no-op pass."""
+    mock_probe_aws.run_instances.side_effect = _non_capacity_error()
+    resolver = AZResolver(_make_params(test_id="t-1"))
+
+    assert resolver.probe_capacity_for_types(types=["m6g.large"], az="a") == {"m6g.large": True}
+
+    mock_probe_aws.terminate_instances.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"pre_flight_capacity_probe": False, "instance_type_db_target": "m6g.large"},
+        {
+            "pre_flight_capacity_probe": True,
+            "instance_type_db_target": None,
+            "nemesis_grow_shrink_instance_type": "",
+        },
+    ],
+    ids=["flag_off", "no_dynamic_types"],
+)
+def test_run_pre_flight_capacity_probe_noop(mock_probe_aws, overrides):
+    """The orchestrator skips all AWS calls when the flag is off or no dynamic-add instance types are configured."""
+    run_pre_flight_capacity_probe(_make_params(**overrides))
+    mock_probe_aws.run_instances.assert_not_called()
+
+
+def test_run_pre_flight_capacity_probe_succeeds_when_all_types_available(mock_probe_aws):
+    mock_probe_aws.run_instances.return_value = {"Instances": [{"InstanceId": "i-1"}]}
+    run_pre_flight_capacity_probe(
+        _make_params(
+            pre_flight_capacity_probe=True,
+            instance_type_db_target="m6g.large",
+            nemesis_grow_shrink_instance_type="i4i.xlarge",
+            availability_zone="a,b",
+            test_id="t-1",
+        )
+    )
+
+    assert mock_probe_aws.run_instances.call_count == 4
+    assert mock_probe_aws.terminate_instances.call_count == 4
+
+
+def test_run_pre_flight_capacity_probe_raises_on_capacity_failure(mock_probe_aws):
+    mock_probe_aws.run_instances.side_effect = _capacity_error()
+    with pytest.raises(ProvisioningCapacityExhausted, match="m6g.large@a"):
+        run_pre_flight_capacity_probe(
+            _make_params(
+                pre_flight_capacity_probe=True,
+                instance_type_db_target="m6g.large",
+                availability_zone="a",
+                test_id="t-1",
+            )
+        )

--- a/unit_tests/unit/provisioner/test_capacity_reservation.py
+++ b/unit_tests/unit/provisioner/test_capacity_reservation.py
@@ -121,6 +121,44 @@ def test_reservation_cancelled_when_one_reservation_fails(mock_ec2, params):
     assert SCTCapacityReservation.reservations == {}
 
 
+def test_request_includes_instance_type_db_target(params):
+    """When `instance_type_db_target` is set, reserve it at `n_db_nodes` count.
+
+    Platform-migration tests add the full target cluster (`n_db_nodes` instances)
+    of the target arch before decommissioning source nodes.
+    """
+    params.update(n_db_nodes=4, instance_type_db_target="m6g.large")
+
+    request, _ = SCTCapacityReservation._get_cr_request_based_on_sct_config(params)
+    assert request["m6g.large"] == 4
+    assert request["i4i.large"] == 1  # cluster_target_size from fixture
+    assert request["t3.small"] == 1
+
+
+@pytest.mark.parametrize(
+    "db_type, expected_present",
+    [
+        ("mixed_scylla", True),
+        ("mixed_cassandra", True),
+        ("scylla", False),
+    ],
+)
+def test_oracle_reservation_gated_by_db_type(params, db_type, expected_present):
+    """Oracle reservation must follow the `_has_oracle` gate: included only when `db_type` is one of
+    `mixed_scylla` / `mixed_cassandra`. `n_test_oracle_db_nodes` as `IntOrList` is summed across regions.
+    """
+    params.update(
+        db_type=db_type,
+        instance_type_db_oracle="i3.large",
+        n_test_oracle_db_nodes=[1, 2],
+    )
+
+    request, _ = SCTCapacityReservation._get_cr_request_based_on_sct_config(params)
+    assert ("i3.large" in request) is expected_present
+    if expected_present:
+        assert request["i3.large"] == 3
+
+
 def test_can_cancel_reservation(mock_ec2, params):
     mock_ec2.describe_capacity_reservations.return_value = {
         "CapacityReservations": [


### PR DESCRIPTION
Phases 6-7 implementation of the plan: [docs/plans/infrastructure/aws-capacity-az-fallback.md](https://github.com/scylladb/scylla-cluster-tests/blob/da3ffd7d51b90b15f10b922b029cc8c6f92dc41b/docs/plans/infrastructure/aws-capacity-az-fallback.md)

Long-running AWS tests that a node of a new type mid-test (upgrade-with-grow, longevity with grow-shrink nemesis, platform migration) could burn hours before failing if InsufficientInstanceCapacity occurs - AZ fallback only retries at provisioning time.

Capacity reservation now also covers `instance_type_db_target` (platform migration) and `instance_type_db_oracle` (for `mixed_scylla` / `mixed_cassandra` tests). These reservations turn on automatically when the corresponding instance-type parameter is set in a config that already opts into capacity reservation via `use_capacity_reservation: true` (currently used by perf tests).

New `pre_flight_capacity_probe` config parameter (default false) verifies capacity for `instance_type_db_target` and `nemesis_grow_shrink_instance_type` before stress runs by briefly starting and terminating one instance per type in each configured AZ; lack of capacity triggers the existing AZ fallback instead of a mid-test failure. Adds ~1 minute per type per AZ — for long-running tests only.

Refs: SCT-295

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :green_circle: [platform-migration test](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/platform-migration/5/)
pre-flight probe ran, once per AZ attempt (the 1st AZ had not enough capacity)
```
23:59:50  pre_flight_capacity_probe enabled — probing types ['i8g.2xlarge'] in AZs ['a'] (~1 min per type per AZ)
23:59:51  Pre-flight probe: capacity available for i8g.2xlarge in eu-west-1a
...
00:00:59  pre_flight_capacity_probe enabled — probing types ['i8g.2xlarge'] in AZs ['b'] (~1 min per type per AZ)
00:01:00  Pre-flight probe: capacity available for i8g.2xlarge in eu-west-1b
```
CR was built for instance_type_db_target (i8g.2xlarge)
```
23:59:52  Creating capacity reservation in eu-west-1a
23:59:52  Capacity reservation created for i7i.2xlarge
00:00:07  Failed to create capacity reservation for i8g.2xlarge. Error: An error occurred (InsufficientInstanceCapacity) when calling the CreateCapacityReservation operation (reached max retries: 4): Insufficient capacity.
00:00:07  Failed to create capacity reservation in eu-west-1a
00:00:07  Capacity reservation cr-08ea0f145d796edc3 for i7i.2xlarge cancelled successfully.
00:00:07  Falling back to next availability zone.
00:00:07  Creating capacity reservation in eu-west-1b
00:00:07  Capacity reservation created for i7i.2xlarge
00:00:07  Capacity reservation created for i8g.2xlarge
00:00:07  Capacity reservation created for c7i.4xlarge
00:00:07  Capacity reservations created in 'eu-west-1b' az: {'b': {'i7i.2xlarge': 'cr-015c53b5f8fc17531', 'i8g.2xlarge': 'cr-08cf42b57a6971bf4', 'c7i.4xlarge': 'cr-0481002e854b4228f'}} for duration: 240
```
- [x] :yellow_circle: [longevity-double-cluster-with-schema-changes test](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/longevity-double-cluster-with-schema-changes-test/2/)
pre-flight probe ran
```
08:06:55 pre_flight_capacity_probe enabled — probing types ['i4i.large'] in AZs ['b'] (~1 min per type per AZ)
08:06:57 Pre-flight probe: capacity available for i4i.large in us-east-1b
  ...
08:07:44 pre_flight_capacity_probe enabled — probing types ['i4i.large'] in AZs ['b']  (re-run with full logger context)
08:07:46 Pre-flight probe: capacity available for i4i.large in us-east-1b
```
Grow-shrink nemesis fired with the right type (nemesis_grow_shrink_instance_type=i4i.large from the config)
```
08:14:04 SisyphusMonkey: List of Nemesis to execute: ['GrowShrinkClusterNemesis', 'GrowShrinkClusterNemesis']
08:14:36 action: Started - Disruption GrowShrinkClusterNemesis on …
08:14:38 action: Started - Add 3 new nodes on None rack, i4i.large type
```

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
