### PR TITLE
Revert "feature(adaptive-timeouts): per-operation timeout multipliers"

### DIFF
--- a/configurations/adaptive_timeout_multipliers.yaml
+++ b/configurations/adaptive_timeout_multipliers.yaml
@@ -1,4 +1,0 @@
-adaptive_timeout_multipliers:
-  decommission: 4
-  new_node: 4
-  remove_node: 4

--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -339,7 +339,6 @@ mgmt_snapshots_preparer_params:
   sequence_end: ''
 
 adaptive_timeout_store_metrics: true
-adaptive_timeout_multipliers: {}
 
 # XCloud-specific defaults
 xcloud_scaling_config: null

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -2041,15 +2041,6 @@ Store adaptive timeout metrics in Argus. Disabled for performance tests only.
 **type:** bool
 
 
-## **adaptive_timeout_multipliers** / SCT_ADAPTIVE_TIMEOUT_MULTIPLIERS
-
-Optional dict of adaptive-timeout multipliers keyed by operation name (from Operations enum value[0], e.g. decommission, remove_node, new_node, repair, etc.). If the current operation key is absent, multiplier 1.0 is used.<br>YAML example:<br>adaptive_timeout_multipliers:<br>  decommission: 4<br>  new_node: 2<br>Environment variable examples:<br>SCT_ADAPTIVE_TIMEOUT_MULTIPLIERS="{'decommission': 4, 'new_node': 2}"<br>Or dot-notation: SCT_ADAPTIVE_TIMEOUT_MULTIPLIERS.decommission=4
-
-**default:** N/A
-
-**type:** sdcm.sct_config.AdaptiveTimeoutMultipliers
-
-
 ## **gce_n_local_ssd_disk_monitor** / SCT_GCE_N_LOCAL_SSD_DISK_MONITOR
 
 Number of local SSD disks for monitor nodes in Google Compute Engine

--- a/jenkins-pipelines/oss/tier1/longevity-mv-si-4days-streaming.jenkinsfile
+++ b/jenkins-pipelines/oss/tier1/longevity-mv-si-4days-streaming.jenkinsfile
@@ -7,6 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: '''["test-cases/longevity/longevity-mv-si-4days.yaml", "configurations/disable_rbno.yaml", "configurations/adaptive_timeout_multipliers.yaml"]'''
+    test_config: '''["test-cases/longevity/longevity-mv-si-4days.yaml", "configurations/disable_rbno.yaml"]'''
 
 )

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -35,8 +35,7 @@ from distutils.util import strtobool
 import anyconfig
 from argus.client.sct.types import Package
 from packaging import version
-from pydantic import BaseModel, Field, ConfigDict, RootModel, fields as pydantic_fields, model_validator
-from pydantic.types import confloat
+from pydantic import BaseModel, Field, ConfigDict, fields as pydantic_fields
 from typing_extensions import Annotated
 from pydantic.functional_validators import BeforeValidator
 from pydantic.fields import FieldInfo
@@ -263,52 +262,6 @@ def dict_or_str(value: dict | str | None) -> dict | None:
 
 
 DictOrStr = Annotated[dict | str, BeforeValidator(dict_or_str)]
-
-
-class AdaptiveTimeoutMultipliers(RootModel):
-    """Per-operation multipliers for adaptive timeouts.
-
-    Keys must be valid operation names from Operations enum (operation.value[0]),
-    e.g. decommission, remove_node, new_node, repair, rebuild, etc.
-    Missing keys default to multiplier 1.
-
-    YAML config example::
-
-        adaptive_timeout_multipliers:
-          decommission: 4
-          new_node: 4
-          remove_node: 4
-
-    Environment variable examples:
-
-        SCT_ADAPTIVE_TIMEOUT_MULTIPLIERS="{'decommission': 2, 'new_node': 3}"
-
-    Or using dot-notation (same pattern as SCT_STRESS_IMAGE.*):
-
-        SCT_ADAPTIVE_TIMEOUT_MULTIPLIERS.decommission=4
-        SCT_ADAPTIVE_TIMEOUT_MULTIPLIERS.new_node=3
-    """
-
-    root: dict[str, confloat(gt=0)] = Field(default_factory=dict)
-
-    @model_validator(mode="before")
-    @classmethod
-    def _validate_operations(cls, value):
-        if not isinstance(value, dict):
-            return value
-
-        # cyclic-import: Operations imports from sct_config indirectly via cluster
-        from sdcm.utils.adaptive_timeouts import Operations  # noqa: PLC0415
-
-        valid_keys = {op.value[0] for op in Operations}
-        for key in value.keys():
-            if key not in valid_keys:
-                raise ValueError(f"Unknown operation key '{key}'. Valid keys: {sorted(valid_keys)}")
-        return value
-
-    def get_multiplier(self, operation_key: str) -> float:
-        """Return multiplier for the given operation key, or 1.0 if not configured."""
-        return float(self.root.get(operation_key, 1.0))
 
 
 def dict_or_str_or_pydantic(value: dict | str | BaseModel | None) -> dict | BaseModel | None:
