### PR TITLE
feature(perf-regression): add GCE z4d perf-regression and elasticity tests

### DIFF
--- a/configurations/gce/z4d-highmem-16-highlssd.yaml
+++ b/configurations/gce/z4d-highmem-16-highlssd.yaml
@@ -1,0 +1,6 @@
+gce_instance_type_db: 'z4d-highmem-16-highlssd'
+gce_root_disk_type_db: 'hyperdisk-balanced'
+gce_n_local_ssd_disk_db: 2
+gce_instance_type_loader: 'c4-highcpu-32'
+gce_root_disk_type_loader: 'hyperdisk-balanced'
+force_run_iotune: true

--- a/configurations/gce/z4d-highmem-16-standardlssd.yaml
+++ b/configurations/gce/z4d-highmem-16-standardlssd.yaml
@@ -1,0 +1,6 @@
+gce_instance_type_db: 'z4d-highmem-16-standardlssd'
+gce_root_disk_type_db: 'hyperdisk-balanced'
+gce_n_local_ssd_disk_db: 1
+gce_instance_type_loader: 'c4-highcpu-32'
+gce_root_disk_type_loader: 'hyperdisk-balanced'
+force_run_iotune: true

--- a/configurations/performance/cassandra_stress_gradual_load_steps_z4d.yaml
+++ b/configurations/performance/cassandra_stress_gradual_load_steps_z4d.yaml
@@ -1,0 +1,9 @@
+# Define load ops for steps for z4d-highmem-16 instances
+# # For debugging, you can set a specific thread count for each step (per load).
+## The value of perf_gradual_threads[load] must be either:
+##   - a single-element list or integer (applied to all throttle steps)
+##   - a list with the same length as perf_gradual_throttle_steps[load] (one thread count per step).
+perf_gradual_threads: {"read": 620, "write": 400, "mixed": 1900, "read_disk_only": 620}
+## The value of perf_gradual_throttle_steps[load] is a percentage of the max throughput (unthrottled) for that load type, which is determined by a preliminary run of the stress command with no throttle and the specified thread count.
+perf_gradual_throttle_steps: {"read": ['500000', '900000', '1200000', '1500000', 'unthrottled'], "mixed": ['250000', '480000', '600000', '750000', 'unthrottled'], "write": ['350000', '600000', 'unthrottled'], "read_disk_only": ['110000', '220000', '330000', '400000', 'unthrottled']}  # where every value is in ops
+perf_gradual_step_duration: {"read": '30m', "write": None, "mixed": '30m', "read_disk_only": '30m'}

--- a/configurations/performance/elasticity-2.5Tb.yaml
+++ b/configurations/performance/elasticity-2.5Tb.yaml
@@ -1,0 +1,10 @@
+prepare_write_cmd: ["cassandra-stress write no-warmup cl=ALL n=650000000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=200 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=1..650000000",
+                    "cassandra-stress write no-warmup cl=ALL n=650000000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=200 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=650000000..1300000000",
+                    "cassandra-stress write no-warmup cl=ALL n=650000000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=200 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=1300000000..1950000000",
+                    "cassandra-stress write no-warmup cl=ALL n=650000000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=200 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=1950000000..2600000000"]
+
+stress_cmd_w: "cassandra-stress write no-warmup cl=QUORUM duration=2850m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate 'threads=250 fixed=20332/s' -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..650000000,325000000,9750000)' "
+stress_cmd_r: "cassandra-stress read no-warmup  cl=QUORUM duration=800m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate 'threads=250 fixed=10310/s' -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..650000000,325000000,9750000)' "
+stress_cmd_m: "cassandra-stress mixed no-warmup cl=QUORUM duration=800m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate 'threads=250 fixed=8750/s' -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..650000000,325000000,6500000)' "
+
+nemesis_add_node_cnt: 9

--- a/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-2.5tb-z4d-highlssd-elasticity.jenkinsfile
+++ b/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-2.5tb-z4d-highlssd-elasticity.jenkinsfile
@@ -1,0 +1,15 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+perfRegressionParallelPipeline(
+    backend: "gce",
+    gce_datacenter: "us-central1",
+    availability_zone: "c",
+    provision_type: 'on_demand',
+    gce_project: 'gcp-local-ssd-latency',
+    test_name: "performance_regression_test.PerformanceRegressionTest",
+    test_config: """["test-cases/performance/perf-regression-latency-650gb-elasticity.yaml", "configurations/disable_kms.yaml", "configurations/performance/elasticity-2.5Tb.yaml", "configurations/gce/z4d-highmem-16-highlssd.yaml", "configurations/performance/latency-decorator-error-thresholds-nemesis-ent-tablets.yaml"]""",
+    sub_tests: ["test_latency_write_with_nemesis", "test_latency_read_with_nemesis", "test_latency_mixed_with_nemesis"],
+)

