### PR TITLE
refactor(monkey): Move SLA nemesis into own module

### DIFF
--- a/jenkins-pipelines/oss/nemesis/longevity-5gb-1h-RemoveServiceLevelMonkey-aws.jenkinsfile
+++ b/jenkins-pipelines/oss/nemesis/longevity-5gb-1h-RemoveServiceLevelMonkey-aws.jenkinsfile
@@ -7,5 +7,5 @@ longevityPipeline(
     backend: "aws",
     region: "eu-west-1",
     test_name: "longevity_test.LongevityTest.test_custom_time",
-    test_config: "['configurations/nemesis/longevity-5gb-1h-nemesis.yaml', 'configurations/nemesis/RemoveServiceLevelMonkey.yaml']"
+    test_config: "['configurations/nemesis/longevity-5gb-1h-nemesis.yaml', 'configurations/nemesis/RemoveServiceLevelMonkey.yaml', 'configurations/nemesis/additional_configs/sla_config.yaml', 'configurations/auth_cassandra.yaml']"
 )

--- a/jenkins-pipelines/oss/nemesis/longevity-5gb-1h-RemoveServiceLevelMonkey-azure.jenkinsfile
+++ b/jenkins-pipelines/oss/nemesis/longevity-5gb-1h-RemoveServiceLevelMonkey-azure.jenkinsfile
@@ -7,5 +7,5 @@ longevityPipeline(
     backend: "azure",
     azure_region_name: "eastus",
     test_name: "longevity_test.LongevityTest.test_custom_time",
-    test_config: "['configurations/nemesis/longevity-5gb-1h-nemesis.yaml', 'configurations/nemesis/RemoveServiceLevelMonkey.yaml']"
+    test_config: "['configurations/nemesis/longevity-5gb-1h-nemesis.yaml', 'configurations/nemesis/RemoveServiceLevelMonkey.yaml', 'configurations/nemesis/additional_configs/sla_config.yaml', 'configurations/auth_cassandra.yaml']"
 )

--- a/jenkins-pipelines/oss/nemesis/longevity-5gb-1h-RemoveServiceLevelMonkey-docker.jenkinsfile
+++ b/jenkins-pipelines/oss/nemesis/longevity-5gb-1h-RemoveServiceLevelMonkey-docker.jenkinsfile
@@ -7,5 +7,5 @@ longevityPipeline(
     backend: "docker",
     region: "eu-west-1",
     test_name: "longevity_test.LongevityTest.test_custom_time",
-    test_config: "['configurations/nemesis/longevity-5gb-1h-nemesis.yaml', 'configurations/nemesis/RemoveServiceLevelMonkey.yaml', 'configurations/nemesis/additional_configs/docker_backend.yaml']"
+    test_config: "['configurations/nemesis/longevity-5gb-1h-nemesis.yaml', 'configurations/nemesis/RemoveServiceLevelMonkey.yaml', 'configurations/nemesis/additional_configs/docker_backend.yaml', 'configurations/nemesis/additional_configs/sla_config.yaml', 'configurations/auth_cassandra.yaml']"
 )

--- a/jenkins-pipelines/oss/nemesis/longevity-5gb-1h-RemoveServiceLevelMonkey-gce.jenkinsfile
+++ b/jenkins-pipelines/oss/nemesis/longevity-5gb-1h-RemoveServiceLevelMonkey-gce.jenkinsfile
@@ -7,5 +7,5 @@ longevityPipeline(
     backend: "gce",
     gce_datacenter: "us-east1",
     test_name: "longevity_test.LongevityTest.test_custom_time",
-    test_config: "['configurations/nemesis/longevity-5gb-1h-nemesis.yaml', 'configurations/nemesis/RemoveServiceLevelMonkey.yaml']"
+    test_config: "['configurations/nemesis/longevity-5gb-1h-nemesis.yaml', 'configurations/nemesis/RemoveServiceLevelMonkey.yaml', 'configurations/nemesis/additional_configs/sla_config.yaml', 'configurations/auth_cassandra.yaml']"
 )

--- a/jenkins-pipelines/oss/nemesis/longevity-5gb-1h-RemoveServiceLevelMonkey-oci.jenkinsfile
+++ b/jenkins-pipelines/oss/nemesis/longevity-5gb-1h-RemoveServiceLevelMonkey-oci.jenkinsfile
@@ -7,5 +7,5 @@ longevityPipeline(
     backend: "oci",
     oci_region_name: "us-phoenix-1",
     test_name: "longevity_test.LongevityTest.test_custom_time",
-    test_config: "['configurations/nemesis/longevity-5gb-1h-nemesis.yaml', 'configurations/nemesis/RemoveServiceLevelMonkey.yaml']"
+    test_config: "['configurations/nemesis/longevity-5gb-1h-nemesis.yaml', 'configurations/nemesis/RemoveServiceLevelMonkey.yaml', 'configurations/nemesis/additional_configs/sla_config.yaml', 'configurations/auth_cassandra.yaml']"
 )

--- a/sdcm/nemesis/__init__.py
+++ b/sdcm/nemesis/__init__.py
@@ -67,7 +67,6 @@ from sdcm.cluster_k8s import (
     KubernetesOps,
     PodCluster,
 )
-from sdcm.db_stats import PrometheusDBStats
 from sdcm.log import SDCMAdapter
 from sdcm.logcollector import save_kallsyms_map
 from sdcm.mgmt.common import TaskStatus, ScyllaManagerError, get_persistent_snapshots, ObjectStorageUploadMode
