### PR TITLE
fix(5k-tables): set big enough timeout for data population using vnodes

### DIFF
--- a/test-cases/scale/longevity-5000-tables-latte-vnodes.yaml
+++ b/test-cases/scale/longevity-5000-tables-latte-vnodes.yaml
@@ -1,4 +1,7 @@
-test_duration: 1080 # ~5h prepare + 10h mixed + 3h margin
+test_duration: 1200 # 20h = ~8h prepare + 10h mixed + 2h margin
+# NOTE: the data population latte command defined at 'prepare_verify_cmd' takes about 8h using vnodes
+#       So, set the timeout for this phase appropriately.
+prepare_stress_duration: 540
 
 n_db_nodes: 6
 instance_type_db: 'i4i.4xlarge'


### PR DESCRIPTION
The data population phase in the `5k tables` test scenario using vnodes is expected to take about `8 hours`.
Default timeout is `5 hours`.

So, explicitly set the big enough timeout for that phase - `9 hours`.

Closes: #SCT-423

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
