### PR TITLE
ci(perf-regression): add billing_project to perf regression schedules

### DIFF
--- a/vars/perfRegressionParallelPipelinebyRegion.groovy
+++ b/vars/perfRegressionParallelPipelinebyRegion.groovy
@@ -65,12 +65,12 @@ def call(Map pipelineParams) {
         triggers {
             parameterizedCron (
                 '''
-                    0 8 * * * %scylla_version=master:latest;labels_selector=alternator-daily;requested_by_user=radoslawcybulski
-                    0 8 * * 6 %scylla_version=master:latest;labels_selector=alternator-weekly;requested_by_user=radoslawcybulski
-                    00 6 * * 0 %scylla_version=master:latest;labels_selector=master-weekly;requested_by_user=juliayakovlev
-                    0 23 */21 * * %scylla_version=master:latest;labels_selector=master-3weeks;requested_by_user=juliayakovlev
-                    0 6 1 * * %scylla_version=master:latest;labels_selector=master-monthly;requested_by_user=juliayakovlev
-                    13 6 8-14 * 2 %scylla_version=master:latest;labels_selector=gce-custom-monthly;requested_by_user=valerii.ponomarov
+                    0 8 * * * %scylla_version=master:latest;labels_selector=alternator-daily;requested_by_user=radoslawcybulski;billing_project=weekly performance regression
+                    0 8 * * 6 %scylla_version=master:latest;labels_selector=alternator-weekly;requested_by_user=radoslawcybulski;billing_project=weekly performance regression
+                    00 6 * * 0 %scylla_version=master:latest;labels_selector=master-weekly;requested_by_user=juliayakovlev;billing_project=weekly performance regression
+                    0 23 */21 * * %scylla_version=master:latest;labels_selector=master-3weeks;requested_by_user=juliayakovlev;billing_project=weekly performance regression
+                    0 6 1 * * %scylla_version=master:latest;labels_selector=master-monthly;requested_by_user=juliayakovlev;billing_project=weekly performance regression
+                    13 6 8-14 * 2 %scylla_version=master:latest;labels_selector=gce-custom-monthly;requested_by_user=valerii.ponomarov;billing_project=weekly performance regression
                 '''
             )
         }


### PR DESCRIPTION
## What

Add `billing_project` parameter to all `parameterizedCron` schedule entries in `perfRegressionParallelPipelinebyRegion.groovy`.

All schedules (including alternator) use `billing_project=weekly performance regression`.

## Companion PR

- scylladb/scylla-pkg#6330 — passes `billing_project` (release branch name, e.g. `"2026.4"`) when release triggers perf regression via `runPerformanceTests()`