@@ -98,7 +97,6 @@ from sdcm.sct_events.group_common_events import (
 from sdcm.sct_events.loaders import CassandraStressLogEvent, ScyllaBenchEvent
 from sdcm.sct_events.nemesis import DisruptionEvent
 from sdcm.sct_events.system import InfoEvent
-from sdcm.sla.sla_tests import SlaTests
 from sdcm.utils.aws_kms import AwsKms
 from sdcm.utils import cdc
 from sdcm.utils.adaptive_timeouts import adaptive_timeout, Operations
@@ -137,7 +135,7 @@ from sdcm.utils.k8s.chaos_mesh import (
     DiskError,
 )
 from sdcm.utils.ldap import SASLAUTHD_AUTHENTICATOR, LdapServerType
-from sdcm.utils.loader_utils import DEFAULT_USER, DEFAULT_USER_PASSWORD, SERVICE_LEVEL_NAME_TEMPLATE
+
 
 from sdcm.nemesis.utils import NEMESIS_TARGET_POOLS, DefaultValue, node_operations, unique_disruption_name
 from sdcm.nemesis.utils.indexes import (
@@ -177,7 +175,6 @@ from sdcm.exceptions import (
     WatcherCallableException,
     UnsupportedNemesis,
     CdcStreamsWasNotUpdated,
-    NemesisSubTestFailure,
     AuditLogTestFailure,
     BootstrapStreamErrorFailure,
     QuotaConfigurationFailure,
@@ -191,7 +188,6 @@ from test_lib.compaction import (
     GcMode,
 )
 from test_lib.cql_types import CQLTypeBuilder
-from test_lib.sla import ServiceLevel, MAX_ALLOWED_SERVICE_LEVELS
 from sdcm.utils.topology_ops import FailedDecommissionOperationMonitoring
 
 if TYPE_CHECKING:
@@ -1861,43 +1857,6 @@ class NemesisRunner:
             self.actions_log.info(f"Restarting scylla on {node.name}")
             node.restart_scylla_server()
             node.wait_db_up()
-
-    def disrupt_remove_service_level_while_load(self):
-        # Temporary solution. We do not want to run SLA nemeses during not-SLA test until the feature is stable
-        if not self.cluster.params.get("sla"):
-            raise UnsupportedNemesis("SLA nemesis can be run during SLA test only")
-
-        if not self.cluster.nodes[0].is_enterprise:
-            raise UnsupportedNemesis("SLA feature is only supported by Scylla Enterprise")
-
-        if not self.cluster.params.get("authenticator"):
-            raise UnsupportedNemesis("SLA feature can't work without authenticator")
-
-        if not getattr(self.tester, "roles", None):
-            raise UnsupportedNemesis("This nemesis is supported with Service Level and role are pre-defined")
-
-        role = self.tester.roles[0]
-
-        with self.cluster.cql_connection_patient(
-            node=self.cluster.nodes[0], user=DEFAULT_USER, password=DEFAULT_USER_PASSWORD
-        ) as session:
-            self.log.info("Drop service level %s", role.attached_service_level_name)
-            removed_shares = role.attached_service_level.shares
-            role.attached_service_level.session = session
-            role.session = session
-            try:
-                self.actions_log.info(f"Dropping service level {role.attached_service_level_name}")
-                role.attached_service_level.drop(if_exists=False)
-                time.sleep(300)  # let load to run without service level for 5 minutes
-            finally:
-                self.actions_log.info(f"Re-creating service level {role.attached_service_level_name}")
-                role.attach_service_level(
-                    ServiceLevel(
-                        session=session,
-                        name=SERVICE_LEVEL_NAME_TEMPLATE % (removed_shares, random.randint(0, 10)),
-                        shares=removed_shares,
-                    ).create()
-                )
 
     # Nemesis running code
     def execute_nemesis(self, nemesis: NemesisBaseClass):
@@ -4471,214 +4430,6 @@ class NemesisRunner:
         else:
             assert actual_cdc_settings == cdc_settings, (
                 f"CDC extension settings are differs. Current: {actual_cdc_settings} expected: {cdc_settings}"
-            )
-
-    def get_cassandra_stress_write_cmds(self):
-        write_cmds = self.tester.params.get("prepare_write_cmd")
-        if not write_cmds:
-            return None
-
-        stress_cmds = [cmd for cmd in write_cmds if " profile=" not in cmd and " n=" in cmd]
-        if not stress_cmds:
-            return None
-
-        return stress_cmds
-
-    def get_cassandra_stress_definition(self, stress_cmds, default_data_set_size=5000000):
-        stress_cmd = stress_cmds[0]
-        self.log.debug("Stress commands to get cassandra_stress_definition: %s", stress_cmd)
-        column_definition = self.tester.get_c_s_column_definition(cs_cmd=stress_cmd)
-        # Set small amount rows 5000000 when can not recognize a real dataset size, suppose that this amount should be
-        # inserted in any case
-        data_set_size = self.tester.get_data_set_size(stress_cmd) or default_data_set_size
-
-        self.log.debug("Dataset size for nemesis: %s", data_set_size)
-        self.log.debug("Cassandra-stress column definition for nemesis: %s", column_definition)
-        return column_definition, data_set_size
-
-    def disrupt_sla_increase_shares_during_load(self):
-        # Temporary solution. We do not want to run SLA nemeses during not-SLA test until the feature is stable
-        if not self.cluster.params.get("sla"):
-            raise UnsupportedNemesis("SLA nemesis can be run during SLA test only")
-
-        if not self.cluster.nodes[0].is_enterprise:
-            raise UnsupportedNemesis("SLA feature is only supported by Scylla Enterprise")
-
-        if not self.cluster.params.get("authenticator"):
-            raise UnsupportedNemesis("SLA feature can't work without authenticator")
-
-        if not (stress_cmds := self.get_cassandra_stress_write_cmds()):
-            raise UnsupportedNemesis(
-                "SLA nemesis needs cassandra-stress default table 'keyspace1.standard1' is created and prefilled"
-            )
-
-        column_definition, dataset_size = self.get_cassandra_stress_definition(stress_cmds)
-
-        prometheus_stats = PrometheusDBStats(host=self.monitoring_set.nodes[0].external_address)
-        sla_tests = SlaTests()
-        error_events = sla_tests.test_increase_shares_during_load(
-            tester=self.tester,
-            prometheus_stats=prometheus_stats,
-            num_of_partitions=dataset_size,
-            cassandra_stress_column_definition=column_definition,
-        )
-        self.format_error_for_sla_test_and_raise(error_events=error_events)
-
-    def disrupt_sla_decrease_shares_during_load(self):
-        # Temporary solution. We do not want to run SLA nemeses during not-SLA test until the feature is stable
-        if not self.cluster.params.get("sla"):
-            raise UnsupportedNemesis("SLA nemesis can be run during SLA test only")
-
-        if not self.cluster.nodes[0].is_enterprise:
-            raise UnsupportedNemesis("SLA feature is only supported by Scylla Enterprise")
-
-        if not self.cluster.params.get("authenticator"):
-            raise UnsupportedNemesis("SLA feature can't work without authenticator")
-
-        if not (stress_cmds := self.get_cassandra_stress_write_cmds()):
-            raise UnsupportedNemesis(
-                "SLA nemesis needs cassandra-stress default table 'keyspace1.standard1' is created and prefilled"
-            )
-
-        column_definition, dataset_size = self.get_cassandra_stress_definition(stress_cmds)
-
-        prometheus_stats = PrometheusDBStats(host=self.monitoring_set.nodes[0].external_address)
-        sla_tests = SlaTests()
-        error_events = sla_tests.test_decrease_shares_during_load(
-            tester=self.tester,
-            prometheus_stats=prometheus_stats,
-            num_of_partitions=dataset_size,
-            cassandra_stress_column_definition=column_definition,
-        )
-        self.format_error_for_sla_test_and_raise(error_events=error_events)
-
-    def disrupt_replace_service_level_using_detach_during_load(self):
-        # Temporary solution. We do not want to run SLA nemeses during not-SLA test until the feature is stable
-        if not self.cluster.params.get("sla"):
-            raise UnsupportedNemesis("SLA nemesis can be run during SLA test only")
-
-        if not self.cluster.nodes[0].is_enterprise:
-            raise UnsupportedNemesis("SLA feature is only supported by Scylla Enterprise")
-
-        if not self.cluster.params.get("authenticator"):
-            raise UnsupportedNemesis("SLA feature can't work without authenticator")
-
-        if not (stress_cmds := self.get_cassandra_stress_write_cmds()):
-            raise UnsupportedNemesis(
-                "SLA nemesis needs cassandra-stress default table 'keyspace1.standard1' is created and prefilled"
-            )
-
-        column_definition, dataset_size = self.get_cassandra_stress_definition(stress_cmds)
-
-        prometheus_stats = PrometheusDBStats(host=self.monitoring_set.nodes[0].external_address)
-        sla_tests = SlaTests()
-        error_events = sla_tests.test_replace_service_level_using_detach_during_load(
-            tester=self.tester,
-            prometheus_stats=prometheus_stats,
-            num_of_partitions=dataset_size,
-            cassandra_stress_column_definition=column_definition,
-        )
-        self.format_error_for_sla_test_and_raise(error_events=error_events)
-
-    def disrupt_replace_service_level_using_drop_during_load(self):
-        # Temporary solution. We do not want to run SLA nemeses during not-SLA test until the feature is stable
-        if not self.cluster.params.get("sla"):
-            raise UnsupportedNemesis("SLA nemesis can be run during SLA test only")
-
-        if not self.cluster.nodes[0].is_enterprise:
-            raise UnsupportedNemesis("SLA feature is only supported by Scylla Enterprise")
-
-        if not self.cluster.params.get("authenticator"):
-            raise UnsupportedNemesis("SLA feature can't work without authenticator")
-
-        if not (stress_cmds := self.get_cassandra_stress_write_cmds()):
-            raise UnsupportedNemesis(
-                "SLA nemesis needs cassandra-stress default table 'keyspace1.standard1' is created and prefilled"
-            )
-
-        column_definition, dataset_size = self.get_cassandra_stress_definition(stress_cmds)
-
-        prometheus_stats = PrometheusDBStats(host=self.monitoring_set.nodes[0].external_address)
-        sla_tests = SlaTests()
-        error_events = sla_tests.test_replace_service_level_using_drop_during_load(
-            tester=self.tester,
-            prometheus_stats=prometheus_stats,
-            num_of_partitions=dataset_size,
-            cassandra_stress_column_definition=column_definition,
-        )
-
-        self.format_error_for_sla_test_and_raise(error_events=error_events)
-
-    def disrupt_increase_shares_by_attach_another_sl_during_load(self):
-        # Temporary solution. We do not want to run SLA nemeses during not-SLA test until the feature is stable
-        if not self.cluster.params.get("sla"):
-            raise UnsupportedNemesis("SLA nemesis can be run during SLA test only")
-
-        if not self.cluster.nodes[0].is_enterprise:
-            raise UnsupportedNemesis("SLA feature is only supported by Scylla Enterprise")
-
-        if not self.cluster.params.get("authenticator"):
-            raise UnsupportedNemesis("SLA feature can't work without authenticator")
-
-        if not (stress_cmds := self.get_cassandra_stress_write_cmds()):
-            raise UnsupportedNemesis(
-                "SLA nemesis needs cassandra-stress default table 'keyspace1.standard1' is created and prefilled"
-            )
-
-        column_definition, dataset_size = self.get_cassandra_stress_definition(stress_cmds)
-
-        prometheus_stats = PrometheusDBStats(host=self.monitoring_set.nodes[0].external_address)
-        sla_tests = SlaTests()
-        error_events = sla_tests.test_increase_shares_by_attach_another_sl_during_load(
-            tester=self.tester,
-            prometheus_stats=prometheus_stats,
-            num_of_partitions=dataset_size,
-            cassandra_stress_column_definition=column_definition,
-        )
-
-        self.format_error_for_sla_test_and_raise(error_events=error_events)
-
-    def disrupt_maximum_allowed_sls_with_max_shares_during_load(self):
-        # Temporary solution. We do not want to run SLA nemeses during not-SLA test until the feature is stable
-        if not self.cluster.params.get("sla"):
-            raise UnsupportedNemesis("SLA nemesis can be run during SLA test only")
-
-        if not self.cluster.nodes[0].is_enterprise:
-            raise UnsupportedNemesis("SLA feature is only supported by Scylla Enterprise")
-
-        if not self.cluster.params.get("authenticator"):
-            raise UnsupportedNemesis("SLA feature can't work without authenticator")
-
-        if not (stress_cmds := self.get_cassandra_stress_write_cmds()):
-            raise UnsupportedNemesis(
-                "SLA nemesis needs cassandra-stress default table 'keyspace1.standard1' is created and prefilled"
-            )
-
-        column_definition, dataset_size = self.get_cassandra_stress_definition(stress_cmds)
-
-        prometheus_stats = PrometheusDBStats(host=self.monitoring_set.nodes[0].external_address)
-        sla_tests = SlaTests()
-        with self.cluster.cql_connection_patient(
-            node=self.cluster.nodes[0], user=DEFAULT_USER, password=DEFAULT_USER_PASSWORD
-        ) as session:
-            # Get amount of existing service levels plus default "cassandra"
-            created_service_levels = len(ServiceLevel(session=session, name="dummy").list_all_service_levels()) + 1
-
-        error_events = sla_tests.test_maximum_allowed_sls_with_max_shares_during_load(
-            tester=self.tester,
-            prometheus_stats=prometheus_stats,
-            num_of_partitions=dataset_size,
-            cassandra_stress_column_definition=column_definition,
-            service_levels_amount=MAX_ALLOWED_SERVICE_LEVELS - created_service_levels,
-        )
-
-        self.format_error_for_sla_test_and_raise(error_events=error_events)
-
-    @staticmethod
-    def format_error_for_sla_test_and_raise(error_events):
-        if any(error_events):
-            raise NemesisSubTestFailure(
-                "\n".join(f"Step: {error.step}. Error:\n - {error}" for error in error_events if error)
             )
 
     def disrupt_create_index(self):

--- a/sdcm/nemesis/monkey/__init__.py
+++ b/sdcm/nemesis/monkey/__init__.py
@@ -244,14 +244,6 @@ class RefreshBigMonkey(NemesisBaseClass):
         self.runner.disrupt_nodetool_refresh(big_sstable=True)
 
 
-class RemoveServiceLevelMonkey(NemesisBaseClass):
-    disruptive = True
-    sla = True
-
-    def disrupt(self):
-        self.runner.disrupt_remove_service_level_while_load()
-
-
 @target_all_nodes
 class EnospcMonkey(NemesisBaseClass):
     disruptive = True
@@ -705,93 +697,6 @@ class StartStopValidationCompaction(NemesisBaseClass):
 
     def disrupt(self):
         self.runner.disrupt_start_stop_validation_compaction()
-
-
-class SlaIncreaseSharesDuringLoad(NemesisBaseClass):
-    disruptive = False
-    sla = True
-
-    additional_configs = [
-        "configurations/nemesis/additional_configs/sla_config.yaml",
-        "configurations/auth_cassandra.yaml",
-    ]
-
-    def disrupt(self):
-        self.runner.disrupt_sla_increase_shares_during_load()
-
-
-class SlaDecreaseSharesDuringLoad(NemesisBaseClass):
-    disruptive = False
-    sla = True
-
-    additional_configs = [
-        "configurations/nemesis/additional_configs/sla_config.yaml",
-        "configurations/auth_cassandra.yaml",
-    ]
-
-    def disrupt(self):
-        self.runner.disrupt_sla_decrease_shares_during_load()
-
-
-class SlaReplaceUsingDetachDuringLoad(NemesisBaseClass):
-    # TODO: This SLA nemesis uses binary disable/enable workaround that in a test with parallel nemeses can cause to the errors and
-    #  failures that is not a problem of Scylla. The option "disruptive" was set to True to prevent irrelevant failures. Should be changed
-    #  to False when the issue https://github.com/scylladb/scylla-enterprise/issues/2572 will be fixed.
-    disruptive = True
-    sla = True
-
-    additional_configs = [
-        "configurations/nemesis/additional_configs/sla_config.yaml",
-        "configurations/auth_cassandra.yaml",
-    ]
-
-    def disrupt(self):
-        self.runner.disrupt_replace_service_level_using_detach_during_load()
-
-
-class SlaReplaceUsingDropDuringLoad(NemesisBaseClass):
-    # TODO: This SLA nemesis uses binary disable/enable workaround that in a test with parallel nemeses can cause to the errors and
-    #  failures that is not a problem of Scylla. The option "disruptive" was set to True to prevent irrelevant failures. Should be changed
-    #  to False when the issue https://github.com/scylladb/scylla-enterprise/issues/2572 will be fixed.
-    disruptive = True
-    sla = True
-
-    additional_configs = [
-        "configurations/nemesis/additional_configs/sla_config.yaml",
-        "configurations/auth_cassandra.yaml",
-    ]
-
-    def disrupt(self):
-        self.runner.disrupt_replace_service_level_using_drop_during_load()
-
-
-class SlaIncreaseSharesByAttachAnotherSlDuringLoad(NemesisBaseClass):
-    # TODO: This SLA nemesis uses binary disable/enable workaround that in a test with parallel nemeses can cause to the errors and
-    #  failures that is not a problem of Scylla. The option "disruptive" was set to True to prevent irrelevant failures. Should be changed
-    #  to False when the issue https://github.com/scylladb/scylla-enterprise/issues/2572 will be fixed.
-    disruptive = True
-    sla = True
-
-    additional_configs = [
-        "configurations/nemesis/additional_configs/sla_config.yaml",
-        "configurations/auth_cassandra.yaml",
-    ]
-
-    def disrupt(self):
-        self.runner.disrupt_increase_shares_by_attach_another_sl_during_load()
-
-
-class SlaMaximumAllowedSlsWithMaxSharesDuringLoad(NemesisBaseClass):
-    disruptive = False
-    sla = True
-
-    additional_configs = [
-        "configurations/nemesis/additional_configs/sla_config.yaml",
-        "configurations/auth_cassandra.yaml",
-    ]
-
-    def disrupt(self):
-        self.runner.disrupt_maximum_allowed_sls_with_max_shares_during_load()
 
 
 @target_data_nodes

--- a/sdcm/nemesis/monkey/sla.py
+++ b/sdcm/nemesis/monkey/sla.py
@@ -1,0 +1,239 @@
+import random
+import time
+
+from sdcm.db_stats import PrometheusDBStats
+from sdcm.exceptions import NemesisSubTestFailure, UnsupportedNemesis
+from sdcm.nemesis import NemesisBaseClass
+from sdcm.sla.sla_tests import SlaTests
+from sdcm.utils.loader_utils import DEFAULT_USER, DEFAULT_USER_PASSWORD, SERVICE_LEVEL_NAME_TEMPLATE
+from test_lib.sla import MAX_ALLOWED_SERVICE_LEVELS, ServiceLevel
+
+
+class SlaMonkeyBase(NemesisBaseClass):
+    """Base class for SLA nemesis with shared validation logic."""
+
+    sla = True
+
+    additional_configs = [
+        "configurations/nemesis/additional_configs/sla_config.yaml",
+        "configurations/auth_cassandra.yaml",
+    ]
+
+    def validate_sla_preconditions(self):
+        """Common validation for all SLA nemeses."""
+        if not self.runner.cluster.params.get("sla"):
+            raise UnsupportedNemesis("SLA nemesis can be run during SLA test only")
+
+        if not self.runner.cluster.nodes[0].is_enterprise:
+            raise UnsupportedNemesis("SLA feature is only supported by Scylla Enterprise")
+
+        if not self.runner.cluster.params.get("authenticator"):
+            raise UnsupportedNemesis("SLA feature can't work without authenticator")
+
+    def get_cassandra_stress_write_cmds(self):
+        write_cmds = self.runner.tester.params.get("prepare_write_cmd")
+        if not write_cmds:
+            return None
+
+        if not isinstance(write_cmds, list):
+            write_cmds = [write_cmds]
+
+        stress_cmds = [cmd for cmd in write_cmds if " profile=" not in cmd and " n=" in cmd]
+        if not stress_cmds:
+            return None
+
+        return stress_cmds
+
+    def get_cassandra_stress_definition(self, stress_cmds, default_data_set_size=5000000):
+        stress_cmd = stress_cmds[0]
+        self.runner.log.debug("Stress commands to get cassandra_stress_definition: %s", stress_cmd)
+        column_definition = self.runner.tester.get_c_s_column_definition(cs_cmd=stress_cmd)
+        # Set small amount rows 5000000 when can not recognize a real dataset size, suppose that this amount should be
+        # inserted in any case
+        data_set_size = self.runner.tester.get_data_set_size(stress_cmd) or default_data_set_size
+
+        self.runner.log.debug("Dataset size for nemesis: %s", data_set_size)
+        self.runner.log.debug("Cassandra-stress column definition for nemesis: %s", column_definition)
+        return column_definition, data_set_size
+
+    def get_stress_params(self):
+        """Return (column_definition, dataset_size) for SLA stress tests."""
+        stress_cmds = self.get_cassandra_stress_write_cmds()
+        if not stress_cmds:
+            raise UnsupportedNemesis(
+                "SLA nemesis needs cassandra-stress default table 'keyspace1.standard1' is created and prefilled"
+            )
+
+        return self.get_cassandra_stress_definition(stress_cmds)
+
+    @staticmethod
+    def format_error_for_sla_test_and_raise(error_events):
+        if any(error_events):
+            raise NemesisSubTestFailure(
+                "\n".join(f"Step: {error.step}. Error:\n - {error}" for error in error_events if error)
+            )
+
+
+class RemoveServiceLevelMonkey(SlaMonkeyBase):
+    """Remove service level while load is running, then re-create it."""
+
+    disruptive = True
+
+    def disrupt(self):
+        self.validate_sla_preconditions()
+
+        if not getattr(self.runner.tester, "roles", None):
+            raise UnsupportedNemesis("This nemesis is supported with Service Level and role are pre-defined")
+
+        role = self.runner.tester.roles[0]
+
+        with self.runner.cluster.cql_connection_patient(
+            node=self.runner.target_node, user=DEFAULT_USER, password=DEFAULT_USER_PASSWORD
+        ) as session:
+            self.runner.log.info("Drop service level %s", role.attached_service_level_name)
+            removed_shares = role.attached_service_level.shares
+            role.attached_service_level.session = session
+            role.session = session
+            try:
+                self.runner.actions_log.info(f"Dropping service level {role.attached_service_level_name}")
+                role.attached_service_level.drop(if_exists=False)
+                time.sleep(300)  # let load to run without service level for 5 minutes
+            finally:
+                self.runner.actions_log.info(f"Re-creating service level {role.attached_service_level_name}")
+                role.attach_service_level(
+                    ServiceLevel(
+                        session=session,
+                        name=SERVICE_LEVEL_NAME_TEMPLATE % (removed_shares, random.randint(0, 10)),
+                        shares=removed_shares,
+                    ).create()
+                )
+
+
+class SlaIncreaseSharesDuringLoad(SlaMonkeyBase):
+    """Increase SLA shares during load and verify throughput changes accordingly."""
+
+    disruptive = False
+
+    def disrupt(self):
+        self.validate_sla_preconditions()
+        column_definition, dataset_size = self.get_stress_params()
+
+        prometheus_stats = PrometheusDBStats(host=self.runner.monitoring_set.nodes[0].external_address)
+        error_events = SlaTests().test_increase_shares_during_load(
+            tester=self.runner.tester,
+            prometheus_stats=prometheus_stats,
+            num_of_partitions=dataset_size,
+            cassandra_stress_column_definition=column_definition,
+        )
+        self.format_error_for_sla_test_and_raise(error_events=error_events)
+
+
+class SlaDecreaseSharesDuringLoad(SlaMonkeyBase):
+    """Decrease SLA shares during load and verify throughput changes accordingly."""
+
+    disruptive = False
+
+    def disrupt(self):
+        self.validate_sla_preconditions()
+        column_definition, dataset_size = self.get_stress_params()
+
+        prometheus_stats = PrometheusDBStats(host=self.runner.monitoring_set.nodes[0].external_address)
+        error_events = SlaTests().test_decrease_shares_during_load(
+            tester=self.runner.tester,
+            prometheus_stats=prometheus_stats,
+            num_of_partitions=dataset_size,
+            cassandra_stress_column_definition=column_definition,
+        )
+        self.format_error_for_sla_test_and_raise(error_events=error_events)
+
+
+class SlaReplaceUsingDetachDuringLoad(SlaMonkeyBase):
+    """Replace service level using detach during load."""
+
+    # TODO: Should be changed to False when https://github.com/scylladb/scylla-enterprise/issues/2572 is fixed.
+    disruptive = True
+
+    def disrupt(self):
+        self.validate_sla_preconditions()
+        column_definition, dataset_size = self.get_stress_params()
+
+        prometheus_stats = PrometheusDBStats(host=self.runner.monitoring_set.nodes[0].external_address)
+        error_events = SlaTests().test_replace_service_level_using_detach_during_load(
+            tester=self.runner.tester,
+            prometheus_stats=prometheus_stats,
+            num_of_partitions=dataset_size,
+            cassandra_stress_column_definition=column_definition,
+        )
+        self.format_error_for_sla_test_and_raise(error_events=error_events)
+
+
+class SlaReplaceUsingDropDuringLoad(SlaMonkeyBase):
+    """Replace service level using drop during load."""
+
+    # TODO: Should be changed to False when https://github.com/scylladb/scylla-enterprise/issues/2572 is fixed.
+    disruptive = True
+
+    def disrupt(self):
+        self.validate_sla_preconditions()
+        column_definition, dataset_size = self.get_stress_params()
+
+        prometheus_stats = PrometheusDBStats(host=self.runner.monitoring_set.nodes[0].external_address)
+        error_events = SlaTests().test_replace_service_level_using_drop_during_load(
+            tester=self.runner.tester,
+            prometheus_stats=prometheus_stats,
+            num_of_partitions=dataset_size,
+            cassandra_stress_column_definition=column_definition,
+        )
+        self.format_error_for_sla_test_and_raise(error_events=error_events)
+
+
+class SlaIncreaseSharesByAttachAnotherSlDuringLoad(SlaMonkeyBase):
+    """Increase shares by attaching another service level during load."""
+
+    # TODO: Should be changed to False when https://github.com/scylladb/scylla-enterprise/issues/2572 is fixed.
+    disruptive = True
+
+    def disrupt(self):
+        self.validate_sla_preconditions()
+        column_definition, dataset_size = self.get_stress_params()
+
+        prometheus_stats = PrometheusDBStats(host=self.runner.monitoring_set.nodes[0].external_address)
+        error_events = SlaTests().test_increase_shares_by_attach_another_sl_during_load(
+            tester=self.runner.tester,
+            prometheus_stats=prometheus_stats,
+            num_of_partitions=dataset_size,
+            cassandra_stress_column_definition=column_definition,
+        )
+        self.format_error_for_sla_test_and_raise(error_events=error_events)
+
+
+class SlaMaximumAllowedSlsWithMaxSharesDuringLoad(SlaMonkeyBase):
+    """Test maximum allowed service levels with max shares during load."""
+
+    disruptive = False
+
+    def disrupt(self):
+        self.validate_sla_preconditions()
+        column_definition, dataset_size = self.get_stress_params()
+
+        prometheus_stats = PrometheusDBStats(host=self.runner.monitoring_set.nodes[0].external_address)
+        with self.runner.cluster.cql_connection_patient(
+            node=self.runner.target_node, user=DEFAULT_USER, password=DEFAULT_USER_PASSWORD
+        ) as session:
+            created_service_levels = len(ServiceLevel(session=session, name="dummy").list_all_service_levels()) + 1
+
+        remaining_service_levels = MAX_ALLOWED_SERVICE_LEVELS - created_service_levels
+        if remaining_service_levels <= 0:
+            raise UnsupportedNemesis(
+                f"No remaining service-level slots: {created_service_levels} already exist "
+                f"(max allowed: {MAX_ALLOWED_SERVICE_LEVELS})"
+            )
+
+        error_events = SlaTests().test_maximum_allowed_sls_with_max_shares_during_load(
+            tester=self.runner.tester,
+            prometheus_stats=prometheus_stats,
+            num_of_partitions=dataset_size,
+            cassandra_stress_column_definition=column_definition,
+            service_levels_amount=remaining_service_levels,
+        )
+        self.format_error_for_sla_test_and_raise(error_events=error_events)

--- a/unit_tests/unit/nemesis/monkey/test_sla.py
+++ b/unit_tests/unit/nemesis/monkey/test_sla.py
@@ -1,0 +1,496 @@
+"""Tests for sdcm.nemesis.monkey.sla module.
+
+Tests focus on deterministic behavior: precondition validation, stress-command
+filtering/building, error formatting, and correct delegation to SlaTests
+methods.  All external I/O (Prometheus, CQL, SlaTests heavy logic) is mocked.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from sdcm.exceptions import NemesisSubTestFailure, UnsupportedNemesis
+from sdcm.nemesis.monkey.sla import (
+    RemoveServiceLevelMonkey,
+    SlaDecreaseSharesDuringLoad,
+    SlaIncreaseSharesByAttachAnotherSlDuringLoad,
+    SlaIncreaseSharesDuringLoad,
+    SlaMaximumAllowedSlsWithMaxSharesDuringLoad,
+    SlaMonkeyBase,
+    SlaReplaceUsingDetachDuringLoad,
+    SlaReplaceUsingDropDuringLoad,
+)
+from sdcm.sct_events.system import TestStepEvent
+
+_MODULE = "sdcm.nemesis.monkey.sla"
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+pytestmark = pytest.mark.usefixtures("events")
+
+
+@pytest.fixture()
+def runner(base_runner):
+    """``base_runner`` extended with SLA-specific attributes.
+
+    Adds ``monitoring_set`` (needed by all SlaTests-delegating monkeys) and
+    configures cluster params so ``validate_sla_preconditions`` passes by default.
+    """
+    # monitoring_set needed by SlaTests-delegating monkeys
+    monitor = MagicMock()
+    monitor.nodes = [MagicMock()]
+    monitor.nodes[0].external_address = "10.0.0.1"
+    base_runner.monitoring_set = monitor
+
+    # pass all three SLA preconditions by default
+    base_runner.cluster.params.get.side_effect = lambda key, **kw: {
+        "sla": True,
+        "authenticator": "PasswordAuthenticator",
+    }.get(key)
+    base_runner.cluster.nodes = base_runner.cluster.data_nodes
+    base_runner.cluster.nodes[0].is_enterprise = True
+
+    # tester.params is None by default in TestRunner — replace with a MagicMock
+    base_runner.tester.params = MagicMock()
+
+    # stress params used by get_stress_params
+    base_runner.tester.params.get.return_value = [
+        "cassandra-stress write n=1000000 -schema 'replication(strategy=NetworkTopologyStrategy)'",
+    ]
+    base_runner.tester.get_c_s_column_definition.return_value = "-col n=5 size=FIXED(64)"
+    base_runner.tester.get_data_set_size.return_value = 1000000
+
+    return base_runner
+
+
+@pytest.fixture()
+def remove_sl_runner(runner):
+    """Runner with a pre-configured role and service level."""
+    role = MagicMock()
+    role.attached_service_level_name = "sl_200"
+    role.attached_service_level.shares = 200
+    runner.tester.roles = [role]
+    return runner
+
+
+# ---------------------------------------------------------------------------
+# validate_sla_preconditions
+# ---------------------------------------------------------------------------
+
+
+def test_preconditions_raises_when_sla_disabled(runner):
+    """Raise UnsupportedNemesis when 'sla' param is falsy."""
+    runner.cluster.params.get.side_effect = lambda key, **kw: {"sla": False, "authenticator": "Password"}.get(key)
+    monkey = SlaIncreaseSharesDuringLoad(runner)
+
+    with pytest.raises(UnsupportedNemesis, match="SLA nemesis can be run during SLA test only"):
+        monkey.validate_sla_preconditions()
+
+
+def test_preconditions_raises_when_not_enterprise(runner):
+    """Raise UnsupportedNemesis when target node is not Scylla Enterprise."""
+    runner.cluster.nodes[0].is_enterprise = False
+    monkey = SlaIncreaseSharesDuringLoad(runner)
+
+    with pytest.raises(UnsupportedNemesis, match="only supported by Scylla Enterprise"):
+        monkey.validate_sla_preconditions()
+
+
+def test_preconditions_raises_when_no_authenticator(runner):
+    """Raise UnsupportedNemesis when authenticator param is falsy."""
+    runner.cluster.params.get.side_effect = lambda key, **kw: {"sla": True, "authenticator": None}.get(key)
+    monkey = SlaIncreaseSharesDuringLoad(runner)
+
+    with pytest.raises(UnsupportedNemesis, match="can't work without authenticator"):
+        monkey.validate_sla_preconditions()
+
+
+def test_preconditions_passes_when_all_conditions_met(runner):
+    """No exception raised when all three preconditions pass."""
+    monkey = SlaIncreaseSharesDuringLoad(runner)
+    monkey.validate_sla_preconditions()  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# get_cassandra_stress_write_cmds
+# ---------------------------------------------------------------------------
+
+
+def test_get_write_cmds_returns_none_when_no_prepare_cmd(runner):
+    """Return None when prepare_write_cmd is not configured."""
+    runner.tester.params.get.return_value = None
+    monkey = SlaIncreaseSharesDuringLoad(runner)
+
+    assert monkey.get_cassandra_stress_write_cmds() is None
+
+
+def test_get_write_cmds_wraps_single_string_into_list(runner):
+    """A single string prepare_write_cmd is treated as a one-element list."""
+    cmd = "cassandra-stress write n=1000 cl=QUORUM"
+    runner.tester.params.get.return_value = cmd
+    monkey = SlaIncreaseSharesDuringLoad(runner)
+
+    result = monkey.get_cassandra_stress_write_cmds()
+
+    assert result == [cmd]
+
+
+def test_get_write_cmds_filters_out_profile_commands(runner):
+    """Commands containing ' profile=' are excluded from the result."""
+    runner.tester.params.get.return_value = [
+        "cassandra-stress write n=1000 profile=/tmp/profile.yaml",  # excluded
+        "cassandra-stress write n=2000 cl=QUORUM",  # included
+    ]
+    monkey = SlaIncreaseSharesDuringLoad(runner)
+
+    result = monkey.get_cassandra_stress_write_cmds()
+
+    assert result == ["cassandra-stress write n=2000 cl=QUORUM"]
+
+
+def test_get_write_cmds_filters_out_commands_without_n(runner):
+    """Commands without ' n=' (e.g. duration-based) are excluded."""
+    runner.tester.params.get.return_value = [
+        "cassandra-stress write duration=30m cl=QUORUM",  # excluded — no n=
+        "cassandra-stress write n=5000 cl=QUORUM",  # included
+    ]
+    monkey = SlaIncreaseSharesDuringLoad(runner)
+
+    result = monkey.get_cassandra_stress_write_cmds()
+
+    assert result == ["cassandra-stress write n=5000 cl=QUORUM"]
+
+
+def test_get_write_cmds_returns_none_when_all_filtered(runner):
+    """Return None when all commands are filtered out."""
+    runner.tester.params.get.return_value = [
+        "cassandra-stress write duration=30m cl=QUORUM",
+        "cassandra-stress write profile=/tmp/p.yaml n=1000",
+    ]
+    monkey = SlaIncreaseSharesDuringLoad(runner)
+
+    assert monkey.get_cassandra_stress_write_cmds() is None
+
+
+# ---------------------------------------------------------------------------
+# get_cassandra_stress_definition
+# ---------------------------------------------------------------------------
+
+
+def test_get_stress_definition_returns_column_def_and_dataset_size(runner):
+    """Returns (column_definition, dataset_size) from tester helpers."""
+    monkey = SlaIncreaseSharesDuringLoad(runner)
+    cmds = ["cassandra-stress write n=1000000 cl=QUORUM"]
+
+    col_def, size = monkey.get_cassandra_stress_definition(cmds)
+
+    assert col_def == "-col n=5 size=FIXED(64)"
+    assert size == 1000000
+    runner.tester.get_c_s_column_definition.assert_called_once_with(cs_cmd=cmds[0])
+    runner.tester.get_data_set_size.assert_called_once_with(cmds[0])
+
+
+def test_get_stress_definition_falls_back_to_default_dataset_size(runner):
+    """When get_data_set_size returns 0/None, use default_data_set_size (5_000_000)."""
+    runner.tester.get_data_set_size.return_value = 0
+    monkey = SlaIncreaseSharesDuringLoad(runner)
+    cmds = ["cassandra-stress write n=0 cl=QUORUM"]
+
+    _, size = monkey.get_cassandra_stress_definition(cmds)
+
+    assert size == 5_000_000
+
+
+def test_get_stress_definition_custom_default(runner):
+    """Custom default_data_set_size is used when get_data_set_size returns 0."""
+    runner.tester.get_data_set_size.return_value = 0
+    monkey = SlaIncreaseSharesDuringLoad(runner)
+    cmds = ["cassandra-stress write n=0 cl=QUORUM"]
+
+    _, size = monkey.get_cassandra_stress_definition(cmds, default_data_set_size=999)
+
+    assert size == 999
+
+
+# ---------------------------------------------------------------------------
+# get_stress_params
+# ---------------------------------------------------------------------------
+
+
+def test_get_stress_params_raises_when_no_cmds(runner):
+    """Raise UnsupportedNemesis when no usable stress commands are found."""
+    runner.tester.params.get.return_value = None
+    monkey = SlaIncreaseSharesDuringLoad(runner)
+
+    with pytest.raises(UnsupportedNemesis, match="keyspace1.standard1"):
+        monkey.get_stress_params()
+
+
+def test_get_stress_params_returns_col_def_and_size(runner):
+    """Return (column_definition, dataset_size) when everything is set up correctly."""
+    monkey = SlaIncreaseSharesDuringLoad(runner)
+
+    col_def, size = monkey.get_stress_params()
+
+    assert col_def == "-col n=5 size=FIXED(64)"
+    assert size == 1000000
+
+
+# ---------------------------------------------------------------------------
+# format_error_for_sla_test_and_raise
+# ---------------------------------------------------------------------------
+
+
+def test_format_error_does_nothing_when_no_errors():
+    """No exception when all events are None."""
+    SlaMonkeyBase.format_error_for_sla_test_and_raise([None, None])
+
+
+def test_format_error_does_nothing_for_empty_list():
+    """No exception for an empty events list."""
+    SlaMonkeyBase.format_error_for_sla_test_and_raise([])
+
+
+def test_format_error_raises_on_error_event():
+    """Raise NemesisSubTestFailure with the error step and message."""
+    event = TestStepEvent(step="Run stress", publish_event=False)
+    event.add_error(["something went wrong"])
+
+    with pytest.raises(NemesisSubTestFailure, match="Step: Run stress"):
+        SlaMonkeyBase.format_error_for_sla_test_and_raise([None, event])
+
+
+def test_format_error_includes_all_error_steps():
+    """All failing steps appear in the exception message."""
+    event_a = TestStepEvent(step="Step A", publish_event=False)
+    event_a.add_error(["err A"])
+    event_b = TestStepEvent(step="Step B", publish_event=False)
+    event_b.add_error(["err B"])
+
+    with pytest.raises(NemesisSubTestFailure) as exc_info:
+        SlaMonkeyBase.format_error_for_sla_test_and_raise([event_a, event_b])
+
+    msg = str(exc_info.value)
+    assert "Step A" in msg
+    assert "Step B" in msg
+
+
+# ---------------------------------------------------------------------------
+# RemoveServiceLevelMonkey
+# ---------------------------------------------------------------------------
+
+
+def test_remove_sl_raises_when_no_roles(runner):
+    """Raise UnsupportedNemesis when tester has no pre-defined roles."""
+    runner.tester.roles = []
+    monkey = RemoveServiceLevelMonkey(runner)
+
+    with pytest.raises(UnsupportedNemesis, match="Service Level and role are pre-defined"):
+        monkey.disrupt()
+
+
+def test_remove_sl_raises_when_roles_attr_missing(runner):
+    """Raise UnsupportedNemesis when tester.roles attribute does not exist."""
+    del runner.tester.roles
+    monkey = RemoveServiceLevelMonkey(runner)
+
+    with pytest.raises(UnsupportedNemesis, match="Service Level and role are pre-defined"):
+        monkey.disrupt()
+
+
+def test_remove_sl_drops_and_recreates_service_level(remove_sl_runner):
+    """disrupt() drops the service level and re-creates it when drop succeeds."""
+    with (
+        patch(f"{_MODULE}.time.sleep"),
+        patch(f"{_MODULE}.ServiceLevel") as mock_sl_cls,
+    ):
+        mock_new_sl = MagicMock()
+        mock_sl_cls.return_value.create.return_value = mock_new_sl
+
+        monkey = RemoveServiceLevelMonkey(remove_sl_runner)
+        monkey.disrupt()
+
+    role = remove_sl_runner.tester.roles[0]
+    role.attached_service_level.drop.assert_called_once_with(if_exists=False)
+    role.attach_service_level.assert_called_once_with(mock_new_sl)
+
+
+def test_remove_sl_recreates_even_when_drop_fails(remove_sl_runner):
+    """When drop() raises, the service level must still be re-created (finally is unconditional).
+
+    If drop() succeeds server-side but the response is lost (e.g. network timeout),
+    skipping recreation would leave the role permanently without a service level.
+    Unconditional recreation in finally avoids that worse outcome.
+    """
+    role = remove_sl_runner.tester.roles[0]
+    role.attached_service_level.drop.side_effect = RuntimeError("drop failed")
+
+    with (
+        patch(f"{_MODULE}.time.sleep"),
+        patch(f"{_MODULE}.ServiceLevel") as mock_sl_cls,
+        pytest.raises(RuntimeError, match="drop failed"),
+    ):
+        mock_new_sl = MagicMock()
+        mock_sl_cls.return_value.create.return_value = mock_new_sl
+        RemoveServiceLevelMonkey(remove_sl_runner).disrupt()
+
+    role.attach_service_level.assert_called_once_with(mock_new_sl)
+
+
+def test_remove_sl_sleeps_between_drop_and_recreate(remove_sl_runner):
+    """Verify the 300s sleep between drop and re-create is called."""
+    with (
+        patch(f"{_MODULE}.time.sleep") as mock_sleep,
+        patch(f"{_MODULE}.ServiceLevel"),
+    ):
+        RemoveServiceLevelMonkey(remove_sl_runner).disrupt()
+
+    mock_sleep.assert_called_once_with(300)
+
+
+# ---------------------------------------------------------------------------
+# SlaTests-delegating monkeys  (SlaIncreaseSharesDuringLoad etc.)
+# ---------------------------------------------------------------------------
+#
+# Pattern: mock PrometheusDBStats and SlaTests, call disrupt(), assert the
+# correct SlaTests method is called with the expected arguments.
+# ---------------------------------------------------------------------------
+
+_SLA_TESTS_PATCH = f"{_MODULE}.SlaTests"
+_PROMETHEUS_PATCH = f"{_MODULE}.PrometheusDBStats"
+
+_EXPECTED_COL_DEF = "-col n=5 size=FIXED(64)"
+_EXPECTED_DATASET = 1000000
+
+
+@pytest.mark.parametrize(
+    "monkey_cls, sla_method",
+    [
+        (SlaIncreaseSharesDuringLoad, "test_increase_shares_during_load"),
+        (SlaDecreaseSharesDuringLoad, "test_decrease_shares_during_load"),
+        (SlaReplaceUsingDetachDuringLoad, "test_replace_service_level_using_detach_during_load"),
+        (SlaReplaceUsingDropDuringLoad, "test_replace_service_level_using_drop_during_load"),
+        (SlaIncreaseSharesByAttachAnotherSlDuringLoad, "test_increase_shares_by_attach_another_sl_during_load"),
+    ],
+)
+def test_sla_monkey_delegates_to_correct_sla_test_method(runner, monkey_cls, sla_method):
+    """Each monkey calls exactly the expected SlaTests method."""
+    with (
+        patch(_PROMETHEUS_PATCH) as mock_prom_cls,
+        patch(_SLA_TESTS_PATCH) as mock_sla_cls,
+    ):
+        mock_sla_instance = mock_sla_cls.return_value
+        getattr(mock_sla_instance, sla_method).return_value = []
+
+        monkey = monkey_cls(runner)
+        monkey.disrupt()
+
+    getattr(mock_sla_instance, sla_method).assert_called_once_with(
+        tester=runner.tester,
+        prometheus_stats=mock_prom_cls.return_value,
+        num_of_partitions=_EXPECTED_DATASET,
+        cassandra_stress_column_definition=_EXPECTED_COL_DEF,
+    )
+
+
+@pytest.mark.parametrize(
+    "monkey_cls, sla_method",
+    [
+        (SlaIncreaseSharesDuringLoad, "test_increase_shares_during_load"),
+        (SlaDecreaseSharesDuringLoad, "test_decrease_shares_during_load"),
+    ],
+)
+def test_sla_monkey_raises_on_error_events(runner, monkey_cls, sla_method):
+    """disrupt() raises NemesisSubTestFailure when SlaTests returns error events."""
+    error_event = MagicMock()
+    error_event.step = "Some step"
+    error_event.__bool__ = lambda self: True
+    error_event.__str__ = lambda self: "validation failed"
+
+    with (
+        patch(_PROMETHEUS_PATCH),
+        patch(_SLA_TESTS_PATCH) as mock_sla_cls,
+    ):
+        getattr(mock_sla_cls.return_value, sla_method).return_value = [error_event]
+
+        with pytest.raises(NemesisSubTestFailure):
+            monkey_cls(runner).disrupt()
+
+
+def test_sla_monkey_passes_prometheus_host(runner):
+    """PrometheusDBStats is constructed with the monitoring node's external address."""
+    with (
+        patch(_PROMETHEUS_PATCH) as mock_prom_cls,
+        patch(_SLA_TESTS_PATCH) as mock_sla_cls,
+    ):
+        mock_sla_cls.return_value.test_increase_shares_during_load.return_value = []
+
+        SlaIncreaseSharesDuringLoad(runner).disrupt()
+
+    mock_prom_cls.assert_called_once_with(host="10.0.0.1")
+
+
+# ---------------------------------------------------------------------------
+# SlaMaximumAllowedSlsWithMaxSharesDuringLoad
+# ---------------------------------------------------------------------------
+
+
+def test_maximum_sls_queries_existing_service_levels(runner):
+    """Monkey queries existing SLs and passes the difference to SlaTests."""
+    existing_sl_count = 3
+
+    with (
+        patch(_PROMETHEUS_PATCH) as mock_prom_cls,
+        patch(_SLA_TESTS_PATCH) as mock_sla_cls,
+        patch(f"{_MODULE}.ServiceLevel") as mock_sl_cls,
+        patch(f"{_MODULE}.MAX_ALLOWED_SERVICE_LEVELS", 10),
+    ):
+        mock_sl_cls.return_value.list_all_service_levels.return_value = ["sl1"] * existing_sl_count
+        mock_sla_cls.return_value.test_maximum_allowed_sls_with_max_shares_during_load.return_value = []
+
+        SlaMaximumAllowedSlsWithMaxSharesDuringLoad(runner).disrupt()
+
+    # MAX_ALLOWED_SERVICE_LEVELS(10) - (existing_sl_count(3) + 1) = 6
+    mock_sla_cls.return_value.test_maximum_allowed_sls_with_max_shares_during_load.assert_called_once_with(
+        tester=runner.tester,
+        prometheus_stats=mock_prom_cls.return_value,
+        num_of_partitions=_EXPECTED_DATASET,
+        cassandra_stress_column_definition=_EXPECTED_COL_DEF,
+        service_levels_amount=6,
+    )
+
+
+def test_maximum_sls_raises_when_no_capacity_remaining(runner):
+    """Raise UnsupportedNemesis when all service-level slots are already occupied."""
+    with (
+        patch(_PROMETHEUS_PATCH),
+        patch(f"{_MODULE}.ServiceLevel") as mock_sl_cls,
+        patch(f"{_MODULE}.MAX_ALLOWED_SERVICE_LEVELS", 3),
+    ):
+        # list_all_service_levels returns 3 entries → created_service_levels = 4 → remaining = -1
+        mock_sl_cls.return_value.list_all_service_levels.return_value = ["sl1", "sl2", "sl3"]
+
+        with pytest.raises(UnsupportedNemesis, match="No remaining service-level slots"):
+            SlaMaximumAllowedSlsWithMaxSharesDuringLoad(runner).disrupt()
+
+
+def test_maximum_sls_raises_on_errors(runner):
+    """disrupt() raises NemesisSubTestFailure when SlaTests returns error events."""
+    error_event = MagicMock()
+    error_event.step = "max SLs step"
+    error_event.__bool__ = lambda self: True
+    error_event.__str__ = lambda self: "max sls failed"
+
+    with (
+        patch(_PROMETHEUS_PATCH),
+        patch(_SLA_TESTS_PATCH) as mock_sla_cls,
+        patch(f"{_MODULE}.ServiceLevel") as mock_sl_cls,
+        patch(f"{_MODULE}.MAX_ALLOWED_SERVICE_LEVELS", 10),
+    ):
+        mock_sl_cls.return_value.list_all_service_levels.return_value = []
+        mock_sla_cls.return_value.test_maximum_allowed_sls_with_max_shares_during_load.return_value = [error_event]
+
+        with pytest.raises(NemesisSubTestFailure):
+            SlaMaximumAllowedSlsWithMaxSharesDuringLoad(runner).disrupt()


### PR DESCRIPTION
Moved 7 nemesis classes into sdcm/nemesis/monkey/sla.py:
- RemoveServiceLevelMonkey
- SlaIncreaseSharesDuringLoad
- SlaDecreaseSharesDuringLoad
- SlaReplaceUsingDetachDuringLoad
- SlaReplaceUsingDropDuringLoad
- SlaIncreaseSharesByAttachAnotherSlDuringLoad
- SlaMaximumAllowedSlsWithMaxSharesDuringLoad

Moved 3 helper methods from NemesisRunner onto SlaMonkeyBase:
- get_cassandra_stress_write_cmds
- get_cassandra_stress_definition
- format_error_for_sla_test_and_raise

Based on https://github.com/scylladb/scylla-cluster-tests/blob/master/docs/plans/nemesis/nemesis-extraction.md

Fixes https://scylladb.atlassian.net/browse/SCT-208

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->

This nemesis migration can't be tested as SLA tests are not working and need further investigation.

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
