### PR TITLE
fix(upgrade): use scylla-enterprise-server for enterprise detection in rolling upgrades

### DIFF
--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -314,13 +314,11 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
 
             orig_is_enterprise = node.is_product_enterprise
             if node.distro.is_rhel_like:
-                result = node.remoter.run("sudo yum search scylla-enterprise 2>&1", ignore_status=True)
-                new_is_enterprise = bool(
-                    "scylla-enterprise.x86_64" in result.stdout or "No matches found" not in result.stdout
-                )
+                result = node.remoter.run("sudo yum search scylla-enterprise-server 2>&1", ignore_status=True)
+                new_is_enterprise = "scylla-enterprise-server" in result.stdout
             else:
-                result = node.remoter.run("sudo apt-cache search scylla-enterprise", ignore_status=True)
-                new_is_enterprise = "scylla-enterprise" in result.stdout
+                result = node.remoter.run("sudo apt-cache search scylla-enterprise-server", ignore_status=True)
+                new_is_enterprise = "scylla-enterprise-server" in result.stdout
 
             scylla_pkg = "scylla-enterprise" if new_is_enterprise else "scylla"
             ver_suffix = r"\*{}".format(new_version) if new_version else ""


### PR DESCRIPTION
## Summary

- Fix false positive enterprise package detection in rolling upgrade that caused `yum update scylla-enterprise*` to be a no-op on Rocky Linux 10
- Search for `scylla-enterprise-server` specifically instead of `scylla-enterprise` which matches transitional packages like `scylla-enterprise-node-exporter`

## Root Cause

PR #14691 reverted the original fix (commit `812248d5fd`) claiming it was superseded by a commit that didn't land on master. This left the broken detection logic in place.

**Affected job**: `rolling-upgrade-rocky10-test` ([build #33](https://jenkins.scylladb.com/job/scylla-master/job/rolling-upgrade/job/rolling-upgrade-rocky10-test/33/))

Fixes: [SCT-425](https://scylladb.atlassian.net/browse/SCT-425)

### Testing

- [x] 🟢 [rolling-upgrade-rocky10-test #11](https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/rolling-upgrade-rocky10-test/12/)

## Manual Testing Required

### What Copilot Couldn't Test

- [x] **Rolling upgrade on Rocky Linux 10**: Requires GCE infrastructure
  - Test: `rolling-upgrade-rocky10-test` pipeline
  - Expected: Node upgrades to new scylla version successfully

[SCT-425]: https://scylladb.atlassian.net/browse/SCT-425?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