### PR TITLE
fix(scylla-doctor): download vitals/logs with sudo on root installs

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -3963,14 +3963,19 @@ class ClusterTester(unittest.TestCase):
                         doctor.install_scylla_doctor()
                         doctor.run_scylla_doctor_and_collect_results()
 
+                        download_with_sudo = not node.is_nonroot_install
                         if doctor.json_result_file:
                             local_json_path = os.path.join(self.logdir, f"scylla_doctor_{node.name}_vitals.json")
-                            node.remoter.receive_files(src=doctor.json_result_file, dst=local_json_path)
+                            node.remoter.receive_files(
+                                src=doctor.json_result_file, dst=local_json_path, sudo=download_with_sudo
+                            )
                             self.log.debug("Downloaded scylla-doctor vitals from %s to %s", node.name, local_json_path)
 
                         if doctor.scylla_logs_file:
                             local_logs_path = os.path.join(self.logdir, f"scylla_doctor_{node.name}_logs.tar.gz")
-                            node.remoter.receive_files(src=doctor.scylla_logs_file, dst=local_logs_path)
+                            node.remoter.receive_files(
+                                src=doctor.scylla_logs_file, dst=local_logs_path, sudo=download_with_sudo
+                            )
                             self.log.debug("Downloaded scylla-doctor logs from %s to %s", node.name, local_logs_path)
 
                         self.log.info("Scylla-doctor completed for node %s", node.name)


### PR DESCRIPTION
scylla-doctor runs via sudo on root installs, so its vitals JSON and scylla_logs tarball are root-owned. The failure-stats download useds a plain rsync as the login user and fails with `Permission denied` error.
This change fixes it by using sudo to receive files for cases with root installs.

Ref: SCT-108

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :green_circle: [artifacts-gce-image regression check](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/artifacts/job/artifacts-gce-image-new/25/)
- [x] :yellow_circle: [pr-provision-test with forced failure](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/pr-provision-test-new/304/)
```
17:28:59  < t:2026-05-29 15:28:57,894 f:tester.py       l:3981 c:LongevityTest        p:INFO  > Scylla-doctor completed for node PR-provision-test-fix-sc-d-db-node-4b105a3a-1
...
17:29:15  < t:2026-05-29 15:29:14,537 f:tester.py       l:3981 c:LongevityTest        p:INFO  > Scylla-doctor completed for node PR-provision-test-fix-sc-d-db-node-4b105a3a-2
...
17:29:31  < t:2026-05-29 15:29:30,040 f:tester.py       l:3981 c:LongevityTest        p:INFO  > Scylla-doctor completed for node PR-provision-test-fix-sc-d-db-node-4b105a3a-3
...
```

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
