### PR TITLE
fix(azure): prolong provision stage for Azure

### DIFF
--- a/vars/longevityPipeline.groovy
+++ b/vars/longevityPipeline.groovy
@@ -347,7 +347,7 @@ def call(Map pipelineParams) {
                     script {
                         wrap([$class: 'BuildUser']) {
                             dir('scylla-cluster-tests') {
-                                timeout(time: 30, unit: 'MINUTES') {
+                                timeout(time: params.backend == 'azure' ? 60 : 30, unit: 'MINUTES') {
                                     provisionResources(params, builder.region)
                                     completed_stages['provision_resources'] = true
                                 }

--- a/vars/managerPipeline.groovy
+++ b/vars/managerPipeline.groovy
@@ -289,7 +289,7 @@ def call(Map pipelineParams) {
                         script {
                             wrap([$class: 'BuildUser']) {
                                 dir('scylla-cluster-tests') {
-                                    timeout(time: 30, unit: 'MINUTES') {
+                                    timeout(time: params.backend == 'azure' ? 60 : 30, unit: 'MINUTES') {
                                         if (params.backend == 'aws' || params.backend == 'azure' || params.backend == 'gce' || params.backend == 'oci') {
                                             provisionResources(params, builder.region)
                                         } else if (params.backend.contains('docker')) {


### PR DESCRIPTION
Many jobs show provision stage for Azure backend takes 25-28 minutes or times out. Probably tiemouts are due Azure infra being very slow (especially when more machines or bigger ones are requested at one time).

Fix by prolonging provision stage when Azure backend is used.

Fixes: https://scylladb.atlassian.net/browse/SCT-396

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] - provision test

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
