### PR TITLE
feature(minicloud): run SCT tests against local QEMU/KVM cloud emulation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,4 @@ scylla-qa-internal/
 
 # AI agent working directory
 .sisyphus/
+sct_runner_ip

--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ so those tests won't honor what is set in `test-cases/your_config.yaml`.
 - **[SCT Configuration Guide](./docs/sct-configuration.md)** - Comprehensive guide on how the configuration system works and how to add new options
 - **[Configuration Options Reference](./docs/configuration_options.md)** - Auto-generated list of all available configuration options
 - **[Cross-Cloud Instance Sizing](./docs/cross-cloud-sizing.md)** - Constraint-based instance selection across AWS, GCE, Azure, and OCI
+- **[Running against minicloud](./docs/minicloud.md)** - Local QEMU/KVM cloud emulation: run SCT tests without real cloud credentials or cost
 
 
 ## Development Plans

--- a/configurations/minicloud.yaml
+++ b/configurations/minicloud.yaml
@@ -1,0 +1,20 @@
+# Overlay for any test run against minicloud instead of a real cloud. Layer it after the
+# test-case yaml, e.g.
+#
+#   test_config: '''["test-cases/artifacts/ami.yaml", "configurations/minicloud.yaml"]'''
+#
+# The pipelines deliberately set none of this (see vars/startMinicloud.groovy). It is
+# configuration, so a single run can override any of it, and none of it needs a pipeline
+# change once minicloud grows the missing feature.
+
+# minicloud implements no KMS endpoint, and its QEMU guests hold no cloud IAM credentials to
+# reach a real one. Both lines go away once minicloud implements KMS.
+enterprise_disable_kms: true
+enable_kms_key_rotation: false
+
+# There is no spot market to be interrupted by: every "instance" is a local QEMU guest.
+instance_provision: 'on_demand'
+
+# Guests live on minicloud's userspace switch and are reachable only from the host running
+# them, which is where SCT itself runs.
+ip_ssh_connections: 'private'

--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -52,6 +52,8 @@ seeds_num: 1
 
 instance_provision: "spot"
 
+minicloud_endpoint_url: ""
+
 execute_post_behavior: false
 post_behavior_db_nodes: "destroy"
 post_behavior_loader_nodes: "destroy"
@@ -380,6 +382,20 @@ download_from_s3: []
 manager_backup_restore_method: ''
 
 argus_email_report_template: email_report_template_basic.yaml
+
+# minicloud params
+# A master-<sha> tag, not a release: the newest release (v0.1.1) predates minicloud#140,
+# which region-scopes EC2 resources and adds the tag/attribute-filtered Describe* that
+# AwsRegion.configure() calls (DescribeSecurityGroups/InternetGateways/RouteTables,
+# DescribeAvailabilityZones, DescribeInstanceTypeOfferings). Region prep fails without it.
+# Move back to a release tag once one ships that includes #140.
+minicloud_docker_image: 'ghcr.io/scylladb/minicloud:master-4bd3fb6'
+minicloud_lightweight: true
+# Lightweight VMs get 1 vCPU and this much RAM regardless of the requested instance type.
+# Scylla needs >1 GiB per shard on top of the ~1.7 GiB it reserves for the guest OS, so
+# anything under ~3 GiB fails to boot with "memory per shard too low". This is per VM.
+minicloud_lightweight_memory: '4GiB'
+minicloud_s3_passthrough_buckets: 'scylla-qa-keystore,cloudius-jenkins-test,downloads.scylladb.com'
 
 # SCT agent defaults
 agent:

--- a/docker/env/hydra.sh
+++ b/docker/env/hydra.sh
@@ -199,6 +199,9 @@ AWS_OPTIONS=$(env | sed -n 's/^\(AWS_[^=]*\)=.*/--env \1/p')
 # export all JENKINS_* env vars into the docker run
 JENKINS_OPTIONS=$(env | sed -n 's/^\(JENKINS_[^=]*\)=.*/--env \1/p')
 
+# export all MINICLOUD_* env vars into the docker run
+MINICLOUD_OPTIONS=$(env | sed -n 's/^\(MINICLOUD_[^=]*\)=.*/--env \1/p')
+
 is_podman="$($tool --help | { grep -o podman || :; })"
 docker_common_args=()
 
