### PR TITLE
fix(gce-provision): enable AZ fallback for GCE to handle zone exhaustion

### DIFF
--- a/defaults/gce_config.yaml
+++ b/defaults/gce_config.yaml
@@ -38,6 +38,8 @@ backup_bucket_backend: 'gcs'
 
 use_preinstalled_scylla: true
 
+fallback_to_next_availability_zone: true
+
 kms_key_rotation_interval: 60
 
 scylla_network_config:


### PR DESCRIPTION
Enable fallback_to_next_availability_zone in GCE defaults so that when a zone returns ZONE_RESOURCE_POOL_EXHAUSTED, provisioning automatically retries in alternative zones within the same region. This matches the existing AWS behavior where the fallback is already enabled by default.

TBD: multiple GCE Longevities got this `ZONE_RESOURCE_POOL_EXHAUSTED`. 
For example: https://argus.scylladb.com/tests/scylla-cluster-tests/b93e9c07-bb6d-4f0c-b07c-a8c051bf6483 got:
```
(TestFrameworkEvent Severity.ERROR) period_type=one-time event_id=22d7a50e-6f92-41c0-917b-e1355be1e2ef, source=LargePartitionLongevityTest.SetUp()
exception=503 SERVICE UNAVAILABLE ZONE_RESOURCE_POOL_EXHAUSTED_WITH_DETAILS: The zone 'projects/sct-project-1/zones/us-east1-c' does not have enough resources available to fulfill the request.  '(resource type:compute)'.
```

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
