### PR TITLE
Introduce Manager 3.11

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -11,7 +11,7 @@ ip_ssh_connections: 'private'
 scylla_repo: ''
 unified_package: ''
 
-manager_version: '3.10'
+manager_version: '3.11'
 manager_scylla_backend_version: '2025.4'
 # Notice: that centos (default monitor), ubuntu 22, ubuntu 20 and debian 11 monitors use 2024, while debian 10 ubuntu 18 use 2023, since we support both
 
@@ -172,8 +172,8 @@ jepsen_test_count: 1
 jepsen_test_run_policy: all
 
 max_events_severities: ""
-scylla_mgmt_agent_version: '3.10.0'
-mgmt_docker_image: 'scylladb/scylla-manager:3.10.0'
+scylla_mgmt_agent_version: '3.11.0'
+mgmt_docker_image: 'scylladb/scylla-manager:3.11.0'
 k8s_log_api_calls: false
 k8s_deploy_monitoring: false
 k8s_minio_storage_size: '10Gi'

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -384,7 +384,7 @@ Url to the repo of scylla manager agent version to install for management tests
 
 Version of Scylla Manager server and agent to install
 
-**default:** 3.10
+**default:** 3.11
 
 **type:** str
 
@@ -411,7 +411,7 @@ Version of ScyllaDB to install as Manager backend
 
 Version of Scylla Manager agent to install for management tests
 
-**default:** 3.10.0
+**default:** 3.11.0
 
 **type:** str
 
@@ -2734,7 +2734,7 @@ Number of nodes in the monitoring pool that will be used for scylla-operator's d
 
 Scylla manager docker image, i.e. 'scylladb/scylla-manager:2.2.1'
 
-**default:** scylladb/scylla-manager:3.10.0
+**default:** scylladb/scylla-manager:3.11.0
 
 **type:** str
 * appendable

--- a/jenkins-pipelines/manager/ubuntu22-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu22-manager-upgrade.jenkinsfile
@@ -10,7 +10,7 @@ managerPipeline(
     scylla_version: '2026.1',
 
     // Upgrade from the previous minor release (the last one)
-    manager_version: '3.9',
+    manager_version: '3.10',
     target_manager_version: 'master_latest',
 
     test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',

--- a/jenkins-pipelines/manager/ubuntu24-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu24-manager-upgrade.jenkinsfile
@@ -8,7 +8,7 @@ managerPipeline(
     region: 'us-east-1',
 
     // Upgrade from the latest patch release
-    manager_version: '3.10',
+    manager_version: '3.11',
     target_manager_version: 'master_latest',
 
     test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',

--- a/unit_tests/unit/test_sdcm_mgmt_common.py
+++ b/unit_tests/unit/test_sdcm_mgmt_common.py
@@ -32,14 +32,14 @@ class TestManagerVersions:
         "version, distro, expected_url",
         [
             (
-                "3.10",
+                "3.11",
                 Distro.UBUNTU24,
-                "https://downloads.scylladb.com/deb/debian/scylladb-manager-3.10.list",
+                "https://downloads.scylladb.com/deb/debian/scylladb-manager-3.11.list",
             ),
             (
-                "3.10",
+                "3.11",
                 Distro.CENTOS9,
-                "https://downloads.scylladb.com/rpm/centos/scylladb-manager-3.10.repo",
+                "https://downloads.scylladb.com/rpm/centos/scylladb-manager-3.11.repo",
             ),
             (
                 "3.8.1",

--- a/vars/longevityPipeline.groovy
+++ b/vars/longevityPipeline.groovy
@@ -127,7 +127,7 @@ def call(Map pipelineParams) {
             // Manager Configuration
             separator(name: 'MANAGER_CONFIG', sectionHeader: 'Manager Configuration')
             string(defaultValue: "${pipelineParams.get('manager_version', '')}",
-                   description: 'master_latest|3.10|3.9',
+                   description: 'master_latest|3.11|3.10',
                    name: 'manager_version')
 
             string(defaultValue: '',

--- a/vars/managerPipeline.groovy
+++ b/vars/managerPipeline.groovy
@@ -124,7 +124,7 @@ def call(Map pipelineParams) {
                    name: 'ip_ssh_connections')
             separator(name: 'MANAGER_CONFIG', sectionHeader: 'Manager Configuration')
             string(defaultValue: "${pipelineParams.get('manager_version', 'master_latest')}",
-                   description: 'master_latest|3.10|3.9',
+                   description: 'master_latest|3.11|3.10',
                    name: 'manager_version')
 
             string(defaultValue: "${pipelineParams.get('scylla_mgmt_address', '')}",
@@ -140,7 +140,7 @@ def call(Map pipelineParams) {
                    name: 'scylla_mgmt_pkg')
 
             string(defaultValue: "${pipelineParams.get('target_manager_version', '')}",
-                   description: 'master_latest|3.10|3.9. Only for upgrade test',
+                   description: 'master_latest|3.11|3.10. Only for upgrade test',
                    name: 'target_manager_version')
 
             string(defaultValue: "${pipelineParams.get('target_scylla_mgmt_server_address', '')}",


### PR DESCRIPTION
Closes https://scylladb.atlassian.net/browse/CLOUD-2093

### Changes

- bump default Manager version to 3.11 across framework

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code
