### PR TITLE
fix(gemini): respect stress_duration override and fix seed reporting in Argus

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -6602,7 +6602,7 @@ class BaseLoaderSet:
         if not self._gemini_version:
             try:
                 result = self.nodes[0].remoter.run(
-                    f"docker run --rm {self.params.get('stress_image.gemini')} gemini --version", ignore_status=True
+                    f"docker run --rm {self.params.get('stress_image.gemini')} --version-json", ignore_status=True
                 )
                 if result.ok:
                     self._gemini_version = get_gemini_version(result.stdout)

--- a/sdcm/stress_thread.py
+++ b/sdcm/stress_thread.py
@@ -587,6 +587,28 @@ stress_cmd_get_duration_pattern = re.compile(r"(?:^|[ \n])[-]{0,2}duration[\s=]+
 stress_cmd_get_warmup_pattern = re.compile(r"(?:^|[ \n])[-]{0,2}warmup[\s=]+([\d]+[hms]+)")
 
 
+def extract_gemini_seed(cmd: str) -> int:
+    """Extract --seed value from a gemini command string.
+
+    Accepts both --seed VALUE and --seed=VALUE formats.
+    Returns the seed as an int, or -1 if not found.
+    """
+    seed_match = re.search(r"--seed[= ](\d+)", cmd)
+    return int(seed_match.group(1)) if seed_match else -1
+
+
+def apply_gemini_stress_duration(cmd: str, stress_duration: int) -> str:
+    """Replace or inject --duration in a gemini command with stress_duration (in minutes).
+
+    Handles both space-delimited (--duration 3h), equals-form (--duration=3h), and YAML
+    block-scalar format where --duration appears at the start of the string with no
+    leading space.
+    """
+    if "--duration" in cmd:
+        return re.sub(r"(^|\s)--duration[\s=]+\S+", f"\\1--duration {stress_duration}m", cmd)
+    return cmd + f" --duration {stress_duration}m"
+
+
 def get_timeout_from_stress_cmd(stress_cmd: str) -> int | None:
     """Gets timeout in seconds based on duration and warmup arguments from stress command."""
     timeout = 0

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -166,7 +166,12 @@ from sdcm.sct_events.system import InfoEvent, TestFrameworkEvent, TestResultEven
 from sdcm.sct_events.file_logger import get_events_grouped_by_category, get_logger_event_summary
 from sdcm.sct_events.events_analyzer import stop_events_analyzer
 from sdcm.sct_events.grafana import start_posting_grafana_annotations
-from sdcm.stress_thread import CassandraStressThread, get_timeout_from_stress_cmd
+from sdcm.stress_thread import (
+    CassandraStressThread,
+    apply_gemini_stress_duration,
+    extract_gemini_seed,
+    get_timeout_from_stress_cmd,
+)
 from sdcm.gemini_thread import GeminiStressThread
 from sdcm.utils.log_time_consistency import DbLogTimeConsistencyAnalyzer
 from sdcm.utils.net import get_my_ip, get_sct_runner_ip
@@ -727,11 +732,7 @@ class ClusterTester(unittest.TestCase):
             seed = self.params.get("gemini_seed")
             gemini_command, *_ = self.gemini_results["cmd"]
             if not seed:
-                seed_match = re.search(r"--seed (?P<seed>\d+) ", gemini_command)
-                if seed_match:
-                    seed = seed_match.groupdict().get("seed", -1)
-                else:
-                    seed = -1
+                seed = extract_gemini_seed(gemini_command)
 
             results = self.gemini_results["results"]
             results = results[0] if len(results) > 0 else None
@@ -3117,10 +3118,9 @@ class ClusterTester(unittest.TestCase):
     def run_gemini(self, cmd, duration=None):
         if duration:
             timeout = self.get_duration(duration)
-        elif self._stress_duration and " --duration" in cmd:
+        elif self._stress_duration:
             timeout = self.get_duration(self._stress_duration)
-            cmd = re.sub(r"\s--duration\s+\d+[mhd]\s", f" --duration {self._stress_duration}m ", cmd)
-            cmd = re.sub(r"\s--warmup\s+\d+[mhd]\s", f" --warmup {int(self._stress_duration * 0.2)}m ", cmd)
+            cmd = apply_gemini_stress_duration(cmd, self._stress_duration)
         else:
             timeout = get_timeout_from_stress_cmd(cmd) or self.get_duration(duration)
         return GeminiStressThread(

--- a/sdcm/utils/version_utils.py
+++ b/sdcm/utils/version_utils.py
@@ -11,6 +11,7 @@
 #
 # Copyright (c) 2020 ScyllaDB
 
+import json
 import re
 import os
 import logging
@@ -42,8 +43,6 @@ from sdcm.utils.features import get_enabled_features
 #   - 3.3.rc1-0.20200209.0d0c1d43188
 #   - 2019.1.4-0.20191217.b59e92dbd
 
-# gemini version 1.0.1, commit ef7c6f422c78ef6b84a6f3bccf52ea9ec846bba0, date 2019-05-16T09:56:16Z
-GEMINI_VERSION_RE = re.compile(r"\s(?P<gemini_version>([\d]+\.[\d]+\.[\d]+)?),")
 REPO_VERSIONS_REGEX = re.compile(r"Filename: .*?server_(.*?)_.*\n", re.DOTALL)
 
 # NOTE: following regex is taken from the 'semver' package as is:
@@ -479,13 +478,16 @@ def assume_version(params: dict[str], scylla_version: Optional[str] = None) -> s
     return version_type
 
 
-def get_gemini_version(output: str):
-    # take only version number - 1.0.1
-    result = GEMINI_VERSION_RE.search(output)
+def get_gemini_version(output: str) -> str | None:
+    """Extract the gemini version from `gemini --version-json` stdout.
 
-    if result:
-        return result.groupdict().get("gemini_version", None)
-    return None
+    Expected JSON shape:
+        {"gemini": {"version": "2.3.9", "commit_date": "...", "commit_sha": "..."}, ...}
+    """
+    try:
+        return json.loads(output).get("gemini", {}).get("version")
+    except json.JSONDecodeError, AttributeError:
+        return None
 
 
 def get_node_supported_sstable_versions(node_system_log) -> List[str]:

--- a/unit_tests/unit/test_stress_thread_functions.py
+++ b/unit_tests/unit/test_stress_thread_functions.py
@@ -13,7 +13,12 @@
 
 import pytest
 
-from sdcm.stress_thread import CassandraStressThread, get_timeout_from_stress_cmd
+from sdcm.stress_thread import (
+    CassandraStressThread,
+    apply_gemini_stress_duration,
+    extract_gemini_seed,
+    get_timeout_from_stress_cmd,
+)
 from sdcm.utils.common import time_period_str_to_seconds
 
 
@@ -232,3 +237,87 @@ def test_set_hdr_tags_user_profile_no_known_ops_raises():
     stub = _make_hdr_tag_stub()
     with pytest.raises(ValueError, match="Cannot detect stress operation type"):
         stub.set_hdr_tags("cassandra-stress user profile=/tmp/test.yaml -mode cql3 native -rate threads=50")
+
+
+@pytest.mark.parametrize(
+    "original_cmd, stress_duration, expected_cmd",
+    [
+        # The core bug: YAML block scalar puts --duration at start with no leading space
+        pytest.param(
+            "--duration 3h\n--concurrency 50\n--mode mixed",
+            60,
+            "--duration 60m\n--concurrency 50\n--mode mixed",
+            id="yaml-block-scalar-no-leading-space",
+        ),
+        # Space-delimited format (inline command)
+        pytest.param(
+            " --duration 3h --concurrency 50",
+            60,
+            " --duration 60m --concurrency 50",
+            id="leading-space-before-duration",
+        ),
+        # warmup must be left completely untouched
+        pytest.param(
+            "--duration 8h\n--warmup 30m\n--concurrency 50",
+            120,
+            "--duration 120m\n--warmup 30m\n--concurrency 50",
+            id="warmup-left-untouched",
+        ),
+        # --duration at end of string (no trailing whitespace)
+        pytest.param(
+            "--concurrency 50\n--duration 3h",
+            45,
+            "--concurrency 50\n--duration 45m",
+            id="duration-at-end-of-command",
+        ),
+        # No --duration present → must be appended
+        pytest.param(
+            "--concurrency 50\n--mode mixed",
+            90,
+            "--concurrency 50\n--mode mixed --duration 90m",
+            id="no-duration-injected",
+        ),
+        # Equals-form must also be rewritten, not silently kept
+        pytest.param(
+            "--duration=3h --concurrency=50 --mode=mixed",
+            75,
+            "--duration 75m --concurrency=50 --mode=mixed",
+            id="equals-form-rewritten",
+        ),
+        pytest.param(
+            "--duration=24h\n--warmup=10m\n--concurrency=200",
+            45,
+            "--duration 45m\n--warmup=10m\n--concurrency=200",
+            id="equals-form-yaml-block-scalar",
+        ),
+    ],
+)
+def test_apply_gemini_stress_duration(original_cmd, stress_duration, expected_cmd):
+    assert apply_gemini_stress_duration(original_cmd, stress_duration) == expected_cmd
+
+
+@pytest.mark.parametrize(
+    "gemini_cmd, expected_seed",
+    [
+        # The bug: gemini generates --seed=VALUE (equals), old regex required space-delimited
+        pytest.param(
+            "--duration 3h --seed=12345 --concurrency 50",
+            12345,
+            id="equals-sign-format",
+        ),
+        # Space-delimited format should also work
+        pytest.param(
+            "--duration 3h --seed 99999 --concurrency 50",
+            99999,
+            id="space-delimited-format",
+        ),
+        # No --seed present → should return -1
+        pytest.param(
+            "--duration 3h --concurrency 50",
+            -1,
+            id="no-seed-returns-minus-one",
+        ),
+    ],
+)
+def test_extract_gemini_seed(gemini_cmd, expected_seed):
+    assert extract_gemini_seed(gemini_cmd) == expected_seed

--- a/unit_tests/unit/test_version_utils.py
+++ b/unit_tests/unit/test_version_utils.py
@@ -12,6 +12,7 @@ from sdcm.utils.version_utils import (
     get_all_versions,
     get_branch_version,
     get_branch_version_for_multiple_repositories,
+    get_gemini_version,
     get_git_tag_from_helm_chart_version,
     get_scylla_urls_from_repository,
     is_enterprise,
@@ -1118,3 +1119,24 @@ class TestLatestUnifiedPackage:
         mock_s3.get_paginator.assert_called_once_with("list_objects_v2")
         call_kwargs = mock_s3.get_paginator.return_value.paginate.call_args[1]
         assert call_kwargs["Prefix"] == "unstable/scylla-enterprise/enterprise/relocatable/latest/"
+
+
+@pytest.mark.parametrize(
+    "output, expected",
+    (
+        pytest.param(
+            '{"gemini":{"version":"2.3.9","commit_date":"2026-05-08T13:55:22Z",'
+            '"commit_sha":"d139eca4bab10c1b2b7a8b73ca85787deadecc6b"},'
+            '"scylla-driver":{"version":"v1.18.0","commit_date":"2026-04-29T17:29:04Z",'
+            '"commit_sha":"51b5d22d574212cc61b46a794e0f2ca5bdad9431"}}',
+            "2.3.9",
+            id="version-json-current",
+        ),
+        pytest.param('{"gemini": {"version": "1.0.1"}}', "1.0.1", id="version-json-minimal"),
+        pytest.param('{"scylla-driver": {"version": "v1.0.0"}}', None, id="missing-gemini-key"),
+        pytest.param("garbage non-json output", None, id="non-json-returns-none"),
+        pytest.param("", None, id="empty-input"),
+    ),
+)
+def test_get_gemini_version(output, expected):
+    assert get_gemini_version(output) == expected


### PR DESCRIPTION
Three bugs fixed:

run_gemini() ignored stress_duration when gemini_cmd used YAML block scalar format (|). The --duration flag appears at the start of the string with no leading space, so the old ' --duration' substring check always evaluated to False, falling through to get_timeout_from_stress_cmd() which parsed the original --duration value unchanged. Fix: drop the leading-space requirement and use a (^|\s) anchor in the replacement regex; use \S+ to match any time-unit format (h/m/s).

The --warmup substitution (stress_duration * 0.2) had no basis; removed.

Gemini seed was always reported as -1 in Argus. The generated command uses --seed=VALUE (equals sign) but the regex looked for '--seed VALUE ' (space-delimited with trailing space), which never matched. Fix: use r'--seed[= ](https://github.com/scylladb/scylla-cluster-tests/compare/master...CodeLieutenant:scylla-cluster-tests:fix/%5Cd+)' for both --seed and the new --schema-seed.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- 🟢 https://argus.scylladb.com/tests/scylla-cluster-tests/d30cb0bd-99e8-489a-9527-76f6fbdbc7e1 (Custom 10 Minute Run)
- 🟢 https://argus.scylladb.com/tests/scylla-cluster-tests/95fdb6f7-6323-414e-abc1-96d07c28f46d


### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)

Closes: https://scylladb.atlassian.net/browse/SCT-196