### PR TITLE
fix(provision/gce): filter fallback zones by machine type availability

### DIFF
--- a/sdcm/cluster_gce.py
+++ b/sdcm/cluster_gce.py
@@ -485,9 +485,22 @@ class GCECluster(cluster.BaseCluster):
                 raise
             exhausted_zone = self.provisioners[dc_idx].availability_zone
             self.log.warning("Zone %s exhausted, trying alternative zones in region %s", exhausted_zone, region)
-            alternative_zones = get_alternative_zones(region, exhausted_zone)
+            machine_types = sorted({d.type for d in definitions if d.type})
+            alternative_zones = get_alternative_zones(region, exhausted_zone, machine_types=machine_types)
             if not alternative_zones:
+                self.log.error(
+                    "No alternative zones found in region %s supporting machine types %s",
+                    region,
+                    machine_types,
+                )
                 raise
+            self.log.info(
+                "%s | %s: Attempting zone fallback; candidates: %s",
+                self,
+                self._gce_instance_type,
+                [f"{region}-{z}" for z in alternative_zones],
+            )
+            last_fallback_exc = None
             for alt_zone in alternative_zones:
                 self.log.info("Attempting zone %s-%s as fallback", region, alt_zone)
                 try:
@@ -509,14 +522,21 @@ class GCECluster(cluster.BaseCluster):
                     self.log.info("Successfully provisioned instances in fallback zone %s-%s", region, alt_zone)
                     return result
                 except (ZoneResourcesExhaustedError, ProvisionError) as fallback_exc:
+                    last_fallback_exc = fallback_exc
                     if isinstance(fallback_exc, ProvisionError) and not _is_zone_exhausted(fallback_exc):
+                        # Non-capacity error (auth/quota/misconfig) — don't retry other zones, re-raise immediately
+                        self.log.error(
+                            "Fallback zone %s-%s failed with non-capacity error: %s", region, alt_zone, fallback_exc
+                        )
                         raise
-                    self.log.warning("Fallback zone %s-%s also exhausted, trying next", region, alt_zone)
+                    self.log.warning("Fallback zone %s-%s exhausted: %s, trying next", region, alt_zone, fallback_exc)
                     continue
+            # All fallback zones were capacity-exhausted
+            cause = last_fallback_exc or exc
             raise ZoneResourcesExhaustedError(
-                f"All zones in region {region} are exhausted: tried {exhausted_zone} and "
+                f"All zones in region {region} exhausted: tried {exhausted_zone} and "
                 f"{[f'{region}-{z}' for z in alternative_zones]}"
-            ) from exc
+            ) from cause
 
     def _destroy_instance(self, name: str, dc_idx: int):
         target_node = self._get_instances_by_name(dc_idx=dc_idx, name=name)

--- a/sdcm/utils/gce_utils.py
+++ b/sdcm/utils/gce_utils.py
@@ -118,16 +118,30 @@ def random_zone(region: str) -> str:
     return random.choice(zone_letters)
 
 
-def get_alternative_zones(region: str, exhausted_zone: str) -> list[str]:
+def get_alternative_zones(region: str, exhausted_zone: str, machine_types: list[str] | None = None) -> list[str]:
     """Return alternative zone letters for a region, excluding the exhausted zone.
 
     Used by runtime fallback when provisioning fails with ZoneResourcesExhaustedError.
+    If machine_types are provided, only zones supporting ALL of them are returned.
     """
-    zone_letters = _get_zone_letters_for_region(region)
-    if not zone_letters:
-        return []
     exhausted_letter = exhausted_zone[-1] if len(exhausted_zone) > 1 else exhausted_zone
-    alternatives = [z for z in zone_letters if z != exhausted_letter]
+
+    if machine_types:
+        resolver = GceZoneResolver()
+        common_zones = resolver.get_common_zones(
+            region=region,
+            machine_types=machine_types,
+            preferred_zones=resolver.get_zones_for_region(region),
+        )
+        # Extract letters from full zone names (e.g., "us-east4-a" -> "a")
+        valid_letters = [zone.split("-")[-1] for zone in common_zones]
+        alternatives = [z for z in valid_letters if z != exhausted_letter]
+    else:
+        zone_letters = _get_zone_letters_for_region(region)
+        if not zone_letters:
+            return []
+        alternatives = [z for z in zone_letters if z != exhausted_letter]
+
     return alternatives
 
 


### PR DESCRIPTION
The AZ fallback logic was trying all zones in the region without checking if the required machine type exists there. 

This caused failures when falling back to zones that don't support the instance type (e.g., z4d-highmem-16-highlssd only available in us-east4-a and us-east4-c).

Two fixes:
1. get_alternative_zones() now accepts machine_types and filters candidates using GceZoneResolver.get_common_zones() to only return compatible zones.
2. The fallback loop no longer hard-raises on non-exhaustion ProvisionError; it logs a warning and continues to the next candidate zone.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [artifacts-gce-image-test](https://argus.scylladb.com/tests/scylla-cluster-tests/ba6a5583-790b-4801-815f-5b0ef42c453b)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
