### PR TITLE
feature(docker): add Scylla Manager support for Docker backend

### DIFF
--- a/sdcm/cluster_docker.py
+++ b/sdcm/cluster_docker.py
@@ -15,6 +15,7 @@ import os
 import re
 import logging
 import shutil
+import time
 from typing import Optional, Union, Dict
 from functools import cached_property
 
@@ -471,6 +472,61 @@ class ScyllaDockerCluster(cluster.BaseScyllaCluster, DockerCluster):
 
         node.config_setup(append_scylla_args=self.get_scylla_args())
         node.restart_scylla(verify_up_before=True)
+
+        if self.params.get("use_mgmt"):
+            self.install_scylla_manager(node)
+
+    def install_scylla_manager(self, node):
+        """Install manager agent into running Scylla Docker container.
+
+        Copies the agent binary from the scylladb/scylla-manager-agent image,
+        writes config with auth_token, and starts the agent process.
+        """
+        mgmt_agent_image = "scylladb/scylla-manager-agent:latest"
+        auth_token = self.test_config.test_id()
+        manager_prometheus_port = self.params.get("manager_prometheus_port") or "56090"
+
+        LOGGER.info("Installing manager agent on Docker node %s", node.name)
+
+        node.remoter.run("sudo mkdir -p /etc/scylla-manager-agent", ignore_status=True)
+        node.remoter.run(
+            f"sudo bash -c 'cat > /etc/scylla-manager-agent/scylla-manager-agent.yaml << EOF\n"
+            f"auth_token: {auth_token}\n"
+            f'prometheus: ":{manager_prometheus_port}"\n'
+            f"EOF'",
+        )
+
+        container = ContainerManager.get_container(node, "node")
+
+        from sdcm.utils.docker_utils import _default_docker_client  # noqa: PLC0415 - avoid circular import
+
+        docker_client = _default_docker_client()
+
+        tmp_container_name = f"mgmt-agent-copy-{node.node_index}"
+        try:
+            docker_client.containers.get(tmp_container_name).remove(force=True)
+        except Exception:  # noqa: BLE001
+            pass
+
+        docker_client.images.pull(*mgmt_agent_image.split(":", maxsplit=1))
+        tmp_container = docker_client.containers.create(
+            mgmt_agent_image,
+            name=tmp_container_name,
+            command="sleep 1",
+        )
+        try:
+            bits, _ = tmp_container.get_archive("/usr/bin/scylla-manager-agent")
+            container.put_archive("/usr/bin/", bits)
+        finally:
+            tmp_container.remove(force=True)
+
+        node.remoter.run("sudo chmod +x /usr/bin/scylla-manager-agent")
+
+        node.remoter.run(
+            "sudo bash -c 'nohup /usr/bin/scylla-manager-agent > /var/log/scylla-manager-agent.log 2>&1 &'",
+        )
+
+        node.wait_manager_agent_up(timeout=60)
 
     def _generate_db_node_certs(self, node):
         """Generate per-node SSL certificates for a Docker DB node."""
@@ -967,6 +1023,9 @@ class MonitorSetDocker(cluster.BaseMonitorSet, DockerCluster):
             n_nodes=n_nodes,
             params=params,
         )
