### PR TITLE
fix(node_exporter): fail on HTTP errors when downloading tarball

### DIFF
--- a/sdcm/node_exporter_setup.py
+++ b/sdcm/node_exporter_setup.py
@@ -1,4 +1,5 @@
 from sdcm.remote import shell_script_cmd
+from sdcm.utils.curl import curl_with_retry
 
 
 NODE_EXPORTER_VERSION = "1.8.2"
@@ -10,13 +11,18 @@ class NodeExporterSetup:
         assert node or remoter, "node or remoter much be pass to this function"
         if node:
             remoter = node.remoter
+        tarball = f"node_exporter-{NODE_EXPORTER_VERSION}.linux-amd64.tar.gz"
+        download_url = (
+            f"https://github.com/prometheus/node_exporter/releases/download/v{NODE_EXPORTER_VERSION}/{tarball}"
+        )
+        download_cmd = curl_with_retry(download_url, retry=8, follow_redirects=True, fail_early=True, output=tarball)
         remoter.sudo(
             shell_script_cmd(f"""
             if ! id node_exporter > /dev/null 2>&1; then
                 useradd -rs /bin/false node_exporter
             fi
-            curl -L --retry 5 --retry-max-time 300 -O https://github.com/prometheus/node_exporter/releases/download/v{NODE_EXPORTER_VERSION}/node_exporter-{NODE_EXPORTER_VERSION}.linux-amd64.tar.gz
-            tar -xzvf node_exporter-{NODE_EXPORTER_VERSION}.linux-amd64.tar.gz
+            {download_cmd}
+            tar -xzvf {tarball}
             mv node_exporter-{NODE_EXPORTER_VERSION}.linux-amd64/node_exporter /usr/local/bin
             # Restore SELinux context so the binary can be executed as a service on RHEL-based systems
             if command -v restorecon > /dev/null 2>&1; then

--- a/unit_tests/test_curl_utils.py
+++ b/unit_tests/test_curl_utils.py
@@ -37,6 +37,11 @@ from sdcm.utils.curl import curl_with_retry
             "curl --connect-timeout 10 --retry 5 --retry-max-time 300 -H 'Accept: json' https://x.com",
         ),
         (
+            "https://x.com",
+            {"fail_early": True},
+            "curl -f --connect-timeout 10 --retry 5 --retry-max-time 300 https://x.com",
+        ),
+        (
             "http://localhost:9180/metrics",
             {"retry": 0},
             "curl --connect-timeout 10 http://localhost:9180/metrics",


### PR DESCRIPTION
node-exporter release tarball is downloaded from Github with curl without `--fail`. So on an HTTP error curl saves the error page as the tarball and exits with 0. Tar then fails with "gzip: not in gzip format", aborting node setup.

The change fixes this by downloading via `curl_with_retry(fail_early=True)`, so curl exits with non-zero on HTTP errors.
Also retries count is raised from 5 to 8, to have more chances to survive transient GitHUb errors.

Fixes: SCT-206.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] simulated the failure from original issue locally - ran the `sdcm.utils.curl.curl_with_retry` against a basic local HTTP server, simulating a flaky GitHub (returned HTTP 503 a few times, then switched to successes). The fix was confirmed - `--retry` helped to survive temporary GitHub outage and to get the correct file. With `--fail` and simulated persistent outage the command eventually exits with non-zero and doesn't save the error page (and without `--fail` the original SCT-206 bug is reproduced).

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
