### PR TITLE
refactor(ssh-transport): make libssh2 the default SSH transport

### DIFF
--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -780,7 +780,7 @@ Email subject postfix
 
 ## **ssh_transport** / SCT_SSH_TRANSPORT
 
-Set type of ssh library to use. Could be 'fabric' (default) or 'libssh2'
+Set type of ssh library to use. Could be 'libssh2' (default) or 'fabric'
 
 **default:** libssh2
 

--- a/sdcm/remote/remote_cmd_runner.py
+++ b/sdcm/remote/remote_cmd_runner.py
@@ -44,7 +44,7 @@ def open_none_auth(self):
     self.transport = self.client._transport = transport
 
 
-class RemoteCmdRunner(RemoteCmdRunnerBase, ssh_transport="fabric", default=True):
+class RemoteCmdRunner(RemoteCmdRunnerBase, ssh_transport="fabric"):
     connection: Connection
     ssh_config: Config = None
     ssh_is_up: threading.Event = None

--- a/sdcm/remote/remote_libssh_cmd_runner.py
+++ b/sdcm/remote/remote_libssh_cmd_runner.py
@@ -32,7 +32,7 @@ from .base import RetryableNetworkException
 from .remote_base import RemoteCmdRunnerBase
 
 
-class RemoteLibSSH2CmdRunner(RemoteCmdRunnerBase, ssh_transport="libssh2"):
+class RemoteLibSSH2CmdRunner(RemoteCmdRunnerBase, ssh_transport="libssh2", default=True):
     """Remoter that mimic RemoteCmdRunner, under the hood it runs libssh2 client, instead of paramiko
     Main problem in libssh2 - is that it is not thread safe, we mitigate this problem by having
       _connection_thread_map - a dictionary in which we bind thread to the libssh2 session.

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -848,7 +848,7 @@ class SCTConfiguration(BaseModel):
         description="""Email subject postfix""",
     )
     ssh_transport: Literal["libssh2", "fabric"] = SctField(
-        description="""Set type of ssh library to use. Could be 'fabric' (default) or 'libssh2'""",
+        description="""Set type of ssh library to use. Could be 'libssh2' (default) or 'fabric'""",
         default="libssh2",
     )
 


### PR DESCRIPTION
## Summary

Switch the default SSH transport from Fabric to libssh2 across all SCT components.

This removes the legacy Fabric dependency from the critical path, including the create-runner flow which was failing on OCI due to key compatibility issues with Fabric.

## Changes

- Remove `default=True` from `RemoteCmdRunner` (Fabric-based)
- Add `default=True` to `RemoteLibSSH2CmdRunner` (libssh2-based)
- Remove hardcoded `set_default_ssh_transport("fabric")` in `sct_ssh.py`
- Update `ssh_transport` config description to reflect new default

## Context

The libssh2 transport has been available as an alternative and is lighter weight, using a thin C library wrapper instead of the full Fabric/Paramiko/Invoke stack. The config default was already set to `"libssh2"` but the programmatic default was still Fabric.

Fixes: https://scylladb.atlassian.net/browse/SCT-343

## Backends Affected
- [x] AWS
- [x] GCE
- [x] Azure
- [x] OCI
- [x] Docker

## Manual Testing Required

### What Copilot Couldn't Test
- [x] **End-to-end provisioning with libssh2**: Requires cloud backends
- [ ] **OCI key compatibility**: The original issue trigger
- [x] **create-runner-instance flow**: Requires actual runner provisioning
