### PR TITLE
fix(oci): wait for NVMe disks spawning DB VMs

### DIFF
--- a/sdcm/sct_provision/user_data_objects/scylla.py
+++ b/sdcm/sct_provision/user_data_objects/scylla.py
@@ -36,6 +36,9 @@ class ScyllaUserDataObject(SctUserDataObject):
             "start_scylla_on_first_boot": False,
             "data_device": data_device,
             "raid_level": self.params.get("raid_level") or 0,
+            # NOTE: the 'device_wait_seconds' is needed for the OCI backend
+            # TODO: take out the 'device_wait_seconds' option when it gets proper per-backend defaults in the SMI
+            "device_wait_seconds": 60,
             "scylla_yaml": scylla_yaml.model_dump(exclude_defaults=True, exclude_none=True, exclude_unset=True),
         }
         return json.dumps(smi_payload)

--- a/unit_tests/unit/provisioner/test_scylla_machine_image_payload.py
+++ b/unit_tests/unit/provisioner/test_scylla_machine_image_payload.py
@@ -19,6 +19,7 @@ def test_can_generate_valid_scylla_machine_image_payload():
             "start_scylla_on_first_boot": False,
             "data_device": "attached",
             "raid_level": 0,
+            "device_wait_seconds": 60,
             "scylla_yaml": {"cluster_name": f"unit-test-{test_id_short}"},
         }
     )
@@ -37,6 +38,7 @@ def test_can_generate_valid_scylla_machine_image_payload_with_minimum_params():
             "start_scylla_on_first_boot": False,
             "data_device": "instance_store",
             "raid_level": 0,
+            "device_wait_seconds": 60,
             "scylla_yaml": {"cluster_name": f"test_user-{test_id_short}"},
         }
     )


### PR DESCRIPTION
It may happen that an OCI VM provisioning may fail the following error:
```
  >   File "<path-to>/sdcm/cluster.py", line 3792, in wait_for_machine_image_configured
  >     wait.wait_for(self.is_machine_image_configured, step=10, timeout=600, throw_exc=True)
  >     ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  >   File "<path-to>/sdcm/wait.py", line 87, in wait_for
  >     raise raising_exc from ex
  > sdcm.exceptions.WaitForTimeoutError: \
        Wait for: is_machine_image_configured: timeout - 600 seconds - expired
```

And in the DB logs we would see the following error:
```
  Create scylla data devices as instance_store
  No data disk found, abort setup
  ...
  subprocess.CalledProcessError: \
    Command '/opt/scylladb/scylla-machine-image/scylla_create_devices \
    --data-device instance_store --raid-level 0' returned non-zero exit status 1.
```

So, make SCT instruct the SMI to wait for 60 seconds while NVMe disks become available.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [scylla-staging/valerii/vp-longevity-100gb-4h-oci-test#34](https://argus.scylladb.com/tests/scylla-cluster-tests/65e3f051-46c4-490a-a444-0c0176f5c159)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
