### PR TITLE
improvement(jenkins): add Argus link and stage tracking to byoLongevityPipeline

### DIFF
--- a/sdcm/cluster_oci.py
+++ b/sdcm/cluster_oci.py
@@ -447,7 +447,40 @@ class ScyllaOciCluster(cluster.BaseScyllaCluster, OciCluster):
 
     @staticmethod
     def _wait_for_preinstalled_scylla(node):
-        node.wait_for_machine_image_configured()
+        try:
+            node.wait_for_machine_image_configured()
+        except Exception:
+            node.log.error("Scylla Machine Image setup failed — collecting NVMe diagnostics")
+            ScyllaOciCluster._collect_nvme_diagnostics(node)
+            raise
+
+    @staticmethod
+    def _collect_nvme_diagnostics(node):
+        """Collect NVMe controller/namespace diagnostics when disk setup fails.
+
+        This helps diagnose OCI DenseIO instances where the NVMe controller
+        is present but no namespace (block device) is attached.
+        """
+        diag_commands = [
+            ("nvme list", "sudo nvme list 2>&1"),
+            ("nvme list-subsys", "sudo nvme list-subsys 2>&1"),
+            ("nvme list-ns (all)", "sudo nvme list-ns /dev/nvme0 --all 2>&1"),
+            ("nvme id-ctrl", "sudo nvme id-ctrl /dev/nvme0 2>&1 | head -40"),
+            ("sysfs nvme0 contents", "ls -la /sys/class/nvme/nvme0/ 2>&1"),
+            ("nvme0 state", "cat /sys/class/nvme/nvme0/state 2>&1"),
+            ("nvme0 model", "cat /sys/class/nvme/nvme0/model 2>&1"),
+            ("nvme0 serial", "cat /sys/class/nvme/nvme0/serial 2>&1"),
+            ("nvme0 firmware_rev", "cat /sys/class/nvme/nvme0/firmware_rev 2>&1"),
+            ("lspci NVMe device", "sudo lspci -vvv -s 00:0a.0 2>&1"),
+            ("lsblk", "lsblk -o NAME,SIZE,TYPE,FSTYPE,MOUNTPOINT,MODEL,SERIAL 2>&1"),
+            ("dmesg nvme", "dmesg | grep -i 'nvme\\|blk\\|namespace' 2>&1"),
+            ("nvme interrupts", "grep nvme /proc/interrupts 2>&1"),
+            ("scylla-image-setup status", "systemctl status scylla-image-setup.service 2>&1"),
+            ("scylla-image-setup journal", "journalctl -u scylla-image-setup.service --no-pager 2>&1 | tail -50"),
+        ]
+        for label, cmd in diag_commands:
+            result = node.remoter.run(cmd, ignore_status=True, verbose=False)
+            node.log.error("NVMe diagnostics [%s]:\n%s", label, result.stdout + result.stderr)
 
     def _reuse_cluster_setup(self, node: OciNode) -> None:
         super()._reuse_cluster_setup(node)

--- a/vars/byoLongevityPipeline.groovy
+++ b/vars/byoLongevityPipeline.groovy
@@ -1,5 +1,6 @@
 #!groovy
 
