### PR TITLE
fix(nemesis): handle list-type stress_cmd in _double_cluster_load

### DIFF
--- a/sdcm/nemesis/__init__.py
+++ b/sdcm/nemesis/__init__.py
@@ -4367,9 +4367,12 @@ class NemesisRunner:
     @latency_calculator_decorator(legend="Doubling cluster load")
     def _double_cluster_load(self, duration: int) -> None:
         duration = 30
+        stress_cmd = self.tester.stress_cmd
+        if isinstance(stress_cmd, list):
+            stress_cmd = stress_cmd[0]
         self.log.info("Doubling the load on the cluster for %s minutes", duration)
         stress_queue = self.tester.run_stress_thread(
-            stress_cmd=self.tester.stress_cmd, stress_num=1, stats_aggregate_cmds=False, duration=duration
+            stress_cmd=stress_cmd, stress_num=1, stats_aggregate_cmds=False, duration=duration
         )
         results = self.tester.verify_stress_thread(
             thread_pool=stress_queue, error_handler=self._nemesis_stress_failure_handler


### PR DESCRIPTION
After pydantic migration, `params.get('stress_cmd_r') `returns a list instead of a string. When run_workload assigns it to `self.stress_cmd` and `_double_cluster_load` passes it to run_stress_thread, it crashes with `AttributeError: 'list' object has no attribute 'startswith'`.

Unwrap single-element list before passing to run_stress_thread.

Failed test: https://argus.scylladb.com/tests/scylla-cluster-tests/7d2b9656-4e8a-4a03-bbad-f704fc32cb9b

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [scylla-enterprise-perf-regression-latency-650gb-elasticity](https://argus.scylladb.com/tests/scylla-cluster-tests/81680385-de2f-49be-a609-3f931e49b2c4)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