@@ -1309,20 +1262,6 @@ class SCTConfiguration(BaseModel):
     )
     adaptive_timeout_store_metrics: Boolean = SctField(
         description="Store adaptive timeout metrics in Argus. Disabled for performance tests only.",
-    )
-    adaptive_timeout_multipliers: Annotated[AdaptiveTimeoutMultipliers, BeforeValidator(dict_or_str_or_pydantic)] = (
-        SctField(
-            description="Optional dict of adaptive-timeout multipliers keyed by operation name "
-            "(from Operations enum value[0], e.g. decommission, remove_node, new_node, repair, etc.). "
-            "If the current operation key is absent, multiplier 1.0 is used.<br>"
-            "YAML example:<br>"
-            "adaptive_timeout_multipliers:<br>"
-            "  decommission: 4<br>"
-            "  new_node: 2<br>"
-            "Environment variable examples:<br>"
-            "SCT_ADAPTIVE_TIMEOUT_MULTIPLIERS=\"{'decommission': 4, 'new_node': 2}\"<br>"
-            "Or dot-notation: SCT_ADAPTIVE_TIMEOUT_MULTIPLIERS.decommission=4",
-        )
     )
 
     # Google Compute Engine options

--- a/sdcm/utils/adaptive_timeouts/__init__.py
+++ b/sdcm/utils/adaptive_timeouts/__init__.py
@@ -16,20 +16,6 @@ from sdcm.utils.features import is_tablets_feature_enabled
 
 LOGGER = logging.getLogger(__name__)
 
-
-def _get_operation_timeout_factor(params, operation: "Operations") -> float:
-    """Return timeout multiplier for the current operation.
-
-    Looks up operation.value[0] in the configured multipliers dict.
-    Missing config or missing operation key returns 1.0.
-    """
-    multipliers = params.get("adaptive_timeout_multipliers")
-    if multipliers is None:
-        return 1.0
-
-    return multipliers.get_multiplier(operation.value[0])
-
-
 TABLETS_SOFT_TIMEOUT = 1 * 60 * 60
 TABLETS_HARD_TIMEOUT = 3 * 60 * 60
 _STREAMING_OVERHEAD = 600  # add 10 minutes overhead for operations other than streaming
