### PR TITLE
fix(driver-connection): shutdown broken driver on connect failure to prevent fd leaks

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4605,7 +4605,21 @@ class BaseCluster:
             connect_timeout=connect_timeout,
             **kwargs,
         )
-        session = cluster_driver.connect()
+        try:
+            session = cluster_driver.connect()
+        except Exception as exc:
+            # Shutdown the broken driver to release internal connection managers, executor threads,
+            # and broken async loop file descriptors. Without this cleanup, the driver leaks resources
+            # and subsequent retries may hit "Bad file descriptor" errors on stale sockets.
+            # See: https://github.com/scylladb/python-driver/issues/614
+            self.log.error(
+                "Failed to connect CQL session due to %s: %s. Shutting down broken driver...", type(exc).__name__, exc
+            )
+            try:
+                cluster_driver.shutdown()
+            except Exception as shutdown_err:  # noqa: BLE001
+                self.log.debug("Ignoring error during broken driver shutdown: %s", shutdown_err)
+            raise
 
         # temporarily increase client-side timeout to 1m to determine
         # if the cluster is simply responding slowly to requests


### PR DESCRIPTION
## Summary

Adds proper cleanup of broken `ClusterDriver` instances when `connect()` fails in `_create_session()`.

### Problem

When the python-driver hits a "Bad file descriptor" error during connection establishment (see [scylladb/python-driver#614](https://github.com/scylladb/python-driver/issues/614)), the `ClusterDriver` instance leaks internal connection managers, executor threads, and broken async loop file descriptors. The existing `@retrying` decorator retries the entire `cql_connection_patient` method, but each failed attempt accumulates broken resources.

### Fix

Wrap `cluster_driver.connect()` in a try/except that calls `cluster_driver.shutdown()` on failure before re-raising. This ensures each retry starts with a clean driver state.

### Testing

This fix targets a transient race condition in the driver that manifests under real cluster conditions (especially during SSL certificate rotation or node restarts). The OCI provision test exercises real cluster provisioning which triggers the affected code path.

## Backends Affected
- All backends (the fix is in the shared `_create_session` method)

## Manual Testing Required
- Run a longevity test with SSL enabled and observe that connection recovery is clean
- The OCI provision test validates real cluster connectivity
- [ ] :clock1: [oss/longevity/longevity-100gb-4h-oci-test #18](https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/oss/job/longevity/job/longevity-100gb-4h-oci-test/18/)