--- a/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-2.5tb-z4d-standardlssd-elasticity.jenkinsfile
+++ b/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-2.5tb-z4d-standardlssd-elasticity.jenkinsfile
@@ -1,0 +1,15 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+perfRegressionParallelPipeline(
+    backend: "gce",
+    gce_datacenter: "us-east4",
+    availability_zone: "c",
+    provision_type: 'on_demand',
+    gce_project: 'gcp-local-ssd-latency',
+    test_name: "performance_regression_test.PerformanceRegressionTest",
+    test_config: """["test-cases/performance/perf-regression-latency-650gb-elasticity.yaml", "configurations/disable_kms.yaml", "configurations/performance/elasticity-2.5Tb.yaml", "configurations/gce/z4d-highmem-16-standardlssd.yaml", "configurations/performance/latency-decorator-error-thresholds-nemesis-ent-tablets.yaml"]""",
+    sub_tests: ["test_latency_write_with_nemesis", "test_latency_read_with_nemesis", "test_latency_mixed_with_nemesis"],
+)

--- a/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-z4d-highlssd-tablets.jenkinsfile
+++ b/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-z4d-highlssd-tablets.jenkinsfile
@@ -8,7 +8,7 @@ perfRegressionParallelPipeline(
     gce_datacenter: "us-east4",
     availability_zone: "a",
     provision_type: 'on_demand',
-    gce_project: 'gce-local-ssd-latency',
+    gce_project: 'gcp-local-ssd-latency',
     test_name: "performance_regression_gradual_grow_throughput.PerformanceRegressionPredefinedStepsTest",
     test_config: '''["test-cases/performance/perf-regression-predefined-throughput-steps.yaml", "configurations/performance/cassandra_stress_gradual_load_steps_z4d.yaml", "configurations/c-s-driver-version-4.yaml", "configurations/disable_kms.yaml", "configurations/disable_speculative_retry.yaml", "configurations/performance/latency-decorator-error-thresholds-steps-ent-tablets.yaml", "configurations/gce/z4d-highmem-16-highlssd.yaml"]''',
     sub_tests: ["test_read_gradual_increase_load", "test_mixed_gradual_increase_load", "test_read_disk_only_gradual_increase_load", "test_write_gradual_increase_load"],

--- a/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-z4d-highlssd-tablets.jenkinsfile
+++ b/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-z4d-highlssd-tablets.jenkinsfile
@@ -1,0 +1,15 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+perfRegressionParallelPipeline(
+    backend: "gce",
+    gce_datacenter: "us-east4",
+    availability_zone: "a",
+    provision_type: 'on_demand',
+    gce_project: 'gce-local-ssd-latency',
+    test_name: "performance_regression_gradual_grow_throughput.PerformanceRegressionPredefinedStepsTest",
+    test_config: '''["test-cases/performance/perf-regression-predefined-throughput-steps.yaml", "configurations/performance/cassandra_stress_gradual_load_steps_z4d.yaml", "configurations/c-s-driver-version-4.yaml", "configurations/disable_kms.yaml", "configurations/disable_speculative_retry.yaml", "configurations/performance/latency-decorator-error-thresholds-steps-ent-tablets.yaml", "configurations/gce/z4d-highmem-16-highlssd.yaml"]''',
+    sub_tests: ["test_read_gradual_increase_load", "test_mixed_gradual_increase_load", "test_read_disk_only_gradual_increase_load", "test_write_gradual_increase_load"],
+)

--- a/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-z4d-standardlssd-tablets.jenkinsfile
+++ b/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-z4d-standardlssd-tablets.jenkinsfile
@@ -1,0 +1,15 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+perfRegressionParallelPipeline(
+    backend: "gce",
+    gce_datacenter: "us-central1",
+    availability_zone: "a",
+    provision_type: 'on_demand',
+    gce_project: 'gce-local-ssd-latency',
+    test_name: "performance_regression_gradual_grow_throughput.PerformanceRegressionPredefinedStepsTest",
+    test_config: '''["test-cases/performance/perf-regression-predefined-throughput-steps.yaml", "configurations/performance/cassandra_stress_gradual_load_steps_z4d.yaml", "configurations/c-s-driver-version-4.yaml", "configurations/disable_kms.yaml", "configurations/disable_speculative_retry.yaml", "configurations/performance/latency-decorator-error-thresholds-steps-ent-tablets.yaml", "configurations/gce/z4d-highmem-16-standardlssd.yaml"]''',
+    sub_tests: ["test_read_gradual_increase_load", "test_mixed_gradual_increase_load", "test_read_disk_only_gradual_increase_load", "test_write_gradual_increase_load"],
+)

--- a/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-z4d-standardlssd-tablets.jenkinsfile
+++ b/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-z4d-standardlssd-tablets.jenkinsfile
@@ -8,7 +8,7 @@ perfRegressionParallelPipeline(
     gce_datacenter: "us-central1",
     availability_zone: "a",
     provision_type: 'on_demand',
-    gce_project: 'gce-local-ssd-latency',
+    gce_project: 'gcp-local-ssd-latency',
     test_name: "performance_regression_gradual_grow_throughput.PerformanceRegressionPredefinedStepsTest",
     test_config: '''["test-cases/performance/perf-regression-predefined-throughput-steps.yaml", "configurations/performance/cassandra_stress_gradual_load_steps_z4d.yaml", "configurations/c-s-driver-version-4.yaml", "configurations/disable_kms.yaml", "configurations/disable_speculative_retry.yaml", "configurations/performance/latency-decorator-error-thresholds-steps-ent-tablets.yaml", "configurations/gce/z4d-highmem-16-standardlssd.yaml"]''',
     sub_tests: ["test_read_gradual_increase_load", "test_mixed_gradual_increase_load", "test_read_disk_only_gradual_increase_load", "test_write_gradual_increase_load"],

--- a/sdcm/provision/gce/instance_provider.py
+++ b/sdcm/provision/gce/instance_provider.py
@@ -42,8 +42,26 @@ LOGGER = logging.getLogger(__name__)
 
 ZONE_EXHAUSTED_MARKER = "ZONE_RESOURCE_POOL_EXHAUSTED"
 
+# Markers indicating a configuration error (e.g., incompatible disk type) rather
+# than a genuine zone capacity issue.  When these appear in an error that also
+# contains ZONE_RESOURCE_POOL_EXHAUSTED, the error should NOT be classified as
+# zone-exhausted because retrying in another zone will not help.
+_CONFIG_ERROR_MARKERS = (
+    "disk type cannot be used",
+    "does not support disk type",
+    "is not compatible with",
+)
+
+
+def _is_config_error(error: BaseException) -> bool:
+    """Return True if the error indicates a configuration/compatibility problem."""
+    error_str = str(error).lower()
+    return any(marker in error_str for marker in _CONFIG_ERROR_MARKERS)
+
 
 def _is_zone_exhausted(error: BaseException) -> bool:
+    if _is_config_error(error):
+        return False
     return ZONE_EXHAUSTED_MARKER in str(error)
 
 
@@ -126,6 +144,10 @@ class VirtualMachineProvider:
                 )
                 pending_instance_creations.append((definition, operation, normalized_name, user_data, startup_script))
             except google.api_core.exceptions.GoogleAPIError as err:
+                if _is_config_error(err):
+                    raise ProvisionError(
+                        f"Failed to create instance {normalized_name} due to configuration error: {err}"
+                    ) from err
                 if _is_zone_exhausted(err):
                     LOGGER.error(
                         "Zone %s resource pool exhausted during insert request for %s",
@@ -147,6 +169,10 @@ class VirtualMachineProvider:
                 # Zone exhaustion is unrecoverable; let it propagate immediately.
                 # Successfully-created instances remain in self._cache so callers
                 # can clean them up before retrying in a different zone.
+                raise
+            except ProvisionError:
+                # Configuration errors (e.g., incompatible disk type) are unrecoverable;
+                # propagate immediately without retrying in other zones.
                 raise
             except google.api_core.exceptions.GoogleAPIError as err:
                 LOGGER.error("Error when waiting for instance %s: %s", normalized_name, str(err))
@@ -193,6 +219,14 @@ class VirtualMachineProvider:
                 raise ZoneResourcesExhaustedError(
                     f"Zone {self.zone} resource pool exhausted: {gce_error}"
                 ) from gce_error
+            if _is_config_error(gce_error):
+                LOGGER.error(
+                    "Instance %s creation failed due to configuration error (not retryable): %s",
+                    normalized_name,
+                    gce_error,
+                )
+                self._cleanup_failed_instance(normalized_name, str(gce_error))
+                raise ProvisionError(f"Failed to create instance {normalized_name}: {gce_error}") from gce_error
             LOGGER.warning("Instance %s creation failed: %s, will retry", normalized_name, gce_error)
             self._cleanup_failed_instance(normalized_name, str(gce_error))
             # Retry the entire creation process with retry decorator


### PR DESCRIPTION
**NOTE: We are currently blocked by an instance capacity issue; @roydahan  is following up with GCE support. After aligning with @fruch, we decided to merge the test for now but keep it disabled until the capacity issue is resolved.**

Add 4 new performance tests with GCE backend using z4d-highmem-16 instances (standardlssd and highlssd variants):
- Predefined throughput steps tests (us-east4)
- 2.5TB elasticity latency tests with nemesis (us-east5)

Includes new GCE instance type configs and z4d-specific load steps.


### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] 

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
