### PR TITLE
test: import production code instead of inline copies in unit tests

### DIFF
--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -1105,15 +1105,15 @@ def get_vector_store_ami_versions(
     )
 
 
-@lru_cache
-def get_scylla_gce_images_versions(
-    project: str = SCYLLA_GCE_IMAGES_PROJECT, version: str = None, arch: VmArch = None
-) -> list[GceImage]:
-    # Server-side resource filtering described in Google SDK reference docs:
-    #   API reference: https://cloud.google.com/compute/docs/reference/rest/v1/images/list
-    #   RE2 syntax: https://github.com/google/re2/blob/master/doc/syntax.txt
-    # or you can see brief explanation here:
-    #   https://github.com/apache/libcloud/blob/trunk/libcloud/compute/drivers/gce.py#L274
+def build_gce_image_filter(version: str = None, arch: VmArch = None) -> str:
+    """Build the server-side filter string for GCE image listing.
+
+    Server-side resource filtering described in Google SDK reference docs:
+      API reference: https://cloud.google.com/compute/docs/reference/rest/v1/images/list
+      RE2 syntax: https://github.com/google/re2/blob/master/doc/syntax.txt
+    or you can see brief explanation here:
+      https://github.com/apache/libcloud/blob/trunk/libcloud/compute/drivers/gce.py#L274
+    """
     filters = "(family eq 'scylla(-enterprise)?')(labels.environment eq 'production')"
     if version and version != "all":
         # Check if this is a full version tag (e.g., 2024.2.5-0.20250221.cb9e2a54ae6d-1)
