### PR TITLE
fix(oci): fix regex for the rack name parsing

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4263,7 +4263,7 @@ class BaseCluster:
             r"(?P<tokens>[\d]+)\s+"
             r"(?P<owns>[\w?]+)\s+"
             r"(?P<host_id>[\w-]+)\s+"
-            r"(?P<rack>[\w]+|$)"
+            r"(?P<rack>[\w-]+|$)"
         )
 
         for dc in data_centers:

--- a/unit_tests/unit/test_cluster.py
+++ b/unit_tests/unit/test_cluster.py
@@ -737,6 +737,54 @@ class TestNodetoolStatus:
             }
         }
 
+    def test_can_get_nodetool_status_oci_hyphenated_rack(self):
+        """OCI rack names contain hyphens (e.g., iad-ad-1). Verify they are parsed fully."""
+        resp = "\n".join(
+            [
+                "Datacenter: iad",
+                "===============",
+                "Status=Up/Down",
+                "|/ State=Normal/Leaving/Joining/Moving",
+                "--  Address      Load       Tokens  Owns    Host ID                               Rack",
+                "UN  10.0.3.109   77.79 GB   256     ?       6367305e-5b28-464c-8f0f-c18094822bbf  iad-ad-1",
+                "UN  10.0.3.112   65.23 GB   256     ?       a1b2c3d4-e5f6-7890-abcd-ef1234567890  iad-ad-2",
+                "UN  10.0.3.130   70.11 GB   256     ?       deadbeef-cafe-babe-dead-beefcafebabe  iad-ad-3",
+            ]
+        )
+        node = NodetoolDummyNode(resp=resp)
+        db_cluster = DummyScyllaCluster([node])
+
+        status = db_cluster.get_nodetool_status()
+
+        assert status == {
+            "iad": {
+                "10.0.3.109": {
+                    "state": "UN",
+                    "load": "77.79GB",
+                    "tokens": "256",
+                    "owns": "?",
+                    "host_id": "6367305e-5b28-464c-8f0f-c18094822bbf",
+                    "rack": "iad-ad-1",
+                },
+                "10.0.3.112": {
+                    "state": "UN",
+                    "load": "65.23GB",
+                    "tokens": "256",
+                    "owns": "?",
+                    "host_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                    "rack": "iad-ad-2",
+                },
+                "10.0.3.130": {
+                    "state": "UN",
+                    "load": "70.11GB",
+                    "tokens": "256",
+                    "owns": "?",
+                    "host_id": "deadbeef-cafe-babe-dead-beefcafebabe",
+                    "rack": "iad-ad-3",
+                },
+            }
+        }
+
 
 @pytest.mark.parametrize(
     "cat_results,expected_core_number",


### PR DESCRIPTION
OCI rack names contain hyphens (-) but our regex was not expecting this symbol.
And it led to the situation where we were getting only first part of a rack name.
Example: instead of the `iad-ad-1` we were taking `iad`.

So, fix the regex by adding hyphen symbol into the expected ones.

Closes: #SCT-386

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [scylla-staging/valerii/vp-oci#182](https://argus.scylladb.com/tests/scylla-cluster-tests/81a74c1f-8497-49a0-81fc-e6623dc56d27)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