@@ -279,6 +282,7 @@ function run_in_docker () {
         ${BUILD_OPTIONS} \
         ${JENKINS_OPTIONS} \
         ${AWS_OPTIONS} \
+        ${MINICLOUD_OPTIONS} \
         --env GIT_BRANCH \
         --env CHANGE_TARGET \
         --env PYTHONFAULTHANDLER=yes \

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -51,6 +51,15 @@ backend that will be used, aws/gce/azure/oci/docker/xcloud
 **type:** str
 
 
+## **minicloud_endpoint_url** / SCT_MINICLOUD_ENDPOINT_URL
+
+EC2 API endpoint URL for minicloud. When set, SCT adapts for minicloud limitations (no spot, no EIP, graceful TerminateInstances). Example: http://localhost:5000
+
+**default:** N/A
+
+**type:** str
+
+
 ## **test_method** / SCT_TEST_METHOD
 
 class.method used to run the test. Filled automatically with run-test sct command.
@@ -4001,6 +4010,42 @@ An escape hatch to disable KMS for enterprise run, when needed. We enable KMS by
 **default:** False
 
 **type:** bool
+
+
+## **minicloud_docker_image** / SCT_MINICLOUD_DOCKER_IMAGE
+
+Docker image for minicloud container (default: ghcr.io/scylladb/minicloud:master-4bd3fb6)
+
+**default:** ghcr.io/scylladb/minicloud:master-4bd3fb6
+
+**type:** str (appendable)
+
+
+## **minicloud_lightweight** / SCT_MINICLOUD_LIGHTWEIGHT
+
+Enable lightweight mode for minicloud deployments
+
+**default:** True
+
+**type:** bool
+
+
+## **minicloud_lightweight_memory** / SCT_MINICLOUD_LIGHTWEIGHT_MEMORY
+
+Memory allocation for lightweight minicloud deployments
+
+**default:** 4GiB
+
+**type:** str (appendable)
+
+
+## **minicloud_s3_passthrough_buckets** / SCT_MINICLOUD_S3_PASSTHROUGH_BUCKETS
+
+S3 buckets to pass through in minicloud deployments
+
+**default:** scylla-qa-keystore,cloudius-jenkins-test,downloads.scylladb.com
+
+**type:** str | list[str] → list[str] (appendable)
 
 
 ## **logs_transport** / SCT_LOGS_TRANSPORT

--- a/docs/minicloud.md
+++ b/docs/minicloud.md
@@ -1,0 +1,136 @@
+# Running SCT against minicloud
+
+[minicloud](https://github.com/scylladb/minicloud) is a local cloud emulator: one container that
+serves the EC2 and GCE compute APIs and backs them with real QEMU/KVM virtual machines on the
+host. SCT points its AWS/GCP SDKs at it and runs otherwise unchanged - same test-cases, same
+provisioning code, same log collection - without real cloud credentials, cost, or quota.
+
+Use it for provisioning-path development, artifact smoke tests, and any test whose value is in
+exercising SCT itself rather than real cloud hardware.
+
+## How activation works
+
+`is_minicloud_active()` (`sdcm/utils/minicloud.py`) switches SCT into minicloud mode when any of
+these is set, in this order of specificity:
+
+| knob | scope | notes |
+|---|---|---|
+| `MINICLOUD_DOCKER` | env | the `scripts/` wrappers' switch; also selects the image |
+| `AWS_ENDPOINT_URL` / `GCE_ENDPOINT_URL` pointing at localhost | env | direct SDK override |
+| `SCT_MINICLOUD_ENDPOINT_URL` | env | **what the Jenkins pipelines set** |
+| `minicloud_endpoint_url` | SCT param | the only way a test-case yaml can switch it on |
+
+`SCT_MINICLOUD_DOCKER_IMAGE` (param: `minicloud_docker_image`) does **not** activate anything -
+it only selects which image runs. Empty values are ignored everywhere: an exported-but-empty
+variable never blanks out a resolved default.
+
+Once active, `tester.py` builds a `MinicloudManager` that preflights, starts the container and
+prepares regions by itself. In CI the container is instead started up front by
+`hydra start-minicloud` with `keep_alive`, because the pipeline's provision/collect/clean stages
+are separate hydra invocations that all need to reach the same live endpoint.
+
+## Configuration
+
+Params (defaults in `defaults/test_default.yaml`, reference in
+[configuration_options](./configuration_options.md)):
+
+- `minicloud_docker_image` - image reference. The default is a `master-<sha>` tag, not a
+  release: the newest release predates the region-scoping and filtered-`Describe*` support that
+  region preparation requires.
+- `minicloud_lightweight` (default `true`) - every guest gets 1 vCPU and a fixed amount of RAM,
+  ignoring the instance type the test asked for. SCT still validates and reports the requested
+  type, so keep it realistic in the yaml.
+- `minicloud_lightweight_memory` (default `4GiB`) - per-guest RAM. Scylla needs >1 GiB per shard
+  on top of the ~1.7 GiB it reserves for the guest OS, so anything under ~3 GiB fails to boot
+  with "memory per shard too low".
+- `minicloud_s3_passthrough_buckets` - S3 buckets proxied to real AWS (keystore, job artifacts,
+  `downloads.scylladb.com`). This is why minicloud runs still need the `qa-aws-secret-*`
+  credentials.
+
+`configurations/minicloud.yaml` is the overlay every minicloud job layers after its test-case
+yaml: KMS off (minicloud implements no KMS endpoint), `instance_provision: on_demand` (there is
+no spot market to be interrupted by), `ip_ssh_connections: private` (guests live on the host's
+userspace switch). `configurations/minicloud/gce.yaml` additionally caps
+`gce_n_local_ssd_disk_db: 1` - guests are qcow2-backed and have no NVMe to pass through.
+
+### Memory arithmetic
+
+The whole test must fit in the host's free RAM:
+
+```
+(n_db_nodes + n_loaders + n_monitor_nodes) x minicloud_lightweight_memory + ~2 GiB host headroom
+```
+
+`preflight_check(params=...)` enforces exactly this before the container starts and prints the
+arithmetic when it fails. Without the check, an oversized test dies mid-run as a cgroup OOM kill
+(container exit 137) that takes every VM with it and surfaces as a wall of SSH timeouts far from
+the cause. `n_db_nodes` is a multi-DC list (`"3 3"`), and is summed.
+
+## Container lifecycle
+
+- One container named `minicloud`, `--network host` (API on `localhost:5000`) but **not**
+  `--pid host`: QEMU guests share the container's PID namespace, so `docker rm -f minicloud`
+  kills every VM with it. Teardown must therefore run **after** log collection.
+- Health probe is EC2 `DescribeVpcs` - an action minicloud implements and serves locally.
+- EC2 resources are scoped per region, as on real AWS: a VPC created in one region is invisible
+  from another, so `prepare_regions()` sets up every SCT-supported region up front (~2s each).
+  `MINICLOUD_AWS_REGION` (comma-separated) narrows that when start-up time matters.
+- Region-less API calls land in the container's own `--aws-region`. That is not cosmetic:
+  RunInstances validates a not-yet-cached AMI against real AWS in *that* region, so a mismatch
+  fails with `InvalidAMIID.NotFound`. Scylla AMIs live in `eu-west-1`, the default.
+- Guest disks for AWS AMIs are built by reading the AMI's snapshot over the EBS direct API and
+  cached under `~/.cache/minicloud/amis` (tens of GiB, tens of minutes to build - never delete
+  it casually). **Dev AMIs (`master:latest`) do not work on the AWS path today**: their
+  snapshots are not shared with the QA account, so `ListSnapshotBlocks` returns
+  `SnapshotNotFound` and the VM never boots. Use a released version. The GCE path is
+  unaffected - dev images cache fine there.
+
+## What minicloud does not implement
+
+- **KMS** (AWS or GCP) - hence `enterprise_disable_kms: true` in the overlay. When minicloud
+  grows KMS support, only the overlay changes; no pipeline knows about KMS.
+- **Spot** - `instance_provision` must stay `on_demand`.
+- **Local SSDs / NVMe passthrough** - guests get qcow2-backed disks.
+- Anything not in the emulated API surface fails closed with an explicit error rather than
+  being silently ignored - by design, on both sides.
+
+## Running locally
+
+Host prerequisites: KVM (`/dev/kvm` writable by your user), docker, ~80 GiB free in `$HOME` for
+the image cache, and AWS credentials for the passthrough buckets. One-time network setup
+(the `minicloud0` TUN device carrying `10.127.0.1`) is created by the container's setup script
+under sudo, or pre-create it via a boot-time unit and no sudo is needed at run time.
+
+```bash
+# start the container and prepare regions (keep_alive - survives across hydra invocations)
+./docker/env/hydra.sh start-minicloud -b aws -c test-cases/minicloud-provision-test.yaml
+
+# then run any SCT command against it
+export SCT_MINICLOUD_ENDPOINT_URL=http://localhost:5000
+./docker/env/hydra.sh run-test artifacts_test --backend aws
+```
+
+The `scripts/run-minicloud-*.sh` wrappers bundle these steps for the common local flows
+(provision test, artifact test, AWS and GCE variants); `scripts/start-minicloud.sh` is the
+container-only entry point. `scripts/run-minicloud-clean-resources.sh` is a local-dev
+convenience only - the pipelines use the regular `clean-resources` path.
+
+## Troubleshooting
+
+| symptom | cause |
+|---|---|
+| container exit 137 mid-test, all VMs unreachable at once | cgroup OOM kill - the test was too big for the host. The preflight prints the required arithmetic; reduce node counts or `minicloud_lightweight_memory`, or use a bigger host |
+| container exit 143 | someone ran `docker stop minicloud` |
+| `InvalidAMIID.NotFound` on launch | AMI not cached and the container's `--aws-region` differs from where the AMI lives - or the AMI id is wrong |
+| `SnapshotNotFound` from `ListSnapshotBlocks` | dev AMI whose snapshot is not shared with the QA account - use a released version |
+| "memory per shard too low" in a guest's Scylla log | `minicloud_lightweight_memory` set below ~3 GiB |
+| every VM silently unreachable, test proceeds anyway | `minicloud0` was never created and host networking setup only warned - pre-create the device or grant passwordless sudo |
+| `clean-resources` reports success but instances survive | the container died and something auto-started a fresh, empty one; check `docker logs minicloud` and the run's `minicloud.log` |
+
+The container's own log is the emulator's view of the run: `docker logs minicloud`, and
+`minicloud.log` in the test's logdir.
+
+## Running in Jenkins
+
+See the pipeline documentation - this section is filled in by the pipeline-integration change
+that adds the `minicloud: true` opt-in to the regular SCT pipelines.

--- a/scripts/run-minicloud-artifact-install-test.sh
+++ b/scripts/run-minicloud-artifact-install-test.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+set -euo pipefail
+
+# Run the SCT artifact install test (clean distro + Scylla repo install) via minicloud.
+#
+# What it tests:
+#   - Clean Ubuntu 26.04 base image provisions correctly
+#   - Scylla installs from deb repository (master/branch)
+#   - Scylla service starts, responds to CQL, nodetool status
+#   - stop/start and restart cycles
+#   - node_exporter, time sync, perftune
+#
+# Required env vars:
+#   MINICLOUD_DOCKER        - Docker image for minicloud (e.g. ghcr.io/scylladb/minicloud:master-4bd3fb6)
+#   SCT_SCYLLA_REPO         - deb repo URL (e.g. https://downloads.scylladb.com/unstable/scylla/master/deb/unified/latest/scylladb-master/scylla.list)
+#
+# Optional env vars:
+#   SCT_REGION_NAME         - GCE region (default: us-east1)
+#   MINICLOUD_KEEP_ALIVE    - set to 1 to keep cluster running after test
+
+export MINICLOUD_DOCKER="${MINICLOUD_DOCKER:?ERROR: MINICLOUD_DOCKER not set. Set to minicloud image (e.g. ghcr.io/scylladb/minicloud:master-4bd3fb6)}"
+
+# Repo URL is required for install-from-repo tests
+if [[ -z "${SCT_SCYLLA_REPO:-}" ]]; then
+    echo "ERROR: SCT_SCYLLA_REPO must be set to a deb repo URL"
+    echo "  Example: export SCT_SCYLLA_REPO='https://downloads.scylladb.com/unstable/scylla/master/deb/unified/latest/scylladb-master/scylla.list'"
+    exit 1
+fi
+
+export SCT_USE_MGMT=false
+export SCT_ENABLE_ARGUS=false
+export SCT_N_DB_NODES=1
+export SCT_N_LOADERS=0
+export SCT_N_MONITOR_NODES=0
+
+# Small Scylla memory footprint — minicloud VMs are constrained
+export SCT_APPEND_SCYLLA_ARGS="${SCT_APPEND_SCYLLA_ARGS:---memory 256M}"
+
+# KMS disabled — minicloud has no KMS endpoint
+export SCT_ENTERPRISE_DISABLE_KMS=true
+export SCT_ENABLE_KMS_KEY_ROTATION=false
+
+# GCE minicloud settings
+export SCT_MINICLOUD_ENDPOINT_URL="${SCT_MINICLOUD_ENDPOINT_URL:-http://localhost:5000}"
+export SCT_REGION_NAME="${SCT_REGION_NAME:-us-east1}"
+
+# Distro install settings — match test-cases/artifacts/ubuntu2604.yaml
+export SCT_SCYLLA_LINUX_DISTRO="ubuntu-resolute"
+export SCT_USE_PREINSTALLED_SCYLLA=false
+export SCT_GCE_IMAGE_USERNAME="ubuntu"
+
+echo ""
+echo "======================================="
+echo "  Minicloud Artifact Install Test"
+echo "  Distro   : Ubuntu 26.04 (resolute)"
+echo "  Repo     : ${SCT_SCYLLA_REPO}"
+echo "  Region   : ${SCT_REGION_NAME}"
+echo "======================================="
+echo ""
+
+uv run sct.py run-test artifacts_test.ArtifactsTest.test_scylla_service \
+    --backend gce \
+    --config test-cases/artifacts/ubuntu2604.yaml

--- a/scripts/run-minicloud-artifact-test-hydra.sh
+++ b/scripts/run-minicloud-artifact-test-hydra.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+set -euo pipefail
+
+# Run the minicloud artifact test inside hydra (SCT's Docker environment).
+#
+# Minicloud runs as a sibling Docker container (ghcr.io/scylladb/minicloud:master-4bd3fb6)
+# on the host network. Hydra connects to it via localhost:5000.
+#
+# Prerequisites:
+#   - /dev/kvm available on host
+#   - Docker running
+#   - AWS credentials configured (for S3 passthrough: AMI downloads, keystore)
+#
+# Optional env vars:
+#   SCT_SCYLLA_VERSION      - e.g. 2025.3.0 (default)
+#   SCT_AMI_ID_DB_SCYLLA    - specific AMI to test
+#   SCT_REGION_NAME         - AWS region (default: eu-west-1)
+#   MINICLOUD_DOCKER        - Docker image (default: ghcr.io/scylladb/minicloud:master-4bd3fb6)
+#   MINICLOUD_PORT          - API port (default: 5000)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MINICLOUD_PORT="${MINICLOUD_PORT:-5000}"
+
+if [[ ! -e /dev/kvm ]]; then
+    echo "ERROR: /dev/kvm not available on host. KVM is required for minicloud."
+    exit 1
+fi
+
+export SCT_SCYLLA_VERSION="${SCT_SCYLLA_VERSION:-2025.3.0}"
+export SCT_USE_MGMT=false
+export SCT_ENABLE_ARGUS=false
+export SCT_ENTERPRISE_DISABLE_KMS=true
+export SCT_ENABLE_KMS_KEY_ROTATION=false
+export SCT_MINICLOUD_ENDPOINT_URL="http://localhost:${MINICLOUD_PORT}"
+export SCT_REGION_NAME="${SCT_REGION_NAME:-eu-west-1}"
+export SCT_INSTANCE_TYPE_DB="${SCT_INSTANCE_TYPE_DB:-i4i.large}"
+export SCT_N_DB_NODES="${SCT_N_DB_NODES:-1}"
+export SCT_N_LOADERS=0
+export SCT_N_MONITOR_NODES=0
+export SCT_APPEND_SCYLLA_ARGS="${SCT_APPEND_SCYLLA_ARGS:---memory 256M}"
+
+# Start minicloud container if not already running
+if ! curl -sf "http://localhost:${MINICLOUD_PORT}" -d "Action=DescribeVpcs&Version=2016-11-15" >/dev/null 2>&1; then
+    echo "Minicloud not running — starting via scripts/start-minicloud.sh..."
+    bash "${SCRIPT_DIR}/start-minicloud.sh"
+fi
+
+echo ""
+echo "======================================="
+echo "  Minicloud Artifact Test (via Hydra)"
+echo "  Version  : ${SCT_SCYLLA_VERSION}"
+echo "  Instance : ${SCT_INSTANCE_TYPE_DB}"
+echo "  Region   : ${SCT_REGION_NAME}"
+echo "  Endpoint : ${SCT_MINICLOUD_ENDPOINT_URL}"
+echo "======================================="
+echo ""
+
+./docker/env/hydra.sh run-test artifacts_test.ArtifactsTest.test_scylla_service \
+    --backend aws \
+    --config test-cases/artifacts/ami.yaml

--- a/scripts/run-minicloud-artifact-test.sh
+++ b/scripts/run-minicloud-artifact-test.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+set -euo pipefail
+
+# Run the SCT artifact test (artifacts_test.ArtifactsTest.test_scylla_service) via minicloud.
+#
+# Minicloud runs as a Docker container (ghcr.io/scylladb/minicloud:master-4bd3fb6).
+# The MinicloudManager in tester.py auto-starts it when SCT_MINICLOUD_ENDPOINT_URL is set,
+# but this script can also pre-start it via scripts/start-minicloud.sh for explicit control.
+#
+# What it tests:
+#   - ENA support (AWS)
+#   - Scylla service starts, responds to CQL, nodetool status
+#   - stop/start and restart cycles
+#   - snitch, node health, node_exporter liveness
+#   - housekeeping DB version reporting
+#   - perftune output (if use_preinstalled_scylla=true)
+#   - time sync service presence
+#
+# Required env vars:
+#   SCT_SCYLLA_VERSION      - e.g. 2025.3.0  (OR SCT_AMI_ID_DB_SCYLLA for specific AMI)
+#
+# Optional env vars:
+#   SCT_AMI_ID_DB_SCYLLA    - specific AMI to test (e.g. ami-0abc1234)
+#   SCT_REGION_NAME         - AWS region (default: eu-west-1)
+#   SCT_N_DB_NODES          - override DB node count (default: 1)
+#   MINICLOUD_DOCKER        - Docker image (default: ghcr.io/scylladb/minicloud:master-4bd3fb6)
+#   MINICLOUD_PORT          - API port (default: 5000)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MINICLOUD_PORT="${MINICLOUD_PORT:-5000}"
+
+export SCT_USE_MGMT=false
+export SCT_ENABLE_ARGUS=false
+export SCT_N_DB_NODES="${SCT_N_DB_NODES:-1}"
+export SCT_N_LOADERS=0
+export SCT_N_MONITOR_NODES=0
+
+# Small Scylla memory footprint — minicloud VMs are constrained
+export SCT_APPEND_SCYLLA_ARGS="${SCT_APPEND_SCYLLA_ARGS:---memory 256M}"
+
+# KMS disabled — minicloud has no KMS endpoint
+export SCT_ENTERPRISE_DISABLE_KMS=true
+export SCT_ENABLE_KMS_KEY_ROTATION=false
+
+export SCT_MINICLOUD_ENDPOINT_URL="${SCT_MINICLOUD_ENDPOINT_URL:-http://localhost:${MINICLOUD_PORT}}"
+export SCT_REGION_NAME="${SCT_REGION_NAME:-eu-west-1}"
+export SCT_INSTANCE_TYPE_DB="${SCT_INSTANCE_TYPE_DB:-i4i.large}"
+
+# Scylla version or AMI ID — one must be set
+if [[ -z "${SCT_AMI_ID_DB_SCYLLA:-}" && -z "${SCT_SCYLLA_VERSION:-}" ]]; then
+    echo "ERROR: set SCT_SCYLLA_VERSION=x.y.z  or  SCT_AMI_ID_DB_SCYLLA=ami-xxxx"
+    exit 1
+fi
+
+# Start minicloud container if not already running
+if ! curl -sf "http://localhost:${MINICLOUD_PORT}" -d "Action=DescribeVpcs&Version=2016-11-15" >/dev/null 2>&1; then
+    echo "Minicloud not running — starting via scripts/start-minicloud.sh..."
+    bash "${SCRIPT_DIR}/start-minicloud.sh"
+fi
+
+echo ""
+echo "======================================="
+echo "  Minicloud Artifact Test"
+echo "  Version  : ${SCT_SCYLLA_VERSION:-from AMI ${SCT_AMI_ID_DB_SCYLLA:-}}"
+echo "  Instance : ${SCT_INSTANCE_TYPE_DB}"
+echo "  Region   : ${SCT_REGION_NAME}"
+echo "  Endpoint : ${SCT_MINICLOUD_ENDPOINT_URL}"
+echo "======================================="
+echo ""
+
+uv run sct.py run-test artifacts_test.ArtifactsTest.test_scylla_service \
+    --backend aws \
+    --config test-cases/artifacts/ami.yaml

--- a/scripts/run-minicloud-clean-resources.sh
+++ b/scripts/run-minicloud-clean-resources.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+set -euo pipefail
+
+# Run the clean-resources stage against minicloud, as the CI pipeline does after a
+# minicloud provision test.
+#
+# SAFETY: clean-resources terminates whatever its filters match. sdcm/utils/common.py
+# decides it is in minicloud mode from MINICLOUD_DOCKER or "localhost" in
+# AWS_ENDPOINT_URL; with neither set, boto3 talks to *real* AWS and the same filters
+# would match real instances. So this script pins the endpoint and refuses to run
+# unless minicloud actually answers on it - never let a missing endpoint fall through
+# to a real account.
+#
+# Usage:
+#   scripts/run-minicloud-clean-resources.sh                    # latest run
+#   TEST_ID=<uuid> scripts/run-minicloud-clean-resources.sh     # a specific run
+#   DRY_RUN=1 scripts/run-minicloud-clean-resources.sh          # show, do not delete
+#   BACKEND=gce scripts/run-minicloud-clean-resources.sh        # GCE provision test
+#   POST_BEHAVIOR=1 scripts/run-minicloud-clean-resources.sh    # honour keep-on-failure
+#
+# Any extra arguments are passed through to sct.py clean-resources.
+
+MINICLOUD_PORT="${MINICLOUD_PORT:-5000}"
+MINICLOUD_ENDPOINT="http://localhost:${MINICLOUD_PORT}"
+
+BACKEND="${BACKEND:-aws}"
+
+# Same variables the provision-test scripts export, so the cleanup talks to exactly
+# the cloud the test provisioned into.
+export AWS_ENDPOINT_URL="${MINICLOUD_ENDPOINT}"
+export SCT_MINICLOUD_ENDPOINT_URL="${MINICLOUD_ENDPOINT}"
+export SCT_REGION_NAME="${SCT_REGION_NAME:-eu-west-1}"
+if [[ "${BACKEND}" == "gce" ]]; then
+    export GCE_ENDPOINT_URL="${MINICLOUD_ENDPOINT}"
+fi
+
+# Fail closed. Same liveness probe as scripts/start-minicloud.sh: DescribeVpcs is
+# implemented locally and never proxied to real AWS.
+if ! curl -sf "${MINICLOUD_ENDPOINT}" -d "Action=DescribeVpcs&Version=2016-11-15" >/dev/null 2>&1; then
+    echo "ERROR: minicloud is not answering at ${MINICLOUD_ENDPOINT}." >&2
+    echo "" >&2
+    echo "Refusing to run clean-resources: without a reachable minicloud, boto3 would" >&2
+    echo "target real AWS and these filters would match real instances." >&2
+    echo "" >&2
+    echo "Start it first:  scripts/start-minicloud.sh" >&2
+    exit 1
+fi
+
+echo "minicloud is reachable at ${MINICLOUD_ENDPOINT} (backend: ${BACKEND})"
+
+CLEAN_ARGS=(--backend "${BACKEND}")
+
+if [[ -n "${TEST_ID:-}" ]]; then
+    CLEAN_ARGS+=(--test-id "${TEST_ID}")
+    echo "Cleaning resources for test-id ${TEST_ID}"
+else
+    # No filter: clean-resources falls back to the most recent run in the logdir.
+    echo "Cleaning resources for the latest run"
+fi
+
+# Deliberately not defaulted: --user matches every run by that user, which is a much
+# broader blast radius than one test-id. Opt in explicitly.
+if [[ -n "${USER_FILTER:-}" ]]; then
+    CLEAN_ARGS+=(--user "${USER_FILTER}")
+fi
+
+if [[ -n "${LOGDIR:-}" ]]; then
+    CLEAN_ARGS+=(--logdir "${LOGDIR}")
+fi
+
+# Off by default: post-behavior honours keep-on-failure, so a failed run would leave
+# its resources behind. When you invoke this script you usually want them gone.
+if [[ -n "${POST_BEHAVIOR:-}" ]]; then
+    CLEAN_ARGS+=(--post-behavior)
+fi
+
+if [[ -n "${DRY_RUN:-}" ]]; then
+    CLEAN_ARGS+=(--dry-run)
+    echo "DRY RUN - nothing will be deleted"
+fi
+
+echo "+ sct.py clean-resources ${CLEAN_ARGS[*]} $*"
+uv run sct.py clean-resources "${CLEAN_ARGS[@]}" "$@"
+
+# clean-resources only removes what the cloud API knows about. minicloud additionally
+# keeps per-VM state on the host, which it will not touch - report it rather than
+# deleting, since the AMI cache next to it is expensive to rebuild.
+STATE_DIR="${MINICLOUD_STATE_DIR:-${HOME}/.cache/minicloud}"
+if [[ -d "${STATE_DIR}/instances" ]]; then
+    leftover=$(find "${STATE_DIR}/instances" -mindepth 1 -maxdepth 1 | wc -l)
+    if [[ "${leftover}" -gt 0 ]]; then
+        echo ""
+        echo "NOTE: ${leftover} VM state dir(s) remain under ${STATE_DIR}/instances"
+        echo "      clean-resources does not remove these. To clear them:"
+        echo "        docker rm -f minicloud && rm -rf ${STATE_DIR}/instances/*"
+        echo "      Keep ${STATE_DIR}/amis - re-downloading images is slow."
+    fi
+fi

--- a/scripts/run-minicloud-gce-artifact-test-hydra.sh
+++ b/scripts/run-minicloud-gce-artifact-test-hydra.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+set -euo pipefail
+
+# Run the GCE artifact test inside hydra (SCT's Docker environment) via minicloud.
+#
+# Minicloud runs as a sibling Docker container (ghcr.io/scylladb/minicloud:master-4bd3fb6)
+# on the host network. Hydra connects to it via localhost:5000.
+#
+# Prerequisites:
+#   - /dev/kvm available on host
+#   - Docker running
+#   - GCP credentials configured (for GCE API passthrough)
+#
+# Optional env vars:
+#   SCT_SCYLLA_VERSION      - e.g. 2025.3.0 (default)
+#   SCT_GCE_IMAGE_DB        - specific GCE image to test
+#   SCT_REGION_NAME         - GCE region (default: us-east1)
+#   MINICLOUD_DOCKER        - Docker image (default: ghcr.io/scylladb/minicloud:master-4bd3fb6)
+#   MINICLOUD_PORT          - API port (default: 5000)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MINICLOUD_PORT="${MINICLOUD_PORT:-5000}"
+
+if [[ ! -e /dev/kvm ]]; then
+    echo "ERROR: /dev/kvm not available on host. KVM is required for minicloud."
+    exit 1
+fi
+
+export SCT_SCYLLA_VERSION="${SCT_SCYLLA_VERSION:-2025.3.0}"
+export SCT_USE_MGMT=false
+export SCT_ENABLE_ARGUS=false
+export SCT_ENTERPRISE_DISABLE_KMS=true
+export SCT_ENABLE_KMS_KEY_ROTATION=false
+
+# On-demand only — minicloud does not implement preemptible/spot instances.
+# test-cases/artifacts/gce-image.yaml requests spot, and MinicloudManager's
+# SCT_INSTANCE_PROVISION override is applied too late to affect config parsing,
+# so it has to be set here, before sct.py builds SCTConfiguration.
+export SCT_INSTANCE_PROVISION=on_demand
+export SCT_MINICLOUD_ENDPOINT_URL="http://localhost:${MINICLOUD_PORT}"
+export SCT_REGION_NAME="${SCT_REGION_NAME:-us-east1}"
+export SCT_N_DB_NODES="${SCT_N_DB_NODES:-1}"
+export SCT_N_LOADERS=0
+export SCT_N_MONITOR_NODES=0
+export SCT_APPEND_SCYLLA_ARGS="${SCT_APPEND_SCYLLA_ARGS:---memory 256M}"
+
+# minicloud needs the GCP service account key mounted at container start — it cannot be
+# added to an already-running container. Without it minicloud's gcp_auth falls back to the
+# GCE metadata service (absent in the container) and every GCP call fails to authenticate.
+export SCT_CLUSTER_BACKEND=gce
+GCS_KEY_FILE="${GCS_KEY_FILE:-${GOOGLE_APPLICATION_CREDENTIALS:-${HOME}/.cache/minicloud/gcp-credentials.json}}"
+export GCS_KEY_FILE
+
+# Start minicloud container if not already running
+if ! curl -sf "http://localhost:${MINICLOUD_PORT}" -d "Action=DescribeVpcs&Version=2016-11-15" >/dev/null 2>&1; then
+    echo "Minicloud not running — starting via scripts/start-minicloud.sh..."
+    bash "${SCRIPT_DIR}/start-minicloud.sh"
+fi
+
+echo ""
+echo "======================================="
+echo "  Minicloud GCE Artifact Test (via Hydra)"
+echo "  Version  : ${SCT_SCYLLA_VERSION}"
+echo "  Region   : ${SCT_REGION_NAME}"
+echo "  Endpoint : ${SCT_MINICLOUD_ENDPOINT_URL}"
+echo "======================================="
+echo ""
+
+./docker/env/hydra.sh run-test artifacts_test.ArtifactsTest.test_scylla_service \
+    --backend gce \
+    --config test-cases/artifacts/gce-image.yaml

--- a/scripts/run-minicloud-gce-artifact-test.sh
+++ b/scripts/run-minicloud-gce-artifact-test.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+set -euo pipefail
+
+# Run the GCE artifact test (artifacts_test.ArtifactsTest.test_scylla_service) via minicloud.
+#
+# Minicloud runs as a Docker container (ghcr.io/scylladb/minicloud:master-4bd3fb6).
+# The MinicloudManager in tester.py auto-starts it when SCT_MINICLOUD_ENDPOINT_URL is set,
+# but this script can also pre-start it via scripts/start-minicloud.sh for explicit control.
+#
+# What it tests:
+#   - Scylla service starts on GCE image, responds to CQL, nodetool status
+#   - stop/start and restart cycles
+#   - snitch, node health, node_exporter liveness
+#   - GCE user verification
+#   - housekeeping DB version reporting
+#   - perftune output (if use_preinstalled_scylla=true)
+#   - time sync service presence
+#
+# Required env vars:
+#   SCT_SCYLLA_VERSION      - e.g. 2025.3.0  (OR SCT_GCE_IMAGE_DB for specific image)
+#
+# Optional env vars:
+#   SCT_GCE_IMAGE_DB        - specific GCE image to test
+#   SCT_REGION_NAME         - GCE region (default: us-east1)
+#   SCT_N_DB_NODES          - override DB node count (default: 1)
+#   MINICLOUD_DOCKER        - Docker image (default: ghcr.io/scylladb/minicloud:master-4bd3fb6)
+#   MINICLOUD_PORT          - API port (default: 5000)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MINICLOUD_PORT="${MINICLOUD_PORT:-5000}"
+
+export SCT_USE_MGMT=false
+export SCT_ENABLE_ARGUS=false
+export SCT_N_DB_NODES="${SCT_N_DB_NODES:-1}"
+export SCT_N_LOADERS=0
+export SCT_N_MONITOR_NODES=0
+
+# Small Scylla memory footprint — minicloud VMs are constrained
+export SCT_APPEND_SCYLLA_ARGS="${SCT_APPEND_SCYLLA_ARGS:---memory 256M}"
+
+# KMS disabled — minicloud has no KMS endpoint
+export SCT_ENTERPRISE_DISABLE_KMS=true
+export SCT_ENABLE_KMS_KEY_ROTATION=false
+
+# On-demand only — minicloud does not implement preemptible/spot instances.
+# test-cases/artifacts/gce-image.yaml requests spot, and MinicloudManager's
+# SCT_INSTANCE_PROVISION override is applied too late to affect config parsing,
+# so it has to be set here, before sct.py builds SCTConfiguration.
+export SCT_INSTANCE_PROVISION=on_demand
+
+export SCT_MINICLOUD_ENDPOINT_URL="${SCT_MINICLOUD_ENDPOINT_URL:-http://localhost:${MINICLOUD_PORT}}"
+export SCT_REGION_NAME="${SCT_REGION_NAME:-us-east1}"
+
+# minicloud needs the GCP service account key mounted at container start — it cannot be
+# added to an already-running container. Without it minicloud's gcp_auth falls back to the
+# GCE metadata service (absent in the container) and every GCP call fails to authenticate.
+export SCT_CLUSTER_BACKEND=gce
+GCS_KEY_FILE="${GCS_KEY_FILE:-${GOOGLE_APPLICATION_CREDENTIALS:-${HOME}/.cache/minicloud/gcp-credentials.json}}"
+export GCS_KEY_FILE
+
+# Scylla version or GCE image — one must be set
+if [[ -z "${SCT_GCE_IMAGE_DB:-}" && -z "${SCT_SCYLLA_VERSION:-}" ]]; then
+    echo "ERROR: set SCT_SCYLLA_VERSION=x.y.z  or  SCT_GCE_IMAGE_DB=<image-name>"
+    exit 1
+fi
+
+# Start minicloud container if not already running
+if ! curl -sf "http://localhost:${MINICLOUD_PORT}" -d "Action=DescribeVpcs&Version=2016-11-15" >/dev/null 2>&1; then
+    echo "Minicloud not running — starting via scripts/start-minicloud.sh..."
+    bash "${SCRIPT_DIR}/start-minicloud.sh"
+fi
+
+echo ""
+echo "======================================="
+echo "  Minicloud GCE Artifact Test"
+echo "  Version  : ${SCT_SCYLLA_VERSION:-from image ${SCT_GCE_IMAGE_DB:-}}"
+echo "  Region   : ${SCT_REGION_NAME}"
+echo "  Endpoint : ${SCT_MINICLOUD_ENDPOINT_URL}"
+echo "======================================="
+echo ""
+
+uv run sct.py run-test artifacts_test.ArtifactsTest.test_scylla_service \
+    --backend gce \
+    --config test-cases/artifacts/gce-image.yaml

--- a/scripts/run-minicloud-gce-provision-test.sh
+++ b/scripts/run-minicloud-gce-provision-test.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -euo pipefail
+
+# MinicloudManager in tester.py handles all lifecycle management:
+# - Preflight checks (/dev/kvm, docker available, AWS creds)
+# - Container start (minicloud-setup.sh runs inside the container)
+# - Health checks and wait loops
+# - Region preparation
+# - Cleanup on exit
+#
+# This script only sets test-specific environment variable overrides.
+
+export MINICLOUD_DOCKER="${MINICLOUD_DOCKER:-ghcr.io/scylladb/minicloud:master-4bd3fb6}"
+export MINICLOUD_GCS_BUCKET="${MINICLOUD_GCS_BUCKET:-}"
+export SCT_CLUSTER_BACKEND=gce
+export SCT_REGION_NAME="${SCT_REGION_NAME:-us-east1}"
+export SCT_SCYLLA_VERSION="${SCT_SCYLLA_VERSION:-2026.1}"
+export SCT_USE_MGMT=false
+export SCT_ENABLE_ARGUS=false
+export SCT_N_DB_NODES="${SCT_N_DB_NODES:-1}"
+export SCT_N_LOADERS="${SCT_N_LOADERS:-1}"
+export SCT_N_MONITOR_NODES="${SCT_N_MONITOR_NODES:-1}"
+export SCT_APPEND_SCYLLA_ARGS="${SCT_APPEND_SCYLLA_ARGS:---memory 256M}"
+
+uv run sct.py run-test longevity_test.LongevityTest.test_custom_time \
+    --backend gce \
+    --config test-cases/minicloud-provision-test.yaml

--- a/scripts/run-minicloud-prepare-region.sh
+++ b/scripts/run-minicloud-prepare-region.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+set -euo pipefail
+
+# Run AwsRegion.configure() against minicloud to set up VPC, subnets, security
+# groups, route tables, and key pairs in minicloud's mock EC2.
+#
+# This MUST run before the provision test so that instances launch into
+# minicloud-managed networking instead of referencing real AWS subnets.
+#
+# Usage:
+#   ./scripts/run-minicloud-prepare-region.sh
+#
+# Expects minicloud to already be running (or set MINICLOUD_START=1 to auto-start via Docker).
+
+MINICLOUD_DOCKER="${MINICLOUD_DOCKER:-ghcr.io/scylladb/minicloud:master-4bd3fb6}"
+MINICLOUD_PORT="${MINICLOUD_PORT:-5000}"
+
+S3_PASSTHROUGH_BUCKETS="${S3_PASSTHROUGH_BUCKETS:-scylla-qa-keystore}"
+AWS_REGION="${SCT_REGION_NAME:-eu-west-1}"
+export AWS_REGION
+
+MINICLOUD_START="${MINICLOUD_START:-1}"
+
+cleanup() {
+    if [[ "$MINICLOUD_START" == "1" ]]; then
+        echo ">>> Stopping minicloud container"
+        docker stop minicloud 2>/dev/null || true
+        docker rm minicloud 2>/dev/null || true
+    fi
+}
+
+if [[ "$MINICLOUD_START" == "1" ]]; then
+    trap cleanup EXIT
+
+    if [[ ! -e /dev/kvm ]]; then
+        echo "ERROR: /dev/kvm not available."
+        exit 1
+    fi
+    if ! aws sts get-caller-identity &>/dev/null; then
+        echo "ERROR: AWS credentials not configured."
+        exit 1
+    fi
+
+    echo ">>> Starting minicloud container..."
+    export MINICLOUD_DOCKER
+    export MINICLOUD_PORT
+    export MINICLOUD_AWS_REGION="$AWS_REGION"
+    export S3_PASSTHROUGH_BUCKETS
+    bash scripts/start-minicloud.sh
+fi
+
+export AWS_ENDPOINT_URL="http://localhost:$MINICLOUD_PORT"
+
+echo ">>> Running AwsRegion.configure() for region '$AWS_REGION' via minicloud..."
+echo "    AWS_ENDPOINT_URL=$AWS_ENDPOINT_URL"
+echo ""
+
+uv run sct.py prepare-regions --cloud-provider aws --regions "$AWS_REGION"
+
+echo ">>> Region '$AWS_REGION' configured in minicloud successfully!"

--- a/scripts/run-minicloud-provision-resources.sh
+++ b/scripts/run-minicloud-provision-resources.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+set -euo pipefail
+
+# Test the provision-resources step locally with minicloud (AWS backend).
+#
+# This exercises the same flow as CI Stage 6 ("Provision Resources"):
+#   hydra --execute-on-runner <IP> provision-resources -b aws -t <test_name>
+#
+# Expected behavior:
+#   1. MinicloudManager detects MINICLOUD_DOCKER and starts the container
+#   2. AWS_ENDPOINT_URL is set to http://localhost:5000
+#   3. SCTProvisionLayout creates instances via minicloud API
+#   4. Instances reach "running" state (QEMU VMs boot)
+#   5. minicloud container stays alive (keep_alive) for the subsequent run-test stage
+#
+# After this succeeds, run the full test with:
+#   scripts/run-minicloud-provision-test.sh
+
+cleanup() {
+    echo "Stopping minicloud container..."
+    docker rm -f minicloud 2>/dev/null || true
+}
+trap cleanup EXIT
+
+export MINICLOUD_DOCKER="${MINICLOUD_DOCKER:-ghcr.io/scylladb/minicloud:master-4bd3fb6}"
+export SCT_MINICLOUD_ENDPOINT_URL="http://localhost:5000"
+export SCT_CLUSTER_BACKEND=aws
+export SCT_REGION_NAME="${SCT_REGION_NAME:-eu-west-1}"
+export MINICLOUD_AWS_REGION="${SCT_REGION_NAME}"
+export SCT_SCYLLA_VERSION="${SCT_SCYLLA_VERSION:-2025.3.0}"
+export SCT_USE_MGMT=false
+export SCT_N_DB_NODES="${SCT_N_DB_NODES:-1}"
+export SCT_N_LOADERS="${SCT_N_LOADERS:-1}"
+export SCT_N_MONITOR_NODES="${SCT_N_MONITOR_NODES:-1}"
+export SCT_INSTANCE_PROVISION=on_demand
+export SCT_APPEND_SCYLLA_ARGS="${SCT_APPEND_SCYLLA_ARGS:---memory 256M}"
+
+export SCT_ENTERPRISE_DISABLE_KMS=true
+export SCT_ENABLE_KMS_KEY_ROTATION=false
+
+export SCT_TEST_ID="${SCT_TEST_ID:-$(python3 -c 'import uuid; print(uuid.uuid4())')}"
+echo "Using test_id: ${SCT_TEST_ID}"
+
+docker rm -f minicloud 2>/dev/null || true
+
+uv run sct.py start-minicloud \
+    -b aws \
+    --config test-cases/minicloud-provision-test.yaml
+
+uv run sct.py provision-resources \
+    -b aws \
+    -t longevity_test.LongevityTest.test_custom_time \
+    --config test-cases/minicloud-provision-test.yaml

--- a/scripts/run-minicloud-provision-test.sh
+++ b/scripts/run-minicloud-provision-test.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -euo pipefail
+
+# MinicloudManager in tester.py handles all lifecycle management:
+# - Preflight checks (/dev/kvm, AWS creds, binary availability)
+# - minicloud-setup.sh execution
+# - minicloud process start and monitoring
+# - Health checks and wait loops
+# - Region preparation
+# - Cleanup on exit
+#
+# This script only sets test-specific environment variable overrides.
+
+export MINICLOUD_BINARY="${MINICLOUD_BINARY:-/usr/local/bin/minicloud}"
+export MINICLOUD_SETUP_SCRIPT="${MINICLOUD_SETUP_SCRIPT:-}"
+export SCT_MINICLOUD_ENDPOINT_URL="http://localhost:5000"
+export SCT_REGION_NAME="${SCT_REGION_NAME:-eu-west-1}"
+export SCT_SCYLLA_VERSION="${SCT_SCYLLA_VERSION:-2025.3.0}"
+export SCT_USE_MGMT=false
+export SCT_N_DB_NODES="${SCT_N_DB_NODES:-1}"
+export SCT_N_LOADERS="${SCT_N_LOADERS:-1}"
+export SCT_N_MONITOR_NODES="${SCT_N_MONITOR_NODES:-1}"
+export SCT_APPEND_SCYLLA_ARGS="${SCT_APPEND_SCYLLA_ARGS:---memory 256M}"
+
+uv run sct.py run-test longevity_test.LongevityTest.test_custom_time \
+    --backend aws \
+    --config test-cases/minicloud-provision-test.yaml

--- a/scripts/start-minicloud.sh
+++ b/scripts/start-minicloud.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+# Start minicloud as a Docker container with all required configuration.
+# Uses the same env vars as MinicloudConfig.from_env() in sdcm/utils/minicloud.py.
+#
+# The container image includes minicloud-setup.sh which is run automatically by
+# the entrypoint to configure networking (TUN/bridges) before starting minicloud.
+#
+# Required:
+#   - Docker with --device /dev/kvm support (KVM-capable host)
+#   - AWS credentials: either ~/.aws/ mount or AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY env vars
+#
+# Environment variables (all optional, defaults match MinicloudConfig):
+#   MINICLOUD_DOCKER          - Docker image (default: ghcr.io/scylladb/minicloud:master-4bd3fb6)
+#   MINICLOUD_PORT            - API port (default: 5000)
+#   MINICLOUD_AWS_REGION      - AWS region to emulate (default: eu-west-1)
+#   S3_PASSTHROUGH_BUCKETS    - Comma-separated S3 buckets to forward to real AWS
+#                               (default: scylla-qa-keystore,cloudius-jenkins-test,downloads.scylladb.com)
+#   MINICLOUD_GCS_BUCKET      - GCS bucket for image staging
+#                               (default: <MINICLOUD_GCP_PROJECT>-minicloud-staging when
+#                               GCS_KEY_FILE is set; required for GCP image downloads)
+#   MINICLOUD_GCP_PROJECT     - GCP project (default: $SCT_GCE_PROJECT or sct-project-1)
+#   MINICLOUD_LIGHTWEIGHT     - Run in lightweight mode (default: true)
+#   MINICLOUD_LIGHTWEIGHT_MEMORY - Memory per VM in lightweight mode (default: 4GiB)
+#   GCS_KEY_FILE              - Path to GCS service account JSON key (optional)
+#   MINICLOUD_CONTAINER_NAME  - Container name (default: minicloud)
+
+set -euo pipefail
+
+MINICLOUD_DOCKER="${MINICLOUD_DOCKER:-ghcr.io/scylladb/minicloud:master-4bd3fb6}"
+MINICLOUD_PORT="${MINICLOUD_PORT:-5000}"
+# eu-west-1, not us-east-1: minicloud validates an uncached AMI against this region
+# rather than the region the RunInstances request targets (QATOOLS-346), and Scylla dev
+# AMIs are published in eu-west-1. Any other default fails every cache-miss launch with
+# InvalidAMIID.NotFound. Revisit once minicloud honours the per-request region.
+MINICLOUD_AWS_REGION="${MINICLOUD_AWS_REGION:-eu-west-1}"
+S3_PASSTHROUGH_BUCKETS="${S3_PASSTHROUGH_BUCKETS:-scylla-qa-keystore,cloudius-jenkins-test,downloads.scylladb.com}"
+MINICLOUD_GCS_BUCKET="${MINICLOUD_GCS_BUCKET:-}"
+MINICLOUD_GCP_PROJECT="${MINICLOUD_GCP_PROJECT:-${SCT_GCE_PROJECT:-sct-project-1}}"
+MINICLOUD_LIGHTWEIGHT="${MINICLOUD_LIGHTWEIGHT:-true}"
+# Keep in sync with MINICLOUD_LIGHTWEIGHT_MEMORY_DEFAULT in sdcm/utils/minicloud.py and the
+# minicloud_lightweight_memory default. Scylla refuses to start below ~3 GiB per VM with
+# "memory per shard too low", which kills the image's first-boot scylla-server.
+MINICLOUD_LIGHTWEIGHT_MEMORY="${MINICLOUD_LIGHTWEIGHT_MEMORY:-4GiB}"
+GCS_KEY_FILE="${GCS_KEY_FILE:-}"
+MINICLOUD_CONTAINER_NAME="${MINICLOUD_CONTAINER_NAME:-minicloud}"
+MINICLOUD_CACHE_DIR="${MINICLOUD_CACHE_DIR:-${HOME}/.cache/minicloud}"
+
+# Ensure KVM kernel module is loaded (required for nested virtualization on c8i/m8i/r8i instances)
+if [ ! -e /dev/kvm ]; then
+    echo "Loading KVM kernel module..."
+    sudo modprobe kvm_intel 2>/dev/null || sudo modprobe kvm_amd 2>/dev/null || true
+    if [ ! -e /dev/kvm ]; then
+        echo "ERROR: /dev/kvm not available after modprobe. Instance may not support nested virtualization." >&2
+        echo "Supported instance families: c8i, m8i, r8i (with NestedVirtualization=enabled at launch)" >&2
+        exit 1
+    fi
+fi
+
+# Stop existing container if running
+docker stop "${MINICLOUD_CONTAINER_NAME}" 2>/dev/null && docker rm "${MINICLOUD_CONTAINER_NAME}" 2>/dev/null || true
+
+mkdir -p "${MINICLOUD_CACHE_DIR}"
+
+# Build docker run arguments
+DOCKER_ARGS=(
+    run -d
+    --name "${MINICLOUD_CONTAINER_NAME}"
+    --device /dev/kvm
+    --device /dev/net/tun
+    --network host
+    --cap-add NET_ADMIN
+    -v "${MINICLOUD_CACHE_DIR}:/root/.cache/minicloud"
+)
+
+# AWS credentials: prefer env vars, fall back to ~/.aws mount
+if [[ -n "${AWS_ACCESS_KEY_ID:-}" && -n "${AWS_SECRET_ACCESS_KEY:-}" ]]; then
+    DOCKER_ARGS+=(-e "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}")
+    DOCKER_ARGS+=(-e "AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}")
+    if [[ -n "${AWS_SESSION_TOKEN:-}" ]]; then
+        DOCKER_ARGS+=(-e "AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN}")
+    fi
+elif [[ -d "${HOME}/.aws" ]]; then
+    DOCKER_ARGS+=(-v "${HOME}/.aws:/root/.aws:ro")
+fi
+
+DOCKER_ARGS+=(-e "AWS_REGION=${MINICLOUD_AWS_REGION}")
+
+# GCS credentials mount
+if [[ -n "${GCS_KEY_FILE}" && -f "${GCS_KEY_FILE}" ]]; then
+    DOCKER_ARGS+=(-v "${GCS_KEY_FILE}:/etc/minicloud/gcs-key.json:ro")
+    DOCKER_ARGS+=(-e "GOOGLE_APPLICATION_CREDENTIALS=/etc/minicloud/gcs-key.json")
+    DOCKER_ARGS+=(-e "GOOGLE_CLOUD_PROJECT=${MINICLOUD_GCP_PROJECT}")
+fi
+
+DOCKER_ARGS+=("${MINICLOUD_DOCKER}")
+
+# Minicloud CLI arguments
+MINICLOUD_ARGS=(
+    --port "${MINICLOUD_PORT}"
+    --aws-region "${MINICLOUD_AWS_REGION}"
+    --s3-passthrough-buckets "${S3_PASSTHROUGH_BUCKETS}"
+)
+
+# --gcs-bucket is mandatory for GCP image downloads; minicloud fails the create-instance
+# call with "500 Internal error: --gcs-bucket is required for GCP image downloads" without
+# it. Pass it (and --gcp-project) whenever GCP credentials are present.
+if [[ -n "${GCS_KEY_FILE}" && -f "${GCS_KEY_FILE}" ]]; then
+    MINICLOUD_ARGS+=(--gcp-project "${MINICLOUD_GCP_PROJECT}")
+    MINICLOUD_ARGS+=(--gcs-bucket "${MINICLOUD_GCS_BUCKET:-${MINICLOUD_GCP_PROJECT}-minicloud-staging}")
+elif [[ -n "${MINICLOUD_GCS_BUCKET}" ]]; then
+    MINICLOUD_ARGS+=(--gcs-bucket "${MINICLOUD_GCS_BUCKET}")
+fi
+
+if [[ "${MINICLOUD_LIGHTWEIGHT}" == "true" ]]; then
+    MINICLOUD_ARGS+=(--lightweight --lightweight-memory "${MINICLOUD_LIGHTWEIGHT_MEMORY}")
+fi
+
+echo "Starting minicloud container (image: ${MINICLOUD_DOCKER}, port: ${MINICLOUD_PORT})..."
+docker "${DOCKER_ARGS[@]}" "${MINICLOUD_ARGS[@]}"
+
+# Wait for health
+echo "Waiting for minicloud to become healthy..."
+for i in $(seq 1 30); do
+    if curl -sf "http://localhost:${MINICLOUD_PORT}" \
+        -d "Action=DescribeVpcs&Version=2016-11-15" >/dev/null 2>&1; then
+        echo "minicloud is healthy on port ${MINICLOUD_PORT}"
+        echo ""
+        echo "Set these environment variables to use minicloud:"
+        echo "  export AWS_ENDPOINT_URL=http://localhost:${MINICLOUD_PORT}"
+        echo "  export SCT_MINICLOUD_ENDPOINT_URL=http://localhost:${MINICLOUD_PORT}"
+        exit 0
+    fi
+    sleep 1
+done
+
+echo "ERROR: minicloud failed to become healthy within 30s" >&2
+echo "Container logs:" >&2
+docker logs "${MINICLOUD_CONTAINER_NAME}" 2>&1 | tail -20 >&2
+exit 1

--- a/scripts/test-minicloud-sct-ci-flow.sh
+++ b/scripts/test-minicloud-sct-ci-flow.sh
@@ -1,0 +1,240 @@
+#!/bin/bash
+# Reproducer #2: Full SCT CI flow simulation against minicloud
+# Starts minicloud, then runs: provision infra → launch instances → discover by tags → cleanup
+#
+# Run: bash scripts/test-minicloud-sct-ci-flow.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+"${SCRIPT_DIR}/start-minicloud.sh"
+
+export AWS_ENDPOINT_URL="http://localhost:${MINICLOUD_PORT:-5000}"
+export AWS_DEFAULT_REGION=us-east-1
+
+TEST_ID="ci-flow-$(date +%s)"
+RUN_BY_USER="repro-test"
+PASS=0
+FAIL=0
+
+check() {
+    local desc="$1" expected="$2" actual="$3"
+    if [ "$actual" = "$expected" ]; then
+        PASS=$((PASS + 1))
+        echo "    ✅ $desc"
+    else
+        FAIL=$((FAIL + 1))
+        echo "    ❌ $desc (expected='$expected', got='$actual')"
+    fi
+}
+
+check_not_empty() {
+    local desc="$1" actual="$2"
+    if [ -n "$actual" ] && [ "$actual" != "null" ] && [ "$actual" != "None" ]; then
+        PASS=$((PASS + 1))
+        echo "    ✅ $desc ($actual)"
+    else
+        FAIL=$((FAIL + 1))
+        echo "    ❌ $desc (got empty/null)"
+    fi
+}
+
+echo "=== SCT CI Flow Simulation ==="
+echo "Endpoint: $AWS_ENDPOINT_URL"
+echo "TestId: $TEST_ID"
+echo ""
+
+echo "[Phase 1] Provision Infrastructure"
+echo ""
+
+echo "  Creating VPC..."
+VPC_ID=$(aws ec2 create-vpc --cidr-block 10.0.0.0/16 \
+    --tag-specifications "ResourceType=vpc,Tags=[{Key=Name,Value=sct-vpc-$TEST_ID},{Key=TestId,Value=$TEST_ID},{Key=RunByUser,Value=$RUN_BY_USER}]" \
+    --query 'Vpc.VpcId' --output text)
+echo "    VPC_ID=$VPC_ID"
+
+echo "  Creating Subnet..."
+SUBNET_ID=$(aws ec2 create-subnet --vpc-id "$VPC_ID" --cidr-block 10.0.1.0/24 \
+    --availability-zone us-east-1a \
+    --tag-specifications "ResourceType=subnet,Tags=[{Key=Name,Value=sct-subnet-us-east-1a-$TEST_ID},{Key=TestId,Value=$TEST_ID},{Key=RunByUser,Value=$RUN_BY_USER}]" \
+    --query 'Subnet.SubnetId' --output text)
+echo "    SUBNET_ID=$SUBNET_ID"
+
+echo "  Creating Security Group..."
+SG_ID=$(aws ec2 create-security-group --group-name "sct-sg-$TEST_ID" --description "SCT SG" \
+    --vpc-id "$VPC_ID" \
+    --tag-specifications "ResourceType=security-group,Tags=[{Key=Name,Value=sct-security-group-$TEST_ID},{Key=TestId,Value=$TEST_ID},{Key=RunByUser,Value=$RUN_BY_USER}]" \
+    --query 'GroupId' --output text)
+echo "    SG_ID=$SG_ID"
+
+echo "  Creating Internet Gateway..."
+IGW_ID=$(aws ec2 create-internet-gateway \
+    --tag-specifications "ResourceType=internet-gateway,Tags=[{Key=Name,Value=sct-igw-$TEST_ID},{Key=TestId,Value=$TEST_ID},{Key=RunByUser,Value=$RUN_BY_USER}]" \
+    --query 'InternetGateway.InternetGatewayId' --output text)
+echo "    IGW_ID=$IGW_ID"
+
+aws ec2 attach-internet-gateway --internet-gateway-id "$IGW_ID" --vpc-id "$VPC_ID" 2>/dev/null || true
+
+echo "  Creating Route Table..."
+RTB_ID=$(aws ec2 create-route-table --vpc-id "$VPC_ID" \
+    --tag-specifications "ResourceType=route-table,Tags=[{Key=Name,Value=sct-rtb-$TEST_ID},{Key=TestId,Value=$TEST_ID},{Key=RunByUser,Value=$RUN_BY_USER}]" \
+    --query 'RouteTable.RouteTableId' --output text)
+echo "    RTB_ID=$RTB_ID"
+
+echo ""
+echo "[Phase 2] Launch Instances (3 DB nodes)"
+echo ""
+
+INSTANCE_IDS=""
+for i in 1 2 3; do
+    INST_ID=$(aws ec2 run-instances \
+        --image-id ami-0ec6833605400f8d5 \
+        --instance-type i4i.large \
+        --network-interfaces "DeviceIndex=0,SubnetId=$SUBNET_ID,Groups=$SG_ID,AssociatePublicIpAddress=true" \
+        --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=sct-db-node-$TEST_ID-$i},{Key=TestId,Value=$TEST_ID},{Key=RunByUser,Value=$RUN_BY_USER},{Key=NodeType,Value=scylla-db}]" \
+        --query 'Instances[0].InstanceId' --output text)
+    echo "    Instance $i: $INST_ID"
+    INSTANCE_IDS="$INSTANCE_IDS $INST_ID"
+done
+
+echo ""
+echo "  Adding post-launch tags via CreateTags..."
+# shellcheck disable=SC2086
+aws ec2 create-tags --resources $INSTANCE_IDS \
+    --tags "Key=keep,Value=0" "Key=keep_action,Value=terminate"
+echo "    Done"
+echo ""
+
+echo "[Phase 3] Discover Resources by Tags"
+echo ""
+
+echo "  3a. Discover VPC by tag:Name..."
+FOUND_VPC=$(aws ec2 describe-vpcs \
+    --filters "Name=tag:Name,Values=sct-vpc-$TEST_ID" \
+    --query 'Vpcs[0].VpcId' --output text 2>/dev/null || echo "None")
+check "VPC found by Name tag" "$VPC_ID" "$FOUND_VPC"
+
+echo "  3b. Discover Subnet by tag:Name..."
+FOUND_SUBNET=$(aws ec2 describe-subnets \
+    --filters "Name=tag:Name,Values=sct-subnet-us-east-1a-$TEST_ID" \
+    --query 'Subnets[0].SubnetId' --output text 2>/dev/null || echo "None")
+check "Subnet found by Name tag" "$SUBNET_ID" "$FOUND_SUBNET"
+
+echo "  3c. Discover Security Group by tag:Name..."
+FOUND_SG=$(aws ec2 describe-security-groups \
+    --filters "Name=tag:Name,Values=sct-security-group-$TEST_ID" \
+    --query 'SecurityGroups[0].GroupId' --output text 2>/dev/null || echo "None")
+check "SG found by Name tag" "$SG_ID" "$FOUND_SG"
+
+echo "  3d. Discover Internet Gateway by tag:Name..."
+FOUND_IGW=$(aws ec2 describe-internet-gateways \
+    --filters "Name=tag:Name,Values=sct-igw-$TEST_ID" \
+    --query 'InternetGateways[0].InternetGatewayId' --output text 2>/dev/null || echo "None")
+check "IGW found by Name tag" "$IGW_ID" "$FOUND_IGW"
+
+echo "  3e. Discover Route Table by tag:Name..."
+FOUND_RTB=$(aws ec2 describe-route-tables \
+    --filters "Name=tag:Name,Values=sct-rtb-$TEST_ID" \
+    --query 'RouteTables[0].RouteTableId' --output text 2>/dev/null || echo "None")
+check "RTB found by Name tag" "$RTB_ID" "$FOUND_RTB"
+
+echo ""
+echo "  3f. Discover Instances by tag:TestId + state=running..."
+FOUND_INSTANCES=$(aws ec2 describe-instances \
+    --filters "Name=tag:TestId,Values=$TEST_ID" "Name=instance-state-name,Values=running" \
+    --query 'Reservations[].Instances[].InstanceId' --output text 2>/dev/null || echo "None")
+FOUND_COUNT=$(echo "$FOUND_INSTANCES" | wc -w)
+check "3 instances found by TestId+running" "3" "$FOUND_COUNT"
+
+echo "  3g. Discover Instances by tag:NodeType=scylla-db..."
+FOUND_DB=$(aws ec2 describe-instances \
+    --filters "Name=tag:NodeType,Values=scylla-db" "Name=tag:TestId,Values=$TEST_ID" \
+    --query 'Reservations[].Instances[].InstanceId' --output text 2>/dev/null || echo "None")
+FOUND_DB_COUNT=$(echo "$FOUND_DB" | wc -w)
+check "3 DB instances found by NodeType tag" "3" "$FOUND_DB_COUNT"
+
+echo "  3h. Verify instance state is 'running'..."
+FIRST_INST=$(echo "$INSTANCE_IDS" | awk '{print $1}')
+STATE=$(aws ec2 describe-instances --instance-ids "$FIRST_INST" \
+    --query 'Reservations[0].Instances[0].State.Name' --output text 2>/dev/null || echo "None")
+check "instance state is running" "running" "$STATE"
+
+echo "  3i. Verify instance private IP assigned..."
+PRIV_IP=$(aws ec2 describe-instances --instance-ids "$FIRST_INST" \
+    --query 'Reservations[0].Instances[0].PrivateIpAddress' --output text 2>/dev/null || echo "None")
+check_not_empty "private IP assigned" "$PRIV_IP"
+
+echo "  3j. Verify instance public IP assigned..."
+PUB_IP=$(aws ec2 describe-instances --instance-ids "$FIRST_INST" \
+    --query 'Reservations[0].Instances[0].PublicIpAddress' --output text 2>/dev/null || echo "None")
+check_not_empty "public IP assigned" "$PUB_IP"
+
+echo "  3k. Verify availability zone matches placement..."
+AZ=$(aws ec2 describe-instances --instance-ids "$FIRST_INST" \
+    --query 'Reservations[0].Instances[0].Placement.AvailabilityZone' --output text 2>/dev/null || echo "None")
+check "AZ is us-east-1a" "us-east-1a" "$AZ"
+
+echo ""
+echo "[Phase 4] Cleanup by Tags"
+echo ""
+
+echo "  4a. Terminate instances found by TestId tag..."
+CLEANUP_INSTANCES=$(aws ec2 describe-instances \
+    --filters "Name=tag:TestId,Values=$TEST_ID" \
+    --query 'Reservations[].Instances[].InstanceId' --output text 2>/dev/null || echo "")
+if [ -n "$CLEANUP_INSTANCES" ]; then
+    # shellcheck disable=SC2086
+    aws ec2 terminate-instances --instance-ids $CLEANUP_INSTANCES >/dev/null 2>&1 || true
+    TERM_COUNT=$(echo "$CLEANUP_INSTANCES" | wc -w)
+    check "terminated instances" "3" "$TERM_COUNT"
+else
+    FAIL=$((FAIL + 1))
+    echo "    ❌ no instances found for cleanup"
+fi
+
+echo "  4b. Verify instances terminated..."
+sleep 1
+REMAINING=$(aws ec2 describe-instances \
+    --filters "Name=tag:TestId,Values=$TEST_ID" "Name=instance-state-name,Values=running" \
+    --query 'Reservations[].Instances[].InstanceId' --output text 2>/dev/null || echo "")
+REMAINING_COUNT=$(echo "$REMAINING" | tr -s ' ' | sed 's/^ *//;s/ *$//' | wc -w)
+if [ "$REMAINING_COUNT" -eq 0 ] || [ -z "$(echo "$REMAINING" | tr -d ' ')" ]; then
+    PASS=$((PASS + 1))
+    echo "    ✅ no running instances remain"
+else
+    FAIL=$((FAIL + 1))
+    echo "    ❌ $REMAINING_COUNT instances still running: $REMAINING"
+fi
+
+echo "  4c. Delete Security Group..."
+aws ec2 delete-security-group --group-id "$SG_ID" 2>/dev/null && \
+    { PASS=$((PASS + 1)); echo "    ✅ SG deleted"; } || \
+    { FAIL=$((FAIL + 1)); echo "    ❌ SG delete failed"; }
+
+echo "  4d. Detach + Delete Internet Gateway..."
+aws ec2 detach-internet-gateway --internet-gateway-id "$IGW_ID" --vpc-id "$VPC_ID" 2>/dev/null || true
+aws ec2 delete-internet-gateway --internet-gateway-id "$IGW_ID" 2>/dev/null && \
+    { PASS=$((PASS + 1)); echo "    ✅ IGW deleted"; } || \
+    { FAIL=$((FAIL + 1)); echo "    ❌ IGW delete failed"; }
+
+echo "  4e. Delete Route Table..."
+aws ec2 delete-route-table --route-table-id "$RTB_ID" 2>/dev/null && \
+    { PASS=$((PASS + 1)); echo "    ✅ RTB deleted"; } || \
+    { FAIL=$((FAIL + 1)); echo "    ❌ RTB delete failed"; }
+
+echo "  4f. Delete Subnet..."
+aws ec2 delete-subnet --subnet-id "$SUBNET_ID" 2>/dev/null && \
+    { PASS=$((PASS + 1)); echo "    ✅ Subnet deleted"; } || \
+    { FAIL=$((FAIL + 1)); echo "    ❌ Subnet delete failed"; }
+
+echo "  4g. Delete VPC..."
+aws ec2 delete-vpc --vpc-id "$VPC_ID" 2>/dev/null && \
+    { PASS=$((PASS + 1)); echo "    ✅ VPC deleted"; } || \
+    { FAIL=$((FAIL + 1)); echo "    ❌ VPC delete failed"; }
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+if [ $FAIL -gt 0 ]; then
+    exit 1
+fi

--- a/scripts/test-minicloud-tags-direct.sh
+++ b/scripts/test-minicloud-tags-direct.sh
@@ -1,0 +1,198 @@
+#!/bin/bash
+# Reproducer #1: Direct tag API validation against minicloud
+# Starts minicloud, then tests each Describe* handler for tag filter support.
+#
+# Run: bash scripts/test-minicloud-tags-direct.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+"${SCRIPT_DIR}/start-minicloud.sh"
+
+export AWS_ENDPOINT_URL="http://localhost:${MINICLOUD_PORT:-5000}"
+export AWS_DEFAULT_REGION=us-east-1
+
+PASS=0
+FAIL=0
+ERRORS=""
+
+check() {
+    local desc="$1" expected="$2" actual="$3"
+    if [ "$actual" = "$expected" ]; then
+        PASS=$((PASS + 1))
+        echo "  ✅ $desc"
+    else
+        FAIL=$((FAIL + 1))
+        ERRORS="${ERRORS}\n  ❌ $desc (expected='$expected', got='$actual')"
+        echo "  ❌ $desc (expected='$expected', got='$actual')"
+    fi
+}
+
+check_not_empty() {
+    local desc="$1" actual="$2"
+    if [ -n "$actual" ] && [ "$actual" != "null" ] && [ "$actual" != "None" ] && [ "$actual" != "[]" ]; then
+        PASS=$((PASS + 1))
+        echo "  ✅ $desc"
+    else
+        FAIL=$((FAIL + 1))
+        ERRORS="${ERRORS}\n  ❌ $desc (got empty/null: '$actual')"
+        echo "  ❌ $desc (got empty/null: '$actual')"
+    fi
+}
+
+echo "=== Minicloud Tag Direct API Test ==="
+echo "Endpoint: $AWS_ENDPOINT_URL"
+echo ""
+
+echo "[Setup] Creating test infrastructure..."
+
+VPC_ID=$(aws ec2 create-vpc --cidr-block 10.0.0.0/16 \
+    --tag-specifications 'ResourceType=vpc,Tags=[{Key=Name,Value=sct-vpc},{Key=TestId,Value=tag-test-001},{Key=RunByUser,Value=repro}]' \
+    --query 'Vpc.VpcId' --output text 2>&1)
+echo "  VPC: $VPC_ID"
+
+SUBNET_ID=$(aws ec2 create-subnet --vpc-id "$VPC_ID" --cidr-block 10.0.1.0/24 \
+    --availability-zone us-east-1a \
+    --tag-specifications 'ResourceType=subnet,Tags=[{Key=Name,Value=sct-subnet-us-east-1a},{Key=TestId,Value=tag-test-001}]' \
+    --query 'Subnet.SubnetId' --output text 2>&1)
+echo "  Subnet: $SUBNET_ID"
+
+SG_ID=$(aws ec2 create-security-group --group-name sct-sg --description "SCT Security Group" \
+    --vpc-id "$VPC_ID" \
+    --tag-specifications 'ResourceType=security-group,Tags=[{Key=Name,Value=sct-sg},{Key=TestId,Value=tag-test-001}]' \
+    --query 'GroupId' --output text 2>&1)
+echo "  SG: $SG_ID"
+
+IGW_ID=$(aws ec2 create-internet-gateway \
+    --tag-specifications 'ResourceType=internet-gateway,Tags=[{Key=Name,Value=sct-igw},{Key=TestId,Value=tag-test-001}]' \
+    --query 'InternetGateway.InternetGatewayId' --output text 2>&1)
+echo "  IGW: $IGW_ID"
+
+RTB_ID=$(aws ec2 create-route-table --vpc-id "$VPC_ID" \
+    --tag-specifications 'ResourceType=route-table,Tags=[{Key=Name,Value=sct-rtb},{Key=TestId,Value=tag-test-001}]' \
+    --query 'RouteTable.RouteTableId' --output text 2>&1)
+echo "  RTB: $RTB_ID"
+
+echo ""
+echo "[Setup] Adding post-creation tags via CreateTags..."
+aws ec2 create-tags --resources "$VPC_ID" "$SUBNET_ID" "$SG_ID" "$IGW_ID" "$RTB_ID" \
+    --tags Key=CreatedVia,Value=CreateTags Key=NodeType,Value=scylla-db 2>&1
+echo "  Done"
+echo ""
+
+echo "[Test Group 1] Tags present in Describe* responses"
+echo ""
+
+echo "  DescribeVpcs:"
+VPC_TAGS=$(aws ec2 describe-vpcs --vpc-ids "$VPC_ID" --query 'Vpcs[0].Tags' --output json 2>/dev/null || echo "null")
+check_not_empty "tags returned" "$VPC_TAGS"
+EXTRA=$(echo "$VPC_TAGS" | python3 -c "import sys,json; tags={t['Key']:t['Value'] for t in json.load(sys.stdin) or []}; print(tags.get('CreatedVia',''))" 2>/dev/null || echo "")
+check "CreateTags tag visible" "CreateTags" "$EXTRA"
+
+echo "  DescribeSubnets:"
+SUBNET_TAGS=$(aws ec2 describe-subnets --subnet-ids "$SUBNET_ID" --query 'Subnets[0].Tags' --output json 2>/dev/null || echo "null")
+check_not_empty "tags returned" "$SUBNET_TAGS"
+EXTRA=$(echo "$SUBNET_TAGS" | python3 -c "import sys,json; tags={t['Key']:t['Value'] for t in json.load(sys.stdin) or []}; print(tags.get('CreatedVia',''))" 2>/dev/null || echo "")
+check "CreateTags tag visible" "CreateTags" "$EXTRA"
+
+echo "  DescribeSecurityGroups:"
+SG_TAGS=$(aws ec2 describe-security-groups --group-ids "$SG_ID" --query 'SecurityGroups[0].Tags' --output json 2>/dev/null || echo "null")
+check_not_empty "tags returned" "$SG_TAGS"
+EXTRA=$(echo "$SG_TAGS" | python3 -c "import sys,json; tags={t['Key']:t['Value'] for t in json.load(sys.stdin) or []}; print(tags.get('CreatedVia',''))" 2>/dev/null || echo "")
+check "CreateTags tag visible" "CreateTags" "$EXTRA"
+
+echo "  DescribeInternetGateways:"
+IGW_RESP=$(aws ec2 describe-internet-gateways --output json 2>/dev/null || echo "{}")
+IGW_TAGS=$(echo "$IGW_RESP" | python3 -c "
+import sys,json
+data=json.load(sys.stdin)
+for igw in data.get('InternetGateways',[]):
+    if igw['InternetGatewayId']=='$IGW_ID':
+        print(json.dumps(igw.get('Tags',[])))
+        break
+else:
+    print('null')
+" 2>/dev/null || echo "null")
+check_not_empty "tags returned" "$IGW_TAGS"
+EXTRA=$(echo "$IGW_TAGS" | python3 -c "import sys,json; tags={t['Key']:t['Value'] for t in json.load(sys.stdin) or []}; print(tags.get('CreatedVia',''))" 2>/dev/null || echo "")
+check "CreateTags tag visible" "CreateTags" "$EXTRA"
+
+echo "  DescribeRouteTables:"
+RTB_TAGS=$(aws ec2 describe-route-tables --route-table-ids "$RTB_ID" --query 'RouteTables[0].Tags' --output json 2>/dev/null || echo "null")
+check_not_empty "tags returned" "$RTB_TAGS"
+EXTRA=$(echo "$RTB_TAGS" | python3 -c "import sys,json; tags={t['Key']:t['Value'] for t in json.load(sys.stdin) or []}; print(tags.get('CreatedVia',''))" 2>/dev/null || echo "")
+check "CreateTags tag visible" "CreateTags" "$EXTRA"
+
+echo ""
+echo "[Test Group 2] Tag filter support (tag:Name=value)"
+echo ""
+
+echo "  DescribeVpcs filter tag:Name=sct-vpc:"
+RESULT=$(aws ec2 describe-vpcs --filters "Name=tag:Name,Values=sct-vpc" --query 'Vpcs[0].VpcId' --output text 2>/dev/null || echo "None")
+check "found by tag" "$VPC_ID" "$RESULT"
+
+echo "  DescribeVpcs filter tag:TestId=tag-test-001:"
+RESULT=$(aws ec2 describe-vpcs --filters "Name=tag:TestId,Values=tag-test-001" --query 'Vpcs[0].VpcId' --output text 2>/dev/null || echo "None")
+check "found by TestId tag" "$VPC_ID" "$RESULT"
+
+echo "  DescribeSubnets filter tag:Name=sct-subnet-us-east-1a:"
+RESULT=$(aws ec2 describe-subnets --filters "Name=tag:Name,Values=sct-subnet-us-east-1a" --query 'Subnets[0].SubnetId' --output text 2>/dev/null || echo "None")
+check "found by tag" "$SUBNET_ID" "$RESULT"
+
+echo "  DescribeSecurityGroups filter tag:Name=sct-sg:"
+RESULT=$(aws ec2 describe-security-groups --filters "Name=tag:Name,Values=sct-sg" --query 'SecurityGroups[0].GroupId' --output text 2>/dev/null || echo "None")
+check "found by tag" "$SG_ID" "$RESULT"
+
+echo "  DescribeSecurityGroups filter tag:TestId=tag-test-001:"
+RESULT=$(aws ec2 describe-security-groups --filters "Name=tag:TestId,Values=tag-test-001" --query 'SecurityGroups[0].GroupId' --output text 2>/dev/null || echo "None")
+check "found by TestId tag" "$SG_ID" "$RESULT"
+
+echo "  DescribeInternetGateways filter tag:Name=sct-igw:"
+RESULT=$(aws ec2 describe-internet-gateways --filters "Name=tag:Name,Values=sct-igw" --query 'InternetGateways[0].InternetGatewayId' --output text 2>/dev/null || echo "None")
+check "found by tag" "$IGW_ID" "$RESULT"
+
+echo "  DescribeRouteTables filter tag:Name=sct-rtb:"
+RESULT=$(aws ec2 describe-route-tables --filters "Name=tag:Name,Values=sct-rtb" --query 'RouteTables[0].RouteTableId' --output text 2>/dev/null || echo "None")
+check "found by tag" "$RTB_ID" "$RESULT"
+
+echo ""
+echo "[Test Group 3] Multi-tag AND filter"
+echo ""
+
+echo "  DescribeVpcs filter tag:Name=sct-vpc AND tag:TestId=tag-test-001:"
+RESULT=$(aws ec2 describe-vpcs --filters "Name=tag:Name,Values=sct-vpc" "Name=tag:TestId,Values=tag-test-001" --query 'Vpcs[0].VpcId' --output text 2>/dev/null || echo "None")
+check "found by two tags" "$VPC_ID" "$RESULT"
+
+echo "  DescribeVpcs filter tag:Name=sct-vpc AND tag:TestId=WRONG:"
+RESULT=$(aws ec2 describe-vpcs --filters "Name=tag:Name,Values=sct-vpc" "Name=tag:TestId,Values=WRONG" --query 'Vpcs' --output text 2>/dev/null || echo "None")
+if [ "$RESULT" = "None" ] || [ -z "$RESULT" ]; then
+    PASS=$((PASS + 1))
+    echo "  ✅ correctly returns empty for non-matching AND"
+else
+    FAIL=$((FAIL + 1))
+    echo "  ❌ should be empty but got: $RESULT"
+fi
+
+echo ""
+echo "[Test Group 4] Non-existent tag filter returns empty"
+echo ""
+
+echo "  DescribeSubnets filter tag:Name=NONEXISTENT:"
+RESULT=$(aws ec2 describe-subnets --filters "Name=tag:Name,Values=NONEXISTENT" --query 'Subnets' --output text 2>/dev/null || echo "None")
+if [ "$RESULT" = "None" ] || [ -z "$RESULT" ]; then
+    PASS=$((PASS + 1))
+    echo "  ✅ correctly returns empty"
+else
+    FAIL=$((FAIL + 1))
+    echo "  ❌ should be empty but got: $RESULT"
+fi
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+if [ $FAIL -gt 0 ]; then
+    echo ""
+    echo "Failures:"
+    echo -e "$ERRORS"
+    exit 1
+fi

--- a/sct.py
+++ b/sct.py
@@ -134,6 +134,13 @@ from sdcm.utils.resources_cleanup import (
 from sdcm.utils.net import get_sct_runner_ip
 from sdcm.utils.jepsen import JepsenResults
 from sdcm.utils.docker_utils import docker_hub_login, running_in_podman
+from sdcm.utils.minicloud import (
+    MinicloudConfig,
+    MinicloudManager,
+    collect_minicloud_logs,
+    ensure_minicloud_ready,
+    is_minicloud_active,
+)
 from sdcm.monitorstack.restore import (
     restore_monitoring_stack,
     get_monitoring_stack_services,
@@ -268,47 +275,44 @@ def cli(ctx):
         docker_hub_login(remoter=LOCALRUNNER)
 
 
-def _report_provision_error_to_argus(backend: str, exc: Exception):
-    """Report a provision-stage failure to Argus with TEST_ERROR status."""
-    test_config = get_test_config()
-    try:
-        params = SCTConfiguration()
-        test_id = params.get("test_id")
-        if test_id and test_id != "None":
-            test_config.set_test_id_only(test_id)
-        test_config.init_argus_client(params)
-    except Exception:  # noqa: BLE001
-        LOGGER.warning("Failed to initialize Argus client for error reporting", exc_info=True)
-        return
+@cli.command(
+    "start-minicloud",
+    help="Start minicloud container and prepare region (must run before provision-resources/collect-logs/clean-resources)",
+)
+@click.option("-b", "--backend", type=click.Choice(available_backends), default="aws", help="Backend to emulate")
+@click.option(
+    "-c",
+    "--config",
+    multiple=True,
+    type=click.Path(exists=True),
+    help="Test config .yaml to use, can have multiple of those",
+)
+def start_minicloud(backend, config):
+    if config:
+        os.environ["SCT_CONFIG_FILES"] = str(list(config))
+    if backend:
+        os.environ["SCT_CLUSTER_BACKEND"] = backend
 
-    error_message = (
-        f"(TestFrameworkEvent Severity.CRITICAL) Failed to provision {backend} resources: {type(exc).__name__}: {exc}"
-    )
-    event_payload: RawEventPayload = {
-        "run_id": str(test_config.test_id()),
-        "severity": "CRITICAL",
-        "ts": time.time(),
-        "message": error_message,
-        "event_type": "TestFrameworkEvent",
-        "received_timestamp": None,
-        "nemesis_name": None,
-        "duration": None,
-        "node": None,
-        "target_node": None,
-        "known_issue": None,
-        "nemesis_status": None,
-    }
+    add_file_logger()
 
-    try:
-        test_config.argus_client().submit_event(event_payload)
-        LOGGER.info("Error event submitted to Argus successfully")
-    except Exception as argus_exc:  # noqa: BLE001
-        LOGGER.warning("Failed to submit error event to Argus: %s", argus_exc)
+    # Build a real SCTConfiguration rather than reading env alone: the minicloud_* params
+    # (lightweight mode, per-guest memory, S3 passthrough buckets) only exist after the
+    # yaml+env merge, and from_env() without params silently ran the container with defaults
+    # while the test's config dump claimed otherwise. Deliberately no verify_configuration():
+    # this command only needs the params values, and a config the full validation would
+    # reject still deserves a container that matches it.
+    params = SCTConfiguration()
+    cfg = MinicloudConfig.from_env(params=params)
+    manager = MinicloudManager(cfg)
+    manager.keep_alive = True
+    manager.preflight_check(params=params)
+    manager.start()
 
-    try:
-        test_config.argus_client().set_sct_run_status(TestStatus.TEST_ERROR)
-    except Exception:  # noqa: BLE001
-        LOGGER.warning("Failed to set TEST_ERROR status in Argus", exc_info=True)
+    if backend in ("aws", "aws-siren"):
+        manager.prepare_regions()
+
+    click.echo(f"Minicloud started (endpoint: http://localhost:{cfg.port}, region: {cfg.region})")
+    click.echo(f"Logs: {cfg.log_file}")
 
 
 @cli.command("provision-resources", help="Provision resources for the test")
@@ -341,6 +345,9 @@ def provision_resources(backend, test_name: str, config: str):
             raise ValueError("No test_id was provided. Aborting provisioning.")
         test_config.set_test_id_only(test_id)
         localhost = LocalHost(user_prefix=params.get("user_prefix"), test_id=test_config.test_id())
+
+        if is_minicloud_active():
+            ensure_minicloud_ready(backend=backend or "aws")
 
         if params.get("logs_transport") == "syslog-ng":
             click.echo("Provision syslog-ng logging service")
@@ -546,6 +553,9 @@ def clean_resources(ctx, post_behavior, user, billing_project, test_id, logdir, 
     Also you can add --dry-run option to see what should be cleaned.
     """
     add_file_logger()
+
+    if is_minicloud_active():
+        ensure_minicloud_ready(backend=backend or "aws")
 
     if clean_runners and not user and not test_id:
         click.echo(
@@ -2289,6 +2299,9 @@ def run_test(argv, backend, config, logdir):
     if backend:
         os.environ["SCT_CLUSTER_BACKEND"] = backend
 
+    if is_minicloud_active():
+        ensure_minicloud_ready(backend=backend or "aws")
+
     if logdir:
         os.environ["_SCT_LOGDIR"] = logdir
 
@@ -2387,6 +2400,10 @@ def cloud_usage_report(emails, report_type, user, billing_project):
 @click.option("--config-file", type=str, help="config test file path")
 def collect_logs(test_id=None, logdir=None, backend=None, config_file=None):
     add_file_logger()
+
+    if is_minicloud_active():
+        ensure_minicloud_ready(backend=backend or "aws")
+        collect_minicloud_logs(get_test_config().logdir())
 
     logging.getLogger("paramiko").setLevel(logging.CRITICAL)
     if backend is None:

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -134,6 +134,7 @@ from sdcm.utils.distro import Distro
 from sdcm.utils.features import get_enabled_features, is_tablets_feature_enabled
 from sdcm.utils.install import InstallMode
 from sdcm.utils.issues import SkipPerIssues
+from sdcm.utils.minicloud import is_minicloud_active
 from sdcm.utils.docker_utils import ContainerManager, NotFound, docker_hub_login
 from sdcm.utils.health_checker import (
     check_nodes_status,
@@ -877,6 +878,8 @@ class BaseNode(AutoSshContainerMixin):
                 if kms_host_data["aws_region"] == "auto":
                     append_scylla_yaml["kms_hosts"][kms_host_name]["aws_region"] = self.vm_region
             scylla_yml.update(append_scylla_yaml)
+        if self.parent_cluster.params.get("minicloud_lightweight"):
+            scylla_yml.developer_mode = True
         if self.parent_cluster.node_type == "oracle-db":
             scylla_yml.experimental_features = []  # Oracle Scylla does not use experimental features
         return scylla_yml
@@ -4158,7 +4161,17 @@ class BaseCluster:
         self.log = SDCMAdapter(LOGGER, extra={"prefix": str(self)})
         self.log.info("Init nodes")
         self.nodes: List[BaseNode] = []
-        self.instance_provision = params.get("instance_provision")
+        if is_minicloud_active():
+            # minicloud emulates no spot market and answers RequestSpotInstances with a
+            # 400, so spot only costs a wasted round-trip before the on-demand fallback.
+            # This has to happen here rather than via the SCT_INSTANCE_PROVISION override
+            # in minicloud.set_env_overrides(): that runs after SCTConfiguration is built,
+            # so the env var never reaches params. The value is spelled out instead of
+            # reusing cluster_aws.INSTANCE_PROVISION_ON_DEMAND because importing it would
+            # close an import cycle (cluster_aws imports this module).
+            self.instance_provision = "on_demand"
+        else:
+            self.instance_provision = params.get("instance_provision")
         self.params = params
         self.datacenter = region_names or []
         self.dead_nodes_list = []
@@ -4505,7 +4518,7 @@ class BaseCluster:
         return [node.private_ip_address for node in self.nodes]
 
     def get_node_public_ips(self):
-        return [node.public_ip_address for node in self.nodes]
+        return [node.public_ip_address for node in self.nodes if node.public_ip_address]
 
     def get_node_cql_ips(self, nodes: list[BaseNode] | None = None):
         nodes = nodes if nodes else self.nodes

--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -54,6 +54,7 @@ from sdcm.utils.aws_utils import tags_as_ec2_tags, ec2_instance_wait_public_ip
 from sdcm.utils.common import list_instances_aws
 from sdcm.kernel_panic_checker import AWSKernelPanicChecker
 from sdcm.utils.decorators import retrying
+from sdcm.utils.minicloud import is_minicloud_active
 from sdcm.nemesis.utils.node_allocator import mark_new_nodes_as_running_nemesis
 from sdcm.utils.net import to_inet_ntop_format
 from sdcm.utils.vector_store_utils import VectorStoreClusterMixin, VectorStoreNodeMixin
@@ -140,6 +141,11 @@ class AWSCluster(cluster.BaseCluster):
 
     @property
     def instance_profile_name(self) -> str | None:
+        if is_minicloud_active():
+            # minicloud emulates no IAM, and rejects the launch outright with
+            # "The parameter 'IamInstanceProfile.Name' is not supported" - so asking for a
+            # profile there is both meaningless and fatal.
+            return None
         if self.node_type == "scylla-db":
             return self.params.get("aws_instance_profile_name_db")
         if self.node_type == "loader":
@@ -687,8 +693,12 @@ class AWSNode(cluster.BaseNode):
                 to_inet_ntop_format(private_address["PrivateIpAddress"])
                 for private_address in interface.private_ip_addresses
             ]
+            # `or []`: real AWS always returns ipv6AddressesSet - empty when the interface
+            # has no IPv6 - but minicloud omits the element entirely, so boto3 surfaces
+            # None and the comprehension raises TypeError (QATOOLS-347). An interface
+            # without IPv6 is legitimate either way, so treat absent as empty.
             ipv6_addresses = [
-                to_inet_ntop_format(ipv6_address["Ipv6Address"]) for ipv6_address in interface.ipv6_addresses
+                to_inet_ntop_format(ipv6_address["Ipv6Address"]) for ipv6_address in interface.ipv6_addresses or []
             ]
             device_indexes.append(interface.attachment["DeviceIndex"])
             ipv4_public_address = (

--- a/sdcm/cluster_gce.py
+++ b/sdcm/cluster_gce.py
@@ -48,6 +48,7 @@ from sdcm.kernel_panic_checker import GCPKernelPanicChecker
 from sdcm.sct_events.system import SpotTerminationEvent
 from sdcm.utils.common import list_instances_gce, gce_meta_to_dict
 from sdcm.utils.decorators import retrying
+from sdcm.utils.minicloud import is_minicloud_active
 from sdcm.nemesis.utils.node_allocator import mark_new_nodes_as_running_nemesis
 from sdcm.utils.net import resolve_ip_to_dns
 
@@ -352,6 +353,8 @@ class GCENode(cluster.BaseNode):
 
     @cached_property
     def image(self):
+        if not self._instance.disks:
+            return self.parent_cluster.params.get("gce_image_db") or "unknown"
         disk_client, _ = get_gce_compute_disks_client()
         disk = disk_client.get(disk=self._instance.disks[0].source.split("/")[-1], project=self.project, zone=self.zone)
         return disk.source_image
@@ -365,7 +368,10 @@ class GCENode(cluster.BaseNode):
 
     @cached_property
     def public_dns_name(self) -> str:
-        return resolve_ip_to_dns(self.public_ip_address)
+        try:
+            return resolve_ip_to_dns(self.public_ip_address)
+        except ValueError:
+            return self.public_ip_address
 
 
 class GCECluster(cluster.BaseCluster):
@@ -447,7 +453,16 @@ class GCECluster(cluster.BaseCluster):
         """Return True when AZ fallback on capacity errors is enabled.
 
         Reads `fallback_to_next_availability_zone`.
+
+        Always disabled on minicloud, mirroring the AWS resolver: the emulator never
+        runs out of capacity, so a fallback can only fire on a genuine bug. Worse, the
+        retry reuses the instance name, so the next zone answers `409 ... already
+        exists` and that 409 is what surfaces - hiding whatever actually went wrong on
+        the first attempt.
         """
+        if is_minicloud_active():
+            LOGGER.debug("minicloud is active; GCE AZ fallback disabled")
+            return False
         if (value := self.params.get("fallback_to_next_availability_zone")) is not None:
             return bool(value)
         return False

--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -67,6 +67,7 @@ from sdcm.utils.distro import Distro
 from sdcm.utils.decorators import retrying
 from sdcm.utils.docker_utils import get_docker_bridge_gateway
 from sdcm.utils.k8s import KubernetesOps
+from sdcm.utils.minicloud import is_minicloud_active
 from sdcm.utils.s3_remote_uploader import upload_remote_files_directly_to_s3
 from sdcm.utils.gce_utils import gce_public_addresses, gce_private_addresses
 from sdcm.localhost import LocalHost
@@ -1229,6 +1230,7 @@ class BaseSCTLogCollector(LogCollector):
         FileLog(name="partition_range_scan_diff_*.log", search_locally=True),
         FileLog(name="junit.xml", search_locally=True),
         FileLog(name="cdc-replicator.log", search_locally=True),
+        FileLog(name="minicloud.log", search_locally=True),
     ]
     cluster_log_type = "sct-runner-events"
     cluster_dir_prefix = "sct-runner-events"
@@ -2096,6 +2098,26 @@ class Collector:
             LOGGER.warning("No test_id provided or found")
             return results, None
         self.get_running_cluster_sets(self.backend)
+
+        # Minicloud instances don't have SSH daemons — skip collectors that require SSH
+        # to avoid 60s timeout × N collectors = 20+ minutes of wasted time.
+        if is_minicloud_active():
+            ssh_dependent = (
+                ScyllaLogCollector,
+                CassandraLogCollector,
+                MonitorLogCollector,
+                LoaderLogCollector,
+                SirenManagerLogCollector,
+                VectorStoreLogCollector,
+                SSTablesCollector,
+                JepsenLogCollector,
+            )
+            skipped = [c.__name__ for c in self.cluster_log_collectors if c in ssh_dependent]
+            self.cluster_log_collectors = {
+                c: nodes for c, nodes in self.cluster_log_collectors.items() if c not in ssh_dependent
+            }
+            if skipped:
+                LOGGER.info("Minicloud active: skipping SSH-dependent collectors: %s", skipped)
 
         local_dir_with_logs = get_testrun_dir(self.sct_result_dir, self.test_id)
         LOGGER.info("Found sct result directory with logs: %s", local_dir_with_logs)

--- a/sdcm/provision/aws/az_resolver.py
+++ b/sdcm/provision/aws/az_resolver.py
@@ -22,6 +22,7 @@ from sdcm.sct_config import AWS_SUPPORTED_REGIONS
 from sdcm.test_config import TestConfig
 from sdcm.utils.aws_peering import AwsVpcPeering
 from sdcm.utils.aws_region import AwsRegion
+from sdcm.utils.minicloud import is_minicloud_active
 
 LOGGER = logging.getLogger(__name__)
 
@@ -98,14 +99,30 @@ def is_az_fallback_enabled(params) -> bool:
 
     Reads `fallback_to_next_availability_zone` (new, backend-agnostic).
     Falls back to the deprecated `aws_fallback_to_next_availability_zone` alias.
+
+    Always disabled on minicloud: the emulator never runs out of capacity, so a
+    fallback can only fire on a genuine bug - and retrying the same failure in another
+    AZ buries the real error behind a chain of identical ones.
     """
+    if is_minicloud_active():
+        LOGGER.debug("minicloud is active; AZ fallback disabled")
+        return False
     if (value := params.get("fallback_to_next_availability_zone")) is not None:
         return bool(value)
     return bool(params.get("aws_fallback_to_next_availability_zone"))
 
 
 def is_region_fallback_enabled(params) -> bool:
-    """Return True when whole-cluster region fallback on capacity errors is enabled."""
+    """Return True when whole-cluster region fallback on capacity errors is enabled.
+
+    Always disabled on minicloud. Beyond the "no capacity errors to recover from"
+    argument above, candidate regions are ranked by VPC peering with the current one,
+    and minicloud rejects DescribeVpcPeeringConnections with UnsupportedOperation - so
+    every candidate is discarded as unpeered and the whole scan is wasted work.
+    """
+    if is_minicloud_active():
+        LOGGER.debug("minicloud is active; region fallback disabled")
+        return False
     return bool(params.get("fallback_to_next_region")) and params.get("cluster_backend") == "aws"
 
 

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -574,6 +574,11 @@ class SCTConfiguration(BaseModel):
         description="backend that will be used, aws/gce/azure/oci/docker/xcloud",
         appendable=False,
     )
+    minicloud_endpoint_url: String = SctField(
+        description="EC2 API endpoint URL for minicloud. When set, SCT adapts for minicloud "
+        "limitations (no spot, no EIP, graceful TerminateInstances). Example: http://localhost:5000",
+        appendable=False,
+    )
     test_method: String = SctField(
         description="class.method used to run the test. Filled automatically with run-test sct command.",
         appendable=False,
@@ -2042,6 +2047,19 @@ class SCTConfiguration(BaseModel):
     )
     enterprise_disable_kms: Boolean = SctField(
         description="An escape hatch to disable KMS for enterprise run, when needed. We enable KMS by default since if we use Scylla 2023.1.3 and up",
+    )
+    # minicloud params
+    minicloud_docker_image: String = SctField(
+        description="Docker image for minicloud container (default: ghcr.io/scylladb/minicloud:master-4bd3fb6)",
+    )
+    minicloud_lightweight: Boolean = SctField(
+        description="Enable lightweight mode for minicloud deployments",
+    )
+    minicloud_lightweight_memory: String = SctField(
+        description="Memory allocation for lightweight minicloud deployments",
+    )
+    minicloud_s3_passthrough_buckets: StringOrList = SctField(
+        description="S3 buckets to pass through in minicloud deployments",
     )
     logs_transport: Literal["ssh", "docker", "syslog-ng", "vector"] = SctField(
         description="How to transport logs: syslog-ng, ssh or docker",

--- a/sdcm/sct_runner.py
+++ b/sdcm/sct_runner.py
@@ -686,7 +686,9 @@ class AwsSctRunner(SctRunner):
 
         return aws_region.resource.Image(existing_amis[0]["ImageId"])
 
-    def _create_instance(
+    NESTED_VIRTUALIZATION_INSTANCE_FAMILIES = ("c8i", "m8i", "r8i")
+
+    def _create_instance(  # noqa: PLR0914
         self,
         instance_type: InstanceTypeType,
         base_image: Any,
@@ -730,21 +732,28 @@ class AwsSctRunner(SctRunner):
             ami_id_param=base_image, region_names=tuple([aws_region.region_name])
         )
 
-        result = aws_region.resource.create_instances(
-            ImageId=base_image,
-            InstanceType=instance_type,
-            MinCount=1,
-            MaxCount=1,
-            KeyName=aws_region.SCT_KEY_PAIR_NAME,
-            NetworkInterfaces=interfaces,
-            TagSpecifications=[
+        instance_family = instance_type.split(".")[0] if "." in instance_type else ""
+        nested_virt = instance_family in self.NESTED_VIRTUALIZATION_INSTANCE_FAMILIES
+        if nested_virt:
+            LOGGER.info(
+                "Enabling nested virtualization for instance type %s (family: %s)", instance_type, instance_family
+            )
+
+        create_kwargs = {
+            "ImageId": base_image,
+            "InstanceType": instance_type,
+            "MinCount": 1,
+            "MaxCount": 1,
+            "KeyName": aws_region.SCT_KEY_PAIR_NAME,
+            "NetworkInterfaces": interfaces,
+            "TagSpecifications": [
                 {
                     "ResourceType": "instance",
                     "Tags": [{"Key": key, "Value": value} for key, value in tags.items()]
                     + [{"Key": "Name", "Value": instance_name}],
                 }
             ],
-            BlockDeviceMappings=[
+            "BlockDeviceMappings": [
                 {
                     "DeviceName": ec2_ami_get_root_device_name(image_id=base_image, region_name=aws_region.region_name),
                     "Ebs": {
@@ -753,7 +762,11 @@ class AwsSctRunner(SctRunner):
                     },
                 }
             ],
-        )
+        }
+        if nested_virt:
+            create_kwargs["CpuOptions"] = {"NestedVirtualization": "enabled"}
+
+        result = aws_region.resource.create_instances(**create_kwargs)
         instance = result[0]
 
         LOGGER.info("Instance created. Waiting until it becomes running... ")
@@ -985,6 +998,11 @@ class GceSctRunner(SctRunner):
     FAMILY = "sct-runner-image"
     SCT_NETWORK = "qa-vpc"
 
+    # GCE nested virtualization: supported on N1, N2, N2D, C2, C2D, C3, C3D, M1, M2, M3 families
+    # NOT supported on E2, T2D, T2A (Arm), A2/A3 (GPU) families
+    # See: https://cloud.google.com/compute/docs/instances/nested-virtualization/enabling
+    NESTED_VIRTUALIZATION_INSTANCE_FAMILIES = ("n1", "n2", "n2d", "c2", "c2d", "c3", "c3d", "m1", "m2", "m3")
+
     def __init__(self, region_name: str, availability_zone: str, params: SCTConfiguration):
         availability_zone = availability_zone or params.get("availability_zone") or random_zone(region_name)
         assert availability_zone, "Availability zone is required for GCE"
@@ -1092,6 +1110,13 @@ class GceSctRunner(SctRunner):
         else:
             external_ipv4 = None
 
+        instance_family = instance_type.split("-")[0] if "-" in instance_type else ""
+        nested_virt = instance_family in self.NESTED_VIRTUALIZATION_INSTANCE_FAMILIES
+        if nested_virt:
+            LOGGER.info(
+                "Enabling nested virtualization for instance type %s (family: %s)", instance_type, instance_family
+            )
+
         instance = create_instance(
             project_id=self.project_name,
             zone=region_az,
@@ -1101,6 +1126,7 @@ class GceSctRunner(SctRunner):
             disks=disks,
             external_access=True,
             external_ipv4=external_ipv4,
+            enable_nested_virtualization=nested_virt,
             metadata=tags
             | {
                 "launch_time": get_current_datetime_formatted(),

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -131,6 +131,7 @@ from sdcm.utils.aws_utils import (
     ec2_ami_get_root_device_name,
 )
 from sdcm.utils.ci_tools import get_job_name, get_job_url
+from sdcm.utils.minicloud import MinicloudConfig, MinicloudManager, is_minicloud_active
 from sdcm.utils.common import (
     wait_ami_available,
     download_dir_from_cloud,
@@ -438,6 +439,7 @@ class ClusterTester(unittest.TestCase):
         # Initialize test_config (was previously done in TestStatsMixin which was removed)
         self.test_config = TestConfig()
         self.prepare_phase_active = threading.Event()
+        self.minicloud: MinicloudManager | None = None
 
     def _init_test_duration(self):
         self._stress_duration: int = self.params.get("stress_duration")
@@ -2872,6 +2874,19 @@ class ClusterTester(unittest.TestCase):
         if cluster_backend is None:
             cluster_backend = "aws"
 
+        if is_minicloud_active(self.params) and self.minicloud is None:
+            cfg = MinicloudConfig.from_env(params=self.params)
+            cfg.log_file = os.path.join(self.logdir, "minicloud.log")
+            manager = MinicloudManager(cfg)
+            manager.keep_alive = os.environ.get("MINICLOUD_KEEP_ALIVE", "").lower() in ("1", "true", "yes")
+            # params gives the memory preflight the test's node counts - without it the check
+            # cannot run, and an oversized test dies mid-run as a container OOM kill instead.
+            manager.preflight_check(skip_aws_creds=True, params=self.params)
+            manager.start()
+            if cluster_backend in ("aws", "aws-siren"):
+                manager.prepare_regions()
+            self.minicloud = manager
+
         self.get_cluster_kafka()
         self.get_cluster_emr()
 
@@ -3899,6 +3914,18 @@ class ClusterTester(unittest.TestCase):
     def show_alive_processes(self):
         return gather_live_processes_and_dump_to_file(self.left_processes_log)
 
+    def _stop_all_kernel_panic_checkers(self):
+        """Stop kernel panic checkers on all nodes across all clusters.
+
+        Must be called before minicloud stops, otherwise the checker threads
+        will spam connection errors trying to reach the dead endpoint.
+        """
+        for cluster in [self.db_cluster, self.loaders, self.monitors]:
+            if not cluster:
+                continue
+            for node in cluster.nodes:
+                node._stop_kernel_panic_checker()  # noqa: SLF001
+
     def _stop_all_node_task_threads(self):
         """Stop DbLogReader and other task threads on all nodes.
 
@@ -3917,6 +3944,10 @@ class ClusterTester(unittest.TestCase):
         self._stop_all_node_task_threads()
         if not self.params.get("execute_post_behavior"):
             self.log.info("Resources will continue to run")
+            if getattr(self, "minicloud", None) is not None:
+                self._stop_all_kernel_panic_checkers()
+                self.minicloud.keep_alive = True
+                self.log.info("minicloud keep_alive set (execute_post_behavior=false)")
             return
 
         actions_per_cluster_type = get_post_behavior_actions(self.params)
@@ -3979,6 +4010,14 @@ class ClusterTester(unittest.TestCase):
             elif action == "keep-on-failure" and critical_events:
                 self.log.info("Critical errors found. Keeping EMR cluster %s", self.emr_cluster.cluster_id)
                 self.test_config.keep_cluster(node_type="emr_cluster", val="keep")
+
+        if getattr(self, "minicloud", None) is not None:
+            self._stop_all_kernel_panic_checkers()
+            if not self.minicloud.keep_alive:
+                self.minicloud.stop()
+                self.minicloud = None
+            else:
+                self.log.info("minicloud keep_alive is set, leaving it running")
 
         self.destroy_credentials()
 

--- a/sdcm/utils/aws_okta.py
+++ b/sdcm/utils/aws_okta.py
@@ -35,7 +35,7 @@ def can_get_to_aws_account():
     """
     try:
         session = boto3.Session()
-        sts = session.client("sts")
+        sts = session.client("sts", region_name="us-east-1", endpoint_url="https://sts.amazonaws.com")
         response = sts.get_caller_identity()
         assert response["Account"] == account_id
         LOGGER.info("logged in as %s", response["Arn"])

--- a/sdcm/utils/aws_region.py
+++ b/sdcm/utils/aws_region.py
@@ -133,7 +133,10 @@ class AwsRegion:
 
     @cached_property
     def vpc_ipv6_cidr(self):
-        return ip_network(self.sct_vpc.ipv6_cidr_block_association_set[0]["Ipv6CidrBlock"])
+        ipv6_associations = self.sct_vpc.ipv6_cidr_block_association_set
+        if not ipv6_associations:
+            return None
+        return ip_network(ipv6_associations[0]["Ipv6CidrBlock"])
 
     def az_subnet_name(self, region_az, subnet_index):
         # To support existing VPC/subnet names convention, ignore the index number for first subnet
@@ -168,24 +171,26 @@ class AwsRegion:
             LOGGER.warning("Subnet '%s' already exists!  Id: '%s'.", subnet_name, subnet_id)
             return
 
-        result = self.client.create_subnet(
-            CidrBlock=str(ipv4_cidr),
-            Ipv6CidrBlock=str(ipv6_cidr),
-            VpcId=self.sct_vpc.vpc_id,
-            AvailabilityZone=region_az,
-        )
+        create_subnet_kwargs = {
+            "CidrBlock": str(ipv4_cidr),
+            "VpcId": self.sct_vpc.vpc_id,
+            "AvailabilityZone": region_az,
+        }
+        if ipv6_cidr:
+            create_subnet_kwargs["Ipv6CidrBlock"] = str(ipv6_cidr)
+
+        result = self.client.create_subnet(**create_subnet_kwargs)
         subnet_id = result["Subnet"]["SubnetId"]
         subnet = self.resource.Subnet(subnet_id)
         subnet.create_tags(Tags=[{"Key": "Name", "Value": subnet_name}])
-        LOGGER.info("Configuring to automatically assign public IPv4 and IPv6 addresses...")
         self.client.modify_subnet_attribute(MapPublicIpOnLaunch={"Value": True}, SubnetId=subnet_id)
-        # for some reason boto3 throws error when both AssignIpv6AddressOnCreation and MapPublicIpOnLaunch are used
-        self.client.modify_subnet_attribute(AssignIpv6AddressOnCreation={"Value": True}, SubnetId=subnet_id)
+        if ipv6_cidr:
+            self.client.modify_subnet_attribute(AssignIpv6AddressOnCreation={"Value": True}, SubnetId=subnet_id)
         LOGGER.info("'%s' with id '%s' created.", subnet_name, subnet_id)
 
     def create_sct_subnets(self):
         ipv4_cidrs_iter = self.vpc_ipv4_cidr.subnets(6)
-        ipv6_cidrs_iter = self.vpc_ipv6_cidr.subnets(8)
+        ipv6_cidrs_iter = self.vpc_ipv6_cidr.subnets(8) if self.vpc_ipv6_cidr else iter(lambda: None, 1)
         # First subnet in each availability zone already exists.
         # It means that first range of CIDRs are in used.
         # For example:
@@ -229,9 +234,20 @@ class AwsRegion:
         associated_route_table_id = associated_route_table[0].get("RouteTableId")
         # If subnet is associated with route table but not that was created for this subnet
         if associated_route_table_id != sct_route_table.route_table_id:
-            self.client.replace_route_table_association(
-                AssociationId=associated_route_table_id, RouteTableId=sct_route_table.route_table_id
-            )
+            associations = associated_route_table[0].get("Associations", [])
+            association_id = None
+            for assoc in associations:
+                if assoc.get("SubnetId") == subnet.subnet_id:
+                    association_id = assoc.get("RouteTableAssociationId")
+                    break
+            if association_id:
+                self.client.replace_route_table_association(
+                    AssociationId=association_id, RouteTableId=sct_route_table.route_table_id
+                )
+            else:
+                self.client.associate_route_table(
+                    RouteTableId=sct_route_table.route_table_id, SubnetId=subnet.subnet_id
+                )
             LOGGER.info(
                 "Subnet '%s' has been associated with '%s' route table.",
                 subnet.subnet_id,
@@ -349,12 +365,23 @@ class AwsRegion:
             )
         else:
             route_tables = list(self.sct_vpc.route_tables.all())
-            assert len(route_tables) == 1, (
-                f"Only one main route table should exist for {self.SCT_VPC_NAME}. Found {len(route_tables)}!"
-            )
-            route_table: EC2ServiceResource.RouteTable = route_tables[0]
-
-            route_table.create_tags(Tags=[{"Key": "Name", "Value": self.sct_route_table_name(index=index)}])
+            if len(route_tables) == 0:
+                result = self.client.create_route_table(
+                    VpcId=self.sct_vpc.vpc_id,
+                    TagSpecifications=[
+                        {
+                            "ResourceType": "route-table",
+                            "Tags": [{"Key": "Name", "Value": self.sct_route_table_name(index=index)}],
+                        }
+                    ],
+                )
+                route_table = self.resource.RouteTable(result["RouteTable"]["RouteTableId"])
+            else:
+                assert len(route_tables) == 1, (
+                    f"Only one main route table should exist for {self.SCT_VPC_NAME}. Found {len(route_tables)}!"
+                )
+                route_table: EC2ServiceResource.RouteTable = route_tables[0]
+                route_table.create_tags(Tags=[{"Key": "Name", "Value": self.sct_route_table_name(index=index)}])
             LOGGER.info("Setting routing of all outbound traffic via Internet Gateway...")
             route_table.create_route(
                 DestinationCidrBlock="0.0.0.0/0", GatewayId=self.sct_internet_gateway.internet_gateway_id
@@ -704,7 +731,7 @@ class AwsRegion:
         try:
             key_pairs = self.client.describe_key_pairs(KeyNames=[self.SCT_KEY_PAIR_NAME])
         except botocore.exceptions.ClientError as ex:
-            if "InvalidKeyPair.NotFound" in str(ex):
+            if "InvalidKeyPair.NotFound" in str(ex) or "does not exist" in str(ex):
                 return None
             raise
         existing = key_pairs.get("KeyPairs", [])
@@ -752,7 +779,13 @@ class AwsRegion:
         if ec2_fingerprint is not None:
             self.client.delete_key_pair(KeyName=self.SCT_KEY_PAIR_NAME)
             LOGGER.info("Deleted old key pair in '%s'.", self.region_name)
-        self.resource.import_key_pair(KeyName=self.SCT_KEY_PAIR_NAME, PublicKeyMaterial=sct_key_pair.public_key)
+        try:
+            self.resource.import_key_pair(KeyName=self.SCT_KEY_PAIR_NAME, PublicKeyMaterial=sct_key_pair.public_key)
+        except botocore.exceptions.ClientError as ex:
+            if "InvalidKeyPair.Duplicate" not in str(ex):
+                raise
+            LOGGER.info("Key pair already exists in '%s', skipping import.", self.region_name)
+            return
         LOGGER.info("SCT Key Pair updated in '%s'.", self.region_name)
 
     def get_vpc_peering_routes(self) -> list[str]:

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -367,7 +367,7 @@ class S3Storage:
     def set_public_access(self, key):
         acl_obj: S3ServiceResource = boto3.resource("s3").ObjectAcl(self.bucket_name, key)
 
-        grants = copy.deepcopy(acl_obj.grants)
+        grants = copy.deepcopy(acl_obj.grants or [])
         grantees = {
             "Grantee": {"Type": "Group", "URI": "http://acs.amazonaws.com/groups/global/AllUsers"},
             "Permission": "READ",
@@ -658,17 +658,23 @@ def list_instances_aws(
                 for key, value in tags_dict.items()
             ]
         response = client.describe_instances(Filters=custom_filter)
-        instances[region] = [
-            instance for reservation in response["Reservations"] for instance in reservation["Instances"]
-        ]
+        all_instances = [instance for reservation in response["Reservations"] for instance in reservation["Instances"]]
+        instances[region] = all_instances
 
         if verbose:
             LOGGER.info("%s: done [%s/%s]", region, len(list(instances.keys())), len(aws_regions))
 
     ParallelObject(aws_regions, timeout=100, num_workers=len(aws_regions)).run(get_instances, ignore_exceptions=True)
 
+    minicloud_mode = bool(os.environ.get("MINICLOUD_DOCKER") or "localhost" in os.environ.get("AWS_ENDPOINT_URL", ""))
     for curr_region_name, per_region_instances in instances.items():
         if running:
+            if minicloud_mode:
+                # Minicloud instances are immediately available; skip state filtering/waiting
+                instances[curr_region_name] = [
+                    i for i in per_region_instances if i.get("State", {}).get("Name") != "terminated"
+                ]
+                continue
             # Filter for running and pending instances
             pending_instances = [i for i in per_region_instances if i["State"]["Name"] == "pending"]
             running_instances = [i for i in per_region_instances if i["State"]["Name"] == "running"]

--- a/sdcm/utils/gce_region.py
+++ b/sdcm/utils/gce_region.py
@@ -12,12 +12,14 @@
 # Copyright (c) 2022 ScyllaDB
 
 import logging
+import os
 import time
 from functools import cached_property
 from typing import Optional
 
 import googleapiclient.errors
 from googleapiclient.discovery import build
+from google.api_core.client_options import ClientOptions
 from google.oauth2 import service_account
 import google.api_core.exceptions
 from google.cloud import storage
@@ -42,17 +44,30 @@ class GceRegion:
 
         credentials = service_account.Credentials.from_service_account_info(info)
 
-        self.iam = build("iam", "v1", credentials=credentials, cache_discovery=False)
+        compute_kwargs = {}
+        storage_kwargs = {}
+        if endpoint := os.environ.get("GCE_ENDPOINT_URL"):
+            compute_kwargs["client_options"] = ClientOptions(api_endpoint=endpoint)
+            storage_kwargs["client_options"] = {"api_endpoint": endpoint}
 
-        self.network_client = compute_v1.NetworksClient(credentials=credentials)
-        self.firewall_client = compute_v1.FirewallsClient(credentials=credentials)
-        self.subnets_client = compute_v1.SubnetworksClient(credentials=credentials)
-        self.routes_client = compute_v1.RoutesClient(credentials=credentials)
-        self.storage_client = storage.Client(credentials=credentials)
+        iam_kwargs = {}
+        if endpoint := os.environ.get("GCE_ENDPOINT_URL"):
+            iam_kwargs["client_options"] = {"api_endpoint": endpoint}
+        self.iam = build("iam", "v1", credentials=credentials, cache_discovery=False, **iam_kwargs)
+
+        self.network_client = compute_v1.NetworksClient(credentials=credentials, **compute_kwargs)
+        self.firewall_client = compute_v1.FirewallsClient(credentials=credentials, **compute_kwargs)
+        self.subnets_client = compute_v1.SubnetworksClient(credentials=credentials, **compute_kwargs)
+        self.routes_client = compute_v1.RoutesClient(credentials=credentials, **compute_kwargs)
+        self.storage_client = storage.Client(credentials=credentials, **storage_kwargs)
 
     @property
     def backup_storage_bucket_name(self):
         return f"manager-backup-tests-{self.project}-{self.region_name}"
+
+    @property
+    def _is_minicloud(self) -> bool:
+        return bool(os.environ.get("GCE_ENDPOINT_URL"))
 
     @cached_property
     def network(self) -> compute_v1.Network:
@@ -254,8 +269,9 @@ class GceRegion:
     def configure(self):
         LOGGER.info("Configuring '%s' region...", self.region_name)
         self.configure_firewall()
-        self.create_backup_service_account()
-        self.configure_backup_storage()
+        if not self._is_minicloud:
+            self.create_backup_service_account()
+            self.configure_backup_storage()
         LOGGER.info("Region configured successfully.")
 
     def add_network_peering(

--- a/sdcm/utils/gce_utils.py
+++ b/sdcm/utils/gce_utils.py
@@ -22,6 +22,7 @@ from functools import cached_property
 from typing import Any, List, Literal, TYPE_CHECKING
 
 import google.api_core.exceptions
+from google.api_core.client_options import ClientOptions
 from google.oauth2 import service_account
 from google.cloud import compute_v1
 from google.cloud.compute_v1 import Image
@@ -145,10 +146,17 @@ def get_alternative_zones(region: str, exhausted_zone: str, machine_types: list[
     return alternatives
 
 
+def _gce_client_options() -> dict:
+    if endpoint := os.environ.get("GCE_ENDPOINT_URL"):
+        LOGGER.info("GCE client using custom endpoint: %s", endpoint)
+        return {"client_options": ClientOptions(api_endpoint=endpoint)}
+    return {}
+
+
 def get_gce_compute_instances_client() -> tuple[compute_v1.InstancesClient, dict]:
     info = KeyStore().get_gcp_credentials()
     credentials = service_account.Credentials.from_service_account_info(info)
-    return compute_v1.InstancesClient(credentials=credentials), info
+    return compute_v1.InstancesClient(credentials=credentials, **_gce_client_options()), info
 
 
 def get_gce_service_accounts() -> list[dict] | None:
@@ -166,25 +174,30 @@ def get_gce_service_accounts() -> list[dict] | None:
 def get_gce_compute_images_client() -> tuple[compute_v1.ImagesClient, dict]:
     info = KeyStore().get_gcp_credentials()
     credentials = service_account.Credentials.from_service_account_info(info)
-    return compute_v1.ImagesClient(credentials=credentials), info
+    return compute_v1.ImagesClient(credentials=credentials, **_gce_client_options()), info
 
 
 def get_gce_compute_addresses_client() -> tuple[compute_v1.AddressesClient, dict]:
     info = KeyStore().get_gcp_credentials()
     credentials = service_account.Credentials.from_service_account_info(info)
-    return compute_v1.AddressesClient(credentials=credentials), info
+    return compute_v1.AddressesClient(credentials=credentials, **_gce_client_options()), info
 
 
 def get_gce_compute_regions_client() -> tuple[compute_v1.RegionsClient, dict]:
     info = KeyStore().get_gcp_credentials()
     credentials = service_account.Credentials.from_service_account_info(info)
-    return compute_v1.RegionsClient(credentials=credentials), info
+    opts = _gce_client_options()
+    LOGGER.debug("Creating RegionsClient with options: %s", opts)
+    return compute_v1.RegionsClient(credentials=credentials, **opts), info
 
 
 def get_gce_storage_client() -> tuple[storage.Client, dict]:
     info = KeyStore().get_gcp_credentials()
     credentials = service_account.Credentials.from_service_account_info(info)
-    return storage.Client(credentials=credentials), info
+    kwargs = {}
+    if endpoint := os.environ.get("GCE_ENDPOINT_URL"):
+        kwargs["client_options"] = {"api_endpoint": endpoint}
+    return storage.Client(credentials=credentials, **kwargs), info
 
 
 def create_gce_storage_bucket(name: str, region: str, object_lock_enabled: bool = False) -> storage.Bucket:
@@ -251,13 +264,15 @@ def gce_override_object_retention(bucket_name: str, path: str) -> None:
 def get_gce_compute_disks_client() -> tuple[compute_v1.DisksClient, dict]:
     info = KeyStore().get_gcp_credentials()
     credentials = service_account.Credentials.from_service_account_info(info)
-    return compute_v1.DisksClient(credentials=credentials), info
+    return compute_v1.DisksClient(credentials=credentials, **_gce_client_options()), info
 
 
 def get_gce_compute_machine_types_client() -> tuple[compute_v1.MachineTypesClient, dict]:
     info = KeyStore().get_gcp_credentials()
     credentials = service_account.Credentials.from_service_account_info(info)
-    return compute_v1.MachineTypesClient(credentials=credentials), info
+    opts = _gce_client_options()
+    LOGGER.debug("Creating MachineTypesClient with options: %s", opts)
+    return compute_v1.MachineTypesClient(credentials=credentials, **opts), info
 
 
 class GceZoneResolver:
@@ -274,10 +289,18 @@ class GceZoneResolver:
     def get_zones_for_region(self, region: str) -> list[str]:
         try:
             regions_client, _ = get_gce_compute_regions_client()
+            LOGGER.debug(
+                "Fetching zones for region %s (project=%s, endpoint=%s)",
+                region,
+                self._project,
+                os.environ.get("GCE_ENDPOINT_URL", "default"),
+            )
             region_info = regions_client.get(project=self._project, region=region)
-            return [z.rsplit("/", 1)[-1] for z in region_info.zones]
+            zones = [z.rsplit("/", 1)[-1] for z in region_info.zones]
+            LOGGER.debug("Got %d zones for region %s: %s", len(zones), region, zones)
+            return zones
         except Exception:  # noqa: BLE001
-            LOGGER.warning("Failed to get zones from GCE API for region %s", region)
+            LOGGER.warning("Failed to get zones from GCE API for region %s", region, exc_info=True)
             return []
 
     def get_zones_for_machine_type(self, region: str, machine_type: str) -> list[str]:
@@ -289,9 +312,10 @@ class GceZoneResolver:
                 self._machine_types_client.get(project=self._project, zone=zone, machine_type=machine_type)
                 available.append(zone)
             except google.api_core.exceptions.NotFound:
+                LOGGER.debug("Machine type %s not found in zone %s", machine_type, zone)
                 continue
             except Exception:  # noqa: BLE001
-                LOGGER.warning("Error checking machine type %s in zone %s; skipping", machine_type, zone)
+                LOGGER.warning("Error checking machine type %s in zone %s", machine_type, zone, exc_info=True)
                 continue
         return available
 
@@ -569,7 +593,10 @@ class GceLoggingClient:
             f" logName : projects/{self.project_id}/logs/cloudaudit.googleapis.com%2Fsystem_event"
             f' timestamp > "{from_}" timestamp < "{until}"',
         }
-        with build("logging", "v2", credentials=self.credentials, cache_discovery=False) as service:
+        kwargs = {}
+        if endpoint := os.environ.get("GCE_ENDPOINT_URL"):
+            kwargs["client_options"] = {"api_endpoint": endpoint}
+        with build("logging", "v2", credentials=self.credentials, cache_discovery=False, **kwargs) as service:
             return self._get_log_entries(service, query)
 
     def _get_log_entries(self, service, query, page_token=None):
@@ -697,6 +724,7 @@ def create_instance(  # noqa: PLR0913
     network_tags: list = None,
     metadata: dict = None,
     service_accounts: list = None,
+    enable_nested_virtualization: bool = False,
 ) -> compute_v1.Instance:
     """
     Send an instance creation request to the Compute Engine API and wait for it to complete.
@@ -736,6 +764,8 @@ def create_instance(  # noqa: PLR0913
         network_tags: List of tags to apply to network labels
         metadata: dict of key values to add to metadata
         service_accounts: list of service account to attach to the instance
+        enable_nested_virtualization: enable nested virtualization (KVM passthrough) on the instance.
+            Supported on Haswell+ CPUs (N1, N2, N2D, C2, C2D families). Not supported on E2/T2D.
     Returns:
         Instance object.
     """
@@ -797,6 +827,11 @@ def create_instance(  # noqa: PLR0913
     if custom_hostname is not None:
         # Set the custom hostname for the instance
         instance.hostname = custom_hostname
+
+    if enable_nested_virtualization:
+        instance.advanced_machine_features = compute_v1.AdvancedMachineFeatures(
+            enable_nested_virtualization=True,
+        )
 
     if delete_protection:
         # Set the delete protection bit

--- a/sdcm/utils/gcp_kms.py
+++ b/sdcm/utils/gcp_kms.py
@@ -12,7 +12,9 @@
 # Copyright (c) 2025 ScyllaDB
 
 import logging
+import os
 
+from google.api_core.client_options import ClientOptions
 from google.cloud import kms
 from google.cloud.exceptions import GoogleCloudError
 from google.oauth2 import service_account
@@ -34,7 +36,10 @@ class GcpKms:
 
         # Create credentials from service account info
         credentials = service_account.Credentials.from_service_account_info(KeyStore().get_gcp_credentials())
-        self.client = kms.KeyManagementServiceClient(credentials=credentials)
+        kwargs = {}
+        if endpoint := os.environ.get("GCE_ENDPOINT_URL"):
+            kwargs["client_options"] = ClientOptions(api_endpoint=endpoint)
+        self.client = kms.KeyManagementServiceClient(credentials=credentials, **kwargs)
 
     def create_test_key(self):
         self.client.create_crypto_key(

--- a/sdcm/utils/minicloud.py
+++ b/sdcm/utils/minicloud.py
@@ -1,0 +1,1107 @@
+import atexit
+import dataclasses
+import logging
+import os
+import re
+import shutil
+import subprocess
+import threading
+import time
+import traceback
+from pathlib import Path
+from typing import List
+
+import json
+
+import requests
+
+from sdcm.keystore import KeyStore
+from sdcm.sct_config import AWS_SUPPORTED_REGIONS
+from sdcm.sct_events import Severity
+from sdcm.sct_events.system import TestFrameworkEvent
+from sdcm.utils.aws_region import AwsRegion
+
+LOGGER = logging.getLogger(__name__)
+
+MINICLOUD_DOCKER_IMAGE_DEFAULT = "ghcr.io/scylladb/minicloud:master-4bd3fb6"
+
+# In lightweight mode minicloud gives every VM 1 vCPU and this much RAM, ignoring the
+# instance type the test asked for. Scylla refuses to start below 1 GiB per shard, and it
+# reserves ~1.7 GiB of the guest for the OS before splitting the rest across shards - so a
+# 2.5 GiB VM leaves only 826 MiB and dies with "memory per shard too low" on first boot,
+# before SCT gets a chance to apply append_scylla_args or developer_mode. 4 GiB leaves
+# ~2.2 GiB for the single shard. Raising this multiplies across every VM in the test, so
+# the sct-runner has to be sized for n_db_nodes + n_loaders + n_monitor_nodes times this.
+MINICLOUD_LIGHTWEIGHT_MEMORY_DEFAULT = "4GiB"
+MINICLOUD_S3_PASSTHROUGH_BUCKETS_DEFAULT = (
+    "scylla-qa-keystore",
+    "cloudius-jenkins-test",
+    "downloads.scylladb.com",
+)
+
+MINICLOUD_PORT = 5000
+MINICLOUD_HEALTH_TIMEOUT = 30
+MINICLOUD_HEALTH_INTERVAL = 1
+# EC2 action used as the liveness probe. Must be an action minicloud actually implements
+# and serves locally, otherwise every probe is rejected and logged as an unknown action.
+MINICLOUD_HEALTH_ACTION = "DescribeVpcs"
+# minicloud validates a not-yet-cached AMI by calling real AWS DescribeImages with the
+# server's own --aws-region (src/api/instance.rs), not the region the RunInstances request
+# targets. Scylla dev AMIs are published in eu-west-1, so any other default makes every
+# cache-miss launch fail with InvalidAMIID.NotFound. Keep this on eu-west-1 until
+# minicloud's create-resource path honours the per-request region.
+MINICLOUD_DEFAULT_REGION = "eu-west-1"
+
+
+class MinicloudError(Exception):
+    """Raised when minicloud lifecycle operations fail with actionable messages."""
+
+
+def _decode_exit(code: int | None) -> str:
+    """Human-readable cause for a container exit code."""
+    match code:
+        case 0:
+            return "clean exit"
+        case 137:
+            return "SIGKILL - `docker rm -f`/`docker kill` from outside, or cgroup OOM"
+        case 143:
+            return "SIGTERM - `docker stop` from outside"
+        case _:
+            return "minicloud process exited on its own"
+
+
+def resolve_minicloud_regions() -> List[str]:
+    """Return every AWS region minicloud should prepare.
+
+    Defaults to all SCT-supported regions. minicloud scopes EC2 resources per region -
+    a VPC/subnet/security group created in one region is invisible from another, as on
+    real AWS - so a region that was never prepared fails provisioning with
+    "No SCT security group configured for <region>". Preparing them all up front means
+    any test, single- or multi-region, finds what it needs without minicloud having to
+    know which regions the test picked.
+
+    ``MINICLOUD_AWS_REGION`` (comma-separated) narrows this to a subset, which is worth
+    it only when start-up time matters: each region costs about two seconds.
+    """
+    if env_regions := os.environ.get("MINICLOUD_AWS_REGION", ""):
+        return [region.strip() for region in env_regions.split(",") if region.strip()]
+    return list(AWS_SUPPORTED_REGIONS)
+
+
+def resolve_minicloud_default_region(params=None) -> str:
+    """Region for the container's ``--aws-region``/``AWS_REGION``.
+
+    Mostly a fallback for requests that carry no region of their own - boto3 signs each
+    call with its target region and minicloud reads that off the SigV4 credential scope.
+    Prefer the test's own region so those region-less requests land where the test works.
+
+    Not purely cosmetic, though: minicloud's RunInstances validates an uncached AMI
+    against this region instead of the request's, so a mismatch fails the launch with
+    InvalidAMIID.NotFound. See MINICLOUD_DEFAULT_REGION.
+    """
+    configured = params.get("region_name") if params else None
+    if not configured:
+        configured = os.environ.get("SCT_REGION_NAME", "")
+    if isinstance(configured, str):
+        configured = configured.replace(",", " ").split()
+    for region in configured or []:
+        if region:
+            return region
+    return MINICLOUD_DEFAULT_REGION
+
+
+@dataclasses.dataclass
+class MinicloudConfig:
+    """Configuration for MinicloudManager."""
+
+    docker_image: str = MINICLOUD_DOCKER_IMAGE_DEFAULT
+    port: int = 5000
+    lightweight: bool = True
+    lightweight_memory: str = MINICLOUD_LIGHTWEIGHT_MEMORY_DEFAULT
+    s3_passthrough_buckets: List[str] = dataclasses.field(
+        default_factory=lambda: list(MINICLOUD_S3_PASSTHROUGH_BUCKETS_DEFAULT)
+    )
+    # Every region the test will use. minicloud stores EC2 resources per region, so each
+    # one has to be prepared separately - a resource created in one region is invisible
+    # from another, exactly as on real AWS.
+    regions: List[str] = dataclasses.field(default_factory=lambda: list(AWS_SUPPORTED_REGIONS))
+    default_region: str = MINICLOUD_DEFAULT_REGION
+    gcp_project: str = "sct-project-1"
+    gcs_bucket: str = ""
+    state_dir: str = dataclasses.field(default_factory=lambda: os.path.expanduser("~/.cache/minicloud"))
+    log_file: str = ""
+    backend: str = ""
+
+    @property
+    def region(self) -> str:
+        """Region passed to the container as --aws-region/AWS_REGION.
+
+        Mostly a fallback for requests that carry no region of their own: boto3 signs
+        every call with its target region and minicloud reads that off the SigV4
+        credential scope, so per-region clients work regardless of this value - except
+        for uncached-AMI validation on RunInstances, which uses this region rather than
+        the request's. See MINICLOUD_DEFAULT_REGION.
+        """
+        if self.default_region in self.regions:
+            return self.default_region
+        return self.regions[0] if self.regions else MINICLOUD_DEFAULT_REGION
+
+    @classmethod
+    def from_env(cls, params=None) -> "MinicloudConfig":
+        """Build MinicloudConfig from SCT params (preferred) or environment variables.
+
+        The `minicloud_*` SCT params are the source of truth - they are the only knob
+        available to a test-case yaml or a Jenkins job. The bare MINICLOUD_* env vars stay
+        supported so the scripts/ wrappers (and a hand-started container) keep working, and
+        they win when set, because they are the more specific, per-invocation override.
+        """
+        state_dir = os.path.expanduser("~/.cache/minicloud")
+        backend = ""
+        docker_image = MINICLOUD_DOCKER_IMAGE_DEFAULT
+        lightweight = True
+        lightweight_memory = MINICLOUD_LIGHTWEIGHT_MEMORY_DEFAULT
+        s3_passthrough_buckets = list(MINICLOUD_S3_PASSTHROUGH_BUCKETS_DEFAULT)
+        if params:
+            backend = params.get("cluster_backend") or ""
+            docker_image = params.get("minicloud_docker_image") or docker_image
+            # only an explicit value overrides - a params mapping that simply lacks the key
+            # (a bare dict from a caller or a test) must not turn lightweight mode off
+            if (explicit_lightweight := params.get("minicloud_lightweight")) is not None:
+                lightweight = bool(explicit_lightweight)
+            lightweight_memory = params.get("minicloud_lightweight_memory") or lightweight_memory
+            # StringOrList hands back a plain string ('a,b,c') for the yaml default and a
+            # list for an explicit yaml list - and does not split on commas either way, so
+            # flatten both shapes rather than trusting the type.
+            if buckets := params.get("minicloud_s3_passthrough_buckets"):
+                if isinstance(buckets, str):
+                    buckets = [buckets]
+                s3_passthrough_buckets = [
+                    bucket.strip() for entry in buckets for bucket in str(entry).split(",") if bucket.strip()
+                ]
+        if not backend:
+            backend = os.environ.get("SCT_CLUSTER_BACKEND", "")
+        # SCT_MINICLOUD_DOCKER_IMAGE is the env form of the minicloud_docker_image param, and
+        # has to be read directly, not only via `params`: the sct.py CLI commands that manage
+        # the container (start-minicloud, provision-resources, clean-resources) build no
+        # SCTConfiguration, so a Jenkins job selecting an image got the built-in default and
+        # silently ran a different minicloud than the one its config reported.
+        #
+        # `or`, not a get() default: an exported-but-empty value (a job or wrapper passing
+        # through an unset image param) must not blank out the resolved image.
+        docker_image = os.environ.get("SCT_MINICLOUD_DOCKER_IMAGE") or docker_image
+        # The bare MINICLOUD_DOCKER stays the most specific override, for the scripts/ wrappers.
+        docker_image = os.environ.get("MINICLOUD_DOCKER") or docker_image
+        return cls(
+            docker_image=docker_image,
+            port=int(os.environ.get("MINICLOUD_PORT", "5000")),
+            lightweight=lightweight,
+            lightweight_memory=os.environ.get("MINICLOUD_LIGHTWEIGHT_MEMORY", lightweight_memory),
+            s3_passthrough_buckets=(
+                os.environ["S3_PASSTHROUGH_BUCKETS"].split(",")
+                if os.environ.get("S3_PASSTHROUGH_BUCKETS")
+                else s3_passthrough_buckets
+            ),
+            regions=resolve_minicloud_regions(),
+            default_region=resolve_minicloud_default_region(params),
+            gcp_project=os.environ.get("SCT_GCE_PROJECT", "sct-project-1"),
+            gcs_bucket=os.environ.get("MINICLOUD_GCS_BUCKET", ""),
+            state_dir=state_dir,
+            log_file=os.path.join(state_dir, "minicloud.log"),
+            backend=backend,
+        )
+
+
+def is_minicloud_active(params=None) -> bool:
+    """Check if minicloud mode is active based on env vars or SCT config.
+
+    ``params`` is optional because most call sites (AZ resolver, log collector, cluster
+    teardown) have no SCTConfiguration to hand. Pass it wherever one is available: the
+    ``minicloud_endpoint_url`` param is the only way a test-case yaml can turn minicloud on,
+    and while this looked at the environment alone, a yaml-only setup silently provisioned
+    against the real cloud instead.
+    """
+    if os.environ.get("MINICLOUD_DOCKER"):
+        return True
+
+    aws_endpoint = os.environ.get("AWS_ENDPOINT_URL", "")
+    if aws_endpoint and "localhost" in aws_endpoint:
+        return True
+
+    gce_endpoint = os.environ.get("GCE_ENDPOINT_URL", "")
+    if gce_endpoint and "localhost" in gce_endpoint:
+        return True
+
+    if os.environ.get("SCT_MINICLOUD_ENDPOINT_URL", ""):
+        return True
+
+    return bool(params is not None and params.get("minicloud_endpoint_url"))
+
+
+def get_minicloud_endpoint(params=None) -> str:
+    """Get the minicloud endpoint URL.
+
+    Mirrors is_minicloud_active()'s precedence, so a yaml that switched minicloud on via
+    ``minicloud_endpoint_url`` is also the one that decides where it listens.
+    """
+    endpoint = os.environ.get("SCT_MINICLOUD_ENDPOINT_URL", "")
+    if endpoint:
+        return endpoint
+    endpoint = os.environ.get("AWS_ENDPOINT_URL", "")
+    if endpoint:
+        return endpoint
+    if params is not None and (endpoint := params.get("minicloud_endpoint_url")):
+        return endpoint
+    return f"http://localhost:{MINICLOUD_PORT}"
+
+
+def check_minicloud_reachability(endpoint: str | None = None, timeout: int = 5) -> bool:
+    """Check if minicloud is reachable at the given endpoint.
+
+    Uses DescribeVpcs as the probe: it is implemented by minicloud, served locally
+    (no passthrough to real AWS), and cheap. Do not use DescribeRegions — minicloud
+    rejects it as an unimplemented action and logs a warning on every probe.
+
+    Returns True if minicloud responds, raises RuntimeError with actionable message if not.
+    """
+    endpoint = endpoint or get_minicloud_endpoint()
+    try:
+        response = requests.post(
+            endpoint,
+            data={"Action": MINICLOUD_HEALTH_ACTION, "Version": "2016-11-15"},
+            timeout=timeout,
+        )
+        if response.status_code != 200:
+            raise RuntimeError(
+                f"minicloud at {endpoint} answered the {MINICLOUD_HEALTH_ACTION} health probe with "
+                f"HTTP {response.status_code} instead of 200: {response.text[:500]}"
+            )
+        return True
+    except requests.ConnectionError as exc:
+        raise RuntimeError(
+            f"minicloud is not reachable at {endpoint}. "
+            f"Ensure minicloud is running: minicloud --port {MINICLOUD_PORT}\n"
+            f"Connection error: {exc}"
+        ) from exc
+    except requests.Timeout as exc:
+        raise RuntimeError(
+            f"minicloud at {endpoint} timed out after {timeout}s. Is it overloaded or starting up?"
+        ) from exc
+
+
+def ensure_minicloud_ready(backend: str = "aws") -> None:
+    """Ensure minicloud is running and AWS_ENDPOINT_URL is set.
+
+    If minicloud is already running, validates reachability and sets env vars.
+    If not running after retries, auto-starts it with keep_alive=True.
+
+    Retries reachability with exponential backoff to handle transient
+    unavailability (e.g., minicloud briefly overloaded or restarting).
+    """
+    endpoint = get_minicloud_endpoint()
+    max_retries = 4
+    for attempt in range(max_retries):
+        try:
+            check_minicloud_reachability(endpoint, timeout=5)
+            os.environ.setdefault("AWS_ENDPOINT_URL", endpoint)
+            return
+        except RuntimeError:
+            if attempt < max_retries - 1:
+                wait = 2**attempt
+                LOGGER.warning(
+                    "Minicloud not reachable at %s (attempt %d/%d), retrying in %ds...",
+                    endpoint,
+                    attempt + 1,
+                    max_retries,
+                    wait,
+                )
+                time.sleep(wait)
+
+    LOGGER.info("Minicloud not reachable after %d attempts — auto-starting", max_retries)
+    cfg = MinicloudConfig.from_env()
+    manager = MinicloudManager(cfg)
+    manager.keep_alive = True
+    # Skip AWS credentials validation on restart — credentials are already
+    # mounted in the container from the initial start-minicloud stage.
+    manager.preflight_check(skip_aws_creds=True)
+    manager.start()
+    if backend in ("aws", "aws-siren"):
+        manager.prepare_regions()
+
+
+def collect_minicloud_logs(logdir: str) -> None:
+    """Dump minicloud container logs and inspect state into the test logdir.
+
+    Produces: minicloud.log, minicloud-stderr.log, minicloud-inspect.json.
+    Never raises — each collector runs independently.
+
+    Runs after the manager has already streamed the log and (on death or teardown)
+    recorded minicloud-inspect.json, so anything already written here wins: those files
+    were captured while the container still existed, this one runs after `docker rm -f`.
+    """
+    container_name = MinicloudManager.MINICLOUD_CONTAINER_NAME
+    os.makedirs(logdir, exist_ok=True)
+
+    # 1. Collect container logs (works on stopped/exited containers, fails only if removed)
+    log_path = os.path.join(logdir, "minicloud.log")
+    if os.path.exists(log_path) and os.path.getsize(log_path):
+        LOGGER.info("minicloud logs already streamed to %s, keeping the streamed copy", log_path)
+    else:
+        result = subprocess.run(["docker", "logs", container_name], capture_output=True, check=False)
+        if result.returncode == 0:
+            with open(log_path, "wb") as fh:
+                fh.write(result.stdout)
+                fh.write(result.stderr)
+            LOGGER.info("Collected minicloud logs to %s (%d bytes)", log_path, len(result.stdout) + len(result.stderr))
+
+            # Write stderr separately for crash diagnostics
+            if result.stderr:
+                stderr_path = os.path.join(logdir, "minicloud-stderr.log")
+                with open(stderr_path, "wb") as fh:
+                    fh.write(result.stderr)
+                LOGGER.info("Collected minicloud stderr to %s (%d bytes)", stderr_path, len(result.stderr))
+        else:
+            LOGGER.warning(
+                "Failed to collect minicloud container logs (container removed?): %s",
+                result.stderr.decode(errors="replace").strip(),
+            )
+
+    # 2. Collect container inspect (state, exit code, health, config)
+    inspect_path = os.path.join(logdir, "minicloud-inspect.json")
+    if os.path.exists(inspect_path):
+        LOGGER.info("minicloud state already recorded to %s while the container existed", inspect_path)
+        return
+    inspect_result = subprocess.run(
+        ["docker", "inspect", container_name],
+        capture_output=True,
+        check=False,
+    )
+    if inspect_result.returncode == 0:
+        with open(inspect_path, "wb") as fh:
+            fh.write(inspect_result.stdout)
+        LOGGER.info("Collected minicloud inspect to %s", inspect_path)
+
+        # Log key state info for quick debugging
+        try:
+            inspect_data = json.loads(inspect_result.stdout)
+            if inspect_data:
+                state = inspect_data[0].get("State", {})
+                LOGGER.info(
+                    "Minicloud container state: Status=%s, ExitCode=%s (%s), OOMKilled=%s",
+                    state.get("Status"),
+                    state.get("ExitCode"),
+                    _decode_exit(state.get("ExitCode")),
+                    state.get("OOMKilled"),
+                )
+        except (json.JSONDecodeError, IndexError, KeyError):
+            pass
+    else:
+        LOGGER.warning(
+            "Failed to collect minicloud inspect (container removed?): %s",
+            inspect_result.stderr.decode(errors="replace").strip(),
+        )
+
+
+class MinicloudManager:
+    """Manages the minicloud Docker container lifecycle for SCT tests.
+
+    Usage:
+        with MinicloudManager() as mc:
+            # minicloud container is running, AWS_ENDPOINT_URL is set
+            # run your test...
+            pass
+        # minicloud container is stopped
+    """
+
+    MINICLOUD_CONTAINER_NAME = "minicloud"
+
+    def __init__(self, config: MinicloudConfig | None = None):
+        self.config = config or MinicloudConfig.from_env()
+        self.port = self.config.port
+        self._container_log_process: subprocess.Popen | None = None
+        self._stopped = False
+        self._owner_pid = os.getpid()
+        self.keep_alive = False
+        # Container ID of the container we started/adopted. Everything that inspects or
+        # removes the container goes through this rather than the name: a concurrent
+        # `docker run --name minicloud` recycles the name, and acting on the name would
+        # then hit somebody else's container.
+        self._container_id: str | None = None
+        self._stopping = False
+        self._state_snapshotted = False
+        self._death_watcher: threading.Thread | None = None
+
+    def preflight_check(self, skip_aws_creds: bool = False, params=None) -> None:
+        """Verify prerequisites before starting minicloud container.
+
+        Pass ``params`` (an SCTConfiguration) wherever one exists: it is the only thing that
+        knows the test's node counts after the yaml+env merge, and without them the memory
+        check below cannot run - the failure then arrives mid-test as a cgroup OOM kill
+        (container exit 137) and a wall of SSH timeouts, far from the cause.
+        """
+        if not Path("/dev/kvm").exists():
+            raise MinicloudError(
+                "/dev/kvm is not available. Ensure KVM is enabled on this host and the current "
+                "user is in the 'kvm' group: sudo usermod -aG kvm $USER"
+            )
+        if not shutil.which("docker"):
+            raise MinicloudError("docker is not available on PATH. Install Docker to run minicloud in container mode.")
+        if params is not None:
+            self._check_host_memory(params)
+        if not skip_aws_creds:
+            self._check_aws_credentials()
+
+    @staticmethod
+    def _sum_node_counts(value) -> int:
+        """Sum an IntOrList param value: an int, a list, or a '3 3' multi-DC string."""
+        if not value:
+            return 0
+        if isinstance(value, int):
+            return value
+        if isinstance(value, str):
+            return sum(int(part) for part in value.split())
+        return sum(int(part) for part in value)
+
+    @staticmethod
+    def _parse_memory_gib(value: str) -> float:
+        """Parse a '4GiB'/'2.5GiB'/'4096MiB' memory string into GiB."""
+        match = re.fullmatch(r"\s*([\d.]+)\s*([KMGT])i?B?\s*", str(value), flags=re.IGNORECASE)
+        if not match:
+            raise MinicloudError(f"cannot parse minicloud_lightweight_memory value: {value!r}")
+        factor = {"K": 1 / 1024 / 1024, "M": 1 / 1024, "G": 1, "T": 1024}[match.group(2).upper()]
+        return float(match.group(1)) * factor
+
+    def _check_host_memory(self, params) -> None:
+        """Fail before start when the test's guests cannot fit into this host's free memory.
+
+        Lightweight mode gives every guest a fixed ``lightweight_memory``, so the requirement
+        is exactly guests x per-guest plus host headroom - and only params knows the guest
+        count: ``n_db_nodes`` is IntOrList ('3 3' for multi-DC), summed the way
+        sct_config.py:sum(n_db_nodes) does. Without this check the container is
+        cgroup-OOM-killed mid-test (exit 137) and every VM dies with it.
+        """
+        if not self.config.lightweight:
+            return  # non-lightweight sizing follows the requested instance types; out of scope here
+        guests = sum(self._sum_node_counts(params.get(name)) for name in ("n_db_nodes", "n_loaders", "n_monitor_nodes"))
+        if not guests:
+            return
+        meminfo = Path("/proc/meminfo")
+        if not meminfo.exists():  # non-Linux dev box; the container will not run here anyway
+            return
+        available_gib = 0.0
+        for line in meminfo.read_text().splitlines():
+            if line.startswith("MemAvailable:"):
+                available_gib = int(line.split()[1]) / 1024 / 1024
+                break
+        per_guest_gib = self._parse_memory_gib(self.config.lightweight_memory)
+        host_headroom_gib = 2.0  # dockerd, hydra, SCT itself and the page cache need to live too
+        needed_gib = guests * per_guest_gib + host_headroom_gib
+        if available_gib and available_gib < needed_gib:
+            raise MinicloudError(
+                f"not enough memory for this test on this host: {guests} guest(s) x "
+                f"{per_guest_gib:.1f}GiB ({self.config.lightweight_memory}) + {host_headroom_gib:.0f}GiB "
+                f"host headroom = {needed_gib:.1f}GiB needed, but only {available_gib:.1f}GiB is "
+                f"available. Reduce n_db_nodes/n_loaders/n_monitor_nodes, lower "
+                f"minicloud_lightweight_memory, or use a bigger host - otherwise the container is "
+                f"OOM-killed mid-test (exit 137) taking every VM with it."
+            )
+
+    def _check_aws_credentials(self) -> None:
+        """Verify AWS credentials are configured and valid."""
+        try:
+            result = subprocess.run(
+                ["aws", "sts", "get-caller-identity"],
+                capture_output=True,
+                timeout=15,
+                check=False,
+            )
+            if result.returncode != 0:
+                raise MinicloudError(
+                    "AWS credentials are not configured or are expired. Run 'aws sts get-caller-identity' to diagnose."
+                )
+        except FileNotFoundError as exc:
+            raise MinicloudError("AWS CLI not found. Install it or ensure it is on PATH.") from exc
+
+    def _is_endpoint_healthy(self) -> bool:
+        """Quick check if minicloud is already responding on the configured endpoint."""
+        endpoint = f"http://localhost:{self.config.port}"
+        try:
+            check_minicloud_reachability(endpoint, timeout=2)
+            return True
+        except RuntimeError:
+            return False
+
+    @property
+    def backend(self) -> str:
+        """Effective backend — from SCT params when available, else the env var."""
+        return self.config.backend or os.environ.get("SCT_CLUSTER_BACKEND", "")
+
+    def _get_running_image(self) -> str:
+        """Return the image name of the running minicloud container, or empty string."""
+        result = subprocess.run(
+            ["docker", "inspect", self.MINICLOUD_CONTAINER_NAME, "--format", "{{.Config.Image}}"],
+            capture_output=True,
+            check=False,
+        )
+        if result.returncode == 0:
+            return result.stdout.decode().strip()
+        return ""
+
+    def _inspect_container(self, go_template: str) -> list | None:
+        """Return a JSON-decoded `docker inspect` field, or None if unavailable."""
+        result = subprocess.run(
+            ["docker", "inspect", self.MINICLOUD_CONTAINER_NAME, "--format", go_template],
+            capture_output=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            return None
+        try:
+            return json.loads(result.stdout.decode())
+        except json.JSONDecodeError:
+            return None
+
+    def _resolve_container_id(self) -> str | None:
+        """Look up the ID of the container currently holding the minicloud name."""
+        container_id = self._inspect_container("{{json .Id}}")
+        return container_id if isinstance(container_id, str) else None
+
+    def _snapshot_container_state(self, reason: str) -> dict | None:
+        """Record the container's exit state while it can still be inspected.
+
+        Must run before any `docker rm -f`: removal destroys the exit code, which is the
+        only thing that distinguishes "minicloud crashed on its own" from "something
+        outside killed it". Writes minicloud-inspect.json next to the streamed log and
+        appends a banner to the log itself, so the evidence lands in the file that gets
+        collected either way. Idempotent and never raises.
+        """
+        if self._state_snapshotted or not self._container_id:
+            return None
+        self._state_snapshotted = True
+
+        result = subprocess.run(["docker", "inspect", self._container_id], capture_output=True, check=False)
+        if result.returncode != 0:
+            LOGGER.warning(
+                "minicloud container %s was removed before it could be inspected (%s): %s",
+                self._container_id[:12],
+                reason,
+                result.stderr.decode(errors="replace").strip(),
+            )
+            return None
+
+        log_path = Path(self.config.log_file)
+        try:
+            (log_path.parent / "minicloud-inspect.json").write_bytes(result.stdout)
+            state = json.loads(result.stdout)[0]["State"]
+        except (OSError, json.JSONDecodeError, IndexError, KeyError) as exc:
+            LOGGER.warning("Could not record minicloud container state (%s): %s", reason, exc)
+            return None
+
+        exited = state.get("Status") != "running"
+        if exited:
+            banner = (
+                f"=== minicloud container {self._container_id[:12]} EXITED at {state.get('FinishedAt')} "
+                f"[{reason}]: ExitCode={state.get('ExitCode')} ({_decode_exit(state.get('ExitCode'))}) "
+                f"OOMKilled={state.get('OOMKilled')} Error={state.get('Error')!r} - every VM it hosted "
+                f"is gone, so all further SSH to node IPs will time out ===\n"
+            )
+        else:
+            banner = (
+                f"=== minicloud container {self._container_id[:12]} still running at {reason}; "
+                f"state recorded to minicloud-inspect.json ===\n"
+            )
+        try:
+            with open(log_path, "a") as fh:
+                fh.write(banner)
+        except OSError as exc:
+            LOGGER.warning("Could not append minicloud state banner to %s: %s", log_path, exc)
+        (LOGGER.error if exited else LOGGER.info)(banner.strip())
+        return state
+
+    def _watch_container_death(self, log_process: subprocess.Popen) -> None:
+        """Snapshot the container's state the moment it dies.
+
+        `docker logs -f` returns exactly when the container exits, so waiting on the
+        streamer we already spawn is a precise death signal that costs nothing - and the
+        snapshot then happens while the exit code is still there to read.
+        """
+        log_process.wait()
+        if self._stopping or self._stopped or self.keep_alive:
+            return  # we tore it down ourselves, nothing to report
+        state = self._snapshot_container_state(reason="died while the test was still running")
+        TestFrameworkEvent(
+            source="MinicloudManager",
+            message=(
+                f"minicloud container died mid-test (ExitCode={(state or {}).get('ExitCode')}); "
+                f"all VMs it hosted are gone - any SSH failure after this is a consequence, not the cause"
+            ),
+            severity=Severity.ERROR,
+        ).publish_or_dump()
+
+    def _container_gce_gaps(self) -> list[str]:
+        """Return the reasons a running container cannot serve the gce backend.
+
+        Both of these are start-time only — neither can be added to a live container:
+
+        * GOOGLE_APPLICATION_CREDENTIALS — without it minicloud's gcp_auth falls back to
+          the GCE metadata service, absent in the container, and every GCP call fails with
+          'no available authentication method found'.
+        * --gcs-bucket — without it image downloads fail with
+          '500 Internal error: --gcs-bucket is required for GCP image downloads'.
+
+        A container missing either still answers EC2 health probes, so liveness alone is
+        not enough to decide the container is reusable.
+        """
+        gaps = []
+        env = self._inspect_container("{{json .Config.Env}}")
+        if not any(str(entry).startswith("GOOGLE_APPLICATION_CREDENTIALS=") for entry in env or []):
+            gaps.append("no GOOGLE_APPLICATION_CREDENTIALS")
+        cmd = self._inspect_container("{{json .Config.Cmd}}")
+        if "--gcs-bucket" not in [str(arg) for arg in cmd or []]:
+            gaps.append("no --gcs-bucket")
+        return gaps
+
+    def _force_stop_container(self) -> None:
+        # Target the ID we started when we know it, so we can never remove a different
+        # container that has meanwhile taken over the 'minicloud' name.
+        target = self._container_id or self.MINICLOUD_CONTAINER_NAME
+        subprocess.run(["docker", "rm", "-f", target], capture_output=True, check=False)
+        subprocess.run(["docker", "network", "disconnect", "-f", "host", target], capture_output=True, check=False)
+
+    def start(self) -> None:
+        """Start minicloud Docker container and wait for it to become healthy.
+
+        If minicloud is already running with the expected image and the credentials the
+        current backend needs, reuse it. Otherwise stop it and start fresh — a container
+        that merely answers health probes may still be unusable for this backend.
+        """
+        self._setup_gcp_credentials()
+        self._setup_host_networking()
+
+        if self._is_endpoint_healthy():
+            running_image = self._get_running_image()
+            expected_image = self.config.docker_image
+            restart_reason = ""
+            if running_image and running_image != expected_image:
+                restart_reason = f"running image '{running_image}' != expected '{expected_image}'"
+            elif self.backend in ("gce", "gce-siren") and (gaps := self._container_gce_gaps()):
+                restart_reason = f"running container is not usable for the '{self.backend}' backend: {', '.join(gaps)}"
+            if restart_reason:
+                LOGGER.info("minicloud restarting — %s", restart_reason)
+                self._force_stop_container()
+            else:
+                endpoint = f"http://localhost:{self.config.port}"
+                LOGGER.info("minicloud already running at %s (image: %s), reusing", endpoint, running_image)
+                self._container_id = self._resolve_container_id()
+                os.environ["AWS_ENDPOINT_URL"] = endpoint
+                self.set_env_overrides()
+                self._start_log_streaming()
+                return
+
+        container_name = self.MINICLOUD_CONTAINER_NAME
+        image = self.config.docker_image
+
+        self._force_stop_container()
+
+        docker_cmd = [
+            "docker",
+            "run",
+            "-d",
+            "--name",
+            container_name,
+            "--device",
+            "/dev/kvm",
+            "--device",
+            "/dev/net/tun",
+            "--network",
+            "host",
+            "--cap-add",
+            "NET_ADMIN",
+            "-v",
+            f"{self.config.state_dir}:/root/.cache/minicloud",
+        ]
+
+        aws_key = os.environ.get("AWS_ACCESS_KEY_ID")
+        aws_secret = os.environ.get("AWS_SECRET_ACCESS_KEY")
+        if aws_key and aws_secret:
+            docker_cmd += ["-e", f"AWS_ACCESS_KEY_ID={aws_key}", "-e", f"AWS_SECRET_ACCESS_KEY={aws_secret}"]
+            aws_token = os.environ.get("AWS_SESSION_TOKEN")
+            if aws_token:
+                docker_cmd += ["-e", f"AWS_SESSION_TOKEN={aws_token}"]
+        else:
+            aws_dir = Path.home() / ".aws"
+            if aws_dir.is_dir():
+                docker_cmd += ["-v", f"{aws_dir}:/root/.aws:ro"]
+
+        docker_cmd += ["-e", f"AWS_REGION={self.config.region}"]
+
+        gcs_key = os.environ.get("GCS_KEY_FILE") or os.environ.get("GOOGLE_APPLICATION_CREDENTIALS", "")
+        if gcs_key and Path(gcs_key).is_file():
+            docker_cmd += [
+                "-v",
+                f"{gcs_key}:/etc/minicloud/gcs-key.json:ro",
+                "-e",
+                "GOOGLE_APPLICATION_CREDENTIALS=/etc/minicloud/gcs-key.json",
+                "-e",
+                f"GOOGLE_CLOUD_PROJECT={self.config.gcp_project}",
+            ]
+
+        docker_cmd.append(image)
+
+        minicloud_args = [
+            "--port",
+            str(self.config.port),
+            "--aws-region",
+            self.config.region,
+            "--s3-passthrough-buckets",
+            ",".join(self.config.s3_passthrough_buckets),
+        ]
+        if self.config.gcs_bucket:
+            minicloud_args += ["--gcs-bucket", self.config.gcs_bucket]
+        minicloud_args += ["--gcp-project", self.config.gcp_project]
+        if self.config.lightweight:
+            minicloud_args += ["--lightweight", "--lightweight-memory", self.config.lightweight_memory]
+
+        full_cmd = docker_cmd + minicloud_args
+        LOGGER.info("Starting minicloud container: %s", " ".join(full_cmd))
+        # `docker run -d` prints the container ID - keep it, it is what we inspect and
+        # remove later, and it stays valid even if the name gets taken over.
+        run_result = subprocess.run(full_cmd, capture_output=True, text=True, check=True)
+        self._container_id = run_result.stdout.strip() or self._resolve_container_id()
+        LOGGER.info("minicloud container id: %s", self._container_id)
+
+        endpoint = f"http://localhost:{self.config.port}"
+        os.environ["AWS_ENDPOINT_URL"] = endpoint
+        LOGGER.info("Set AWS_ENDPOINT_URL=%s", endpoint)
+
+        self._wait_for_health(endpoint)
+        self.set_env_overrides()
+        self._start_log_streaming()
+
+        atexit.register(self._atexit_stop)
+        LOGGER.info("minicloud container is ready")
+
+    def stop(self) -> None:
+        """Stop and remove the minicloud Docker container."""
+        if self._stopped:
+            return
+        if self.keep_alive:
+            LOGGER.info("minicloud keep_alive is set, skipping stop")
+            return
+        container_name = self.MINICLOUD_CONTAINER_NAME
+        # Set before terminating the streamer: that terminate wakes the death watcher, and
+        # this flag is how it tells our own teardown apart from an external kill.
+        self._stopping = True
+        if self._container_log_process:
+            self._container_log_process.terminate()
+            self._container_log_process = None
+        LOGGER.warning(
+            "DEBUG: docker rm -f %s called from stop(), pid=%s, owner_pid=%s\n%s",
+            container_name,
+            os.getpid(),
+            self._owner_pid,
+            "".join(traceback.format_stack()),
+        )
+        LOGGER.info("Stopping minicloud container '%s'...", container_name)
+        # Snapshot before removal - `docker rm -f` destroys the exit code for good.
+        self._snapshot_container_state(reason="teardown")
+        self._force_stop_container()
+        os.environ.pop("AWS_ENDPOINT_URL", None)
+        os.environ.pop("GCE_ENDPOINT_URL", None)
+        self._stopped = True
+        LOGGER.info("minicloud stopped")
+
+    def _atexit_stop(self) -> None:
+        """Atexit handler — only stops if we own the process and haven't stopped yet."""
+        LOGGER.warning(
+            "DEBUG: _atexit_stop called, pid=%s, owner_pid=%s, stopped=%s", os.getpid(), self._owner_pid, self._stopped
+        )
+        if os.getpid() != self._owner_pid:
+            return
+        if not self._stopped:
+            self.stop()
+
+    def _start_log_streaming(self) -> None:
+        """Stream minicloud container logs to the configured log file."""
+        log_path = Path(self.config.log_file)
+        os.makedirs(log_path.parent, exist_ok=True)
+        log_fh = open(log_path, "a")  # noqa: SIM115
+        self._container_log_process = subprocess.Popen(
+            ["docker", "logs", "-f", self._container_id or self.MINICLOUD_CONTAINER_NAME],
+            stdout=log_fh,
+            stderr=log_fh,
+        )
+        LOGGER.info("minicloud logs streaming to %s", log_path)
+        # `docker logs -f` returns exactly when the container exits, so waiting on the
+        # streamer we already spawn is a free, precise death signal.
+        self._death_watcher = threading.Thread(
+            target=self._watch_container_death,
+            args=(self._container_log_process,),
+            name="minicloud-death-watcher",
+            daemon=True,
+        )
+        self._death_watcher.start()
+
+    def prepare_regions(self) -> None:
+        """Configure every region in the config via AwsRegion.configure().
+
+        Must be called only after AWS_ENDPOINT_URL is set (i.e., after start()).
+        SSM configuration failures are logged as warnings and do not abort.
+
+        All regions are prepared, not just the one the test names: minicloud keeps EC2
+        resources per region, so a region that was skipped has no VPC, subnets or
+        security group and provisioning into it fails outright.
+        """
+        LOGGER.info("Preparing %d AWS region(s) for minicloud: %s", len(self.config.regions), self.config.regions)
+        for region_name in self.config.regions:
+            LOGGER.info("Preparing AWS region '%s' for minicloud...", region_name)
+            region = AwsRegion(region_name=region_name)
+            try:
+                region.configure()
+            except Exception as exc:  # noqa: BLE001
+                exc_str = str(exc).lower()
+                if "ssm" in exc_str or "systems manager" in exc_str:
+                    LOGGER.warning("SSM configuration failed (expected on minicloud, ignoring): %s", exc)
+                else:
+                    raise
+            LOGGER.info("Region '%s' prepared.", region_name)
+
+    def set_env_overrides(self) -> None:
+        """Set SCT environment overrides required for minicloud mode."""
+        endpoint = f"http://localhost:{self.config.port}"
+        overrides = {
+            "AWS_ENDPOINT_URL": endpoint,
+            "SCT_MINICLOUD_ENDPOINT_URL": endpoint,
+            "SCT_IP_SSH_CONNECTIONS": "private",
+            "SCT_INSTANCE_PROVISION": "on_demand",
+            "SCT_ENTERPRISE_DISABLE_KMS": "true",
+            "SCT_FORCE_RUN_IOTUNE": "false",
+        }
+        if self.backend in ("gce", "gce-siren"):
+            overrides["GCE_ENDPOINT_URL"] = endpoint
+        for key, value in overrides.items():
+            os.environ[key] = value
+            LOGGER.debug("Set %s=%s", key, value)
+        LOGGER.info("minicloud env overrides applied")
+
+    def _setup_host_networking(self) -> None:
+        """Extract and run minicloud-setup.sh on the host to configure TUN device and routes.
+
+        minicloud requires a persistent TUN device (minicloud0) with IP 10.127.0.1/24 on the host
+        for VM networking (IMDS, DNS, and host↔VM connectivity). The setup script is bundled inside
+        the container image and must be run with sudo on the host before the container starts.
+        """
+        tun_name = "minicloud0"
+        result = subprocess.run(
+            ["ip", "addr", "show", tun_name],
+            capture_output=True,
+            check=False,
+        )
+        if result.returncode == 0 and b"10.127.0.1" in result.stdout:
+            LOGGER.info("Host networking already configured (%s has 10.127.0.1)", tun_name)
+            return
+
+        LOGGER.info("Configuring host networking for minicloud...")
+        image = self.config.docker_image
+        setup_script_path = os.path.join(self.config.state_dir, "minicloud-setup.sh")
+        os.makedirs(self.config.state_dir, exist_ok=True)
+
+        extract = subprocess.run(
+            ["docker", "run", "--rm", "--entrypoint", "cat", image, "/usr/local/bin/minicloud-setup.sh"],
+            capture_output=True,
+            check=False,
+        )
+        if extract.returncode != 0:
+            LOGGER.warning("Could not extract minicloud-setup.sh from image %s: %s", image, extract.stderr.decode())
+            return
+
+        with open(setup_script_path, "wb") as fh:
+            fh.write(extract.stdout)
+        os.chmod(setup_script_path, 0o755)
+
+        run_result = subprocess.run(
+            ["sudo", setup_script_path],
+            capture_output=True,
+            check=False,
+        )
+        if run_result.returncode != 0:
+            LOGGER.warning(
+                "minicloud-setup.sh failed (exit %d): %s",
+                run_result.returncode,
+                run_result.stderr.decode().strip(),
+            )
+        else:
+            LOGGER.info("Host networking configured successfully")
+
+    def _setup_gcp_credentials(self) -> None:
+        """Download GCP service account JSON from KeyStore and set GOOGLE_APPLICATION_CREDENTIALS.
+
+        minicloud's Rust gcp_auth crate uses Application Default Credentials (ADC).
+        Setting GOOGLE_APPLICATION_CREDENTIALS to a service account JSON file is the
+        simplest way to provide credentials for GCE API passthrough.
+        """
+        if self.backend not in ("gce", "gce-siren"):
+            return
+
+        creds = None
+        creds_path = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS", "")
+
+        if creds_path and Path(creds_path).is_file():
+            LOGGER.info("GOOGLE_APPLICATION_CREDENTIALS already set to %s", creds_path)
+            with open(creds_path) as fh:
+                creds = json.load(fh)
+        else:
+            try:
+                creds = KeyStore().get_gcp_credentials()
+                creds_path = os.path.join(self.config.state_dir, "gcp-credentials.json")
+                os.makedirs(self.config.state_dir, exist_ok=True)
+                with open(creds_path, "w") as fh:
+                    json.dump(creds, fh)
+                os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = creds_path
+                LOGGER.info("Set GOOGLE_APPLICATION_CREDENTIALS=%s", creds_path)
+            except Exception:  # noqa: BLE001
+                LOGGER.warning(
+                    "Failed to download GCP credentials from KeyStore; minicloud GCE passthrough may not work"
+                )
+
+        if not self.config.gcs_bucket and creds:
+            self.config.gcs_bucket = self._ensure_gcs_bucket(creds)
+
+    @staticmethod
+    def _ensure_gcs_bucket(creds: dict) -> str:
+        """Create the minicloud staging GCS bucket if it doesn't exist, return its name."""
+        from google.cloud import storage  # noqa: PLC0415 - optional GCE dependency
+        from google.oauth2 import service_account  # noqa: PLC0415
+
+        project_id = os.environ.get("SCT_GCE_PROJECT", "sct-project-1")
+        bucket_name = f"{project_id}-minicloud-staging"
+        credentials = service_account.Credentials.from_service_account_info(creds)
+        client = storage.Client(credentials=credentials, project=project_id)
+
+        bucket = client.bucket(bucket_name)
+        if not bucket.exists():
+            LOGGER.info("Creating GCS bucket %s for minicloud image staging", bucket_name)
+            bucket.storage_class = "STANDARD"
+            client.create_bucket(bucket, location="us")
+            bucket.lifecycle_rules = [{"action": {"type": "Delete"}, "condition": {"age": 7}}]
+            bucket.patch()
+            LOGGER.info("Created GCS bucket %s with 7-day lifecycle", bucket_name)
+        else:
+            LOGGER.info("GCS bucket %s already exists", bucket_name)
+
+        MinicloudManager._ensure_cloudbuild_access(creds, project_id, bucket_name)
+        return bucket_name
+
+    @staticmethod
+    def _ensure_cloudbuild_access(creds: dict, project_id: str, bucket_name: str) -> None:
+        """Ensure Cloud Build API is enabled and service account has bucket access.
+
+        minicloud exports GCP images via Cloud Build. This requires:
+        1. cloudbuild.googleapis.com enabled on the project
+        2. The Cloud Build service account has objectAdmin on the staging bucket
+        3. The compute service account has cloudbuild.builds.builder role
+
+        These are idempotent operations — safe to call on every run.
+        """
+        from google.cloud import storage  # noqa: PLC0415 - optional GCE dependency
+        from google.oauth2 import service_account  # noqa: PLC0415
+
+        credentials = service_account.Credentials.from_service_account_info(creds)
+
+        try:
+            scoped_creds = credentials.with_scopes(["https://www.googleapis.com/auth/cloud-platform"])
+            import google.auth.transport.requests  # noqa: PLC0415
+
+            request = google.auth.transport.requests.Request()
+            scoped_creds.refresh(request)
+
+            import requests as http_requests  # noqa: PLC0415
+
+            url = f"https://serviceusage.googleapis.com/v1/projects/{project_id}/services/cloudbuild.googleapis.com:enable"
+            resp = http_requests.post(
+                url,
+                headers={"Authorization": f"Bearer {scoped_creds.token}"},
+                timeout=30,
+            )
+            if resp.status_code in (200, 409):
+                LOGGER.info("Cloud Build API enabled (or already enabled) for %s", project_id)
+            else:
+                LOGGER.warning(
+                    "Could not enable Cloud Build API (status %d): %s. "
+                    "Run manually: gcloud services enable cloudbuild.googleapis.com --project=%s",
+                    resp.status_code,
+                    resp.text[:200],
+                    project_id,
+                )
+        except Exception:  # noqa: BLE001
+            LOGGER.warning(
+                "Could not enable Cloud Build API programmatically. "
+                "Run manually: gcloud services enable cloudbuild.googleapis.com --project=%s",
+                project_id,
+            )
+
+        try:
+            client = storage.Client(credentials=credentials, project=project_id)
+            bucket = client.bucket(bucket_name)
+            policy = bucket.get_iam_policy(requested_policy_version=3)
+
+            cloudbuild_sa = None
+            for binding in policy.bindings:
+                for member in binding.get("members", []):
+                    if "@cloudbuild.gserviceaccount.com" in member:
+                        cloudbuild_sa = member
+                        break
+
+            if cloudbuild_sa:
+                LOGGER.info("Cloud Build SA %s already has bucket access", cloudbuild_sa)
+            else:
+                LOGGER.warning(
+                    "Cloud Build service account not found in bucket IAM. "
+                    "If image export fails, run:\n"
+                    "  gcloud services enable cloudbuild.googleapis.com --project=%s\n"
+                    "  # Wait 60s, then:\n"
+                    "  gsutil iam ch serviceAccount:$(gcloud projects describe %s "
+                    "--format='value(projectNumber)')@cloudbuild.gserviceaccount.com:objectAdmin "
+                    "gs://%s",
+                    project_id,
+                    project_id,
+                    bucket_name,
+                )
+        except Exception:  # noqa: BLE001
+            LOGGER.warning("Could not verify Cloud Build bucket access")
+
+    def _wait_for_health(self, endpoint: str) -> None:
+        """Wait for minicloud to respond to health checks."""
+        deadline = time.time() + MINICLOUD_HEALTH_TIMEOUT
+        last_error = None
+
+        while time.time() < deadline:
+            try:
+                check_minicloud_reachability(endpoint, timeout=2)
+                LOGGER.info("minicloud is healthy at %s", endpoint)
+                return
+            except RuntimeError as exc:
+                last_error = exc
+                time.sleep(MINICLOUD_HEALTH_INTERVAL)
+
+        raise RuntimeError(
+            f"minicloud did not become healthy within {MINICLOUD_HEALTH_TIMEOUT}s.\nLast error: {last_error}"
+        )
+
+    @property
+    def is_running(self) -> bool:
+        """Check if minicloud container is running."""
+        result = subprocess.run(
+            ["docker", "inspect", "-f", "{{.State.Running}}", self.MINICLOUD_CONTAINER_NAME],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        return result.returncode == 0 and "true" in result.stdout
+
+    def __enter__(self):
+        self.start()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.stop()
+        return False

--- a/test-cases/minicloud-provision-test.yaml
+++ b/test-cases/minicloud-provision-test.yaml
@@ -1,0 +1,58 @@
+# Minicloud Provision Test Configuration
+#
+# Backend-agnostic test config for local provision testing via minicloud.
+# Used with both AWS and GCE backends — minicloud emulates the cloud APIs locally
+# using QEMU/KVM VMs, so tests run without real cloud credentials or costs.
+#
+# Usage:
+#   scripts/run-minicloud-provision-test.sh          (AWS backend)
+#   scripts/run-minicloud-gce-provision-test.sh      (GCE backend, future)
+
+test_duration: 60
+
+# Lightweight workload to verify the cluster is functional after provisioning.
+# Not a stress test — just confirms nodes accept writes and reads end-to-end.
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=1m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=1000 -pop seq=1..10000000 -log interval=5",
+             ]
+
+# Pre-test data load: write small dataset then verify reads work.
+# Exercises scylla-bench to confirm loader → DB connectivity and basic I/O.
+prepare_write_cmd:  ["scylla-bench -workload=sequential -mode=write -max-rate=300 -replication-factor=3 -partition-count=10 -clustering-row-count=100 -clustering-row-size=5120 -concurrency=7 -rows-per-request=10",
+                     "scylla-bench -workload=uniform -mode=read -replication-factor=3 -partition-count=10 -clustering-row-count=100 -clustering-row-size=5120 -rows-per-request=10 -concurrency=7 -max-rate=32000 -duration=1m"
+                    ]
+
+# Data validation: confirm written partitions are readable and consistent.
+data_validation: |
+  validate_partitions: false
+  table_name: "scylla_bench.test"
+  primary_key_column: "pk"
+  max_partitions_in_test_table: 10
+  partition_range_with_data_validation: 0-5
+
+# Cluster topology — minimal but realistic (3 DB for quorum, 1 loader, 1 monitor).
+n_loaders: 1
+n_db_nodes: 3
+instance_type_db: 'i4i.large'
+
+# Light nemesis to verify disruption framework works, without destroying the short test.
+nemesis_class_name: SisyphusMonkey
+nemesis_selector: "not disruptive"
+nemesis_interval: 1
+
+user_prefix: 'minicloud-provision-test'
+instance_provision: 'spot'
+
+use_preinstalled_scylla: true
+
+# KMS must be disabled — minicloud doesn't implement AWS KMS / GCP KMS endpoints,
+# and the QEMU VMs have no valid cloud IAM credentials for real KMS calls.
+enterprise_disable_kms: true
+enable_kms_key_rotation: false
+
+# sct-runner needs nested virtualization (KVM) for minicloud QEMU VMs.
+# Only c8i/m8i/r8i instance families support NestedVirtualization on AWS.
+#
+# Sizing: minicloud lightweight VMs get minicloud_lightweight_memory each (4GiB default),
+# and Scylla cannot start below ~3GiB. 3 DB + 1 loader + 1 monitor × 4GiB = 20GiB, so
+# m8i.xlarge (16GiB) no longer fits — m8i.2xlarge (32GiB) leaves room for host overhead.
+instance_type_runner: 'm8i.2xlarge'

--- a/unit_tests/test_scylla_doctor.py
+++ b/unit_tests/test_scylla_doctor.py
@@ -383,22 +383,26 @@ def test_download_and_extract_tarball_rejects_non_gzip(mock_node, mock_test_conf
     """When downloaded file is not a gzip tarball, ScyllaDoctorException should be raised."""
     test_config, _params = mock_test_config
 
-    # Make the file check return non-gzip
+    # Magic byte check returns non-gzip (e.g. "3c45" for XML error page)
     check_result = MagicMock()
     check_result.ok = True
-    check_result.stdout = "ASCII text"
+    check_result.stdout = "3c45"
 
-    head_result = MagicMock()
-    head_result.stdout = "<Error><Code>AccessDenied</Code></Error>"
+    hexdump_result = MagicMock()
+    hexdump_result.stdout = "00000000: 3c45 7272 6f72 3e3c  <Error><"
+
+    dns_result = MagicMock()
+    dns_result.stdout = "93.184.216.34  example.com"
 
     rm_result = MagicMock()
     rm_result.ok = True
 
-    # First call: curl download (succeeds), second: file check, third: head, fourth: rm
+    # Flow: curl download, magic byte check (fails), xxd hexdump, getent hosts, rm -f
     mock_node.remoter.run.side_effect = [
         MagicMock(ok=True),  # curl download
-        check_result,  # file check
-        head_result,  # head -c 500
+        check_result,  # head -c 2 | od (non-gzip magic bytes)
+        hexdump_result,  # xxd | head -20
+        dns_result,  # getent hosts
         rm_result,  # rm -f
     ]
 

--- a/unit_tests/unit/provisioner/test_az_resolver.py
+++ b/unit_tests/unit/provisioner/test_az_resolver.py
@@ -21,6 +21,7 @@ from sdcm.provision.aws.az_resolver import (
     NoValidAvailabilityZoneError,
     _node_count_positive,
     is_az_fallback_enabled,
+    is_region_fallback_enabled,
     run_pre_flight_capacity_probe,
 )
 from sdcm.provision.aws.capacity_errors import ProvisioningCapacityExhausted
@@ -285,9 +286,41 @@ def test_resolve_with_unset_availability_zone_stays_unset(mock_aws_region_cls, a
         (False, True, False),
     ],
 )
-def test_is_az_fallback_enabled(new_param, alias, expected):
+def test_is_az_fallback_enabled(new_param, alias, expected, monkeypatch):
+    monkeypatch.setattr("sdcm.provision.aws.az_resolver.is_minicloud_active", lambda: False)
     params = _make_params(fallback_to_next_availability_zone=new_param, aws_fallback_to_next_availability_zone=alias)
     assert is_az_fallback_enabled(params) is expected
+
+
+def test_is_region_fallback_enabled(monkeypatch):
+    monkeypatch.setattr("sdcm.provision.aws.az_resolver.is_minicloud_active", lambda: False)
+    params = _make_params(fallback_to_next_region=True, cluster_backend="aws")
+    assert is_region_fallback_enabled(params) is True
+
+
+@pytest.mark.parametrize("check", [is_az_fallback_enabled, is_region_fallback_enabled])
+def test_fallback_disabled_on_minicloud(check, monkeypatch):
+    """minicloud has no capacity limits, so a fallback can only mask a real bug."""
+    monkeypatch.setattr("sdcm.provision.aws.az_resolver.is_minicloud_active", lambda: True)
+    params = _make_params(
+        fallback_to_next_availability_zone=True,
+        aws_fallback_to_next_availability_zone=True,
+        fallback_to_next_region=True,
+        cluster_backend="aws",
+    )
+    assert check(params) is False
+
+
+@pytest.mark.parametrize("check", [is_az_fallback_enabled, is_region_fallback_enabled])
+def test_fallback_disabled_when_aws_endpoint_is_local(check, monkeypatch):
+    """The real gate: an AWS_ENDPOINT_URL pointing at localhost means minicloud."""
+    monkeypatch.setenv("AWS_ENDPOINT_URL", "http://localhost:5000")
+    params = _make_params(
+        fallback_to_next_availability_zone=True,
+        fallback_to_next_region=True,
+        cluster_backend="aws",
+    )
+    assert check(params) is False
 
 
 def test_get_fallback_candidates_single_az(mock_aws_region_cls):

--- a/unit_tests/unit/test_minicloud.py
+++ b/unit_tests/unit/test_minicloud.py
@@ -1,0 +1,979 @@
+import os
+from unittest.mock import patch, MagicMock
+
+import pytest
+import requests
+
+from sdcm.sct_config import AWS_SUPPORTED_REGIONS
+from sdcm.utils.gce_region import GceRegion
+from sdcm.utils.gce_utils import _gce_client_options
+from sdcm.utils.minicloud import (
+    MINICLOUD_DEFAULT_REGION,
+    MINICLOUD_DOCKER_IMAGE_DEFAULT,
+    MINICLOUD_LIGHTWEIGHT_MEMORY_DEFAULT,
+    MinicloudConfig,
+    MinicloudError,
+    MinicloudManager,
+    check_minicloud_reachability,
+    ensure_minicloud_ready,
+    get_minicloud_endpoint,
+    is_minicloud_active,
+)
+
+
+@pytest.fixture(autouse=True)
+def clean_env(monkeypatch):
+    # MinicloudManager.set_env_overrides() writes straight into os.environ (that is its
+    # job - it configures the SCT process). monkeypatch cannot undo what it never saw, so
+    # snapshot and restore the whole environment: a leaked AWS_ENDPOINT_URL makes
+    # is_minicloud_active() true for every test that runs afterwards in this process,
+    # which silently disables AZ/region fallback and reds the provisioner suite.
+    original_env = os.environ.copy()
+    monkeypatch.delenv("AWS_ENDPOINT_URL", raising=False)
+    monkeypatch.delenv("SCT_MINICLOUD_ENDPOINT_URL", raising=False)
+    monkeypatch.delenv("MINICLOUD_DOCKER", raising=False)
+    # region resolution reads both of these; a developer's exported value must not
+    # decide what these tests assert
+    monkeypatch.delenv("MINICLOUD_AWS_REGION", raising=False)
+    monkeypatch.delenv("SCT_REGION_NAME", raising=False)
+    yield
+    os.environ.clear()
+    os.environ.update(original_env)
+
+
+def test_is_minicloud_active_from_aws_endpoint_url(monkeypatch):
+    monkeypatch.setenv("AWS_ENDPOINT_URL", "http://localhost:5000")
+    assert is_minicloud_active() is True
+
+
+def test_is_minicloud_active_from_sct_env(monkeypatch):
+    monkeypatch.setenv("SCT_MINICLOUD_ENDPOINT_URL", "http://localhost:5000")
+    assert is_minicloud_active() is True
+
+
+def test_is_minicloud_active_from_docker_env(monkeypatch):
+    monkeypatch.setenv("MINICLOUD_DOCKER", "minicloud:latest")
+    assert is_minicloud_active() is True
+
+
+def test_is_minicloud_active_from_params():
+    """A test-case yaml can only switch minicloud on through the param, not the environment."""
+    assert is_minicloud_active(params={"minicloud_endpoint_url": "http://localhost:5000"}) is True
+    assert get_minicloud_endpoint(params={"minicloud_endpoint_url": "http://localhost:6000"}) == "http://localhost:6000"
+
+
+def test_is_minicloud_inactive_for_empty_params():
+    assert is_minicloud_active(params={}) is False
+    assert is_minicloud_active(params={"minicloud_endpoint_url": ""}) is False
+
+
+def test_minicloud_endpoint_env_beats_params(monkeypatch):
+    monkeypatch.setenv("SCT_MINICLOUD_ENDPOINT_URL", "http://localhost:7000")
+    assert get_minicloud_endpoint(params={"minicloud_endpoint_url": "http://localhost:6000"}) == "http://localhost:7000"
+
+
+def test_is_minicloud_inactive_by_default():
+    assert is_minicloud_active() is False
+
+
+def test_is_minicloud_inactive_for_real_aws_endpoint(monkeypatch):
+    monkeypatch.setenv("AWS_ENDPOINT_URL", "https://ec2.us-east-1.amazonaws.com")
+    assert is_minicloud_active() is False
+
+
+def test_get_minicloud_endpoint_from_env(monkeypatch):
+    monkeypatch.setenv("AWS_ENDPOINT_URL", "http://localhost:9999")
+    assert get_minicloud_endpoint() == "http://localhost:9999"
+
+
+def test_get_minicloud_endpoint_default():
+    assert get_minicloud_endpoint() == "http://localhost:5000"
+
+
+def test_check_minicloud_reachability_success():
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    with patch("sdcm.utils.minicloud.requests.post", return_value=mock_response) as mock_post:
+        assert check_minicloud_reachability("http://localhost:5000") is True
+    assert mock_post.call_args.kwargs["data"]["Action"] == "DescribeVpcs"
+
+
+def test_check_minicloud_reachability_400_is_unhealthy():
+    mock_response = MagicMock()
+    mock_response.status_code = 400
+    mock_response.text = "<Error><Code>UnsupportedOperation</Code></Error>"
+    with patch("sdcm.utils.minicloud.requests.post", return_value=mock_response):
+        with pytest.raises(RuntimeError, match="HTTP 400"):
+            check_minicloud_reachability("http://localhost:5000")
+
+
+def test_check_minicloud_reachability_connection_error():
+    with patch("sdcm.utils.minicloud.requests.post", side_effect=requests.ConnectionError("refused")):
+        with pytest.raises(RuntimeError, match="minicloud is not reachable"):
+            check_minicloud_reachability("http://localhost:5000")
+
+
+def test_check_minicloud_reachability_timeout():
+    with patch("sdcm.utils.minicloud.requests.post", side_effect=requests.Timeout("timed out")):
+        with pytest.raises(RuntimeError, match="timed out"):
+            check_minicloud_reachability("http://localhost:5000")
+
+
+def test_minicloud_config_defaults():
+    config = MinicloudConfig()
+    assert config.port == 5000
+    assert config.lightweight is True
+    assert config.lightweight_memory == MINICLOUD_LIGHTWEIGHT_MEMORY_DEFAULT
+    assert config.s3_passthrough_buckets == ["scylla-qa-keystore", "cloudius-jenkins-test", "downloads.scylladb.com"]
+    assert config.region == MINICLOUD_DEFAULT_REGION
+    assert config.docker_image == "ghcr.io/scylladb/minicloud:master-4bd3fb6"
+
+
+def test_minicloud_config_from_env_defaults(monkeypatch):
+    for key in (
+        "MINICLOUD_DOCKER",
+        "MINICLOUD_PORT",
+        "MINICLOUD_LIGHTWEIGHT_MEMORY",
+        "S3_PASSTHROUGH_BUCKETS",
+        "MINICLOUD_AWS_REGION",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+    config = MinicloudConfig.from_env()
+    assert config.docker_image == "ghcr.io/scylladb/minicloud:master-4bd3fb6"
+    assert config.port == 5000
+    assert config.lightweight is True
+    assert config.lightweight_memory == MINICLOUD_LIGHTWEIGHT_MEMORY_DEFAULT
+    assert config.s3_passthrough_buckets == ["scylla-qa-keystore", "cloudius-jenkins-test", "downloads.scylladb.com"]
+    assert config.region == MINICLOUD_DEFAULT_REGION
+
+
+def test_minicloud_lightweight_memory_default_can_start_scylla():
+    """Scylla terminates below 1 GiB/shard, and the guest OS eats ~1.7 GiB of the VM.
+
+    A default that cannot boot scylla-server is a silent trap: the image starts scylla on
+    first boot, long before SCT could apply append_scylla_args or developer_mode.
+    """
+    gib = float(MINICLOUD_LIGHTWEIGHT_MEMORY_DEFAULT.removesuffix("GiB"))
+    assert gib >= 3.0, f"{MINICLOUD_LIGHTWEIGHT_MEMORY_DEFAULT} leaves under 1 GiB/shard for scylla"
+
+
+def test_minicloud_config_from_env_custom_docker_image(monkeypatch):
+    monkeypatch.setenv("MINICLOUD_DOCKER", "minicloud:v2.0")
+    config = MinicloudConfig.from_env()
+    assert config.docker_image == "minicloud:v2.0"
+
+
+def test_minicloud_config_from_env_empty_docker_image_env_does_not_win(monkeypatch):
+    """An exported-but-empty MINICLOUD_DOCKER must not blank out the param/default image.
+
+    A Jenkins job or scripts/ wrapper that passes an unset image param through as an empty
+    env var would otherwise resolve to `docker run ''`.
+    """
+    monkeypatch.setenv("MINICLOUD_DOCKER", "")
+    assert MinicloudConfig.from_env().docker_image == MINICLOUD_DOCKER_IMAGE_DEFAULT
+    config = MinicloudConfig.from_env(params={"minicloud_docker_image": "minicloud:from-params"})
+    assert config.docker_image == "minicloud:from-params"
+
+
+def test_minicloud_config_from_env_sct_docker_image_env(monkeypatch):
+    """The sct.py container commands build no SCTConfiguration, so the env form must be read.
+
+    Without this, `sct.py start-minicloud` ignored the job's image selection and started the
+    built-in default while the run's config dump reported the selected one.
+    """
+    monkeypatch.setenv("SCT_MINICLOUD_DOCKER_IMAGE", "minicloud:from-sct-env")
+    assert MinicloudConfig.from_env().docker_image == "minicloud:from-sct-env"
+
+    # the bare MINICLOUD_DOCKER stays the more specific override
+    monkeypatch.setenv("MINICLOUD_DOCKER", "minicloud:from-bare-env")
+    assert MinicloudConfig.from_env().docker_image == "minicloud:from-bare-env"
+
+
+def test_minicloud_config_from_env_custom_port(monkeypatch):
+    monkeypatch.setenv("MINICLOUD_PORT", "9000")
+    config = MinicloudConfig.from_env()
+    assert config.port == 9000
+
+
+def test_minicloud_config_from_env_custom_region(monkeypatch):
+    monkeypatch.setenv("MINICLOUD_AWS_REGION", "eu-west-1")
+    config = MinicloudConfig.from_env()
+    assert config.region == "eu-west-1"
+
+
+def test_minicloud_config_prepares_all_supported_regions_by_default():
+    """minicloud scopes resources per region, so every region a test might use must exist."""
+    config = MinicloudConfig.from_env()
+    assert config.regions == AWS_SUPPORTED_REGIONS
+    assert "eu-west-1" in config.regions
+    assert "us-east-1" in config.regions
+
+
+def test_minicloud_config_env_narrows_regions(monkeypatch):
+    monkeypatch.setenv("MINICLOUD_AWS_REGION", "eu-west-1,us-east-2")
+    config = MinicloudConfig.from_env()
+    assert config.regions == ["eu-west-1", "us-east-2"]
+
+
+def test_minicloud_config_default_region_follows_the_test(monkeypatch):
+    """The container's --aws-region should point at the region the test provisions in."""
+    config = MinicloudConfig.from_env(params={"region_name": ["eu-west-1"]})
+    assert config.region == "eu-west-1"
+    assert config.regions == AWS_SUPPORTED_REGIONS
+
+    monkeypatch.setenv("SCT_REGION_NAME", "eu-north-1")
+    assert MinicloudConfig.from_env().region == "eu-north-1"
+
+
+def test_minicloud_config_default_region_outside_prepared_set(monkeypatch):
+    """A narrowed region set wins: never hand the container a region we did not prepare."""
+    monkeypatch.setenv("MINICLOUD_AWS_REGION", "us-east-2")
+    config = MinicloudConfig.from_env(params={"region_name": ["eu-west-1"]})
+    assert config.regions == ["us-east-2"]
+    assert config.region == "us-east-2"
+
+
+def test_prepare_regions_configures_every_region(tmp_path):
+    config = MinicloudConfig(regions=["eu-west-1", "us-east-1", "eu-north-1"], state_dir=str(tmp_path))
+    manager = MinicloudManager(config=config)
+
+    with patch("sdcm.utils.minicloud.AwsRegion") as mock_region_cls:
+        mock_region_cls.return_value = MagicMock()
+        manager.prepare_regions()
+
+    assert [call.kwargs["region_name"] for call in mock_region_cls.call_args_list] == [
+        "eu-west-1",
+        "us-east-1",
+        "eu-north-1",
+    ]
+    assert mock_region_cls.return_value.configure.call_count == 3
+
+
+def test_minicloud_config_from_env_custom_buckets(monkeypatch):
+    monkeypatch.setenv("S3_PASSTHROUGH_BUCKETS", "bucket-a,bucket-b,bucket-c")
+    config = MinicloudConfig.from_env()
+    assert config.s3_passthrough_buckets == ["bucket-a", "bucket-b", "bucket-c"]
+
+
+def test_minicloud_config_from_env_custom_memory(monkeypatch):
+    monkeypatch.setenv("MINICLOUD_LIGHTWEIGHT_MEMORY", "8GiB")
+    config = MinicloudConfig.from_env()
+    assert config.lightweight_memory == "8GiB"
+
+
+def test_minicloud_config_lightweight_params_are_honoured(monkeypatch):
+    """A test-case yaml (or Jenkins job) must be able to size the lightweight VMs.
+
+    These params were declared in sct_config but never read, so every run silently got the
+    hardcoded default no matter what the yaml said.
+    """
+    monkeypatch.delenv("MINICLOUD_LIGHTWEIGHT_MEMORY", raising=False)
+    monkeypatch.delenv("S3_PASSTHROUGH_BUCKETS", raising=False)
+
+    config = MinicloudConfig.from_env(
+        params={
+            "cluster_backend": "gce",
+            "minicloud_lightweight": True,
+            "minicloud_lightweight_memory": "6GiB",
+            "minicloud_s3_passthrough_buckets": ["bucket-a", "bucket-b"],
+        }
+    )
+    assert config.lightweight is True
+    assert config.lightweight_memory == "6GiB"
+    assert config.s3_passthrough_buckets == ["bucket-a", "bucket-b"]
+
+
+def test_minicloud_config_env_overrides_lightweight_params(monkeypatch):
+    """The bare env var is the per-invocation override, so it wins over the param."""
+    monkeypatch.setenv("MINICLOUD_LIGHTWEIGHT_MEMORY", "12GiB")
+    config = MinicloudConfig.from_env(params={"minicloud_lightweight_memory": "6GiB"})
+    assert config.lightweight_memory == "12GiB"
+
+
+def test_minicloud_config_splits_comma_joined_bucket_param(monkeypatch):
+    """StringOrList does not split on commas, so the yaml default arrives as one string.
+
+    Passing it through unsplit hands minicloud a single bogus bucket name and every S3
+    passthrough (keystore creds included) starts failing.
+    """
+    monkeypatch.delenv("S3_PASSTHROUGH_BUCKETS", raising=False)
+    config = MinicloudConfig.from_env(params={"minicloud_s3_passthrough_buckets": "bucket-a,bucket-b"})
+    assert config.s3_passthrough_buckets == ["bucket-a", "bucket-b"]
+
+    # and the same value wrapped in a list, which is what an explicit yaml list yields
+    config = MinicloudConfig.from_env(params={"minicloud_s3_passthrough_buckets": ["bucket-a,bucket-b"]})
+    assert config.s3_passthrough_buckets == ["bucket-a", "bucket-b"]
+
+
+def test_minicloud_config_lightweight_can_be_disabled_by_param():
+    config = MinicloudConfig.from_env(params={"minicloud_lightweight": False})
+    assert config.lightweight is False
+
+
+def test_minicloud_config_lightweight_stays_on_when_param_absent():
+    """A params mapping without the key must not read as 'lightweight off'."""
+    config = MinicloudConfig.from_env(params={"cluster_backend": "aws"})
+    assert config.lightweight is True
+
+
+def test_minicloud_config_falls_back_to_defaults_on_empty_params():
+    """An unset/blank param must not blank out the default."""
+    config = MinicloudConfig.from_env(
+        params={"minicloud_lightweight_memory": "", "minicloud_s3_passthrough_buckets": []}
+    )
+    assert config.lightweight_memory == MINICLOUD_LIGHTWEIGHT_MEMORY_DEFAULT
+    assert config.s3_passthrough_buckets == [
+        "scylla-qa-keystore",
+        "cloudius-jenkins-test",
+        "downloads.scylladb.com",
+    ]
+
+
+def test_minicloud_error_is_exception():
+    err = MinicloudError("something went wrong")
+    assert isinstance(err, Exception)
+    assert "something went wrong" in str(err)
+
+
+def test_minicloud_error_preserves_message():
+    msg = "KVM not available on this host"
+    err = MinicloudError(msg)
+    assert str(err) == msg
+
+
+def test_preflight_check_fails_no_kvm(tmp_path):
+    manager = MinicloudManager(config=MinicloudConfig(state_dir=str(tmp_path)))
+
+    with patch("sdcm.utils.minicloud.Path") as mock_path_cls:
+        mock_kvm = MagicMock()
+        mock_kvm.exists.return_value = False
+
+        def path_side_effect(arg):
+            if str(arg) == "/dev/kvm":
+                return mock_kvm
+            from pathlib import Path as RealPath  # noqa: PLC0415
+
+            return RealPath(arg)
+
+        mock_path_cls.side_effect = path_side_effect
+
+        with pytest.raises(MinicloudError, match="/dev/kvm"):
+            manager.preflight_check()
+
+
+def test_preflight_check_fails_docker_not_found(tmp_path):
+    manager = MinicloudManager(config=MinicloudConfig(state_dir=str(tmp_path)))
+
+    with patch("sdcm.utils.minicloud.Path") as mock_path_cls:
+        mock_kvm = MagicMock()
+        mock_kvm.exists.return_value = True
+
+        def path_side_effect(arg):
+            if str(arg) == "/dev/kvm":
+                return mock_kvm
+            from pathlib import Path as RealPath  # noqa: PLC0415
+
+            return RealPath(arg)
+
+        mock_path_cls.side_effect = path_side_effect
+
+        with patch("sdcm.utils.minicloud.shutil.which", return_value=None):
+            with pytest.raises(MinicloudError, match="docker is not available"):
+                manager.preflight_check()
+
+
+def test_preflight_check_fails_bad_aws_credentials(tmp_path):
+    manager = MinicloudManager(config=MinicloudConfig(state_dir=str(tmp_path)))
+
+    bad_result = MagicMock()
+    bad_result.returncode = 1
+
+    with patch("sdcm.utils.minicloud.Path") as mock_path_cls:
+        mock_kvm = MagicMock()
+        mock_kvm.exists.return_value = True
+
+        def path_side_effect(arg):
+            if str(arg) == "/dev/kvm":
+                return mock_kvm
+            from pathlib import Path as RealPath  # noqa: PLC0415
+
+            return RealPath(arg)
+
+        mock_path_cls.side_effect = path_side_effect
+
+        with patch("sdcm.utils.minicloud.shutil.which", return_value="/usr/bin/docker"):
+            with patch("sdcm.utils.minicloud.subprocess.run", return_value=bad_result):
+                with pytest.raises(MinicloudError, match="AWS credentials"):
+                    manager.preflight_check()
+
+
+def test_preflight_check_fails_aws_cli_not_found(tmp_path):
+    manager = MinicloudManager(config=MinicloudConfig(state_dir=str(tmp_path)))
+
+    with patch("sdcm.utils.minicloud.Path") as mock_path_cls:
+        mock_kvm = MagicMock()
+        mock_kvm.exists.return_value = True
+
+        def path_side_effect(arg):
+            if str(arg) == "/dev/kvm":
+                return mock_kvm
+            from pathlib import Path as RealPath  # noqa: PLC0415
+
+            return RealPath(arg)
+
+        mock_path_cls.side_effect = path_side_effect
+
+        with patch("sdcm.utils.minicloud.shutil.which", return_value="/usr/bin/docker"):
+            with patch("sdcm.utils.minicloud.subprocess.run", side_effect=FileNotFoundError("aws not found")):
+                with pytest.raises(MinicloudError, match="AWS CLI not found"):
+                    manager.preflight_check()
+
+
+def test_preflight_check_skip_aws_creds(tmp_path):
+    manager = MinicloudManager(config=MinicloudConfig(state_dir=str(tmp_path)))
+
+    with patch("sdcm.utils.minicloud.Path") as mock_path_cls:
+        mock_kvm = MagicMock()
+        mock_kvm.exists.return_value = True
+
+        def path_side_effect(arg):
+            if str(arg) == "/dev/kvm":
+                return mock_kvm
+            from pathlib import Path as RealPath  # noqa: PLC0415
+
+            return RealPath(arg)
+
+        mock_path_cls.side_effect = path_side_effect
+
+        with patch("sdcm.utils.minicloud.shutil.which", return_value="/usr/bin/docker"):
+            with patch("sdcm.utils.minicloud.subprocess.run") as mock_run:
+                manager.preflight_check(skip_aws_creds=True)
+                mock_run.assert_not_called()
+
+
+def test_start_runs_docker_container(tmp_path, monkeypatch):
+    monkeypatch.delenv("AWS_ACCESS_KEY_ID", raising=False)
+    monkeypatch.delenv("AWS_SECRET_ACCESS_KEY", raising=False)
+
+    config = MinicloudConfig(
+        docker_image="minicloud:test",
+        state_dir=str(tmp_path / "state"),
+        log_file=str(tmp_path / "minicloud.log"),
+    )
+    manager = MinicloudManager(config=config)
+
+    with patch("sdcm.utils.minicloud.MinicloudManager._is_endpoint_healthy", return_value=False):
+        with patch("sdcm.utils.minicloud.MinicloudManager._wait_for_health"):
+            with patch("sdcm.utils.minicloud.MinicloudManager._start_log_streaming"):
+                with patch("sdcm.utils.minicloud.MinicloudManager._setup_host_networking"):
+                    with patch("sdcm.utils.minicloud.subprocess.run") as mock_run:
+                        manager.start()
+
+    run_calls = mock_run.call_args_list
+    docker_run_call = run_calls[2]
+    cmd = docker_run_call[0][0]
+    assert cmd[0] == "docker"
+    assert cmd[1] == "run"
+    assert "-d" in cmd
+    assert "--name" in cmd
+    assert "minicloud:test" in cmd
+    assert "--port" in cmd
+    assert "5000" in cmd
+
+
+def test_start_reuses_healthy_endpoint(tmp_path, monkeypatch):
+    config = MinicloudConfig(state_dir=str(tmp_path), log_file=str(tmp_path / "minicloud.log"))
+    manager = MinicloudManager(config=config)
+
+    with patch("sdcm.utils.minicloud.MinicloudManager._is_endpoint_healthy", return_value=True):
+        with patch("sdcm.utils.minicloud.MinicloudManager._start_log_streaming"):
+            with patch("sdcm.utils.minicloud.MinicloudManager._setup_host_networking"):
+                with patch("sdcm.utils.minicloud.subprocess.run") as mock_run:
+                    manager.start()
+
+    for call in mock_run.call_args_list:
+        cmd = call[0][0]
+        assert "run" not in cmd or cmd[0] != "docker"
+
+
+def test_container_gce_gaps_detects_both_missing(tmp_path):
+    manager = MinicloudManager(config=MinicloudConfig(state_dir=str(tmp_path)))
+    result = MagicMock(returncode=0, stdout=b'["AWS_REGION=us-east-1"]')
+    with patch("sdcm.utils.minicloud.subprocess.run", return_value=result):
+        assert manager._container_gce_gaps() == ["no GOOGLE_APPLICATION_CREDENTIALS", "no --gcs-bucket"]
+
+
+def test_container_gce_gaps_detects_missing_bucket(tmp_path):
+    """Credentials present but no --gcs-bucket: image downloads would 500."""
+    manager = MinicloudManager(config=MinicloudConfig(state_dir=str(tmp_path)))
+    with patch.object(
+        MinicloudManager,
+        "_inspect_container",
+        side_effect=[["GOOGLE_APPLICATION_CREDENTIALS=/etc/minicloud/gcs-key.json"], ["--port", "5000"]],
+    ):
+        assert manager._container_gce_gaps() == ["no --gcs-bucket"]
+
+
+def test_container_gce_gaps_none_when_fully_configured(tmp_path):
+    manager = MinicloudManager(config=MinicloudConfig(state_dir=str(tmp_path)))
+    with patch.object(
+        MinicloudManager,
+        "_inspect_container",
+        side_effect=[
+            ["AWS_REGION=us-east-1", "GOOGLE_APPLICATION_CREDENTIALS=/etc/minicloud/gcs-key.json"],
+            ["--port", "5000", "--gcs-bucket", "sct-project-1-minicloud-staging"],
+        ],
+    ):
+        assert manager._container_gce_gaps() == []
+
+
+def test_start_restarts_gce_container_with_gaps(tmp_path, monkeypatch):
+    """A healthy container missing GCP credentials or --gcs-bucket is unusable for gce."""
+    monkeypatch.setenv("SCT_CLUSTER_BACKEND", "gce")
+    config = MinicloudConfig(
+        backend="gce", docker_image="minicloud:test", state_dir=str(tmp_path), log_file=str(tmp_path / "mc.log")
+    )
+    manager = MinicloudManager(config=config)
+
+    with (
+        patch("sdcm.utils.minicloud.MinicloudManager._is_endpoint_healthy", return_value=True),
+        patch("sdcm.utils.minicloud.MinicloudManager._get_running_image", return_value="minicloud:test"),
+        patch("sdcm.utils.minicloud.MinicloudManager._container_gce_gaps", return_value=["no --gcs-bucket"]),
+        patch("sdcm.utils.minicloud.MinicloudManager._setup_gcp_credentials"),
+        patch("sdcm.utils.minicloud.MinicloudManager._setup_host_networking"),
+        patch("sdcm.utils.minicloud.MinicloudManager._wait_for_health"),
+        patch("sdcm.utils.minicloud.MinicloudManager._start_log_streaming"),
+        patch("sdcm.utils.minicloud.subprocess.run") as mock_run,
+    ):
+        manager.start()
+
+    assert any(cmd[:2] == ["docker", "run"] for cmd in (c[0][0] for c in mock_run.call_args_list)), (
+        "expected the unusable container to be replaced by a fresh 'docker run'"
+    )
+
+
+def test_start_reuses_fully_configured_gce_container(tmp_path, monkeypatch):
+    monkeypatch.setenv("SCT_CLUSTER_BACKEND", "gce")
+    config = MinicloudConfig(
+        backend="gce", docker_image="minicloud:test", state_dir=str(tmp_path), log_file=str(tmp_path / "mc.log")
+    )
+    manager = MinicloudManager(config=config)
+
+    with (
+        patch("sdcm.utils.minicloud.MinicloudManager._is_endpoint_healthy", return_value=True),
+        patch("sdcm.utils.minicloud.MinicloudManager._get_running_image", return_value="minicloud:test"),
+        patch("sdcm.utils.minicloud.MinicloudManager._container_gce_gaps", return_value=[]),
+        patch("sdcm.utils.minicloud.MinicloudManager._setup_gcp_credentials"),
+        patch("sdcm.utils.minicloud.MinicloudManager._setup_host_networking"),
+        patch("sdcm.utils.minicloud.MinicloudManager._start_log_streaming"),
+        patch("sdcm.utils.minicloud.subprocess.run") as mock_run,
+    ):
+        manager.start()
+
+    assert not any(cmd[:2] == ["docker", "run"] for cmd in (c[0][0] for c in mock_run.call_args_list))
+
+
+def test_start_sets_aws_endpoint_url(tmp_path, monkeypatch):
+    monkeypatch.delenv("AWS_ENDPOINT_URL", raising=False)
+    config = MinicloudConfig(port=5000, state_dir=str(tmp_path), log_file=str(tmp_path / "minicloud.log"))
+    manager = MinicloudManager(config=config)
+
+    with patch("sdcm.utils.minicloud.MinicloudManager._is_endpoint_healthy", return_value=False):
+        with patch("sdcm.utils.minicloud.MinicloudManager._wait_for_health"):
+            with patch("sdcm.utils.minicloud.MinicloudManager._start_log_streaming"):
+                with patch("sdcm.utils.minicloud.MinicloudManager._setup_host_networking"):
+                    with patch("sdcm.utils.minicloud.subprocess.run"):
+                        manager.start()
+
+    assert os.environ["AWS_ENDPOINT_URL"] == "http://localhost:5000"
+
+
+def test_stop_calls_docker_rm_force(tmp_path):
+    config = MinicloudConfig(state_dir=str(tmp_path))
+    manager = MinicloudManager(config=config)
+
+    with patch("sdcm.utils.minicloud.subprocess.run") as mock_run:
+        manager.stop()
+
+    cmds = [c[0][0] for c in mock_run.call_args_list]
+    assert ["docker", "rm", "-f", "minicloud"] in cmds
+    assert ["docker", "network", "disconnect", "-f", "host", "minicloud"] in cmds
+
+
+def test_stop_clears_env_vars(tmp_path, monkeypatch):
+    monkeypatch.setenv("AWS_ENDPOINT_URL", "http://localhost:5000")
+    monkeypatch.setenv("GCE_ENDPOINT_URL", "http://localhost:5000")
+
+    config = MinicloudConfig(state_dir=str(tmp_path))
+    manager = MinicloudManager(config=config)
+
+    with patch("sdcm.utils.minicloud.subprocess.run"):
+        manager.stop()
+
+    assert "AWS_ENDPOINT_URL" not in os.environ
+    assert "GCE_ENDPOINT_URL" not in os.environ
+
+
+def test_stop_terminates_log_process(tmp_path):
+    config = MinicloudConfig(state_dir=str(tmp_path))
+    manager = MinicloudManager(config=config)
+    mock_log_proc = MagicMock()
+    manager._container_log_process = mock_log_proc
+
+    with patch("sdcm.utils.minicloud.subprocess.run"):
+        manager.stop()
+
+    mock_log_proc.terminate.assert_called_once()
+    assert manager._container_log_process is None
+
+
+def test_stop_is_idempotent(tmp_path):
+    config = MinicloudConfig(state_dir=str(tmp_path))
+    manager = MinicloudManager(config=config)
+
+    with patch("sdcm.utils.minicloud.subprocess.run") as mock_run:
+        manager.stop()
+        call_count_first = mock_run.call_count
+        manager.stop()
+        assert mock_run.call_count == call_count_first
+
+
+def test_stop_skipped_when_keep_alive(tmp_path):
+    config = MinicloudConfig(state_dir=str(tmp_path))
+    manager = MinicloudManager(config=config)
+    manager.keep_alive = True
+
+    with patch("sdcm.utils.minicloud.subprocess.run") as mock_run:
+        manager.stop()
+
+    mock_run.assert_not_called()
+
+
+def test_set_env_overrides_sets_all_six_vars(tmp_path, monkeypatch):
+    for key in (
+        "AWS_ENDPOINT_URL",
+        "SCT_MINICLOUD_ENDPOINT_URL",
+        "SCT_IP_SSH_CONNECTIONS",
+        "SCT_INSTANCE_PROVISION",
+        "SCT_ENTERPRISE_DISABLE_KMS",
+        "SCT_FORCE_RUN_IOTUNE",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+    config = MinicloudConfig(port=5000, state_dir=str(tmp_path))
+    manager = MinicloudManager(config=config)
+    manager.set_env_overrides()
+
+    assert os.environ["AWS_ENDPOINT_URL"] == "http://localhost:5000"
+    assert os.environ["SCT_MINICLOUD_ENDPOINT_URL"] == "http://localhost:5000"
+    assert os.environ["SCT_IP_SSH_CONNECTIONS"] == "private"
+    assert os.environ["SCT_INSTANCE_PROVISION"] == "on_demand"
+    assert os.environ["SCT_ENTERPRISE_DISABLE_KMS"] == "true"
+    assert os.environ["SCT_FORCE_RUN_IOTUNE"] == "false"
+
+
+def test_set_env_overrides_uses_config_port(tmp_path, monkeypatch):
+    monkeypatch.delenv("AWS_ENDPOINT_URL", raising=False)
+    config = MinicloudConfig(port=9876, state_dir=str(tmp_path))
+    manager = MinicloudManager(config=config)
+    manager.set_env_overrides()
+    assert os.environ["AWS_ENDPOINT_URL"] == "http://localhost:9876"
+    assert os.environ["SCT_MINICLOUD_ENDPOINT_URL"] == "http://localhost:9876"
+
+
+def test_prepare_regions_calls_configure(tmp_path):
+    config = MinicloudConfig(regions=["eu-west-1"], state_dir=str(tmp_path))
+    manager = MinicloudManager(config=config)
+
+    with patch("sdcm.utils.minicloud.AwsRegion") as mock_region_cls:
+        mock_region = MagicMock()
+        mock_region_cls.return_value = mock_region
+        manager.prepare_regions()
+
+    mock_region_cls.assert_called_once_with(region_name="eu-west-1")
+    mock_region.configure.assert_called_once()
+
+
+def test_prepare_regions_silences_ssm_failures(tmp_path):
+    config = MinicloudConfig(regions=["eu-west-1"], state_dir=str(tmp_path))
+    manager = MinicloudManager(config=config)
+
+    with patch("sdcm.utils.minicloud.AwsRegion") as mock_region_cls:
+        mock_region = MagicMock()
+        mock_region.configure.side_effect = Exception("SSM Systems Manager parameter not found")
+        mock_region_cls.return_value = mock_region
+        manager.prepare_regions()
+
+
+def test_prepare_regions_silences_ssm_lowercase(tmp_path):
+    config = MinicloudConfig(regions=["eu-west-1"], state_dir=str(tmp_path))
+    manager = MinicloudManager(config=config)
+
+    with patch("sdcm.utils.minicloud.AwsRegion") as mock_region_cls:
+        mock_region = MagicMock()
+        mock_region.configure.side_effect = Exception("ssm parameter store unavailable")
+        mock_region_cls.return_value = mock_region
+        manager.prepare_regions()
+
+
+def test_prepare_regions_reraises_non_ssm_exceptions(tmp_path):
+    config = MinicloudConfig(regions=["eu-west-1"], state_dir=str(tmp_path))
+    manager = MinicloudManager(config=config)
+
+    with patch("sdcm.utils.minicloud.AwsRegion") as mock_region_cls:
+        mock_region = MagicMock()
+        mock_region.configure.side_effect = Exception("vpc configuration failed: subnet not found")
+        mock_region_cls.return_value = mock_region
+        with pytest.raises(Exception, match="vpc"):
+            manager.prepare_regions()
+
+
+def test_is_running_true_when_container_running(tmp_path):
+    config = MinicloudConfig(state_dir=str(tmp_path))
+    manager = MinicloudManager(config=config)
+
+    result = MagicMock()
+    result.returncode = 0
+    result.stdout = "true\n"
+    with patch("sdcm.utils.minicloud.subprocess.run", return_value=result):
+        assert manager.is_running is True
+
+
+def test_is_running_false_when_container_not_running(tmp_path):
+    config = MinicloudConfig(state_dir=str(tmp_path))
+    manager = MinicloudManager(config=config)
+
+    result = MagicMock()
+    result.returncode = 1
+    result.stdout = ""
+    with patch("sdcm.utils.minicloud.subprocess.run", return_value=result):
+        assert manager.is_running is False
+
+
+def test_set_env_overrides_sets_gce_endpoint_url_when_backend_is_gce(tmp_path, monkeypatch):
+    monkeypatch.delenv("GCE_ENDPOINT_URL", raising=False)
+
+    config = MinicloudConfig(port=5000, state_dir=str(tmp_path), backend="gce")
+    manager = MinicloudManager(config=config)
+    manager.set_env_overrides()
+
+    assert os.environ["GCE_ENDPOINT_URL"] == "http://localhost:5000"
+
+
+def test_set_env_overrides_does_not_set_gce_endpoint_url_when_backend_is_aws(tmp_path, monkeypatch):
+    monkeypatch.delenv("GCE_ENDPOINT_URL", raising=False)
+
+    config = MinicloudConfig(port=5000, state_dir=str(tmp_path), backend="aws")
+    manager = MinicloudManager(config=config)
+    manager.set_env_overrides()
+
+    assert "GCE_ENDPOINT_URL" not in os.environ
+
+
+def test_set_env_overrides_does_not_set_gce_endpoint_url_when_no_backend(tmp_path, monkeypatch):
+    monkeypatch.delenv("SCT_CLUSTER_BACKEND", raising=False)
+    monkeypatch.delenv("GCE_ENDPOINT_URL", raising=False)
+
+    config = MinicloudConfig(port=5000, state_dir=str(tmp_path))
+    manager = MinicloudManager(config=config)
+    manager.set_env_overrides()
+
+    assert "GCE_ENDPOINT_URL" not in os.environ
+
+
+def test_gce_client_options_returns_client_options_when_endpoint_set(monkeypatch):
+    from google.api_core.client_options import ClientOptions  # noqa: PLC0415
+
+    monkeypatch.setenv("GCE_ENDPOINT_URL", "http://localhost:9099")
+    result = _gce_client_options()
+
+    assert "client_options" in result
+    assert isinstance(result["client_options"], ClientOptions)
+    assert result["client_options"].api_endpoint == "http://localhost:9099"
+
+
+def test_gce_client_options_returns_empty_dict_when_no_endpoint(monkeypatch):
+    monkeypatch.delenv("GCE_ENDPOINT_URL", raising=False)
+    result = _gce_client_options()
+
+    assert result == {}
+
+
+def test_gce_region_is_minicloud_true_when_endpoint_set(monkeypatch):
+    monkeypatch.setenv("GCE_ENDPOINT_URL", "http://localhost:9099")
+
+    fake_info = {
+        "project_id": "test-project",
+        "type": "service_account",
+        "client_email": "test@test-project.iam.gserviceaccount.com",
+        "private_key_id": "key-id",
+        "private_key": "",
+        "client_id": "123",
+        "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+        "token_uri": "https://oauth2.googleapis.com/token",
+    }
+    with patch("sdcm.utils.gce_region.KeyStore") as mock_keystore_cls:
+        mock_keystore_cls.return_value.get_gcp_credentials.return_value = fake_info
+        with patch("sdcm.utils.gce_region.service_account.Credentials.from_service_account_info"):
+            with patch("sdcm.utils.gce_region.build"):
+                with patch("sdcm.utils.gce_region.compute_v1.NetworksClient"):
+                    with patch("sdcm.utils.gce_region.compute_v1.FirewallsClient"):
+                        with patch("sdcm.utils.gce_region.compute_v1.SubnetworksClient"):
+                            with patch("sdcm.utils.gce_region.compute_v1.RoutesClient"):
+                                with patch("sdcm.utils.gce_region.storage.Client"):
+                                    region = GceRegion("us-central1")
+                                    assert region._is_minicloud is True
+
+
+def test_gce_region_is_minicloud_false_when_no_endpoint(monkeypatch):
+    monkeypatch.delenv("GCE_ENDPOINT_URL", raising=False)
+
+    fake_info = {
+        "project_id": "test-project",
+        "type": "service_account",
+        "client_email": "test@test-project.iam.gserviceaccount.com",
+        "private_key_id": "key-id",
+        "private_key": "",
+        "client_id": "123",
+        "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+        "token_uri": "https://oauth2.googleapis.com/token",
+    }
+    with patch("sdcm.utils.gce_region.KeyStore") as mock_keystore_cls:
+        mock_keystore_cls.return_value.get_gcp_credentials.return_value = fake_info
+        with patch("sdcm.utils.gce_region.service_account.Credentials.from_service_account_info"):
+            with patch("sdcm.utils.gce_region.build"):
+                with patch("sdcm.utils.gce_region.compute_v1.NetworksClient"):
+                    with patch("sdcm.utils.gce_region.compute_v1.FirewallsClient"):
+                        with patch("sdcm.utils.gce_region.compute_v1.SubnetworksClient"):
+                            with patch("sdcm.utils.gce_region.compute_v1.RoutesClient"):
+                                with patch("sdcm.utils.gce_region.storage.Client"):
+                                    region = GceRegion("us-central1")
+                                    assert region._is_minicloud is False
+
+
+def test_ensure_minicloud_ready_retries_then_succeeds(monkeypatch):
+    monkeypatch.setenv("SCT_MINICLOUD_ENDPOINT_URL", "http://localhost:5000")
+
+    call_count = {"n": 0}
+
+    def mock_check(endpoint=None, timeout=5):
+        call_count["n"] += 1
+        if call_count["n"] < 3:
+            raise RuntimeError("not reachable")
+        return True
+
+    with patch("sdcm.utils.minicloud.check_minicloud_reachability", side_effect=mock_check):
+        with patch("sdcm.utils.minicloud.time.sleep"):
+            ensure_minicloud_ready()
+
+    assert call_count["n"] == 3
+    assert os.environ.get("AWS_ENDPOINT_URL") == "http://localhost:5000"
+
+
+def test_ensure_minicloud_ready_falls_through_to_auto_start(monkeypatch):
+    monkeypatch.setenv("SCT_MINICLOUD_ENDPOINT_URL", "http://localhost:5000")
+
+    def mock_check_always_fails(endpoint=None, timeout=5):
+        raise RuntimeError("not reachable")
+
+    mock_manager = MagicMock()
+
+    with patch("sdcm.utils.minicloud.check_minicloud_reachability", side_effect=mock_check_always_fails):
+        with patch("sdcm.utils.minicloud.time.sleep"):
+            with patch("sdcm.utils.minicloud.MinicloudConfig.from_env"):
+                with patch("sdcm.utils.minicloud.MinicloudManager", return_value=mock_manager):
+                    ensure_minicloud_ready(backend="aws")
+
+    mock_manager.preflight_check.assert_called_once_with(skip_aws_creds=True)
+    mock_manager.start.assert_called_once()
+    mock_manager.prepare_regions.assert_called_once()
+
+
+# --- host memory preflight -----------------------------------------------------------------
+
+
+def _meminfo_path_patch(available_kib):
+    """Patch sdcm.utils.minicloud.Path so /proc/meminfo reports the given MemAvailable."""
+    mock_meminfo = MagicMock()
+    mock_meminfo.exists.return_value = True
+    mock_meminfo.read_text.return_value = f"MemTotal: 999999999 kB\nMemAvailable: {available_kib} kB\n"
+
+    def path_side_effect(arg):
+        if str(arg) == "/proc/meminfo":
+            return mock_meminfo
+        from pathlib import Path as RealPath  # noqa: PLC0415
+
+        return RealPath(arg)
+
+    return patch("sdcm.utils.minicloud.Path", side_effect=path_side_effect)
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [("4GiB", 4.0), ("2.5GiB", 2.5), ("4096MiB", 4.0), ("4G", 4.0), ("1TiB", 1024.0)],
+)
+def test_parse_memory_gib(value, expected):
+    assert MinicloudManager._parse_memory_gib(value) == pytest.approx(expected)
+
+
+def test_parse_memory_gib_rejects_garbage():
+    with pytest.raises(MinicloudError, match="cannot parse"):
+        MinicloudManager._parse_memory_gib("lots")
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [(3, 3), ("3 3", 6), ([3, 3], 6), (None, 0), ("", 0), ([], 0)],
+)
+def test_sum_node_counts(value, expected):
+    assert MinicloudManager._sum_node_counts(value) == expected
+
+
+def test_check_host_memory_fails_when_guests_exceed_available(tmp_path):
+    # 6 db + 1 loader + 1 monitor = 8 guests x 4GiB + 2GiB headroom = 34GiB needed, 16GiB available
+    manager = MinicloudManager(config=MinicloudConfig(state_dir=str(tmp_path), lightweight=True))
+    params = {"n_db_nodes": "3 3", "n_loaders": 1, "n_monitor_nodes": 1}
+    with _meminfo_path_patch(16 * 1024 * 1024):
+        with pytest.raises(MinicloudError, match="8 guest.*34.0GiB needed.*16.0GiB"):
+            manager._check_host_memory(params)
+
+
+def test_check_host_memory_passes_when_it_fits(tmp_path):
+    manager = MinicloudManager(config=MinicloudConfig(state_dir=str(tmp_path), lightweight=True))
+    params = {"n_db_nodes": 1, "n_loaders": 0, "n_monitor_nodes": 0}
+    with _meminfo_path_patch(16 * 1024 * 1024):
+        manager._check_host_memory(params)
+
+
+def test_check_host_memory_skipped_outside_lightweight_mode(tmp_path):
+    # non-lightweight sizing follows the requested instance types - no fixed per-guest figure
+    manager = MinicloudManager(config=MinicloudConfig(state_dir=str(tmp_path), lightweight=False))
+    with patch("sdcm.utils.minicloud.Path") as mock_path_cls:
+        manager._check_host_memory({"n_db_nodes": 100})
+        mock_path_cls.assert_not_called()
+
+
+def test_preflight_check_runs_memory_check_when_params_given(tmp_path):
+    manager = MinicloudManager(config=MinicloudConfig(state_dir=str(tmp_path), lightweight=True))
+    params = {"n_db_nodes": "3 3", "n_loaders": 1, "n_monitor_nodes": 1}
+
+    mock_kvm = MagicMock()
+    mock_kvm.exists.return_value = True
+    mock_meminfo = MagicMock()
+    mock_meminfo.exists.return_value = True
+    mock_meminfo.read_text.return_value = "MemAvailable: 8388608 kB\n"  # 8GiB
+
+    def path_side_effect(arg):
+        if str(arg) == "/dev/kvm":
+            return mock_kvm
+        if str(arg) == "/proc/meminfo":
+            return mock_meminfo
+        from pathlib import Path as RealPath  # noqa: PLC0415
+
+        return RealPath(arg)
+
+    with patch("sdcm.utils.minicloud.Path", side_effect=path_side_effect):
+        with patch("sdcm.utils.minicloud.shutil.which", return_value="/usr/bin/docker"):
+            with pytest.raises(MinicloudError, match="not enough memory"):
+                manager.preflight_check(skip_aws_creds=True, params=params)

--- a/utils/scylla_doctor.py
+++ b/utils/scylla_doctor.py
@@ -4,6 +4,7 @@ import json
 import logging
 import pprint
 import re
+import urllib.parse
 from functools import cached_property
 from textwrap import dedent
 from urllib.parse import urlparse
@@ -342,27 +343,41 @@ class ScyllaDoctor:
                 extraction failure.
         """
         tmp_tarball = "/tmp/scylla_doctor_download.tar.gz"
-        # -f/--fail  → exit code 22 on HTTP 4xx/5xx instead of saving the error page
+        # -f/--fail       → exit code 22 on HTTP 4xx/5xx instead of saving the error page
         # -S/--show-error → print error message even when -f is used
-        # -L/--location  → follow redirects
+        # -L/--location   → follow redirects
+        # -4/--ipv4       → force IPv4 (minicloud QEMU VMs have no routable IPv6)
+        # --compressed    → handle Content-Encoding (zstd/br/gzip) transparently;
+        #                    prevents saving a zstd-compressed blob when CloudFront
+        #                    negotiates compression with curl's advertised zstd support
         self.node.remoter.run(
-            f"curl -fSL -o {tmp_tarball} '{url}'",
+            f"curl -4 --compressed -fSL -o {tmp_tarball} '{url}'",
         )
-        # Sanity-check: a valid tarball is at least a few KB
+        # Sanity-check: verify the downloaded file is a valid gzip archive.
+        # Use magic-byte check (1f8b) instead of `file` command which may not be
+        # installed on minimal ScyllaDB AMIs.
         check = self.node.remoter.run(
-            f"test -s {tmp_tarball} && file {tmp_tarball}",
+            f"test -s {tmp_tarball} && head -c 2 {tmp_tarball} | od -An -tx1 | tr -d ' \\n'",
             verbose=False,
             ignore_status=True,
         )
-        if not check.ok or "gzip" not in check.stdout.lower():
-            body_head = self.node.remoter.run(
-                f"head -c 500 {tmp_tarball}",
+        if not check.ok or "1f8b" not in check.stdout.strip():
+            hexdump = self.node.remoter.run(
+                f"xxd {tmp_tarball} | head -20",
                 verbose=False,
                 ignore_status=True,
             ).stdout.strip()
+            parsed = urllib.parse.urlparse(url)
+            dns_result = self.node.remoter.run(
+                f"getent hosts {parsed.hostname} || echo 'DNS_LOOKUP_FAILED'",
+                verbose=False,
+                ignore_status=True,
+            )
             self.node.remoter.run(f"rm -f {tmp_tarball}", verbose=False, ignore_status=True)
             raise ScyllaDoctorException(
-                f"Downloaded {description} file is not a valid gzip tarball. First 500 bytes of response:\n{body_head}"
+                f"Downloaded {description} file is not a valid gzip tarball.\n"
+                f"DNS: {dns_result.stdout.strip()}\n"
+                f"Hexdump:\n{hexdump}"
             )
         LOGGER.info("Extracting %s tarball...", description)
         # --no-same-owner: avoid chown failures in Docker containers running as non-root
@@ -788,6 +803,11 @@ class ScyllaDoctor:
         if self.node.parent_cluster.cluster_backend == "docker" and collector in [
             "StorageConfigurationCollector",
             "PerftuneSystemConfigurationCollector",
+        ]:
+            return True
+
+        if self.test_config.tester_obj().params.get("minicloud_endpoint_url") and collector in [
+            "MaintenanceEventsCollector",
         ]:
             return True
 


### PR DESCRIPTION
## What

Core SCT support for [minicloud](https://github.com/scylladb/minicloud) — a local container serving the EC2 and GCE compute APIs, backed by real QEMU/KVM guests. SCT points its SDKs at it and runs otherwise unchanged: same test-cases, same provisioning code, same log collection, no real cloud credentials or cost.

**Scope note:** this PR was rewritten from its earlier 72-file form. It now carries *only* the core integration — `sdcm/`, `sct.py`, defaults, hydra env forwarding, unit tests, local-dev scripts, and `docs/minicloud.md`. All Jenkins pipeline work (the `minicloud: true` opt-in for artifacts/longevity/rolling-upgrade, the local-agent seam, the jobs) is split into `feature/minicloud-pipelines`, a follow-up PR stacked on this one. The unrelated argus KeyError fix moved to its own PR as well.

## Highlights

- `sdcm/utils/minicloud.py` — `MinicloudConfig`/`MinicloudManager`: config resolution (SCT params are the source of truth, bare `MINICLOUD_*` env vars are the per-invocation override, empty values never blank a default), preflight, start with container-death watch, `DescribeVpcs` health probe, per-region resource preparation, log collection.
- **Activation** is `SCT_MINICLOUD_ENDPOINT_URL` (or a localhost endpoint override, or the `minicloud_endpoint_url` param — the only yaml-visible knob). The docker-image knob selects an image and activates nothing.
- **Host-memory gate in preflight**: in lightweight mode every guest gets a fixed `minicloud_lightweight_memory`, so an oversized test is rejected up front with the arithmetic in the message, instead of dying mid-run as a cgroup OOM kill (exit 137) that takes every VM with it.
- `sct.py start-minicloud` runs the container with `keep_alive` for CI and builds a real `SCTConfiguration`, so the `minicloud_*` params actually reach the container on that path.
- `configurations/minicloud.yaml` — the overlay for any minicloud run: KMS off (minicloud implements no KMS endpoint; when it does, only this file changes), `on_demand`, private ssh.
- `docs/minicloud.md` (linked from the README): activation, config, memory arithmetic, lifecycle semantics, what is deliberately not implemented, local usage, troubleshooting by symptom.

## Tests

`unit_tests/unit/test_minicloud.py`: 88 tests covering config resolution, lifecycle, health checks and the memory gate. Plain pytest, no cloud access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

