### PR TITLE
test(manager): switch upgrade from (<= 3.9) tests to eu-west-1 region

### DIFF
--- a/jenkins-pipelines/manager/debian12-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/debian12-manager-upgrade.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 managerPipeline(
     backend: 'aws',
-    region: 'us-east-1',
+    region: 'eu-west-1',
 
     scylla_version: '2025.4',
 

--- a/jenkins-pipelines/manager/ubuntu22-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu22-manager-upgrade.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 managerPipeline(
     backend: 'aws',
-    region: 'us-east-1',
+    region: 'eu-west-1',
 
     scylla_version: '2026.1',
 
@@ -14,5 +14,5 @@ managerPipeline(
     target_manager_version: 'master_latest',
 
     test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',
-    test_config: '''["test-cases/upgrades/manager-upgrade.yaml", "configurations/object_storage_s3.yaml", "configurations/object_storage_native_method.yaml"]'''
+    test_config: 'test-cases/upgrades/manager-upgrade.yaml'
 )

--- a/jenkins-pipelines/manager/ubuntu24-manager-older-enterprise-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu24-manager-older-enterprise-upgrade.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 managerPipeline(
     backend: 'aws',
-    region: 'us-east-1',
+    region: 'eu-west-1',
 
     scylla_version: '2025.1',
 


### PR DESCRIPTION
`manager-backup-tests-us-east-1` bucket has started to be used by some other teams. It resulted in tons of extra dir/files uploaded into bucket's root.

Before release 3.10 Manager was listing bucket's root and while encountering so many dir/files there - timed out. Release 3.10 addressed this issue and now Manager lists items in /backup directory.

The listing of bucket's root dir by Manager is not an issue itself since we do not recommend one bucket sharing, but it's an issue for tests.

Since we still need to cover upgrades from version lower than 3.10, upgrade tests covering that versions switching to another region to use different bucket which is not shared with anyone else.

Additionally, for ubuntu22-manager-upgrade the backup method is set to rclone since object_storage configuration is hardcoded to us-east-1.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [ubuntu24-upgrade-test 3.9 -> 3.10](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/mikita/job/manager-master-clone/job/ubuntu24-upgrade-test/15/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code