+def completed_stages = [:]
 
 def call() {
 
@@ -17,7 +18,7 @@ def call() {
             AWS_ACCESS_KEY_ID     = credentials('qa-aws-secret-key-id')
             AWS_SECRET_ACCESS_KEY = credentials('qa-aws-secret-access-key')
             SCT_TEST_ID = UUID.randomUUID().toString()
-		}
+        }
 
          parameters {
             separator(name: 'SCT_CONFIG', sectionHeader: 'SCT Repository Configuration')
@@ -125,6 +126,7 @@ def call() {
             stage('Checkout') {
                steps {
                   script {
+                      completed_stages = [:]
                       loadEnvFromString(params.extra_environment_variables)
                       tagBuilder()
                   }
@@ -137,6 +139,21 @@ def call() {
                   }
                   dockerLogin(params)
                }
+            }
+            stage('Create Argus Test Run') {
+                steps {
+                    catchError(stageResult: 'FAILURE') {
+                        script {
+                            wrap([$class: 'BuildUser']) {
+                                dir('scylla-cluster-tests') {
+                                    timeout(time: 5, unit: 'MINUTES') {
+                                        createArgusTestRun(params)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
             }
             stage('Create SCT Runner') {
                 steps {
@@ -158,6 +175,7 @@ def call() {
                             wrap([$class: 'BuildUser']) {
                                 dir('scylla-cluster-tests') {
                                     runSctTest(params, builder.region)
+                                    completed_stages['run_tests'] = true
                                 }
                             }
                         }
@@ -171,6 +189,7 @@ def call() {
                             wrap([$class: 'BuildUser']) {
                                 dir('scylla-cluster-tests') {
                                     runCollectLogs(params, builder.region)
+                                    completed_stages['collect_logs'] = true
                                 }
                             }
                         }
@@ -184,6 +203,23 @@ def call() {
                             wrap([$class: 'BuildUser']) {
                                 dir('scylla-cluster-tests') {
                                     runCleanupResource(params, builder.region)
+                                    completed_stages['clean_resources'] = true
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            stage('Finish Argus Test Run') {
+                steps {
+                    catchError(stageResult: 'FAILURE') {
+                        script {
+                            wrap([$class: 'BuildUser']) {
+                                dir('scylla-cluster-tests') {
+                                    timeout(time: 5, unit: 'MINUTES') {
+                                        finishArgusTestRun(params, currentBuild)
+                                        completed_stages['report_to_argus'] = true
+                                    }
                                 }
                             }
                         }
@@ -197,6 +233,7 @@ def call() {
                             wrap([$class: 'BuildUser']) {
                                 dir('scylla-cluster-tests') {
                                     runSendEmail(params, currentBuild)
+                                    completed_stages['send_email'] = true
                                 }
                             }
                         }
@@ -210,6 +247,82 @@ def call() {
                             wrap([$class: 'BuildUser']) {
                                 dir('scylla-cluster-tests') {
                                     cleanSctRunners(params, currentBuild)
+                                    completed_stages['clean_sct_runner'] = true
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        post {
+            always {
+                script {
+                    def run_tests = completed_stages['run_tests']
+                    def collect_logs = completed_stages['collect_logs']
+                    def clean_resources = completed_stages['clean_resources']
+                    def send_email = completed_stages['send_email']
+                    def clean_sct_runner = completed_stages['clean_sct_runner']
+                    sh """
+                        echo "'run_tests' stage is completed: $run_tests"
+                        echo "'collect_logs' stage is completed: $collect_logs"
+                        echo "'clean_resources' stage is completed: $clean_resources"
+                        echo "'send_email' stage is completed: $send_email"
+                        echo "'clean_sct_runner' stage is completed: $clean_sct_runner"
+                    """
+                    if (!completed_stages['collect_logs']) {
+                        catchError {
+                            script {
+                                wrap([$class: 'BuildUser']) {
+                                    dir('scylla-cluster-tests') {
+                                        runCollectLogs(params, builder.region)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    if (!completed_stages['clean_resources']) {
+                        catchError {
+                            script {
+                                wrap([$class: 'BuildUser']) {
+                                    dir('scylla-cluster-tests') {
+                                        runCleanupResource(params, builder.region)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    if (!completed_stages['report_to_argus']) {
+                        catchError {
+                            script {
+                                wrap([$class: 'BuildUser']) {
+                                    dir('scylla-cluster-tests') {
+                                        timeout(time: 5, unit: 'MINUTES') {
+                                            finishArgusTestRun(params, currentBuild)
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    if (!completed_stages['send_email']) {
+                        catchError {
+                            script {
+                                wrap([$class: 'BuildUser']) {
+                                    dir('scylla-cluster-tests') {
+                                        runSendEmail(params, currentBuild)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    if (!completed_stages['clean_sct_runner']) {
+                        catchError {
+                            script {
+                                wrap([$class: 'BuildUser']) {
+                                    dir('scylla-cluster-tests') {
+                                        cleanSctRunners(params, currentBuild)
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
## Summary

Aligned `byoLongevityPipeline.groovy` with other pipelines (longevityPipeline, managerPipeline, jepsenPipeline) by adding:

- **Create Argus Test Run** stage after Checkout — registers the test run and adds the Argus link to the Jenkins build description (sidebar link)
- **Finish Argus Test Run** stage — finalizes the Argus test run status
- **`completed_stages` tracking** on all stages
- **`post { always { ... } }` block** — retries any failed stages (collect_logs, clean_resources, report_to_argus, send_email, clean_sct_runner) ensuring cleanup always happens even on pipeline failure

## Why

The BYO longevity pipeline was the only pipeline missing Argus integration. Without it, there was no Argus link in the Jenkins build sidebar and no guaranteed cleanup on failure.

## Manual Testing Required

- [ ] Run a BYO longevity job and verify the Argus link appears in the Jenkins build description
- [ ] Verify the Finish Argus Test Run stage completes successfully
- [ ] Verify post-failure retry logic works (e.g., abort mid-run and confirm cleanup stages execute)