### PR TITLE
improvement(test-cases): reduce instance size for longevity-100gb-4h test

### DIFF
--- a/test-cases/longevity/longevity-100gb-4h.yaml
+++ b/test-cases/longevity/longevity-100gb-4h.yaml
@@ -10,7 +10,7 @@ n_db_nodes: 6
 n_loaders: 2
 seeds_num: 3
 
-instance_type_db: 'i4i.4xlarge'
+instance_type_db: 'i7i.2xlarge'
 
 nemesis_class_name: 'SisyphusMonkey'
 nemesis_seed: '032'


### PR DESCRIPTION
Changed database instance type from i4i.4xlarge (16 vCPUs) to i7i.2xlarge (8 vCPUs) to reduce AWS infrastructure costs while maintaining test coverage with newer generation hardware.

This change will reduce monthly cost of:
- jenkins-scylla-master-longevity-longevity-100gb-4h-test from **923$** to **507$** (May 2026 costs).
- jenkins-scylla-master-features-FIPS-longevity-100gb-4h-fips-test from **1063$** to **557$** 

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] https://argus.scylladb.com/tests/scylla-cluster-tests/b89a6723-fc8c-473c-a441-decc2d05e13b
- [ ] https://argus.scylladb.com/tests/scylla-cluster-tests/8f0d731d-c052-4ae1-ac15-1432a02a0b2d


### Backports:
For now I set it to "none" but we may consider backporting it to all live releases we have to reduce cost.

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