+        self._manager_container = None
+        self._manager_db_container = None
+        self.manager_container_name = None
 
     def _create_node(self, node_index, container=None, after_config=None):
         node = DockerMonitoringNode(
@@ -996,6 +1055,73 @@ class MonitorSetDocker(cluster.BaseMonitorSet, DockerCluster):
     def install_scylla_monitoring_prereqs(node):
         pass  # since running local, don't install anything, just the monitor
 
+    def install_scylla_manager(self, node):
+        """Start manager server + manager-db as Docker containers."""
+        from sdcm.utils.docker_utils import _default_docker_client  # noqa: PLC0415 - avoid circular import
+
+        docker_client = _default_docker_client()
+        docker_network = self.params.get("docker_network")
+        user_prefix = self.params.get("user_prefix") or "sct"
+
+        LOGGER.info("Starting Scylla Manager DB container")
+        mgr_db_name = f"{user_prefix}-manager-db"
+        try:
+            docker_client.containers.get(mgr_db_name).remove(force=True)
+        except Exception:  # noqa: BLE001
+            pass
+
+        mgr_db_image = self.params.get("scylla_docker_image") or "scylladb/scylla:latest"
+        docker_client.images.pull(*mgr_db_image.split(":", maxsplit=1))
+        self._manager_db_container = docker_client.containers.run(
+            image=mgr_db_image,
+            name=mgr_db_name,
+            command="--smp 1 --memory 512M --developer-mode 1",
+            network=docker_network,
+            detach=True,
+        )
+
+        LOGGER.info("Waiting for manager DB to be ready")
+        for _ in range(60):
+            time.sleep(5)
+            exit_code, _ = self._manager_db_container.exec_run("cqlsh -e 'SELECT now() FROM system.local'")
+            if exit_code == 0:
+                break
+        else:
+            raise RuntimeError("Manager DB did not become ready in time")
+
+        LOGGER.info("Starting Scylla Manager server container")
+        mgr_name = f"{user_prefix}-manager-server"
+        try:
+            docker_client.containers.get(mgr_name).remove(force=True)
+        except Exception:  # noqa: BLE001
+            pass
+
+        mgmt_image = self.params.get("mgmt_docker_image") or "scylladb/scylla-manager:latest"
+        docker_client.images.pull(*mgmt_image.split(":", maxsplit=1))
+        self._manager_container = docker_client.containers.run(
+            image=mgmt_image,
+            name=mgr_name,
+            network=docker_network,
+            environment={
+                "SCYLLA_MANAGER_DB_HOSTS": mgr_db_name,
+            },
+            detach=True,
+        )
+
+        LOGGER.info("Waiting for manager server to be ready")
+        for _ in range(60):
+            time.sleep(5)
+            exit_code, output = self._manager_container.exec_run(
+                'curl --silent --output /dev/null --write-out "%{http_code}" http://127.0.0.1:5080/ping'
+            )
+            if exit_code == 0 and b"204" in output:
+                break
+        else:
+            raise RuntimeError("Manager server did not become ready in time")
+
+        LOGGER.info("Scylla Manager is running in container %s", mgr_name)
+        self.manager_container_name = mgr_name
+
     def get_backtraces(self):
         pass
 
@@ -1007,3 +1133,14 @@ class MonitorSetDocker(cluster.BaseMonitorSet, DockerCluster):
             except Exception as exc:  # noqa: BLE001
                 self.log.error(f"Stopping scylla monitoring failed with {exc!s}")
             node.destroy()
+
+        if self._manager_container:
+            try:
+                self._manager_container.remove(force=True)
+            except Exception:  # noqa: BLE001
+                pass
+        if self._manager_db_container:
+            try:
+                self._manager_db_container.remove(force=True)
+            except Exception:  # noqa: BLE001
+                pass

--- a/sdcm/cluster_docker.py
+++ b/sdcm/cluster_docker.py
@@ -31,7 +31,13 @@ from sdcm.remote import LOCALRUNNER
 from sdcm.remote.docker_cmd_runner import DockerCmdRunner
 from sdcm.sct_events.database import DatabaseLogEvent
 from sdcm.sct_events.filters import DbEventsFilter
-from sdcm.utils.docker_utils import get_docker_bridge_gateway, Container, ContainerManager, DockerException
+from sdcm.utils.docker_utils import (
+    get_docker_bridge_gateway,
+    Container,
+    ContainerManager,
+    DockerException,
+    _default_docker_client,
+)
 from sdcm.utils.health_checker import check_nodes_status
 from sdcm.nemesis.utils.node_allocator import mark_new_nodes_as_running_nemesis
 from sdcm.utils.net import get_my_public_ip
@@ -202,6 +208,8 @@ class DockerNode(cluster.BaseNode, NodeContainerMixin):
         if verify_up:
             self.wait_db_up(timeout=verify_up_timeout)
 
+        self._restart_manager_agent_if_needed()
+
     @cluster.log_run_info
     def start_scylla(self, verify_up=True, verify_down=False, timeout=300):
         self.start_scylla_server(verify_up=verify_up, verify_down=verify_down, timeout=timeout)
@@ -242,6 +250,17 @@ class DockerNode(cluster.BaseNode, NodeContainerMixin):
     @cluster.log_run_info
     def restart_scylla(self, verify_up_before=False, verify_up_after=True, timeout=1800) -> None:
         self.restart_scylla_server(verify_up_before=verify_up_before, verify_up_after=verify_up_after, timeout=timeout)
+
+    def _restart_manager_agent_if_needed(self):
+        """Restart the manager agent process if it was previously installed (e.g. after container restart by nemesis)."""
+        exit_code, _ = ContainerManager.get_container(self, "node").exec_run("test -x /usr/bin/scylla-manager-agent")
+        if exit_code != 0:
+            return
+        # Agent binary exists but process may be dead after container restart — re-launch it
+        self.remoter.run(
+            "sudo bash -c 'nohup /usr/bin/scylla-manager-agent > /var/log/scylla-manager-agent.log 2>&1 &'",
+        )
+        self.log.info("Scylla Manager agent restarted after container start")
 
     @property
     def image(self) -> str:
@@ -497,8 +516,6 @@ class ScyllaDockerCluster(cluster.BaseScyllaCluster, DockerCluster):
         )
 
         container = ContainerManager.get_container(node, "node")