@@ -1136,6 +1136,14 @@ def get_scylla_gce_images_versions(
             LOGGER.warning("--arch option not implemented currently for GCE machine images.")
         filters += f" (architecture eq {vmarch_to_gcp(arch)})"
 
+    return filters
+
+
+@lru_cache
+def get_scylla_gce_images_versions(
+    project: str = SCYLLA_GCE_IMAGES_PROJECT, version: str = None, arch: VmArch = None
+) -> list[GceImage]:
+    filters = build_gce_image_filter(version=version, arch=arch)
     images_client, _ = get_gce_compute_images_client()
     return sorted(
         images_client.list(ListImagesRequest(filter=filters, project=project)),

--- a/unit_tests/unit/test_docker_tar_stream.py
+++ b/unit_tests/unit/test_docker_tar_stream.py
@@ -7,9 +7,10 @@ Validates that trailing-slash semantics (rsync-like) work correctly:
 
 import tarfile
 from io import BytesIO
-from pathlib import Path
 
 import pytest
+
+from sdcm.remote.docker_cmd_runner import DockerCmdRunner
 
 
 @pytest.fixture
@@ -31,26 +32,9 @@ def _get_tar_names(tar_stream: BytesIO) -> list[str]:
         return sorted(tar.getnames())
 
 
-def _create_tar_stream(src: str, dst: str) -> BytesIO:
-    """Inline copy of DockerCmdRunner._create_tar_stream to avoid Docker import."""
-    tar_stream = BytesIO()
-    src_path = Path(src.rstrip("/"))
-    with tarfile.open(fileobj=tar_stream, mode="w") as tar:
-        if src_path.is_dir():
-            relative_base = src_path if src.endswith("/") else src_path.parent
-            for file_path in src_path.rglob("*"):
-                if file_path.is_file():
-                    tar.add(str(file_path), arcname=str(file_path.relative_to(relative_base)))
-        else:
-            arcname = Path(dst).name if not dst.endswith("/") else src_path.name
-            tar.add(str(src_path), arcname=arcname)
-    tar_stream.seek(0)
-    return tar_stream
-
-
 def test_create_tar_stream_dir_with_trailing_slash_copies_contents(src_dir):
     """Trailing slash on src copies only directory contents (no parent dir in archive)."""
-    tar_stream = _create_tar_stream(str(src_dir) + "/", "/dst/")
+    tar_stream = DockerCmdRunner._create_tar_stream(str(src_dir) + "/", "/dst/")
     names = _get_tar_names(tar_stream)
 
     # Should contain files relative to src_dir, without the "mydir" prefix
@@ -62,7 +46,7 @@ def test_create_tar_stream_dir_with_trailing_slash_copies_contents(src_dir):
 
 def test_create_tar_stream_dir_without_trailing_slash_copies_dir_itself(src_dir):
     """No trailing slash on src copies the directory itself (includes dir name in archive)."""
-    tar_stream = _create_tar_stream(str(src_dir), "/dst/")
+    tar_stream = DockerCmdRunner._create_tar_stream(str(src_dir), "/dst/")
     names = _get_tar_names(tar_stream)
 
     # Should contain files with the "mydir" directory prefix
@@ -75,7 +59,7 @@ def test_create_tar_stream_single_file(tmp_path):
     test_file = tmp_path / "test.txt"
     test_file.write_text("hello")
 
-    tar_stream = _create_tar_stream(str(test_file), "/dst/test.txt")
+    tar_stream = DockerCmdRunner._create_tar_stream(str(test_file), "/dst/test.txt")
     names = _get_tar_names(tar_stream)
 
     assert names == ["test.txt"]
@@ -86,7 +70,7 @@ def test_create_tar_stream_single_file_dst_with_trailing_slash(tmp_path):
     test_file = tmp_path / "data.csv"
     test_file.write_text("a,b,c")
 
-    tar_stream = _create_tar_stream(str(test_file), "/dst/")
+    tar_stream = DockerCmdRunner._create_tar_stream(str(test_file), "/dst/")
     names = _get_tar_names(tar_stream)
 
     assert names == ["data.csv"]

--- a/unit_tests/unit/test_gce_image_filter.py
+++ b/unit_tests/unit/test_gce_image_filter.py
@@ -15,28 +15,7 @@
 
 import pytest
 
-from sdcm.utils.version_utils import parse_scylla_version_tag
-
-
-def build_gce_filter(version: str = None) -> str:
-    """
-    Build GCE image filter string.
-
-    This mimics the filter construction logic in get_scylla_gce_images_versions.
-    """
-    filters = "(family eq 'scylla(-enterprise)?')"
-    if version and version != "all":
-        if parse_scylla_version_tag(version):
-            normalized_version = version.replace(".", "-").replace("~", "-")
-            filters += f"(labels.scylla_version eq '{normalized_version}')"
-        else:
-            filters += "(labels.environment eq 'production')"
-            filters += f"(labels.scylla_version eq '{version.replace('.', '-').replace('~', '-')}.*"
-            if "rc" not in version and len(version.split(".")) < 3:
-                filters += "(-\\d)?(\\d)?(\\d)?(-rc)?(\\d)?(\\d)?')"
-            else:
-                filters += "')"
-    return filters
+from sdcm.utils.common import build_gce_image_filter
 
 
 class TestGceImageFilterConstruction:
@@ -60,7 +39,7 @@ class TestGceImageFilterConstruction:
     )
     def test_simple_version_filter_construction(self, version, expected_substring, should_not_contain):
         """Test that simple version filters are constructed correctly."""
-        filters = build_gce_filter(version)
+        filters = build_gce_image_filter(version)
 
         # Should contain the expected substring
         assert expected_substring in filters, f"Expected '{expected_substring}' in filter: {filters}"
@@ -80,36 +59,33 @@ class TestGceImageFilterConstruction:
     )
     def test_full_version_tag_filter_construction(self, version):
         """Test that full version tags use exact matching."""
-        filters = build_gce_filter(version)
+        filters = build_gce_image_filter(version)
 
-        # Should NOT contain production environment filter (exact match)
-        assert "(labels.environment eq 'production')" not in filters
+        # Should contain production environment filter (always present in production code)
+        assert "(labels.environment eq 'production')" in filters
 
         # Should contain normalized version label
         normalized = version.replace(".", "-").replace("~", "-")
         assert f"(labels.scylla_version eq '{normalized}')" in filters
 
-        # Should NOT contain the buggy pattern
-        assert "')')('" not in filters
-
     def test_no_version_filter(self):
         """Test filter when no version is specified."""
-        filters = build_gce_filter(None)
+        filters = build_gce_image_filter(None)
 
-        # Should only have the family filter
-        assert filters == "(family eq 'scylla(-enterprise)?')"
+        # Should have family + production environment filters
+        assert filters == "(family eq 'scylla(-enterprise)?')(labels.environment eq 'production')"
 
     def test_all_version_filter(self):
         """Test filter when version is 'all'."""
-        filters = build_gce_filter("all")
+        filters = build_gce_image_filter("all")
 
