### PR TITLE
fix(docker): use local runner for Docker backend loaders instead of containers

### DIFF
--- a/sdcm/cluster_docker.py
+++ b/sdcm/cluster_docker.py
@@ -729,6 +729,85 @@ class VectorStoreSetDocker(VectorStoreClusterMixin, DockerCluster):
         return result
 
 
+class DockerLoaderNode(cluster.BaseNode):
+    """A lightweight loader node that runs locally on the host using LOCALRUNNER.
+
+    Instead of spinning up a Scylla container just to serve as a Docker host for
+    stress tool containers (docker-in-docker), this node runs directly on the host.
+    Stress tool containers (RemoteDocker) are launched directly via the local Docker daemon.
+    """
+
+    log = LOGGER
+
+    def __init__(
+        self,
+        parent_cluster: "LoaderSetDocker",
+        node_prefix: str = "loader-node",
+        base_logdir: Optional[str] = None,
+        node_index: int = 1,
+        ssh_login_info: Optional[dict] = None,
+        after_config=None,
+    ) -> None:
+        super().__init__(
+            name=f"{node_prefix}-{node_index}",
+            parent_cluster=parent_cluster,
+            base_logdir=base_logdir,
+            node_prefix=node_prefix,
+            ssh_login_info=ssh_login_info,
+            after_config=after_config,
+        )
+        self.node_index = node_index
+
+    def wait_for_cloud_init(self):
+        pass
+
+    def wait_ssh_up(self, verbose=True, timeout=500):
+        pass
+
+    @staticmethod
+    def is_docker() -> bool:
+        return False
+
+    @cached_property
+    def tags(self) -> dict[str, str]:
+        return {
+            **super().tags,
+            "NodeIndex": str(self.node_index),
+        }
+
+    def _init_remoter(self, ssh_login_info):
+        self.remoter = LOCALRUNNER
+
+    def _init_port_mapping(self):
+        pass
+
+    def update_repo_cache(self):
+        pass
+
+    def _refresh_instance_state(self):
+        return ["127.0.0.1"], ["127.0.0.1"]
+
+    def refresh_ip_address(self):
+        pass
+
+    def start_journal_thread(self):
+        pass
+
+    def disable_daily_triggered_services(self):
+        pass
+
+    def _set_keep_duration(self, duration_in_hours: int) -> None:
+        pass
+
+    @property
+    def vm_region(self):
+        return "docker"
+
+    @property
+    def region(self):
+        return "docker"
+
+
 class LoaderSetDocker(cluster.BaseLoaderSet, DockerCluster):
     def __init__(
         self,
@@ -745,9 +824,6 @@ class LoaderSetDocker(cluster.BaseLoaderSet, DockerCluster):
         cluster.BaseLoaderSet.__init__(self, params=params)
         DockerCluster.__init__(
             self,
-            docker_image=docker_image,
-            docker_image_tag=docker_image_tag,
-            node_key_file=node_key_file,
             cluster_prefix=cluster_prefix,
             node_prefix=node_prefix,
             node_type="loader",
@@ -755,19 +831,35 @@ class LoaderSetDocker(cluster.BaseLoaderSet, DockerCluster):
             params=params,
         )
 
-    def node_setup(self, node: DockerNode, verbose=False, **kwargs):
-        node.remoter.sudo("apt update", verbose=True, ignore_status=True)
-        node.remoter.sudo("apt install -y openjdk-8-jre", verbose=True, ignore_status=True)
-        node.remoter.sudo(
-            "ln -sf /usr/lib/jvm/java-1.8.0-openjdk-amd64/jre/bin/java* /etc/alternatives/java",
-            verbose=True,
-            ignore_status=True,
+    def _create_node(self, node_index, container=None, after_config=None):
+        node = DockerLoaderNode(
+            parent_cluster=self,
+            base_logdir=self.logdir,
+            node_prefix=self.node_prefix,
+            node_index=node_index,
+            ssh_login_info=None,
         )
+        node.init()
+        return node
 
-        self._install_docker_cli(node, verbose=verbose)
+    def add_nodes(
+        self,
+        count,
+        ec2_user_data="",
+        dc_idx=0,
+        rack=0,
+        enable_auto_bootstrap=False,
+        instance_type=None,
+        after_config=None,
+    ):
+        assert instance_type is None, "docker can provision different instance types"
+        return self._create_nodes(count, enable_auto_bootstrap)
+
+    def node_setup(self, node: DockerLoaderNode, verbose=False, **kwargs):
+        # No container setup needed - stress tools run directly on the host via LOCALRUNNER.
+        # Docker is already available on the host machine.
         if self.params.get("client_encrypt"):
             self._generate_loader_certs(node)
-            node.config_client_encrypt()
 
     def _generate_loader_certs(self, node):
         """Generate SSL client certificates for a Docker loader node."""
@@ -781,42 +873,6 @@ class LoaderSetDocker(cluster.BaseLoaderSet, DockerCluster):
             node.ssl_conf_dir / TLSAssets.CLIENT_KEY,
             node.ssl_conf_dir / TLSAssets.PKCS12_KEYSTORE,
         )
-
-    def _install_docker_cli(self, node, verbose=False):
-        result = node.remoter.run("docker --version", ignore_status=True, verbose=False)
-        if result.ok:
-            self.log.debug("Docker CLI already installed on loader node: %s", result.stdout.strip())
-            return
-
-        self.log.debug("Installing Docker CLI on loader node")
-
-        commands = (
-            [
-                "apt update",
-                "apt install -y gnupg2 software-properties-common lsb-release",
-                "curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -",
-                'add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"',
-                "apt update",
-                "apt install -y docker-ce-cli",
-            ]
-            if node.distro.is_debian_like
-            else [
-                "curl -L https://download.docker.com/linux/centos/docker-ce.repo -o /etc/yum.repos.d/docker-ce.repo",
-                "microdnf -y update",
-                "microdnf -y install docker-ce-cli",
-            ]
-        )
-
-        for cmd in commands:
-            result = node.remoter.run(cmd, timeout=300, verbose=verbose, ignore_status=True, retry=3, user="root")
-            if not result.ok:
-                raise RuntimeError(f"Command {cmd} failed with error: {result.stderr.strip()}")
-
-        verify = node.remoter.run("docker --version", ignore_status=True)
-        if verify.ok:
-            self.log.info("Docker CLI installed successfully: %s", verify.stdout.strip())
-        else:
-            raise RuntimeError("Docker CLI installation verification failed")
 
 
 class DockerMonitoringNode(cluster.BaseNode):

--- a/sdcm/cluster_docker.py
+++ b/sdcm/cluster_docker.py
@@ -855,7 +855,7 @@ class LoaderSetDocker(cluster.BaseLoaderSet, DockerCluster):
         assert instance_type is None, "docker can provision different instance types"
         return self._create_nodes(count, enable_auto_bootstrap)
 
-    def node_setup(self, node: DockerLoaderNode, verbose=False, **kwargs):
+    def node_setup(self, node: DockerLoaderNode, verbose=False, timeout=3600, **kwargs):
         # No container setup needed - stress tools run directly on the host via LOCALRUNNER.
         # Docker is already available on the host machine.
         if self.params.get("client_encrypt"):

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -2149,10 +2149,6 @@ class ClusterTester(unittest.TestCase):
                 node_key_file=self.credentials[0].key_file,
             )
 
