### PR TITLE
fix(oci): properly set rack info

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4158,7 +4158,12 @@ class BaseCluster:
                     for idx in range(num):
                         nodes_per_az[idx % azs] += 1
                     for az_index in range(azs):
-                        rack = None if self.params.get("simulated_racks") else az_index
+                        # NOTE: OCI pre-provisioner places VMs using per-node round-robin
+                        #       so rack must be 'None' to let the 'add_nodes' derive it from the 'node_index'.
+                        if self.params.get("simulated_racks") or self.params.get("cluster_backend") == "oci":
+                            rack = None
+                        else:
+                            rack = az_index
                         self.add_nodes(
                             nodes_per_az[az_index], dc_idx=dc_idx, rack=rack, enable_auto_bootstrap=self.auto_bootstrap
                         )
@@ -4168,7 +4173,10 @@ class BaseCluster:
                 for idx in range(n_nodes):
                     nodes_per_az[idx % azs] += 1
                 for az_index in range(azs):
-                    rack = None if self.params.get("simulated_racks") else az_index
+                    if self.params.get("simulated_racks") or self.params.get("cluster_backend") == "oci":
+                        rack = None
+                    else:
+                        rack = az_index
                     self.add_nodes(nodes_per_az[az_index], rack=rack, enable_auto_bootstrap=self.auto_bootstrap)
             else:
                 raise ValueError("Unsupported type: {}".format(type(n_nodes)))


### PR DESCRIPTION
Provision DB nodes phase uses round robin approach to assign racks to provisioned VMs like following:
- DB-1 -> rack 1
- DB-2 -> rack 2
- DB-3 -> rack 3
- DB-4 -> rack 1
- DB-5 -> rack 2
- DB-6 -> rack 3

But registration of racks info is using batches per AZ. Example for 6 DB-nodes cluster with 3 racks:
- DB-1 -> rack 1
- DB-2 -> rack 1 - mismatch
- DB-3 -> rack 2 - mismatch
- DB-4 -> rack 2 - mismatch
- DB-5 -> rack 3 - mismatch
- DB-6 -> rack 3

So, we had 2/3 probability to hit the SCT-389 bug.

Fix it by untying the racks info from AZ indexes.

Closes: #SCT-389

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [scylla-staging/valerii/vp-longevity-100gb-4h-oci-test#34](https://argus.scylladb.com/tests/scylla-cluster-tests/65e3f051-46c4-490a-a444-0c0176f5c159)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