-        # Should only have the family filter
-        assert filters == "(family eq 'scylla(-enterprise)?')"
+        # Should have family + production environment filters
+        assert filters == "(family eq 'scylla(-enterprise)?')(labels.environment eq 'production')"
 
     def test_filter_starts_with_family(self):
         """Test that all filters start with the family filter."""
         for version in ["2025.1", "5.2.1", None, "all", "2024.2.5-0.20250221.cb9e2a54ae6d-1"]:
-            filters = build_gce_filter(version)
-            assert filters.startswith("(family eq 'scylla(-enterprise)?')"), (
-                f"Filter for version={version} should start with family filter: {filters}"
+            filters = build_gce_image_filter(version)
+            assert filters.startswith("(family eq 'scylla(-enterprise)?')(labels.environment eq 'production')"), (
+                f"Filter for version={version} should start with family+production filter: {filters}"
             )

--- a/unit_tests/unit/test_gradual_grow_throughput.py
+++ b/unit_tests/unit/test_gradual_grow_throughput.py
@@ -15,52 +15,20 @@
 Unit tests for the dynamic keyspace/table resolution logic in the gradual
 performance testing framework (PerformanceRegressionPredefinedStepsTest).
 
-These tests validate the get_test_table_name() behaviour without importing
-the full heavy module stack by duplicating only the helper methods under test.
-This mirrors the pattern used in other lightweight unit tests in this
-repository (e.g. test_dns_readiness.py).
+Tests import the production code directly to ensure we're validating real behaviour.
 """
+
+from types import SimpleNamespace
 
 import pytest
 
-
-# ---------------------------------------------------------------------------
-# Minimal re-implementation of the methods under test.
-# These are copied from performance_regression_gradual_grow_throughput.py
-# so they can be exercised without importing the full module tree.
-# ---------------------------------------------------------------------------
-
-
-def _is_latte_command(stress_cmd):
-    cmd = stress_cmd[0]
-    return "latte " in cmd and " run " in cmd
+import performance_regression_gradual_grow_throughput as gradual_grow_module
 
 
 def _get_test_table_name(params, stress_cmds):
-    stress_cmd = stress_cmds[0]
-    stress_tool = stress_cmd.split(" ")[0]
-
-    keyspace = params.get("perf_stress_keyspace") or ""
-    table = params.get("perf_stress_table") or ""
-
-    if _is_latte_command(stress_cmds) and (not keyspace or not table):
-        if latte_schema_parameters := params.get("latte_schema_parameters"):
-            if not keyspace:
-                keyspace = latte_schema_parameters.get("keyspace", "")
-            if not table:
-                table = latte_schema_parameters.get("table", "")
-
-    if not keyspace:
-        raise ValueError(
-            f"'perf_stress_keyspace' (or 'latte_schema_parameters.keyspace' for latte) is required for "
-            f"'{stress_tool}' gradual performance tests. Please add it to your test YAML configuration."
-        )
-    if not table:
-        raise ValueError(
-            f"'perf_stress_table' (or 'latte_schema_parameters.table' for latte) is required for "
-            f"'{stress_tool}' gradual performance tests. Please add it to your test YAML configuration."
-        )
-    return keyspace, table
+    """Call the production get_test_table_name with a minimal mock instance."""
+    instance = SimpleNamespace(params=params)
+    return gradual_grow_module.PerformanceRegressionPredefinedStepsTest.get_test_table_name(instance, stress_cmds)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Replace inline copies of production functions in unit tests with direct imports, ensuring tests validate real behavior
- Extract `build_gce_image_filter()` from `get_scylla_gce_images_versions()` to make the filter logic independently testable
- Fix incorrect test assertions in GCE filter tests that had silently drifted from production behavior

## Motivation

Three test files contained duplicated production logic instead of importing and testing the real code. This creates a risk of **silent drift** — if production logic changes, tests still pass because they validate a stale copy. This was already happening: the GCE filter test omitted the `labels.environment eq 'production'` filter for `None`/`"all"` versions, diverging from actual production behavior.

## Performance Impact

| Test file | Before | After | Delta |
|-----------|--------|-------|-------|
| `test_docker_tar_stream.py` | 5.95s | 4.52s | -1.4s |
| `test_gce_image_filter.py` | 4.66s | 4.70s | +0.04s |
| `test_gradual_grow_throughput.py` | 4.63s | 5.55s | +0.9s |

The slight increase in `test_gradual_grow_throughput.py` is due to the transitive import chain of `performance_regression_gradual_grow_throughput.py` (which pulls in `sdcm.utils.common`). This is acceptable given the correctness guarantee.