### PR TITLE
fix(nemesis): fix adaptive timeout for replacing a node

### DIFF
--- a/sdcm/nemesis/__init__.py
+++ b/sdcm/nemesis/__init__.py
@@ -1240,8 +1240,13 @@ class NemesisRunner:
             new_node.replacement_host_id = host_id
         else:
             new_node.replacement_node_ip = old_node_ip
+        # With RBNO, the new node will also stream data during init
+        if verification_node.get_scylla_config_param("enable_repair_based_node_ops") == "false":
+            operation = Operations.NEW_NODE
+        else:
+            operation = Operations.TABLET_MIGRATION
         try:
-            with adaptive_timeout(Operations.NEW_NODE, node=self.cluster.data_nodes[0], timeout=timeout):
+            with adaptive_timeout(operation, node=self.cluster.data_nodes[0], timeout=timeout):
                 self.cluster.wait_for_init(node_list=[new_node], timeout=timeout, check_node_health=False)
             self.actions_log.info(f"New node initialized: {new_node.name}")
             self.cluster.clean_replacement_node_options(new_node)


### PR DESCRIPTION
When replacing a node with RBNO enabled, the TABLET_MIGRATION operation should be used, since it will also stream the data during init.

Fixes: SCT-437

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/cezar/job/jira/job/SCT-437-rbno-timeout/3/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
