### PR TITLE
fix(test): filter GCE region builder test by NodeType tag instead of name substring

### DIFF
--- a/unit_tests/unit/provisioner/test_gce_region_definition_builder.py
+++ b/unit_tests/unit/provisioner/test_gce_region_definition_builder.py
@@ -58,23 +58,23 @@ def build_region_defs():
 
 
 @pytest.mark.parametrize(
-    "extra_env,name_filter,expected_disk_type",
+    "extra_env,node_type,expected_disk_type",
     [
         ({"SCT_GCE_ROOT_DISK_TYPE_LOADER": "pd-ssd"}, "loader", "pd-ssd"),
-        ({"SCT_GCE_ROOT_DISK_TYPE_DB": "pd-ssd"}, "db", "pd-ssd"),
+        ({"SCT_GCE_ROOT_DISK_TYPE_DB": "pd-ssd"}, "scylla-db", "pd-ssd"),
         ({"SCT_GCE_ROOT_DISK_TYPE_MONITOR": "pd-standard"}, "monitor", "pd-standard"),
     ],
 )
 def test_root_disk_type_flows_into_instance_definition(
-    make_config, build_region_defs, extra_env, name_filter, expected_disk_type
+    make_config, build_region_defs, extra_env, node_type, expected_disk_type
 ):
     """root_disk_type config must appear in the InstanceDefinition for the corresponding node type."""
     config, test_config = make_config(extra_env)
     region_defs = build_region_defs(config, test_config)
 
-    defs = [d for d in region_defs[0].definitions if d.name and name_filter in d.name]
-    assert defs, f"No {name_filter} definitions found"
+    defs = [d for d in region_defs[0].definitions if d.tags.get("NodeType") == node_type]
+    assert defs, f"No definitions with NodeType='{node_type}' found"
     for defn in defs:
         assert defn.root_disk_type == expected_disk_type, (
-            f"Expected root_disk_type='{expected_disk_type}' for {name_filter}, got '{defn.root_disk_type}'"
+            f"Expected root_disk_type='{expected_disk_type}' for NodeType='{node_type}', got '{defn.root_disk_type}'"
         )


### PR DESCRIPTION
## Summary

The GCE region builder test was filtering instance definitions by substring match on their name (e.g. `"db" in d.name`). This is fragile because the test ID is embedded in the name — if the short test ID happens to contain the filter string (e.g. `"db"`), unrelated node types match and assertions fail.

## Fix

Filter instance definitions by their `tags["NodeType"]` value (`"scylla-db"`, `"loader"`, `"monitor"`) instead of matching substrings in the instance name. This uses the actual semantic type and is immune to test ID content.

## Test plan

- [x] All 3 parametrized GCE tests pass in isolation
- [x] All 148 provisioner unit tests pass