-
-        from sdcm.utils.docker_utils import _default_docker_client  # noqa: PLC0415 - avoid circular import
 
         docker_client = _default_docker_client()
 
@@ -1057,8 +1074,6 @@ class MonitorSetDocker(cluster.BaseMonitorSet, DockerCluster):
 
     def install_scylla_manager(self, node):
         """Start manager server + manager-db as Docker containers."""
-        from sdcm.utils.docker_utils import _default_docker_client  # noqa: PLC0415 - avoid circular import
-
         docker_client = _default_docker_client()
         docker_network = self.params.get("docker_network")
         user_prefix = self.params.get("user_prefix") or "sct"
@@ -1070,7 +1085,7 @@ class MonitorSetDocker(cluster.BaseMonitorSet, DockerCluster):
         except Exception:  # noqa: BLE001
             pass
 
-        mgr_db_image = self.params.get("scylla_docker_image") or "scylladb/scylla:latest"
+        mgr_db_image = self.params.get("docker_image") or "scylladb/scylla:latest"
         docker_client.images.pull(*mgr_db_image.split(":", maxsplit=1))
         self._manager_db_container = docker_client.containers.run(
             image=mgr_db_image,
@@ -1098,12 +1113,17 @@ class MonitorSetDocker(cluster.BaseMonitorSet, DockerCluster):
 
         mgmt_image = self.params.get("mgmt_docker_image") or "scylladb/scylla-manager:latest"
         docker_client.images.pull(*mgmt_image.split(":", maxsplit=1))
+        self._manager_db_container.reload()
+        mgr_db_ip = self._manager_db_container.attrs["NetworkSettings"]["Networks"][docker_network or "bridge"][
+            "IPAddress"
+        ]
+
         self._manager_container = docker_client.containers.run(
             image=mgmt_image,
             name=mgr_name,
             network=docker_network,
             environment={
-                "SCYLLA_MANAGER_DB_HOSTS": mgr_db_name,
+                "SCYLLA_MANAGER_DB_HOSTS": mgr_db_ip,
             },
             detach=True,
         )

--- a/sdcm/mgmt/__init__.py
+++ b/sdcm/mgmt/__init__.py
@@ -15,8 +15,15 @@ def get_scylla_manager_tool(manager_node, scylla_cluster=None) -> AnyManagerTool
     if manager_node.is_kubernetes():
         return ScyllaManagerToolOperator(manager_node=manager_node, scylla_cluster=scylla_cluster)
     if manager_node.is_docker():
-        container_name = manager_node.parent_cluster.manager_container_name
-        return ScyllaManagerToolDocker(manager_node=manager_node, manager_container_name=container_name)
+        parent_cluster = getattr(manager_node, "parent_cluster", None)
+        if not parent_cluster or not getattr(parent_cluster, "manager_container_name", None):
+            raise RuntimeError(
+                "Cannot initialize ScyllaManagerToolDocker: manager_container_name not set on parent_cluster. "
+                "Ensure install_scylla_manager() was called on the monitor set."
+            )
+        return ScyllaManagerToolDocker(
+            manager_node=manager_node, manager_container_name=parent_cluster.manager_container_name
+        )
     if manager_node.distro.is_rhel_like:
         return ScyllaManagerToolRedhatLike(manager_node=manager_node)
     return ScyllaManagerToolNonRedhat(manager_node=manager_node)

--- a/sdcm/mgmt/__init__.py
+++ b/sdcm/mgmt/__init__.py
@@ -1,17 +1,22 @@
 from typing import Union
 
 from .common import ScyllaManagerError, TaskStatus, HostStatus, HostSsl, HostRestStatus
-from .cli import ScyllaManagerToolRedhatLike, ScyllaManagerToolNonRedhat, ManagerCluster
+from .cli import ScyllaManagerToolRedhatLike, ScyllaManagerToolNonRedhat, ScyllaManagerToolDocker, ManagerCluster
 from .operator import ScyllaManagerToolOperator, OperatorManagerCluster
 
 
-AnyManagerTool = Union[ScyllaManagerToolOperator, ScyllaManagerToolRedhatLike, ScyllaManagerToolNonRedhat]
+AnyManagerTool = Union[
+    ScyllaManagerToolOperator, ScyllaManagerToolRedhatLike, ScyllaManagerToolNonRedhat, ScyllaManagerToolDocker
+]
 AnyManagerCluster = Union[OperatorManagerCluster, ManagerCluster]
 
 
 def get_scylla_manager_tool(manager_node, scylla_cluster=None) -> AnyManagerTool:
     if manager_node.is_kubernetes():
         return ScyllaManagerToolOperator(manager_node=manager_node, scylla_cluster=scylla_cluster)
+    if manager_node.is_docker():
+        container_name = manager_node.parent_cluster.manager_container_name
+        return ScyllaManagerToolDocker(manager_node=manager_node, manager_container_name=container_name)
     if manager_node.distro.is_rhel_like:
         return ScyllaManagerToolRedhatLike(manager_node=manager_node)
     return ScyllaManagerToolNonRedhat(manager_node=manager_node)

--- a/sdcm/mgmt/cli.py
+++ b/sdcm/mgmt/cli.py
@@ -1584,3 +1584,50 @@ class SCTool:
         date_obj = datetime.datetime.strptime(date_str, "%Y%m%d")
         timestamp = int(date_obj.timestamp())
         return timestamp
+
+
+class SCToolDocker(SCTool):
+    def __init__(self, manager_node, container_name):
+        super().__init__(manager_node=manager_node)
+        self.container_name = container_name
+
+    def run(
+        self,
+        cmd,
+        is_verify_errorless_result=False,
+        parse_table_res=True,
+        is_multiple_tables=False,
+        replace_broken_unicode_values=True,
+    ):
+        LOGGER.debug("Issuing: 'sctool %s' in container %s", cmd, self.container_name)
+        try:
+            res = self.manager_node.remoter.run(f"docker exec {self.container_name} sctool {cmd}")
+            LOGGER.debug("sctool output: %s", res.stdout)
+        except (InvokeFailure, Libssh2Failure) as ex:
+            raise ScyllaManagerError(f"Encountered an error on sctool command: {cmd}: {ex}") from ex
+
+        if replace_broken_unicode_values:
+            res.stdout = self.replace_broken_unicode_values(res.stdout)
+
+        if is_verify_errorless_result:
+            verify_errorless_result(cmd=cmd, res=res)
+        if parse_table_res:
+            res = self.parse_result_table(res=res)
+            if is_multiple_tables:
+                dict_res_tables = self.parse_result_multiple_tables(res=res)
+                return dict_res_tables
+        LOGGER.debug("sctool res after parsing: %s", res)
+        return res
+
+
+class ScyllaManagerToolDocker(ScyllaManagerTool):
+    def __init__(self, manager_node, manager_container_name):
+        self.manager_container_name = manager_container_name
+        ScyllaManagerBase.__init__(self, id="MANAGER", manager_node=manager_node)
+        self.sctool = SCToolDocker(manager_node=manager_node, container_name=manager_container_name)
+        self._initial_wait(20)
+        LOGGER.info("Initiating Scylla-Manager (Docker), version: {}".format(self.sctool.version))
+        self.default_user = "root"
+
+    def rollback_upgrade(self, scylla_mgmt_address):
+        raise NotImplementedError("Rollback not supported for Docker manager")

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -4775,8 +4775,7 @@ class SCTConfiguration(BaseModel):
                     raise ValueError(f"Scylla-bench command {cmd} doesn't have parameter -workload")
 
     def _validate_docker_backend_parameters(self):
-        if self.get("use_mgmt"):
-            raise ValueError("Scylla Manager is not supported for docker backend")
+        pass
 
     def _verify_rackaware_configuration(self):
         if not self.get("rack_aware_loader"):


### PR DESCRIPTION
## Summary

Implement Scylla Manager integration for the Docker backend, enabling manager operations (backup, repair) in local Docker-based test runs.

## Changes

- Remove validation block that prevented `use_mgmt` on Docker backend
- Add `install_scylla_manager` to `ScyllaDockerCluster` (copies agent binary from `scylladb/scylla-manager-agent` image into running Scylla containers)
- Add `MonitorSetDocker.install_scylla_manager` (runs manager server and its backing ScyllaDB as separate Docker containers on the test network)
- Add `SCToolDocker` class that executes sctool via `docker exec` on the manager server container
- Add `ScyllaManagerToolDocker` class that bypasses distro check and uses `SCToolDocker` for all sctool operations
- Wire up `get_scylla_manager_tool` to return `ScyllaManagerToolDocker` when `manager_node.is_docker()` is true
- Manager DB uses `--developer-mode 1` to work around SCYLLADB-2043 (I/O error on non-XFS filesystems with 4096 block size)

The default `use_mgmt=true` now applies to Docker backend as well.

## Backends Affected
- [x] Docker - Modified cluster_docker.py, mgmt/__init__.py, mgmt/cli.py, sct_config.py

## Required Labels
- `test-provision-docker`

## Manual Testing Required

### What Copilot Couldn't Test

- [x] **End-to-end manager operations on Docker**: Requires stable multi-node cluster
  - Test: `SCT_USE_MGMT=true SCT_SCYLLA_VERSION=2025.3.0 uv run sct.py run-test longevity_test.LongevityTest.test_custom_time --backend docker --config test-cases/PR-provision-test.yaml`
  - Expected: Manager registers cluster and basic backup/repair operations succeed

### Notes
- Agent installation (image pull + binary copy) verified working
- Manager DB + server container creation verified working
- `get_scylla_manager_tool` dispatch verified working
- Full E2E blocked by pre-existing ZFS issue on local machine (SCT-428 / SCYLLADB-2043)

