### PR TITLE
fix(nemesis): lower audit error severity during NetworkStartStopInterface nemesis

### DIFF
--- a/sdcm/nemesis/__init__.py
+++ b/sdcm/nemesis/__init__.py
@@ -84,6 +84,7 @@ from sdcm.sct_events.decorators import raise_event_on_failure
 from sdcm.sct_events.filters import DbEventsFilter, EventsSeverityChangerFilter
 from sdcm.sct_events.group_common_events import (
     ignore_alternator_client_errors,
+    ignore_audit_errors,
     ignore_no_space_errors,
     ignore_scrub_invalid_errors,
     decorate_with_context,
@@ -4038,16 +4039,17 @@ class NemesisRunner:
         wait_time = self.random.choice(list_of_timeout_options)
         self.log.debug("Taking down eth1 for %dsec", wait_time)
 
-        try:
-            self.target_node.stop_network_interface()
-            self.actions_log.info(f"Taking {self.target_node.name} node network interface down")
-            time.sleep(wait_time)
-        finally:
-            self.actions_log.info(f"Brigning {self.target_node.name} node network interface up")
-            self.target_node.start_network_interface()
-            with self.action_log_scope("Wait all nodes up and normal"):
-                self.cluster.wait_all_nodes_un()
-        self.actions_log.info(f"Network interface down/up finished on {self.target_node.name} node")
+        with ignore_audit_errors():
+            try:
+                self.target_node.stop_network_interface()
+                self.actions_log.info(f"Taking {self.target_node.name} node network interface down")
+                time.sleep(wait_time)
+            finally:
+                self.actions_log.info(f"Brigning {self.target_node.name} node network interface up")
+                self.target_node.start_network_interface()
+                with self.action_log_scope("Wait all nodes up and normal"):
+                    self.cluster.wait_all_nodes_un()
+            self.actions_log.info(f"Network interface down/up finished on {self.target_node.name} node")
 
     def _call_disrupt_func_after_expression_logged(
         self,

--- a/sdcm/sct_events/group_common_events.py
+++ b/sdcm/sct_events/group_common_events.py
@@ -710,3 +710,22 @@ def decorate_with_context_if_issues_open(
         return wrapper
 
     return decorator
+
+
+@contextmanager
+def ignore_audit_errors():
+    """Suppress audit unavailable_exception errors by lowering their severity to WARNING.
+
+    After network disruptions (e.g. interface down/up, node restart), there is a brief
+    period where a node may fail to write to the audit table because it still considers
+    other nodes as down. This is expected behavior and should not fail the test.
+
+    See: https://scylladb.atlassian.net/browse/SCYLLADB-706
+    """
+    with EventsSeverityChangerFilter(
+        new_severity=Severity.WARNING,
+        event_class=DatabaseLogEvent,
+        regex=r".*audit - Unexpected exception when writing.*unavailable_exception.*",
+        extra_time_to_expiration=30,
+    ):
+        yield


### PR DESCRIPTION
During NetworkStartStopInterface nemesis, after the network interface is restored there is a brief period where the node may fail to write to the audit table because it still considers other nodes as down. This causes DATABASE_ERROR events that fail the test unnecessarily. Lower the severity of these audit unavailable_exception errors to WARNING during the nemesis.

[SCYLLADB-706]

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)


[SCYLLADB-706]: https://scylladb.atlassian.net/browse/SCYLLADB-706?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