@@ -274,11 +260,6 @@ def adaptive_timeout(  # noqa: PLR0914
         hard_timeout = None
     if store_metrics:
         load_metrics.update(TestInfoServices.get(node))
-
-    # Apply operation-based timeout scaling (opt-in via config)
-    operation_factor = _get_operation_timeout_factor(node.parent_cluster.params, operation)
-    soft_timeout = soft_timeout * operation_factor if soft_timeout else None
-    hard_timeout = hard_timeout * operation_factor if hard_timeout else None
 
     start_time = time.monotonic()
     timeout_occurred = False

--- a/unit_tests/unit/test_adaptive_timeouts.py
+++ b/unit_tests/unit/test_adaptive_timeouts.py
@@ -20,7 +20,7 @@ import pytest
 from invoke import Result
 
 from sdcm.remote import RemoteCmdRunnerBase
-from sdcm.sct_config import AdaptiveTimeoutMultipliers, SCTConfiguration
+from sdcm.sct_config import SCTConfiguration
 from sdcm.utils.adaptive_timeouts.load_info_store import (
     AdaptiveTimeoutStore,
     NodeLoadInfoService,
@@ -28,13 +28,7 @@ from sdcm.utils.adaptive_timeouts.load_info_store import (
     _I4I_LARGE_BASELINE_THROUGHPUT_MB_PER_SEC,
     _I4I_LARGE_SHARD_COUNT,
 )
-from sdcm.utils.adaptive_timeouts import (
-    _STREAMING_OVERHEAD,
-    _get_operation_timeout_factor,
-    Operations,
-    adaptive_timeout,
-    TABLETS_HARD_TIMEOUT,
-)
+from sdcm.utils.adaptive_timeouts import _STREAMING_OVERHEAD, Operations, adaptive_timeout, TABLETS_HARD_TIMEOUT
 from unit_tests.lib.fake_cluster import DummyDbCluster
 
 LOGGER = logging.getLogger(__name__)
@@ -338,171 +332,3 @@ def test_expected_throughput_falls_back_to_estimate_when_zero(fake_node):
     """When stream_io_throughput_mb_per_sec is explicitly 0, fall back to the estimate."""
     service = _make_service(fake_node, "stream_io_throughput_mb_per_sec: 0\n")
     assert service.expected_throughput == _I4I_LARGE_BASELINE_THROUGHPUT_MB_PER_SEC / _I4I_LARGE_SHARD_COUNT * 3
-
-
-# ===== Adaptive timeout multipliers tests =====
-
-
-@pytest.mark.parametrize(
-    ("operation", "config_value", "expected"),
-    [
-        pytest.param(Operations.DECOMMISSION, {"decommission": 4}, 4, id="decommission"),
-        pytest.param(Operations.REMOVE_NODE, {"remove_node": 3}, 3, id="remove_node"),
-        pytest.param(Operations.NEW_NODE, {"new_node": 2}, 2, id="new_node"),
-        pytest.param(Operations.NEW_NODE, {"decommission": 4}, 1.0, id="missing-key-defaults-to-1"),
-        pytest.param(Operations.SOFT_TIMEOUT, {"decommission": 4}, 1.0, id="unconfigured-operation"),
-        pytest.param(Operations.REMOVE_NODE, {}, 1.0, id="empty-config"),
-    ],
-)
-def test_get_operation_timeout_factor(operation, config_value, expected):
-    params = SCTConfiguration()
-    params["adaptive_timeout_multipliers"] = config_value
-    assert _get_operation_timeout_factor(params, operation) == expected
-
-
-@pytest.mark.parametrize(
-    "input_val,expected_key,expected_val",
-    [
-        pytest.param({"decommission": 4, "remove_node": 2}, "decommission", 4, id="dict-input"),
-        pytest.param({"new_node": 3}, "new_node", 3, id="single-key-dict"),
-        pytest.param({"decommission": 5, "new_node": 2.5}, "decommission", 5, id="multiple-keys"),
-    ],
-)
-def test_multiplier_model_validates_input(input_val, expected_key, expected_val):
-    model = AdaptiveTimeoutMultipliers.model_validate(input_val)
-    assert model.root[expected_key] == expected_val
-
-
-@pytest.mark.parametrize(
-    "input_val,match_pattern",
-    [
-        pytest.param({"unknown": 2}, "Unknown operation key 'unknown'", id="unknown-key"),
-        pytest.param({"decommission": -1}, "Input should be greater than 0", id="negative-value"),
-        pytest.param({"decommission": 0}, "Input should be greater than 0", id="zero-value"),
-    ],
-)
-def test_multiplier_model_rejects_invalid_input(input_val, match_pattern):
-    with pytest.raises(ValueError, match=match_pattern):
-        AdaptiveTimeoutMultipliers.model_validate(input_val)
-
-
-@pytest.mark.parametrize(
-    "multipliers,operation,timeout_arg,expected",
-    [
-        pytest.param({"new_node": 3}, Operations.NEW_NODE, 600, 1800, id="multiplier-scales-timeout"),
-        pytest.param({"decommission": 4}, Operations.REMOVE_NODE, 600, 600, id="missing-key-unscaled"),
-        pytest.param({}, Operations.DECOMMISSION, None, 7200, id="empty-config-preserves-base"),
-    ],
-)
-@mock.patch("sdcm.sct_events.base.SctEvent.publish_or_dump")
-def test_multiplier_scaling(
-    publish_or_dump, fake_node, adaptive_timeout_store, multipliers, operation, timeout_arg, expected
-):
-    fake_node.parent_cluster.params["adaptive_timeout_multipliers"] = multipliers
-
-    kwargs = dict(operation=operation, node=fake_node, stats_storage=adaptive_timeout_store)
-    if timeout_arg is not None:
-        kwargs["timeout"] = timeout_arg
-
-    with adaptive_timeout(**kwargs) as timeout:
-        assert timeout == expected
-
-
-@mock.patch("sdcm.sct_events.system.SoftTimeoutEvent.publish_or_dump")
-@mock.patch("sdcm.sct_events.system.HardTimeoutEvent.publish_or_dump")
-def test_decommission_multiplier_scales_hard_timeout_for_tablets(
-    hard_timeout_mock, soft_timeout_mock, fake_node, adaptive_timeout_store, mock_tablets_feature
-):
-    mock_tablets_feature.return_value = True
-
-    # Get base timeout without multiplier
-    fake_node.parent_cluster.params["adaptive_timeout_multipliers"] = {}
-    with adaptive_timeout(
-        operation=Operations.DECOMMISSION, node=fake_node, stats_storage=adaptive_timeout_store
-    ) as base_timeout:
-        pass
-
-    # Apply multiplier and verify scaling
-    fake_node.parent_cluster.params["adaptive_timeout_multipliers"] = {"decommission": 2}
-    with adaptive_timeout(
-        operation=Operations.DECOMMISSION, node=fake_node, stats_storage=adaptive_timeout_store
-    ) as scaled_timeout:
-        assert scaled_timeout == base_timeout * 2
-
-
-@pytest.mark.parametrize(
-    "env_value,expected_field,expected_val",
-    [
-        pytest.param("{'decommission': 4, 'new_node': 3}", "decommission", 4, id="python-dict-string"),
-        pytest.param('{"remove_node": 5}', "remove_node", 5, id="json-string"),
-        pytest.param(None, None, None, id="unset-env-uses-empty-default"),
-    ],
-)
-def test_multiplier_env_var_loaded_by_sct_config(monkeypatch, env_value, expected_field, expected_val):
-    """SCT_ADAPTIVE_TIMEOUT_MULTIPLIERS env var is parsed into the model; unset uses empty dict default."""
-    if env_value is not None:
-        monkeypatch.setenv("SCT_ADAPTIVE_TIMEOUT_MULTIPLIERS", env_value)
-    else:
-        monkeypatch.delenv("SCT_ADAPTIVE_TIMEOUT_MULTIPLIERS", raising=False)
-    config = SCTConfiguration()
-    multipliers = config.get("adaptive_timeout_multipliers")
-    if expected_field is not None:
-        assert multipliers.root[expected_field] == expected_val
-    else:
-        # When env is unset, defaults/test_default.yaml provides {} which
-        # becomes an empty AdaptiveTimeoutMultipliers
-        assert multipliers.root == {}
-
-
-@pytest.mark.parametrize(
-    "env_value,match_pattern",
-    [
-        pytest.param("", "failed to parse SCT_ADAPTIVE_TIMEOUT_MULTIPLIERS", id="empty-string"),
-        pytest.param("   ", "failed to parse SCT_ADAPTIVE_TIMEOUT_MULTIPLIERS", id="whitespace-only"),
-        pytest.param("not_a_dict", "failed to parse SCT_ADAPTIVE_TIMEOUT_MULTIPLIERS", id="plain-string"),
-        pytest.param("[1, 2, 3]", "isn't a dict, str or Pydantic model", id="list-value"),
-        pytest.param("{'unknown_op': 2}", "Unknown operation key 'unknown_op'", id="invalid-operation-key"),
-        pytest.param("{'decommission': -1}", "Input should be greater than 0", id="negative-multiplier"),
-        pytest.param("{'decommission': 0}", "Input should be greater than 0", id="zero-multiplier"),
-    ],
-)
-def test_multiplier_invalid_env_var_raises(monkeypatch, env_value, match_pattern):
-    """SCT_ADAPTIVE_TIMEOUT_MULTIPLIERS with invalid values is rejected during config init."""
-    monkeypatch.setenv("SCT_ADAPTIVE_TIMEOUT_MULTIPLIERS", env_value)
-    with pytest.raises(Exception, match=match_pattern):
-        SCTConfiguration()
-
-
-@pytest.mark.parametrize(
-    "env_vars,expected_multipliers",
-    [
-        pytest.param(
-            {"SCT_ADAPTIVE_TIMEOUT_MULTIPLIERS.decommission": "4"},
-            {"decommission": 4.0, "repair": 1.0},
-            id="single-operation",
-        ),
-        pytest.param(
-            {"SCT_ADAPTIVE_TIMEOUT_MULTIPLIERS.decommission": "4", "SCT_ADAPTIVE_TIMEOUT_MULTIPLIERS.new_node": "3"},
-            {"decommission": 4.0, "new_node": 3.0, "repair": 1.0},
-            id="multiple-operations",
-        ),
-        pytest.param(
-            {"SCT_ADAPTIVE_TIMEOUT_MULTIPLIERS.remove_node": "2.5"},
-            {"remove_node": 2.5, "decommission": 1.0},
-            id="float-value",
-        ),
-    ],
-)
-def test_multiplier_dot_notation_env_var(monkeypatch, env_vars, expected_multipliers):
-    """SCT_ADAPTIVE_TIMEOUT_MULTIPLIERS.operation=value dot-notation is parsed into the model.
-
-    This mirrors the pattern used by SCT_STRESS_IMAGE.cassandra-stress=... in pipelines.
-    Values arrive as strings and are coerced to floats by Pydantic.
-    """
-    monkeypatch.delenv("SCT_ADAPTIVE_TIMEOUT_MULTIPLIERS", raising=False)
-    for key, value in env_vars.items():
-        monkeypatch.setenv(key, value)
-    config = SCTConfiguration()
-    multipliers = config.get("adaptive_timeout_multipliers")
-    for operation, expected in expected_multipliers.items():
-        assert multipliers.get_multiplier(operation) == expected


### PR DESCRIPTION
Reverts scylladb/scylla-cluster-tests#14669

```
20:22:18  < t:2026-05-29 17:22:18,502 f:tester.py       l:443  c:LongevityTest        p:INFO  > sct_runner info in Argus TestRun is updated
20:22:18  < t:2026-05-29 17:22:18,503 f:tester.py       l:449  c:LongevityTest        p:ERROR > General Error submitting data to Argus < t:2026-05-29 17:22:18,503 f:tester.py       l:449  c:LongevityTest        p:ERROR > General Error submitting data to Argus
20:22:18  < t:2026-05-29 17:22:18,503 f:tester.py       l:449  c:LongevityTest        p:ERROR > Traceback (most recent call last):
20:22:18  < t:2026-05-29 17:22:18,503 f:tester.py       l:449  c:LongevityTest        p:ERROR >   File "/home/ubuntu/scylla-cluster-tests/sdcm/tester.py", line 444, in init_argus_run
20:22:18  < t:2026-05-29 17:22:18,503 f:tester.py       l:449  c:LongevityTest        p:ERROR >     self.test_config.argus_client().sct_submit_config(name="sct_config", content=json.dumps(dict(self.params)))
20:22:18  < t:2026-05-29 17:22:18,503 f:tester.py       l:449  c:LongevityTest        p:ERROR >                                                                                  ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
20:22:18  < t:2026-05-29 17:22:18,503 f:tester.py       l:449  c:LongevityTest        p:ERROR >   File "/usr/local/lib/python3.14/json/__init__.py", line 231, in dumps
20:22:18  < t:2026-05-29 17:22:18,503 f:tester.py       l:449  c:LongevityTest        p:ERROR >     return _default_encoder.encode(obj)
20:22:18  < t:2026-05-29 17:22:18,503 f:tester.py       l:449  c:LongevityTest        p:ERROR >            ~~~~~~~~~~~~~~~~~~~~~~~^^^^^
20:22:18  < t:2026-05-29 17:22:18,503 f:tester.py       l:449  c:LongevityTest        p:ERROR >   File "/usr/local/lib/python3.14/json/encoder.py", line 200, in encode
20:22:18  < t:2026-05-29 17:22:18,503 f:tester.py       l:449  c:LongevityTest        p:ERROR >     chunks = self.iterencode(o, _one_shot=True)
20:22:18  < t:2026-05-29 17:22:18,503 f:tester.py       l:449  c:LongevityTest        p:ERROR >   File "/usr/local/lib/python3.14/json/encoder.py", line 261, in iterencode
20:22:18  < t:2026-05-29 17:22:18,503 f:tester.py       l:449  c:LongevityTest        p:ERROR >     return _iterencode(o, 0)
20:22:18  < t:2026-05-29 17:22:18,503 f:tester.py       l:449  c:LongevityTest        p:ERROR > ValueError: Circular reference detected
20:22:18  < t:2026-05-29 17:22:18,503 f:tester.py       l:449  c:LongevityTest        p:ERROR > when serializing method object
20:22:18  < t:2026-05-29 17:22:18,503 f:tester.py       l:449  c:LongevityTest        p:ERROR > when serializing sdcm.sct_config.AdaptiveTimeoutMultipliers object
20:22:18  < t:2026-05-29 17:22:18,503 f:tester.py       l:449  c:LongevityTest        p:ERROR > when serializing dict item 'adaptive_timeout_multipliers'
```