-        # TODO: for Docker backend, loaders are Scylla containers used only as a Docker host
-        # to launch stress tool containers (RemoteDocker) via docker-in-docker.
-        # This is wasteful — stress containers could run directly on the host via LOCALRUNNER.
-        # See docs/plans/infrastructure/cassandra-cluster-support.md for refactor notes.
         self.loaders = cluster_docker.LoaderSetDocker(
             n_nodes=self.params.get("n_loaders"), **container_node_params, **common_params
         )

--- a/unit_tests/unit/test_cluster.py
+++ b/unit_tests/unit/test_cluster.py
@@ -980,6 +980,7 @@ _NARROWED_KWARGS: dict[str, frozenset[str]] = {
     "LoaderPodContainer": _NO_SSH,
     "OciNode": _NO_SSH,
     "VectorStoreAWSNode": _NO_SSH,
+    "DockerLoaderNode": _NO_DC_RACK,
     "DockerMonitoringNode": _NO_DC_RACK,
     "DockerNode": _NO_DC_RACK,
     "VectorStoreDockerNode": _NO_DC_RACK,


### PR DESCRIPTION
## Summary
Replace wasteful Scylla containers (used only as Docker hosts for stress tool containers via docker-in-docker) with lightweight local loader nodes that use LOCALRUNNER directly.

## Problem
Docker backend loaders spin up full Scylla containers only to serve as Docker hosts for launching stress tool containers (RemoteDocker / docker-in-docker). This wastes resources — the stress containers can run directly on the host.

## Solution
- Introduce `DockerLoaderNode` (modeled after `DockerMonitoringNode`) that uses `LOCALRUNNER` instead of running inside a container
- Simplify `LoaderSetDocker` to create local nodes, skipping container provisioning and Docker CLI installation
- Remove the intermediate container layer: stress tool containers (`RemoteDocker`) now launch directly via the host Docker daemon

## Before
```
Host → Scylla container (loader) [Docker socket mounted] → Stress container (docker-in-docker)
```

## After
```
Host → LOCALRUNNER → Stress container (direct Docker)
```

## Backends Affected
- [x] Docker

## Testing
- Provision test on Docker backend validates the change end-to-end

[SCT-172](https://scylladb.atlassian.net/browse/SCT-172)

[SCT-172]: https://scylladb.atlassian.net/browse/SCT-172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