### PR TITLE
improvement(grafana-api): migrate dashboard API from /api to /apis endpoints

### DIFF
--- a/configurations/manager/debian12.yaml
+++ b/configurations/manager/debian12.yaml
@@ -1,3 +1,3 @@
 ami_id_monitor: 'resolve:ssm:/aws/service/debian/release/12/latest/amd64'  # Debian Bookworm latest image
 ami_monitor_user: 'admin'
-monitor_branch: 'branch-4.15'  # Pass it as debian image is not the formal monitor image
+monitor_branch: 'branch-4.16'  # Pass it as debian image is not the formal monitor image

--- a/configurations/manager/rocky9.yaml
+++ b/configurations/manager/rocky9.yaml
@@ -1,3 +1,3 @@
 ami_id_monitor: 'ami-09fb459fad4613d55'  # Rocky Linux 9 (Official) image, region - us-east-1
 ami_monitor_user: 'rocky'
-monitor_branch: 'branch-4.15'  # Pass it as rocky image is not the formal monitor image
+monitor_branch: 'branch-4.16'  # Pass it as rocky image is not the formal monitor image

--- a/configurations/manager/ubuntu24.yaml
+++ b/configurations/manager/ubuntu24.yaml
@@ -1,3 +1,3 @@
 ami_id_monitor: 'resolve:ssm:/aws/service/canonical/ubuntu/server/24.04/stable/current/amd64/hvm/ebs-gp3/ami-id'  # Canonical, Ubuntu, 24.04 LTS, amd64 focal latest image
 ami_monitor_user: 'ubuntu'
-monitor_branch: 'branch-4.15'  # Pass it as the image is not the formal monitor image
+monitor_branch: 'branch-4.16'  # Pass it as the image is not the formal monitor image

--- a/data_dir/monitoring-dash-template.json
+++ b/data_dir/monitoring-dash-template.json
@@ -1,1411 +1,1536 @@
 {
     "rows": [
         {
-            "class": "row",
-            "panels": [
-                {
-                    "class": "collapsible_row_panel",
-                    "title": "SCT Information",
-                    "dashproduct": "sct-tests"
-                }
-            ]
-        },
-        {
-            "class": "row",
+            "title": "SCT Information",
+            "collapse": false,
             "dashproduct": "sct-tests",
-            "panels": [
+            "rows": [
                 {
-                    "class": "percent_panel",
-                    "gridPos": {
-                        "h": 12,
-                        "w": 12
-                    },
-                    "targets": [
+                    "class": "row",
+                    "panels": [
                         {
-                            "expr": "avg(scylla_reactor_utilization{cluster=\"$cluster\", dc=~\"$dc\"} ) by ([[by]])",
-                            "intervalFactor": 1,
-                            "legendFormat": "",
-                            "refId": "A",
-                            "step": 1
-                        }
-                    ],
-                    "title": "Load per [[by]]",
-                    "type": "timeseries"
-                },
-                {
-                    "class": "ops_panel",
-                    "gridPos": {
-                        "x": 12,
-                        "h": 6,
-                        "w": 12
-                    },
-                    "targets": [
+                            "class": "percent_panel",
+                            "gridPos": {
+                                "h": 12,
+                                "w": 12
+                            },
+                            "spec/title": "Load per [[by]]",
+                            "spec/vizConfig/spec/options/legend": {
+                                "calcs": [],
+                                "displayMode": "list",
+                                "placement": "bottom",
+                                "showLegend": true
+                            },
+                            "spec/data/spec/queries/0/spec/query/spec/expr": "avg(scylla_reactor_utilization{cluster=\"$cluster\", dc=~\"$dc\"} ) by ([[by]])"
+                        },
                         {
-                            "expr": "(sum(irate(scylla_transport_requests_served{cluster=\"$cluster\"}[60s])) or vector(0)) + (sum(irate(scylla_alternator_operation{cluster=\"$cluster\"}[60s])) or vector(0))",
-                            "interval": "",
-                            "legendFormat": "Total Requests",
-                            "refId": "A"
-                        }
-                    ],
-                    "title": "Total Requests",
-                    "type": "timeseries"
-                },
-                {
-                    "class": "ops_panel",
-                    "gridPos": {
-                        "x": 12,
-                        "h": 6,
-                        "w": 12
-                    },
-                    "fieldConfig": {
-                        "overrides": [
-                            {
-                                "matcher": {
-                                    "id": "byRegexp",
-                                    "options": "/method=\"[a-zA-Z]/"
+                            "class": "ops_panel",
+                            "gridPos": {
+                                "x": 12,
+                                "h": 6,
+                                "w": 12
+                            },
+                            "spec/title": "Total Requests",
+                            "spec/vizConfig/spec/options/legend": {
+                                "calcs": [],
+                                "displayMode": "list",
+                                "placement": "bottom",
+                                "showLegend": true
+                            },
+                            "spec/data/spec/queries/0/spec/query/spec/expr": "(sum(irate(scylla_transport_requests_served{cluster=\"$cluster\"}[60s])) or vector(0)) + (sum(irate(scylla_alternator_operation{cluster=\"$cluster\"}[60s])) or vector(0))",
+                            "spec/data/spec/queries/0/spec/query/spec/legendFormat": "Total Requests"
+                        },
+                        {
+                            "class": "ops_panel",
+                            "gridPos": {
+                                "x": 12,
+                                "h": 6,
+                                "w": 12
+                            },
+                            "spec/title": "Requests Served per [[by]]",
+                            "spec/vizConfig/spec/options/legend": {
+                                "calcs": [],
+                                "displayMode": "list",
+                                "placement": "bottom",
+                                "showLegend": true
+                            },
+                            "spec/vizConfig/spec/fieldConfig/overrides": [
+                                {
+                                    "matcher": {
+                                        "id": "byRegexp",
+                                        "options": "/method=\"[a-zA-Z]/"
+                                    },
+                                    "properties": [
+                                        {
+                                            "id": "custom.fillOpacity",
+                                            "value": 20
+                                        },
+                                        {
+                                            "id": "custom.drawStyle",
+                                            "value": "line"
+                                        },
+                                        {
+                                            "id": "unit",
+                                            "value": "short"
+                                        },
+                                        {
+                                            "id": "max",
+                                            "value": 1
+                                        },
+                                        {
+                                            "id": "custom.axisPlacement",
+                                            "value": "right"
+                                        },
+                                        {
+                                            "id": "custom.axisLabel",
+                                            "value": "Nemesis"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "spec/data/spec/queries": [
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "A",
+                                    "spec/query/spec/expr": "sum(rate(scylla_transport_requests_served{cluster=\"$cluster\", dc=~\"$dc\"}[$__rate_interval])) by ([[by]])"
                                 },
-                                "properties": [
-                                    {
-                                        "id": "custom.fillOpacity",
-                                        "value": 20
-                                    },
-                                    {
-                                        "id": "custom.drawStyle",
-                                        "value": "line"
-                                    },
-                                    {
-                                        "id": "unit",
-                                        "value": "short"
-                                    },
-                                    {
-                                        "id": "max",
-                                        "value": 1
-                                    },
-                                    {
-                                        "id": "custom.axisPlacement",
-                                        "value": "right"
-                                    },
-                                    {
-                                        "id": "custom.axisLabel",
-                                        "value": "Nemesis"
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "B",
+                                    "spec/query/spec/expr": "{__name__=~'nemesis(.*)(?:gauge)(.*)'}"
+                                }
+                            ]
+                        },
+                        {
+                            "kind": "Panel",
+                            "gridPos": {
+                                "h": 13,
+                                "w": 24
+                            },
+                            "repeat": {
+                                "mode": "variable",
+                                "value": "cluster",
+                                "direction": "v"
+                            },
+                            "spec": {
+                                "id": "auto",
+                                "title": "SCT Events",
+                                "description": "",
+                                "links": [],
+                                "data": {
+                                    "kind": "QueryGroup",
+                                    "spec": {
+                                        "queries": [],
+                                        "transformations": [],
+                                        "queryOptions": {}
                                     }
-                                ]
+                                },
+                                "vizConfig": {
+                                    "kind": "VizConfig",
+                                    "group": "annolist",
+                                    "version": "13.0.1",
+                                    "spec": {
+                                        "options": {
+                                            "onlyFromThisDashboard": false,
+                                            "onlyInTimeRange": true,
+                                            "limit": 1000,
+                                            "showUser": true,
+                                            "showTime": true,
+                                            "showTags": true,
+                                            "navigateToPanel": true,
+                                            "navigateBefore": "10m",
+                                            "navigateAfter": "10m"
+                                        },
+                                        "fieldConfig": {
+                                            "defaults": {},
+                                            "overrides": []
+                                        }
+                                    }
+                                }
                             }
-                        ]
-                    },
-                    "targets": [
-                        {
-                            "expr": "sum(rate(scylla_transport_requests_served{cluster=\"$cluster\", dc=~\"$dc\"}[$__rate_interval])) by ([[by]])",
-                            "intervalFactor": 1,
-                            "legendFormat": "",
-                            "metric": "",
-                            "refId": "A",
-                            "step": 1
-                        },
-                        {
-                            "expr": "{__name__=~'nemesis(.*)(?:gauge)(.*)'}",
-                            "intervalFactor": 2,
-                            "refId": "B"
                         }
-                    ],
-                    "title": "Requests Served per [[by]]",
-                    "type": "timeseries"
-                },
-                {
-                    "datasource": {
-                        "type": "datasource",
-                        "uid": "grafana"
-                    },
-                    "gridPos": {
-                        "h": 13,
-                        "w": 24
-                    },
-                    "links": [],
-                    "options": {
-                        "onlyFromThisDashboard": false,
-                        "onlyInTimeRange": true,
-                        "limit": 1000,
-                        "showUser": true,
-                        "showTime": true,
-                        "showTags": true,
-                        "navigateToPanel": true,
-                        "navigateBefore": "10m",
-                        "navigateAfter": "10m"
-                    },
-                    "repeat": "cluster",
-                    "repeatDirection": "v",
-                    "title": "SCT Events",
-                    "type": "annolist",
-                    "id": "auto",
-                    "scopedVars": {
-                        "cluster": {
-                            "text": "None",
-                            "value": "",
-                            "isNone": true,
-                            "selected": true
-                        }
-                    }
+                    ]
                 }
             ]
         },
         {
-            "class": "row",
-            "panels": [
-                {
-                    "class": "collapsible_row_panel",
-                    "title": "C-S, CQL-stress and Latte benchmarking tools latency 95%",
-                    "dashproduct": "sct-tests"
-                }
-            ]
-        },
-        {
-            "class": "row",
+            "title": "C-S, CQL-stress and Latte benchmarking tools latency 95%",
+            "collapse": false,
             "dashproduct": "sct-tests",
-            "panels": [
+            "rows": [
                 {
-                    "targets": [
+                    "class": "row",
+                    "panels": [
                         {
-                            "expr": "sct_cassandra_stress_write_gauge{type=\"lat_perc_95\"}",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "refId": "A"
-                        },
-                        {
-                            "expr": "sct_cassandra_stress_counter_write_gauge{type=\"lat_perc_95\"}",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "refId": "B"
-                        },
-                        {
-                            "expr": "sct_latte_write_gauge{type=\"lat_perc_95\"}",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "refId": "C"
-                        },
-                        {
-                            "expr": "sct_latte_counter_write_gauge{type=\"lat_perc_95\"}",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "refId": "D"
-                        },
-                        {
-                            "expr": "sct_cql_stress_cassandra_stress_write_gauge{type=\"lat_perc_95\"}",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "refId": "E"
-                        },
-                        {
-                            "expr": "sct_cql_stress_cassandra_stress_counter_write_gauge{type=\"lat_perc_95\"}",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "refId": "F"
-                        }
-                    ],
-                    "title": "WRITE P95 latency | C-S and/or CQL-stress and/or Latte benchmarking tools",
-                    "type": "timeseries",
-                    "span": 6,
-                    "class": "ms_panel"
-                },
-                {
-                    "fieldConfig": {
-                        "defaults": {
-                            "class": "fieldConfig_defaults",
-                            "custom": {
-                                "fillOpacity": 80
+                            "class": "ms_panel",
+                            "span": 6,
+                            "spec/title": "WRITE P95 latency | C-S and/or CQL-stress and/or Latte benchmarking tools",
+                            "spec/vizConfig/spec/options/legend": {
+                                "calcs": [],
+                                "displayMode": "list",
+                                "placement": "bottom",
+                                "showLegend": true
                             },
-                            "color": {
-                                "mode": "thresholds"
-                            }
-                        },
-                        "overrides": []
-                    },
-                    "options": {
-                        "bucketSize": 2
-                    },
-                    "targets": [
-                        {
-                            "expr": "sct_cassandra_stress_write_gauge{type=\"lat_perc_95\"}",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "refId": "A"
-                        },
-                        {
-                            "expr": "sct_cassandra_stress_counter_write_gauge{type=\"lat_perc_95\"}",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "refId": "B"
-                        },
-                        {
-                            "expr": "sct_latte_write_gauge{type=\"lat_perc_95\"}",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "refId": "C"
-                        },
-                        {
-                            "expr": "sct_latte_counter_write_gauge{type=\"lat_perc_95\"}",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "refId": "D"
+                            "spec/data/spec/queries": [
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "A",
+                                    "spec/query/spec/expr": "sct_cassandra_stress_write_gauge{type=\"lat_perc_95\"}"
+                                },
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "B",
+                                    "spec/query/spec/expr": "sct_cassandra_stress_counter_write_gauge{type=\"lat_perc_95\"}"
+                                },
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "C",
+                                    "spec/query/spec/expr": "sct_latte_write_gauge{type=\"lat_perc_95\"}"
+                                },
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "D",
+                                    "spec/query/spec/expr": "sct_latte_counter_write_gauge{type=\"lat_perc_95\"}"
+                                },
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "E",
+                                    "spec/query/spec/expr": "sct_cql_stress_cassandra_stress_write_gauge{type=\"lat_perc_95\"}"
+                                },
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "F",
+                                    "spec/query/spec/expr": "sct_cql_stress_cassandra_stress_counter_write_gauge{type=\"lat_perc_95\"}"
+                                }
+                            ]
                         },
                         {
-                            "expr": "sct_cql_stress_cassandra_stress_write_gauge{type=\"lat_perc_95\"}",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "refId": "E"
-                        },
-                        {
-                            "expr": "sct_cql_stress_cassandra_stress_counter_write_gauge{type=\"lat_perc_95\"}",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "refId": "F"
-                        }
-                    ],
-                    "title": "WRITE P95 latency histogram | C-S and/or CQL-stress and/or Latte benchmarking tools",
-                    "type": "histogram",
-                    "span": 6,
-                    "class": "ms_panel"
-                },
-                {
-                    "targets": [
-                        {
-                            "expr": "sct_cassandra_stress_read_gauge{type=\"lat_perc_95\"}",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "refId": "A"
-                        },
-                        {
-                            "expr": "sct_cassandra_stress_counter_read_gauge{type=\"lat_perc_95\"}",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "refId": "B"
-                        },
-                        {
-                            "expr": "sct_latte_read_gauge{type=\"lat_perc_95\"}",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "refId": "C"
-                        },
-                        {
-                            "expr": "sct_cql_stress_cassandra_stress_read_gauge{type=\"lat_perc_95\"}",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "refId": "D"
-                        },
-                        {
-                            "expr": "sct_cql_stress_cassandra_stress_counter_read_gauge{type=\"lat_perc_95\"}",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "refId": "E"
-                        }
-                    ],
-                    "title": "READ P95 latency | C-S and/or CQL-stress and/or Latte benchmarking tools",
-                    "type": "timeseries",
-                    "span": 6,
-                    "class": "ms_panel"
-                },
-                {
-                    "fieldConfig": {
-                        "defaults": {
-                            "class": "fieldConfig_defaults",
-                            "custom": {
-                                "fillOpacity": 80
+                            "class": "ms_panel",
+                            "span": 6,
+                            "spec/title": "WRITE P95 latency histogram | C-S and/or CQL-stress and/or Latte benchmarking tools",
+                            "spec/vizConfig": {
+                                "kind": "VizConfig",
+                                "group": "histogram",
+                                "version": "13.0.1",
+                                "spec": {
+                                    "options": {
+                                        "bucketSize": 2,
+                                        "combine": false,
+                                        "legend": {
+                                            "calcs": [],
+                                            "displayMode": "list",
+                                            "placement": "bottom",
+                                            "showLegend": true
+                                        }
+                                    },
+                                    "fieldConfig": {
+                                        "defaults": {
+                                            "unit": "ms",
+                                            "color": {
+                                                "mode": "thresholds"
+                                            },
+                                            "thresholds": {
+                                                "mode": "absolute",
+                                                "steps": [
+                                                    {
+                                                        "color": "green",
+                                                        "value": null
+                                                    },
+                                                    {
+                                                        "color": "red",
+                                                        "value": 80
+                                                    }
+                                                ]
+                                            },
+                                            "custom": {
+                                                "fillOpacity": 80,
+                                                "gradientMode": "none",
+                                                "hideFrom": {
+                                                    "legend": false,
+                                                    "tooltip": false,
+                                                    "viz": false
+                                                },
+                                                "lineWidth": 1,
+                                                "stacking": {
+                                                    "group": "A",
+                                                    "mode": "none"
+                                                }
+                                            }
+                                        },
+                                        "overrides": []
+                                    }
+                                }
                             },
-                            "color": {
-                                "mode": "thresholds"
-                            }
-                        },
-                        "overrides": []
-                    },
-                    "options": {
-                        "bucketSize": 2
-                    },
-                    "targets": [
-                        {
-                            "expr": "sct_cassandra_stress_read_gauge{type=\"lat_perc_95\"}",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "refId": "A"
-                        },
-                        {
-                            "expr": "sct_cassandra_stress_counter_read_gauge{type=\"lat_perc_95\"}",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "refId": "B"
-                        },
-                        {
-                            "expr": "sct_latte_read_gauge{type=\"lat_perc_95\"}",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "refId": "C"
-                        },
-                        {
-                            "expr": "sct_cql_stress_cassandra_stress_read_gauge{type=\"lat_perc_95\"}",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "refId": "D"
+                            "spec/data/spec/queries": [
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "A",
+                                    "spec/query/spec/expr": "sct_cassandra_stress_write_gauge{type=\"lat_perc_95\"}"
+                                },
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "B",
+                                    "spec/query/spec/expr": "sct_cassandra_stress_counter_write_gauge{type=\"lat_perc_95\"}"
+                                },
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "C",
+                                    "spec/query/spec/expr": "sct_latte_write_gauge{type=\"lat_perc_95\"}"
+                                },
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "D",
+                                    "spec/query/spec/expr": "sct_latte_counter_write_gauge{type=\"lat_perc_95\"}"
+                                },
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "E",
+                                    "spec/query/spec/expr": "sct_cql_stress_cassandra_stress_write_gauge{type=\"lat_perc_95\"}"
+                                },
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "F",
+                                    "spec/query/spec/expr": "sct_cql_stress_cassandra_stress_counter_write_gauge{type=\"lat_perc_95\"}"
+                                }
+                            ]
                         },
                         {
-                            "expr": "sct_cql_stress_cassandra_stress_counter_read_gauge{type=\"lat_perc_95\"}",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "refId": "E"
-                        }
-                    ],
-                    "title": "READ P95 latency histogram | C-S and/or CQL-stress and/or Latte benchmarking tools",
-                    "type": "histogram",
-                    "span": 6,
-                    "class": "ms_panel"
-                },
-                {
-                    "targets": [
-                        {
-                            "expr": "sct_cassandra_stress_mixed_gauge{type=\"lat_perc_95\"}",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "refId": "A"
-                        },
-                        {
-                            "expr": "sct_latte_mixed_gauge{type=\"lat_perc_95\"}",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "refId": "B"
-                        },
-                        {
-                            "expr": "sct_cql_stress_cassandra_stress_mixed_gauge{type=\"lat_perc_95\"}",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "refId": "C"
-                        }
-                    ],
-                    "title": "MIXED P95 latency | C-S and/or CQL-stress and/or Latte benchmarking tools",
-                    "type": "timeseries",
-                    "span": 6,
-                    "class": "ms_panel"
-                },
-                {
-                    "fieldConfig": {
-                        "defaults": {
-                            "class": "fieldConfig_defaults",
-                            "custom": {
-                                "fillOpacity": 80
+                            "class": "ms_panel",
+                            "span": 6,
+                            "spec/title": "READ P95 latency | C-S and/or CQL-stress and/or Latte benchmarking tools",
+                            "spec/vizConfig/spec/options/legend": {
+                                "calcs": [],
+                                "displayMode": "list",
+                                "placement": "bottom",
+                                "showLegend": true
                             },
-                            "color": {
-                                "mode": "thresholds"
-                            }
-                        },
-                        "overrides": []
-                    },
-                    "options": {
-                        "bucketSize": 2
-                    },
-                    "targets": [
-                        {
-                            "expr": "sct_cassandra_stress_mixed_gauge{type=\"lat_perc_95\"}",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "refId": "A"
-                        },
-                        {
-                            "expr": "sct_latte_mixed_gauge{type=\"lat_perc_95\"}",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "refId": "B"
-                        },
-                        {
-                            "expr": "sct_cql_stress_cassandra_stress_mixed_gauge{type=\"lat_perc_95\"}",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "refId": "C"
-                        }
-                    ],
-                    "title": "MIXED P95 latency histogram | C-S and/or CQL-stress and/or Latte benchmarking tools",
-                    "type": "histogram",
-                    "span": 6,
-                    "class": "ms_panel"
-                },
-                {
-                    "targets": [
-                        {
-                            "expr": "sct_cassandra_stress_user_gauge{type=\"lat_perc_95\"}",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "refId": "A"
+                            "spec/data/spec/queries": [
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "A",
+                                    "spec/query/spec/expr": "sct_cassandra_stress_read_gauge{type=\"lat_perc_95\"}"
+                                },
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "B",
+                                    "spec/query/spec/expr": "sct_cassandra_stress_counter_read_gauge{type=\"lat_perc_95\"}"
+                                },
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "C",
+                                    "spec/query/spec/expr": "sct_latte_read_gauge{type=\"lat_perc_95\"}"
+                                },
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "D",
+                                    "spec/query/spec/expr": "sct_cql_stress_cassandra_stress_read_gauge{type=\"lat_perc_95\"}"
+                                },
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "E",
+                                    "spec/query/spec/expr": "sct_cql_stress_cassandra_stress_counter_read_gauge{type=\"lat_perc_95\"}"
+                                }
+                            ]
                         },
                         {
-                            "expr": "sct_latte_user_gauge{type=\"lat_perc_95\"}",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "refId": "B"
-                        },
-                        {
-                            "expr": "sct_cql_stress_cassandra_stress_user_gauge{type=\"lat_perc_95\"}",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "refId": "C"
-                        }
-                    ],
-                    "title": "USER PROFILE P95 latency | C-S and/or CQL-stress and/or Latte benchmarking tools",
-                    "type": "timeseries",
-                    "span": 6,
-                    "class": "ms_panel"
-                },
-                {
-                    "fieldConfig": {
-                        "defaults": {
-                            "class": "fieldConfig_defaults",
-                            "custom": {
-                                "fillOpacity": 80
+                            "class": "ms_panel",
+                            "span": 6,
+                            "spec/title": "READ P95 latency histogram | C-S and/or CQL-stress and/or Latte benchmarking tools",
+                            "spec/vizConfig": {
+                                "kind": "VizConfig",
+                                "group": "histogram",
+                                "version": "13.0.1",
+                                "spec": {
+                                    "options": {
+                                        "bucketSize": 2,
+                                        "combine": false,
+                                        "legend": {
+                                            "calcs": [],
+                                            "displayMode": "list",
+                                            "placement": "bottom",
+                                            "showLegend": true
+                                        }
+                                    },
+                                    "fieldConfig": {
+                                        "defaults": {
+                                            "unit": "ms",
+                                            "color": {
+                                                "mode": "thresholds"
+                                            },
+                                            "thresholds": {
+                                                "mode": "absolute",
+                                                "steps": [
+                                                    {
+                                                        "color": "green",
+                                                        "value": null
+                                                    },
+                                                    {
+                                                        "color": "red",
+                                                        "value": 80
+                                                    }
+                                                ]
+                                            },
+                                            "custom": {
+                                                "fillOpacity": 80,
+                                                "gradientMode": "none",
+                                                "hideFrom": {
+                                                    "legend": false,
+                                                    "tooltip": false,
+                                                    "viz": false
+                                                },
+                                                "lineWidth": 1,
+                                                "stacking": {
+                                                    "group": "A",
+                                                    "mode": "none"
+                                                }
+                                            }
+                                        },
+                                        "overrides": []
+                                    }
+                                }
                             },
-                            "color": {
-                                "mode": "thresholds"
-                            }
+                            "spec/data/spec/queries": [
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "A",
+                                    "spec/query/spec/expr": "sct_cassandra_stress_read_gauge{type=\"lat_perc_95\"}"
+                                },
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "B",
+                                    "spec/query/spec/expr": "sct_cassandra_stress_counter_read_gauge{type=\"lat_perc_95\"}"
+                                },
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "C",
+                                    "spec/query/spec/expr": "sct_latte_read_gauge{type=\"lat_perc_95\"}"
+                                },
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "D",
+                                    "spec/query/spec/expr": "sct_cql_stress_cassandra_stress_read_gauge{type=\"lat_perc_95\"}"
+                                },
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "E",
+                                    "spec/query/spec/expr": "sct_cql_stress_cassandra_stress_counter_read_gauge{type=\"lat_perc_95\"}"
+                                }
+                            ]
                         },
-                        "overrides": []
-                    },
-                    "options": {
-                        "bucketSize": 2
-                    },
-                    "targets": [
                         {
-                            "expr": "sct_cassandra_stress_user_gauge{type=\"lat_perc_95\"}",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "refId": "A"
+                            "class": "ms_panel",
+                            "span": 6,
+                            "spec/title": "MIXED P95 latency | C-S and/or CQL-stress and/or Latte benchmarking tools",
+                            "spec/vizConfig/spec/options/legend": {
+                                "calcs": [],
+                                "displayMode": "list",
+                                "placement": "bottom",
+                                "showLegend": true
+                            },
+                            "spec/data/spec/queries": [
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "A",
+                                    "spec/query/spec/expr": "sct_cassandra_stress_mixed_gauge{type=\"lat_perc_95\"}"
+                                },
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "B",
+                                    "spec/query/spec/expr": "sct_latte_mixed_gauge{type=\"lat_perc_95\"}"
+                                },
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "C",
+                                    "spec/query/spec/expr": "sct_cql_stress_cassandra_stress_mixed_gauge{type=\"lat_perc_95\"}"
+                                }
+                            ]
                         },
                         {
-                            "expr": "sct_latte_user_gauge{type=\"lat_perc_95\"}",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "refId": "B"
+                            "class": "ms_panel",
+                            "span": 6,
+                            "spec/title": "MIXED P95 latency histogram | C-S and/or CQL-stress and/or Latte benchmarking tools",
+                            "spec/vizConfig": {
+                                "kind": "VizConfig",
+                                "group": "histogram",
+                                "version": "13.0.1",
+                                "spec": {
+                                    "options": {
+                                        "bucketSize": 2,
+                                        "combine": false,
+                                        "legend": {
+                                            "calcs": [],
+                                            "displayMode": "list",
+                                            "placement": "bottom",
+                                            "showLegend": true
+                                        }
+                                    },
+                                    "fieldConfig": {
+                                        "defaults": {
+                                            "unit": "ms",
+                                            "color": {
+                                                "mode": "thresholds"
+                                            },
+                                            "thresholds": {
+                                                "mode": "absolute",
+                                                "steps": [
+                                                    {
+                                                        "color": "green",
+                                                        "value": null
+                                                    },
+                                                    {
+                                                        "color": "red",
+                                                        "value": 80
+                                                    }
+                                                ]
+                                            },
+                                            "custom": {
+                                                "fillOpacity": 80,
+                                                "gradientMode": "none",
+                                                "hideFrom": {
+                                                    "legend": false,
+                                                    "tooltip": false,
+                                                    "viz": false
+                                                },
+                                                "lineWidth": 1,
+                                                "stacking": {
+                                                    "group": "A",
+                                                    "mode": "none"
+                                                }
+                                            }
+                                        },
+                                        "overrides": []
+                                    }
+                                }
+                            },
+                            "spec/data/spec/queries": [
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "A",
+                                    "spec/query/spec/expr": "sct_cassandra_stress_mixed_gauge{type=\"lat_perc_95\"}"
+                                },
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "B",
+                                    "spec/query/spec/expr": "sct_latte_mixed_gauge{type=\"lat_perc_95\"}"
+                                },
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "C",
+                                    "spec/query/spec/expr": "sct_cql_stress_cassandra_stress_mixed_gauge{type=\"lat_perc_95\"}"
+                                }
+                            ]
                         },
                         {
-                            "expr": "sct_cql_stress_cassandra_stress_user_gauge{type=\"lat_perc_95\"}",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "refId": "C"
+                            "class": "ms_panel",
+                            "span": 6,
+                            "spec/title": "USER PROFILE P95 latency | C-S and/or CQL-stress and/or Latte benchmarking tools",
+                            "spec/vizConfig/spec/options/legend": {
+                                "calcs": [],
+                                "displayMode": "list",
+                                "placement": "bottom",
+                                "showLegend": true
+                            },
+                            "spec/data/spec/queries": [
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "A",
+                                    "spec/query/spec/expr": "sct_cassandra_stress_user_gauge{type=\"lat_perc_95\"}"
+                                },
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "B",
+                                    "spec/query/spec/expr": "sct_latte_user_gauge{type=\"lat_perc_95\"}"
+                                },
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "C",
+                                    "spec/query/spec/expr": "sct_cql_stress_cassandra_stress_user_gauge{type=\"lat_perc_95\"}"
+                                }
+                            ]
+                        },
+                        {
+                            "class": "ms_panel",
+                            "span": 6,
+                            "spec/title": "USER PROFILE P95 latency histogram | C-S and/or CQL-stress and/or Latte benchmarking tools",
+                            "spec/vizConfig": {
+                                "kind": "VizConfig",
+                                "group": "histogram",
+                                "version": "13.0.1",
+                                "spec": {
+                                    "options": {
+                                        "bucketSize": 2,
+                                        "combine": false,
+                                        "legend": {
+                                            "calcs": [],
+                                            "displayMode": "list",
+                                            "placement": "bottom",
+                                            "showLegend": true
+                                        }
+                                    },
+                                    "fieldConfig": {
+                                        "defaults": {
+                                            "unit": "ms",
+                                            "color": {
+                                                "mode": "thresholds"
+                                            },
+                                            "thresholds": {
+                                                "mode": "absolute",
+                                                "steps": [
+                                                    {
+                                                        "color": "green",
+                                                        "value": null
+                                                    },
+                                                    {
+                                                        "color": "red",
+                                                        "value": 80
+                                                    }
+                                                ]
+                                            },
+                                            "custom": {
+                                                "fillOpacity": 80,
+                                                "gradientMode": "none",
+                                                "hideFrom": {
+                                                    "legend": false,
+                                                    "tooltip": false,
+                                                    "viz": false
+                                                },
+                                                "lineWidth": 1,
+                                                "stacking": {
+                                                    "group": "A",
+                                                    "mode": "none"
+                                                }
+                                            }
+                                        },
+                                        "overrides": []
+                                    }
+                                }
+                            },
+                            "spec/data/spec/queries": [
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "A",
+                                    "spec/query/spec/expr": "sct_cassandra_stress_user_gauge{type=\"lat_perc_95\"}"
+                                },
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "B",
+                                    "spec/query/spec/expr": "sct_latte_user_gauge{type=\"lat_perc_95\"}"
+                                },
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "C",
+                                    "spec/query/spec/expr": "sct_cql_stress_cassandra_stress_user_gauge{type=\"lat_perc_95\"}"
+                                }
+                            ]
                         }
-                    ],
-                    "title": "USER PROFILE P95 latency histogram | C-S and/or CQL-stress and/or Latte benchmarking tools",
-                    "type": "histogram",
-                    "span": 6,
-                    "class": "ms_panel"
+                    ]
                 }
             ]
         },
         {
-            "class": "row",
-            "panels": [
-                {
-                    "class": "collapsible_row_panel",
-                    "title": "C-S, CQL-stress and Latte benchmarking tools latency 99%",
-                    "dashproduct": "sct-tests"
-                }
-            ]
-        },
-        {
-            "class": "row",
+            "title": "C-S, CQL-stress and Latte benchmarking tools latency 99%",
+            "collapse": false,
             "dashproduct": "sct-tests",
-            "panels": [
+            "rows": [
                 {
-                    "targets": [
+                    "class": "row",
+                    "panels": [
                         {
-                            "expr": "sct_cassandra_stress_write_gauge{type=\"lat_perc_99\"}",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "refId": "A"
-                        },
-                        {
-                            "expr": "sct_cassandra_stress_counter_write_gauge{type=\"lat_perc_99\"}",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "refId": "B"
-                        },
-                        {
-                            "expr": "sct_latte_write_gauge{type=\"lat_perc_99\"}",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "refId": "C"
-                        },
-                        {
-                            "expr": "sct_latte_counter_write_gauge{type=\"lat_perc_99\"}",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "refId": "D"
-                        },
-                        {
-                            "expr": "sct_cql_stress_cassandra_stress_write_gauge{type=\"lat_perc_99\"}",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "refId": "E"
-                        },
-                        {
-                            "expr": "sct_cql_stress_cassandra_stress_counter_write_gauge{type=\"lat_perc_99\"}",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "refId": "F"
-                        }
-                    ],
-                    "title": "WRITE P99 latency | C-S and/or CQL-stress and/or Latte benchmarking tools",
-                    "type": "timeseries",
-                    "span": 6,
-                    "class": "ms_panel"
-                },
-                {
-                    "fieldConfig": {
-                        "defaults": {
-                            "class": "fieldConfig_defaults",
-                            "custom": {
-                                "fillOpacity": 80
+                            "class": "ms_panel",
+                            "span": 6,
+                            "spec/title": "WRITE P99 latency | C-S and/or CQL-stress and/or Latte benchmarking tools",
+                            "spec/vizConfig/spec/options/legend": {
+                                "calcs": [],
+                                "displayMode": "list",
+                                "placement": "bottom",
+                                "showLegend": true
                             },
-                            "color": {
-                                "mode": "thresholds"
-                            }
-                        },
-                        "overrides": []
-                    },
-                    "options": {
-                        "bucketSize": 2
-                    },
-                    "targets": [
-                        {
-                            "expr": "sct_cassandra_stress_write_gauge{type=\"lat_perc_99\"}",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "refId": "A"
-                        },
-                        {
-                            "expr": "sct_cassandra_stress_counter_write_gauge{type=\"lat_perc_99\"}",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "refId": "B"
-                        },
-                        {
-                            "expr": "sct_latte_write_gauge{type=\"lat_perc_99\"}",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "refId": "C"
-                        },
-                        {
-                            "expr": "sct_latte_counter_write_gauge{type=\"lat_perc_99\"}",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "refId": "D"
+                            "spec/data/spec/queries": [
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "A",
+                                    "spec/query/spec/expr": "sct_cassandra_stress_write_gauge{type=\"lat_perc_99\"}"
+                                },
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "B",
+                                    "spec/query/spec/expr": "sct_cassandra_stress_counter_write_gauge{type=\"lat_perc_99\"}"
+                                },
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "C",
+                                    "spec/query/spec/expr": "sct_latte_write_gauge{type=\"lat_perc_99\"}"
+                                },
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "D",
+                                    "spec/query/spec/expr": "sct_latte_counter_write_gauge{type=\"lat_perc_99\"}"
+                                },
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "E",
+                                    "spec/query/spec/expr": "sct_cql_stress_cassandra_stress_write_gauge{type=\"lat_perc_99\"}"
+                                },
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "F",
+                                    "spec/query/spec/expr": "sct_cql_stress_cassandra_stress_counter_write_gauge{type=\"lat_perc_99\"}"
+                                }
+                            ]
                         },
                         {
-                            "expr": "sct_cql_stress_cassandra_stress_write_gauge{type=\"lat_perc_99\"}",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "refId": "E"
-                        },
-                        {
-                            "expr": "sct_cql_stress_cassandra_stress_counter_write_gauge{type=\"lat_perc_99\"}",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "refId": "F"
-                        }
-                    ],
-                    "title": "WRITE P99 latency histogram | C-S and/or CQL-stress and/or Latte benchmarking tools",
-                    "type": "histogram",
-                    "span": 6,
-                    "class": "ms_panel"
-                },
-                {
-                    "targets": [
-                        {
-                            "expr": "sct_cassandra_stress_read_gauge{type=\"lat_perc_99\"}",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "refId": "A"
-                        },
-                        {
-                            "expr": "sct_cassandra_stress_counter_read_gauge{type=\"lat_perc_99\"}",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "refId": "B"
-                        },
-                        {
-                            "expr": "sct_latte_read_gauge{type=\"lat_perc_99\"}",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "refId": "C"
-                        },
-                        {
-                            "expr": "sct_cql_stress_cassandra_stress_read_gauge{type=\"lat_perc_99\"}",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "refId": "D"
-                        },
-                        {
-                            "expr": "sct_cql_stress_cassandra_stress_counter_read_gauge{type=\"lat_perc_99\"}",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "refId": "E"
-                        }
-                    ],
-                    "title": "READ P99 latency | C-S and/or CQL-stress and/or Latte benchmarking tools",
-                    "type": "timeseries",
-                    "span": 6,
-                    "class": "ms_panel"
-                },
-                {
-                    "fieldConfig": {
-                        "defaults": {
-                            "class": "fieldConfig_defaults",
-                            "custom": {
-                                "fillOpacity": 80
+                            "class": "ms_panel",
+                            "span": 6,
+                            "spec/title": "WRITE P99 latency histogram | C-S and/or CQL-stress and/or Latte benchmarking tools",
+                            "spec/vizConfig": {
+                                "kind": "VizConfig",
+                                "group": "histogram",
+                                "version": "13.0.1",
+                                "spec": {
+                                    "options": {
+                                        "bucketSize": 2,
+                                        "combine": false,
+                                        "legend": {
+                                            "calcs": [],
+                                            "displayMode": "list",
+                                            "placement": "bottom",
+                                            "showLegend": true
+                                        }
+                                    },
+                                    "fieldConfig": {
+                                        "defaults": {
+                                            "unit": "ms",
+                                            "color": {
+                                                "mode": "thresholds"
+                                            },
+                                            "thresholds": {
+                                                "mode": "absolute",
+                                                "steps": [
+                                                    {
+                                                        "color": "green",
+                                                        "value": null
+                                                    },
+                                                    {
+                                                        "color": "red",
+                                                        "value": 80
+                                                    }
+                                                ]
+                                            },
+                                            "custom": {
+                                                "fillOpacity": 80,
+                                                "gradientMode": "none",
+                                                "hideFrom": {
+                                                    "legend": false,
+                                                    "tooltip": false,
+                                                    "viz": false
+                                                },
+                                                "lineWidth": 1,
+                                                "stacking": {
+                                                    "group": "A",
+                                                    "mode": "none"
+                                                }
+                                            }
+                                        },
+                                        "overrides": []
+                                    }
+                                }
                             },
-                            "color": {
-                                "mode": "thresholds"
-                            }
-                        },
-                        "overrides": []
-                    },
-                    "options": {
-                        "bucketSize": 2
-                    },
-                    "targets": [
-                        {
-                            "expr": "sct_cassandra_stress_read_gauge{type=\"lat_perc_99\"}",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "refId": "A"
-                        },
-                        {
-                            "expr": "sct_cassandra_stress_counter_read_gauge{type=\"lat_perc_99\"}",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "refId": "B"
-                        },
-                        {
-                            "expr": "sct_latte_read_gauge{type=\"lat_perc_99\"}",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "refId": "C"
-                        },
-                        {
-                            "expr": "sct_cql_stress_cassandra_stress_read_gauge{type=\"lat_perc_99\"}",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "refId": "D"
+                            "spec/data/spec/queries": [
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "A",
+                                    "spec/query/spec/expr": "sct_cassandra_stress_write_gauge{type=\"lat_perc_99\"}"
+                                },
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "B",
+                                    "spec/query/spec/expr": "sct_cassandra_stress_counter_write_gauge{type=\"lat_perc_99\"}"
+                                },
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "C",
+                                    "spec/query/spec/expr": "sct_latte_write_gauge{type=\"lat_perc_99\"}"
+                                },
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "D",
+                                    "spec/query/spec/expr": "sct_latte_counter_write_gauge{type=\"lat_perc_99\"}"
+                                },
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "E",
+                                    "spec/query/spec/expr": "sct_cql_stress_cassandra_stress_write_gauge{type=\"lat_perc_99\"}"
+                                },
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "F",
+                                    "spec/query/spec/expr": "sct_cql_stress_cassandra_stress_counter_write_gauge{type=\"lat_perc_99\"}"
+                                }
+                            ]
                         },
                         {
-                            "expr": "sct_cql_stress_cassandra_stress_counter_read_gauge{type=\"lat_perc_99\"}",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "refId": "E"
-                        }
-                    ],
-                    "title": "READ P99 latency histogram | C-S and/or CQL-stress and/or Latte benchmarking tools",
-                    "type": "histogram",
-                    "span": 6,
-                    "class": "ms_panel"
-                },
-                {
-                    "targets": [
-                        {
-                            "expr": "sct_cassandra_stress_mixed_gauge{type=\"lat_perc_99\"}",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "refId": "A"
-                        },
-                        {
-                            "expr": "sct_latte_mixed_gauge{type=\"lat_perc_99\"}",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "refId": "B"
-                        },
-                        {
-                            "expr": "sct_cql_stress_cassandra_stress_mixed_gauge{type=\"lat_perc_99\"}",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "refId": "C"
-                        }
-                    ],
-                    "title": "MIXED P99 latency | C-S and/or CQL-stress and/or Latte benchmarking tools",
-                    "type": "timeseries",
-                    "span": 6,
-                    "class": "ms_panel"
-                },
-                {
-                    "fieldConfig": {
-                        "defaults": {
-                            "class": "fieldConfig_defaults",
-                            "custom": {
-                                "fillOpacity": 80
+                            "class": "ms_panel",
+                            "span": 6,
+                            "spec/title": "READ P99 latency | C-S and/or CQL-stress and/or Latte benchmarking tools",
+                            "spec/vizConfig/spec/options/legend": {
+                                "calcs": [],
+                                "displayMode": "list",
+                                "placement": "bottom",
+                                "showLegend": true
                             },
-                            "color": {
-                                "mode": "thresholds"
-                            }
-                        },
-                        "overrides": []
-                    },
-                    "options": {
-                        "bucketSize": 2
-                    },
-                    "targets": [
-                        {
-                            "expr": "sct_cassandra_stress_mixed_gauge{type=\"lat_perc_99\"}",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "refId": "A"
-                        },
-                        {
-                            "expr": "sct_latte_mixed_gauge{type=\"lat_perc_99\"}",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "refId": "B"
-                        },
-                        {
-                            "expr": "sct_cql_stress_cassandra_stress_mixed_gauge{type=\"lat_perc_99\"}",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "refId": "C"
-                        }
-                    ],
-                    "title": "MIXED P99 latency histogram | C-S and/or CQL-stress and/or Latte benchmarking tools",
-                    "type": "histogram",
-                    "span": 6,
-                    "class": "ms_panel"
-                },
-                {
-                    "targets": [
-                        {
-                            "expr": "sct_cassandra_stress_user_gauge{type=\"lat_perc_99\"}",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "refId": "A"
+                            "spec/data/spec/queries": [
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "A",
+                                    "spec/query/spec/expr": "sct_cassandra_stress_read_gauge{type=\"lat_perc_99\"}"
+                                },
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "B",
+                                    "spec/query/spec/expr": "sct_cassandra_stress_counter_read_gauge{type=\"lat_perc_99\"}"
+                                },
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "C",
+                                    "spec/query/spec/expr": "sct_latte_read_gauge{type=\"lat_perc_99\"}"
+                                },
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "D",
+                                    "spec/query/spec/expr": "sct_cql_stress_cassandra_stress_read_gauge{type=\"lat_perc_99\"}"
+                                },
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "E",
+                                    "spec/query/spec/expr": "sct_cql_stress_cassandra_stress_counter_read_gauge{type=\"lat_perc_99\"}"
+                                }
+                            ]
                         },
                         {
-                            "expr": "sct_latte_user_gauge{type=\"lat_perc_99\"}",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "refId": "B"
-                        },
-                        {
-                            "expr": "sct_cql_stress_cassandra_stress_user_gauge{type=\"lat_perc_99\"}",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "refId": "C"
-                        }
-                    ],
-                    "title": "USER PROFILE P99 latency | C-S and/or CQL-stress and/or Latte benchmarking tools",
-                    "type": "timeseries",
-                    "span": 6,
-                    "class": "ms_panel"
-                },
-                {
-                    "fieldConfig": {
-                        "defaults": {
-                            "class": "fieldConfig_defaults",
-                            "custom": {
-                                "fillOpacity": 80
+                            "class": "ms_panel",
+                            "span": 6,
+                            "spec/title": "READ P99 latency histogram | C-S and/or CQL-stress and/or Latte benchmarking tools",
+                            "spec/vizConfig": {
+                                "kind": "VizConfig",
+                                "group": "histogram",
+                                "version": "13.0.1",
+                                "spec": {
+                                    "options": {
+                                        "bucketSize": 2,
+                                        "combine": false,
+                                        "legend": {
+                                            "calcs": [],
+                                            "displayMode": "list",
+                                            "placement": "bottom",
+                                            "showLegend": true
+                                        }
+                                    },
+                                    "fieldConfig": {
+                                        "defaults": {
+                                            "unit": "ms",
+                                            "color": {
+                                                "mode": "thresholds"
+                                            },
+                                            "thresholds": {
+                                                "mode": "absolute",
+                                                "steps": [
+                                                    {
+                                                        "color": "green",
+                                                        "value": null
+                                                    },
+                                                    {
+                                                        "color": "red",
+                                                        "value": 80
+                                                    }
+                                                ]
+                                            },
+                                            "custom": {
+                                                "fillOpacity": 80,
+                                                "gradientMode": "none",
+                                                "hideFrom": {
+                                                    "legend": false,
+                                                    "tooltip": false,
+                                                    "viz": false
+                                                },
+                                                "lineWidth": 1,
+                                                "stacking": {
+                                                    "group": "A",
+                                                    "mode": "none"
+                                                }
+                                            }
+                                        },
+                                        "overrides": []
+                                    }
+                                }
                             },
-                            "color": {
-                                "mode": "thresholds"
-                            }
+                            "spec/data/spec/queries": [
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "A",
+                                    "spec/query/spec/expr": "sct_cassandra_stress_read_gauge{type=\"lat_perc_99\"}"
+                                },
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "B",
+                                    "spec/query/spec/expr": "sct_cassandra_stress_counter_read_gauge{type=\"lat_perc_99\"}"
+                                },
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "C",
+                                    "spec/query/spec/expr": "sct_latte_read_gauge{type=\"lat_perc_99\"}"
+                                },
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "D",
+                                    "spec/query/spec/expr": "sct_cql_stress_cassandra_stress_read_gauge{type=\"lat_perc_99\"}"
+                                },
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "E",
+                                    "spec/query/spec/expr": "sct_cql_stress_cassandra_stress_counter_read_gauge{type=\"lat_perc_99\"}"
+                                }
+                            ]
                         },
-                        "overrides": []
-                    },
-                    "options": {
-                        "bucketSize": 2
-                    },
-                    "targets": [
                         {
-                            "expr": "sct_cassandra_stress_user_gauge{type=\"lat_perc_99\"}",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "refId": "A"
+                            "class": "ms_panel",
+                            "span": 6,
+                            "spec/title": "MIXED P99 latency | C-S and/or CQL-stress and/or Latte benchmarking tools",
+                            "spec/vizConfig/spec/options/legend": {
+                                "calcs": [],
+                                "displayMode": "list",
+                                "placement": "bottom",
+                                "showLegend": true
+                            },
+                            "spec/data/spec/queries": [
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "A",
+                                    "spec/query/spec/expr": "sct_cassandra_stress_mixed_gauge{type=\"lat_perc_99\"}"
+                                },
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "B",
+                                    "spec/query/spec/expr": "sct_latte_mixed_gauge{type=\"lat_perc_99\"}"
+                                },
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "C",
+                                    "spec/query/spec/expr": "sct_cql_stress_cassandra_stress_mixed_gauge{type=\"lat_perc_99\"}"
+                                }
+                            ]
                         },
                         {
-                            "expr": "sct_latte_user_gauge{type=\"lat_perc_99\"}",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "refId": "B"
+                            "class": "ms_panel",
+                            "span": 6,
+                            "spec/title": "MIXED P99 latency histogram | C-S and/or CQL-stress and/or Latte benchmarking tools",
+                            "spec/vizConfig": {
+                                "kind": "VizConfig",
+                                "group": "histogram",
+                                "version": "13.0.1",
+                                "spec": {
+                                    "options": {
+                                        "bucketSize": 2,
+                                        "combine": false,
+                                        "legend": {
+                                            "calcs": [],
+                                            "displayMode": "list",
+                                            "placement": "bottom",
+                                            "showLegend": true
+                                        }
+                                    },
+                                    "fieldConfig": {
+                                        "defaults": {
+                                            "unit": "ms",
+                                            "color": {
+                                                "mode": "thresholds"
+                                            },
+                                            "thresholds": {
+                                                "mode": "absolute",
+                                                "steps": [
+                                                    {
+                                                        "color": "green",
+                                                        "value": null
+                                                    },
+                                                    {
+                                                        "color": "red",
+                                                        "value": 80
+                                                    }
+                                                ]
+                                            },
+                                            "custom": {
+                                                "fillOpacity": 80,
+                                                "gradientMode": "none",
+                                                "hideFrom": {
+                                                    "legend": false,
+                                                    "tooltip": false,
+                                                    "viz": false
+                                                },
+                                                "lineWidth": 1,
+                                                "stacking": {
+                                                    "group": "A",
+                                                    "mode": "none"
+                                                }
+                                            }
+                                        },
+                                        "overrides": []
+                                    }
+                                }
+                            },
+                            "spec/data/spec/queries": [
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "A",
+                                    "spec/query/spec/expr": "sct_cassandra_stress_mixed_gauge{type=\"lat_perc_99\"}"
+                                },
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "B",
+                                    "spec/query/spec/expr": "sct_latte_mixed_gauge{type=\"lat_perc_99\"}"
+                                },
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "C",
+                                    "spec/query/spec/expr": "sct_cql_stress_cassandra_stress_mixed_gauge{type=\"lat_perc_99\"}"
+                                }
+                            ]
                         },
                         {
-                            "expr": "sct_cql_stress_cassandra_stress_user_gauge{type=\"lat_perc_99\"}",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "refId": "C"
+                            "class": "ms_panel",
+                            "span": 6,
+                            "spec/title": "USER PROFILE P99 latency | C-S and/or CQL-stress and/or Latte benchmarking tools",
+                            "spec/vizConfig/spec/options/legend": {
+                                "calcs": [],
+                                "displayMode": "list",
+                                "placement": "bottom",
+                                "showLegend": true
+                            },
+                            "spec/data/spec/queries": [
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "A",
+                                    "spec/query/spec/expr": "sct_cassandra_stress_user_gauge{type=\"lat_perc_99\"}"
+                                },
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "B",
+                                    "spec/query/spec/expr": "sct_latte_user_gauge{type=\"lat_perc_99\"}"
+                                },
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "C",
+                                    "spec/query/spec/expr": "sct_cql_stress_cassandra_stress_user_gauge{type=\"lat_perc_99\"}"
+                                }
+                            ]
+                        },
+                        {
+                            "class": "ms_panel",
+                            "span": 6,
+                            "spec/title": "USER PROFILE P99 latency histogram | C-S and/or CQL-stress and/or Latte benchmarking tools",
+                            "spec/vizConfig": {
+                                "kind": "VizConfig",
+                                "group": "histogram",
+                                "version": "13.0.1",
+                                "spec": {
+                                    "options": {
+                                        "bucketSize": 2,
+                                        "combine": false,
+                                        "legend": {
+                                            "calcs": [],
+                                            "displayMode": "list",
+                                            "placement": "bottom",
+                                            "showLegend": true
+                                        }
+                                    },
+                                    "fieldConfig": {
+                                        "defaults": {
+                                            "unit": "ms",
+                                            "color": {
+                                                "mode": "thresholds"
+                                            },
+                                            "thresholds": {
+                                                "mode": "absolute",
+                                                "steps": [
+                                                    {
+                                                        "color": "green",
+                                                        "value": null
+                                                    },
+                                                    {
+                                                        "color": "red",
+                                                        "value": 80
+                                                    }
+                                                ]
+                                            },
+                                            "custom": {
+                                                "fillOpacity": 80,
+                                                "gradientMode": "none",
+                                                "hideFrom": {
+                                                    "legend": false,
+                                                    "tooltip": false,
+                                                    "viz": false
+                                                },
+                                                "lineWidth": 1,
+                                                "stacking": {
+                                                    "group": "A",
+                                                    "mode": "none"
+                                                }
+                                            }
+                                        },
+                                        "overrides": []
+                                    }
+                                }
+                            },
+                            "spec/data/spec/queries": [
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "A",
+                                    "spec/query/spec/expr": "sct_cassandra_stress_user_gauge{type=\"lat_perc_99\"}"
+                                },
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "B",
+                                    "spec/query/spec/expr": "sct_latte_user_gauge{type=\"lat_perc_99\"}"
+                                },
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "C",
+                                    "spec/query/spec/expr": "sct_cql_stress_cassandra_stress_user_gauge{type=\"lat_perc_99\"}"
+                                }
+                            ]
                         }
-                    ],
-                    "title": "USER PROFILE P99 latency histogram | C-S and/or CQL-stress and/or Latte benchmarking tools",
-                    "type": "histogram",
-                    "span": 6,
-                    "class": "ms_panel"
+                    ]
                 }
             ]
         },
         {
-            "class": "row",
-            "panels": [
-                {
-                    "class": "collapsible_row_panel",
-                    "title": "Other Stress tools latency",
-                    "dashproduct": "sct-tests"
-                }
-            ]
-        },
-        {
-            "class": "row",
+            "title": "Other Stress tools latency",
+            "collapse": false,
             "dashproduct": "sct-tests",
-            "panels": [
+            "rows": [
                 {
-                    "targets": [
+                    "class": "row",
+                    "panels": [
                         {
-                            "expr": "avg(sct_ycsb_read_gauge{type=\"p90\"}) by (instance)",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "legendFormat": "YCSB READ [{{instance}}]",
-                            "refId": "G"
+                            "class": "ms_panel",
+                            "span": 6,
+                            "spec/title": "Other(YCSB/Scylla-bench) Stress tools latency 95%",
+                            "spec/vizConfig/spec/options/legend": {
+                                "calcs": [],
+                                "displayMode": "list",
+                                "placement": "bottom",
+                                "showLegend": true
+                            },
+                            "spec/data/spec/queries": [
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "G",
+                                    "spec/query/spec/expr": "avg(sct_ycsb_read_gauge{type=\"p90\"}) by (instance)",
+                                    "spec/query/spec/legendFormat": "YCSB READ [{{instance}}]"
+                                },
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "H",
+                                    "spec/query/spec/expr": "avg(sct_ycsb_update_gauge{type=\"p90\"}) by (instance)",
+                                    "spec/query/spec/legendFormat": "YCSB UPDATE [{{instance}}]"
+                                },
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "I",
+                                    "spec/query/spec/expr": "avg(sct_ycsb_insert_gauge{type=\"p90\"}) by (instance)",
+                                    "spec/query/spec/legendFormat": "YCSB INSERT [{{instance}}]"
+                                },
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "J",
+                                    "spec/query/spec/expr": "sct_scylla_bench_stress_write_gauge{type=\"lat_perc_95\"}"
+                                },
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "K",
+                                    "spec/query/spec/expr": "sct_scylla_bench_stress_read_gauge{type=\"lat_perc_95\"}"
+                                }
+                            ]
                         },
                         {
-                            "expr": "avg(sct_ycsb_update_gauge{type=\"p90\"}) by (instance)",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "legendFormat": "YCSB UPDATE [{{instance}}]",
-                            "refId": "H"
+                            "class": "ms_panel",
+                            "span": 6,
+                            "spec/title": "Other(YCSB/Scylla-bench) Stress tools latency 99%",
+                            "spec/vizConfig/spec/options/legend": {
+                                "calcs": [],
+                                "displayMode": "list",
+                                "placement": "bottom",
+                                "showLegend": true
+                            },
+                            "spec/data/spec/queries": [
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "G",
+                                    "spec/query/spec/expr": "avg(sct_ycsb_read_gauge{type=\"p99\"}) by (instance)",
+                                    "spec/query/spec/legendFormat": "YCSB READ [{{instance}}]"
+                                },
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "H",
+                                    "spec/query/spec/expr": "avg(sct_ycsb_update_gauge{type=\"p99\"}) by (instance)",
+                                    "spec/query/spec/legendFormat": "YCSB UPDATE [{{instance}}]"
+                                },
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "I",
+                                    "spec/query/spec/expr": "avg(sct_ycsb_insert_gauge{type=\"p99\"}) by (instance)",
+                                    "spec/query/spec/legendFormat": "YCSB INSERT [{{instance}}]"
+                                },
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "J",
+                                    "spec/query/spec/expr": "sct_scylla_bench_stress_write_gauge{type=\"lat_perc_99\"}"
+                                },
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "K",
+                                    "spec/query/spec/expr": "sct_scylla_bench_stress_read_gauge{type=\"lat_perc_99\"}"
+                                }
+                            ]
                         },
                         {
-                            "expr": "avg(sct_ycsb_insert_gauge{type=\"p90\"}) by (instance)",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "legendFormat": "YCSB INSERT [{{instance}}]",
-                            "refId": "I"
-                        },
-                        {
-                            "expr": "sct_scylla_bench_stress_write_gauge{type=\"lat_perc_95\"}",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "refId": "J"
-                        },
-                        {
-                            "expr": "sct_scylla_bench_stress_read_gauge{type=\"lat_perc_95\"}",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "refId": "K"
+                            "class": "graph_panel",
+                            "span": 6,
+                            "spec/title": "YCSB Error metrics",
+                            "spec/vizConfig/spec/options/legend": {
+                                "calcs": [],
+                                "displayMode": "list",
+                                "placement": "bottom",
+                                "showLegend": true
+                            },
+                            "spec/data/spec/queries": [
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "A",
+                                    "spec/query/spec/expr": "rate(sct_ycsb_read_failed_gauge{type=\"count\"}[1m])"
+                                },
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "B",
+                                    "spec/query/spec/expr": "rate(sct_ycsb_insert_failed_gauge{type=\"count\"}[1m])"
+                                },
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "C",
+                                    "spec/query/spec/expr": "rate(sct_ycsb_verify_gauge{type=\"ERROR\"}[1m])"
+                                },
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "D",
+                                    "spec/query/spec/expr": "rate(sct_ycsb_update_failed_gauge{type=\"count\"}[1m])"
+                                },
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "E",
+                                    "spec/query/spec/expr": "rate(sct_ycsb_verify_gauge{type=\"UNEXPECTED_STATE\"}[1m])"
+                                }
+                            ]
                         }
-                    ],
-                    "title": "Other(YCSB/Scylla-bench) Stress tools latency 95%",
-                    "type": "graph",
-                    "span": 6,
-                    "class": "ms_panel"
-                },
-                {
-                    "targets": [
-                        {
-                            "expr": "avg(sct_ycsb_read_gauge{type=\"p99\"}) by (instance)",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "legendFormat": "YCSB READ [{{instance}}]",
-                            "refId": "G"
-                        },
-                        {
-                            "expr": "avg(sct_ycsb_update_gauge{type=\"p99\"}) by (instance)",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "legendFormat": "YCSB UPDATE [{{instance}}]",
-                            "refId": "H"
-                        },
-                        {
-                            "expr": "avg(sct_ycsb_insert_gauge{type=\"p99\"}) by (instance)",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "legendFormat": "YCSB INSERT [{{instance}}]",
-                            "refId": "I"
-                        },
-                        {
-                            "expr": "sct_scylla_bench_stress_write_gauge{type=\"lat_perc_99\"}",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "refId": "J"
-                        },
-                        {
-                            "expr": "sct_scylla_bench_stress_read_gauge{type=\"lat_perc_99\"}",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "refId": "K"
-                        }
-                    ],
-                    "title": "Other(YCSB/Scylla-bench) Stress tools latency 99%",
-                    "type": "graph",
-                    "span": 6,
-                    "class": "ms_panel"
-                },
-                {
-                    "class": "graph_panel",
-                    "span": 6,
-                    "title": "YCSB Error metrics",
-                    "targets": [
-                        {
-                            "expr": "rate(sct_ycsb_read_failed_gauge{type=\"count\"}[1m])",
-                            "format": "time_series",
-                            "hide": false,
-                            "intervalFactor": 1,
-                            "refId": "A"
-                        },
-                        {
-                            "expr": "rate(sct_ycsb_insert_failed_gauge{type=\"count\"}[1m])",
-                            "format": "time_series",
-                            "hide": false,
-                            "intervalFactor": 1,
-                            "refId": "B"
-                        },
-                        {
-                            "expr": "rate(sct_ycsb_verify_gauge{type=\"ERROR\"}[1m])",
-                            "format": "time_series",
-                            "hide": false,
-                            "intervalFactor": 1,
-                            "refId": "C"
-                        },
-                        {
-                            "expr": "rate(sct_ycsb_update_failed_gauge{type=\"count\"}[1m])",
-                            "format": "time_series",
-                            "hide": false,
-                            "intervalFactor": 1,
-                            "refId": "D"
-                        },
-                        {
-                            "expr": "rate(sct_ycsb_verify_gauge{type=\"UNEXPECTED_STATE\"}[1m])",
-                            "format": "time_series",
-                            "hide": false,
-                            "intervalFactor": 1,
-                            "refId": "E"
-                        }
-                    ],
-                    "type": "graph"
+                    ]
                 }
             ]
         },
         {
-            "class": "row",
-            "panels": [
+            "title": "NoSQL Bench metrics",
+            "collapse": false,
+            "dashproduct": "sct-tests",
+            "rows": [
                 {
-                    "class": "collapsible_row_panel",
-                    "title": "NoSQL Bench metrics",
-                    "dashproduct": "sct-tests"
+                    "class": "row",
+                    "panels": [
+                        {
+                            "class": "ops_panel",
+                            "span": 6,
+                            "spec/title": "Ops vs successful ops / minute",
+                            "spec/vizConfig/spec/options/legend": {
+                                "calcs": [],
+                                "displayMode": "list",
+                                "placement": "bottom",
+                                "showLegend": true
+                            },
+                            "spec/data/spec/queries": [
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "A",
+                                    "spec/query/spec/expr": "result{type=\"avg_rate\",avg_of=\"1m\"}",
+                                    "spec/query/spec/legendFormat": "{{instance}}-allops"
+                                },
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "B",
+                                    "spec/query/spec/expr": "result_success{type=\"avg_rate\",avg_of=\"1m\"}",
+                                    "spec/query/spec/legendFormat": "{{instance}}-success"
+                                }
+                            ]
+                        },
+                        {
+                            "class": "percent_panel",
+                            "span": 6,
+                            "spec/title": "Service time distribution",
+                            "spec/vizConfig/spec/options/legend": {
+                                "calcs": [],
+                                "displayMode": "list",
+                                "placement": "bottom",
+                                "showLegend": true
+                            },
+                            "spec/data/spec/queries/0/spec/query/spec/expr": "result_success{type=\"pctile\"}",
+                            "spec/data/spec/queries/0/spec/query/spec/legendFormat": "{{instance}}-{{step}}-p{{pctile}}"
+                        },
+                        {
+                            "class": "seconds_panel",
+                            "span": 6,
+                            "spec/title": "Service time range",
+                            "spec/vizConfig/spec/options/legend": {
+                                "calcs": [],
+                                "displayMode": "list",
+                                "placement": "bottom",
+                                "showLegend": true
+                            },
+                            "spec/data/spec/queries": [
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "A",
+                                    "spec/query/spec/expr": "result_success{type=\"pctile\",pctile=\"0\"}",
+                                    "spec/query/spec/legendFormat": "{{instance}}-{{step}}-min"
+                                },
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "B",
+                                    "spec/query/spec/expr": "result_success{type=\"pctile\",pctile=\"100\"}",
+                                    "spec/query/spec/legendFormat": "{{instance}}-{{step}}-max"
+                                }
+                            ]
+                        },
+                        {
+                            "class": "seconds_panel",
+                            "span": 6,
+                            "spec/title": "Service time median",
+                            "spec/vizConfig/spec/options/legend": {
+                                "calcs": [],
+                                "displayMode": "list",
+                                "placement": "bottom",
+                                "showLegend": true
+                            },
+                            "spec/data/spec/queries/0/spec/query/spec/expr": "result_success{type=\"pctile\",pctile=\"50\"}",
+                            "spec/data/spec/queries/0/spec/query/spec/legendFormat": "{{instance}}-{{step}}-median"
+                        },
+                        {
+                            "class": "ops_panel",
+                            "span": 6,
+                            "spec/title": "Write ops / minute",
+                            "spec/vizConfig/spec/options/legend": {
+                                "calcs": [],
+                                "displayMode": "list",
+                                "placement": "bottom",
+                                "showLegend": true
+                            },
+                            "spec/data/spec/queries": [
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "A",
+                                    "spec/query/spec/expr": "main_write__main_write__success{property=\"m1_rate\"}",
+                                    "spec/query/spec/legendFormat": "{{instance}}-{{step}}"
+                                },
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "B",
+                                    "spec/query/spec/expr": "main_write__main_write__error{property=\"m1_rate\"}",
+                                    "spec/query/spec/legendFormat": "{{instance}}-{{step}}"
+                                }
+                            ]
+                        },
+                        {
+                            "class": "ops_panel",
+                            "span": 6,
+                            "spec/title": "Read ops / minute",
+                            "spec/vizConfig/spec/options/legend": {
+                                "calcs": [],
+                                "displayMode": "list",
+                                "placement": "bottom",
+                                "showLegend": true
+                            },
+                            "spec/data/spec/queries": [
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "A",
+                                    "spec/query/spec/expr": "main_read__main_select_all__success{property=\"m1_rate\"}",
+                                    "spec/query/spec/legendFormat": "{{instance}}-{{step}}"
+                                },
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "B",
+                                    "spec/query/spec/expr": "main_read__main_select_all__error{property=\"m1_rate\"}",
+                                    "spec/query/spec/legendFormat": "{{instance}}-{{step}}"
+                                }
+                            ]
+                        },
+                        {
+                            "class": "graph_panel",
+                            "span": 6,
+                            "spec/title": "Cycle count",
+                            "spec/vizConfig/spec/options/legend": {
+                                "calcs": [],
+                                "displayMode": "list",
+                                "placement": "bottom",
+                                "showLegend": true
+                            },
+                            "spec/data/spec/queries/0/spec/query/spec/expr": "cycles_servicetime{type=\"counter\"}",
+                            "spec/data/spec/queries/0/spec/query/spec/legendFormat": "{{instance}}-{{step}}"
+                        },
+                        {
+                            "class": "ms_panel",
+                            "span": 6,
+                            "spec/title": "p99 client overhead",
+                            "spec/vizConfig/spec/options/legend": {
+                                "calcs": [],
+                                "displayMode": "list",
+                                "placement": "bottom",
+                                "showLegend": true
+                            },
+                            "spec/data/spec/queries/0/spec/query/spec/expr": "{__name__=~\"read_input|bind|execute\",type=\"pctile\",pctile=\"99\"}",
+                            "spec/data/spec/queries/0/spec/query/spec/legendFormat": "{{instance}}-{{__name__}}-p{{pctile}}"
+                        },
+                        {
+                            "class": "graph_panel",
+                            "span": 6,
+                            "spec/title": "Errors",
+                            "spec/vizConfig/spec/options/legend": {
+                                "calcs": [],
+                                "displayMode": "list",
+                                "placement": "bottom",
+                                "showLegend": true
+                            },
+                            "spec/data/spec/queries/0/spec/query/spec/expr": "{__name__=~\"errorcounts.*\"}",
+                            "spec/data/spec/queries/0/spec/query/spec/legendFormat": "{{instance}}-{{error}}"
+                        }
+                    ]
                 }
             ]
         },
         {
-            "class": "row",
-            "panels": [
+            "title": "SLA Per-User Metrics",
+            "collapse": false,
+            "dashproduct": "sct-tests",
+            "rows": [
                 {
-                    "class": "ops_panel",
-                    "span": 6,
-                    "title": "Ops vs successful ops / minute",
-                    "targets": [
+                    "class": "row",
+                    "panels": [
                         {
-                            "exemplar": true,
-                            "expr": "result{type=\"avg_rate\",avg_of=\"1m\"}",
-                            "format": "time_series",
-                            "hide": false,
-                            "interval": "",
-                            "intervalFactor": 1,
-                            "legendFormat": "{{instance}}-allops",
-                            "refId": "A"
+                            "class": "ops_panel",
+                            "span": 6,
+                            "spec/title": "cassandra-stress ops",
+                            "spec/vizConfig/spec/options/legend": {
+                                "calcs": [],
+                                "displayMode": "list",
+                                "placement": "bottom",
+                                "showLegend": true
+                            },
+                            "spec/data/spec/queries": [
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "C",
+                                    "spec/query/spec/expr": "sct_cassandra_stress_read_gauge{type=\"ops\"}"
+                                },
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "A",
+                                    "spec/query/spec/expr": "sct_cassandra_stress_write_gauge{type=\"ops\"}"
+                                }
+                            ]
                         },
                         {
-                            "exemplar": true,
-                            "expr": "result_success{type=\"avg_rate\",avg_of=\"1m\"}",
-                            "hide": false,
-                            "interval": "",
-                            "legendFormat": "{{instance}}-success",
-                            "refId": "B"
+                            "class": "ops_panel",
+                            "span": 6,
+                            "spec/title": "cql-stress-cassandra-stress ops",
+                            "spec/vizConfig/spec/options/legend": {
+                                "calcs": [],
+                                "displayMode": "list",
+                                "placement": "bottom",
+                                "showLegend": true
+                            },
+                            "spec/data/spec/queries": [
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "C",
+                                    "spec/query/spec/expr": "sct_cql_stress_cassandra_stress_read_gauge{type=\"ops\"}"
+                                },
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "A",
+                                    "spec/query/spec/expr": "sct_cql_stress_cassandra_stress_write_gauge{type=\"ops\"}"
+                                }
+                            ]
                         }
-                    ],
-                    "type": "graph"
-                },
-                {
-                    "class": "percent_panel",
-                    "span": 6,
-                    "title": "Service time distribution",
-                    "targets": [
-                        {
-                            "exemplar": true,
-                            "expr": "result_success{type=\"pctile\"}",
-                            "format": "time_series",
-                            "hide": false,
-                            "interval": "",
-                            "intervalFactor": 1,
-                            "legendFormat": "{{instance}}-{{step}}-p{{pctile}}",
-                            "refId": "A"
-                        }
-                    ],
-                    "type": "graph"
-                },
-                {
-                    "class": "seconds_panel",
-                    "span": 6,
-                    "title": "Service time range",
-                    "targets": [
-                        {
-                            "exemplar": true,
-                            "expr": "result_success{type=\"pctile\",pctile=\"0\"}",
-                            "format": "time_series",
-                            "hide": false,
-                            "interval": "",
-                            "intervalFactor": 1,
-                            "legendFormat": "{{instance}}-{{step}}-min",
-                            "refId": "A"
-                        },
-                        {
-                            "exemplar": true,
-                            "expr": "result_success{type=\"pctile\",pctile=\"100\"}",
-                            "hide": false,
-                            "interval": "",
-                            "legendFormat": "{{instance}}-{{step}}-max",
-                            "refId": "B"
-                        }
-                    ],
-                    "type": "graph"
-                },
-                {
-                    "class": "seconds_panel",
-                    "span": 6,
-                    "title": "Service time median",
-                    "targets": [
-                        {
-                            "exemplar": true,
-                            "expr": "result_success{type=\"pctile\",pctile=\"50\"}",
-                            "hide": false,
-                            "interval": "",
-                            "legendFormat": "{{instance}}-{{step}}-median",
-                            "refId": "B"
-                        }
-                    ],
-                    "type": "graph"
-                },
-                {
-                    "class": "ops_panel",
-                    "span": 6,
-                    "title": "Write ops / minute",
-                    "targets": [
-                        {
-                            "exemplar": true,
-                            "expr": "main_write__main_write__success{property=\"m1_rate\"}",
-                            "format": "time_series",
-                            "hide": false,
-                            "interval": "",
-                            "intervalFactor": 1,
-                            "legendFormat": "{{instance}}-{{step}}",
-                            "refId": "A"
-                        },
-                        {
-                            "exemplar": true,
-                            "expr": "main_write__main_write__error{property=\"m1_rate\"}",
-                            "hide": false,
-                            "interval": "",
-                            "legendFormat": "{{instance}}-{{step}}",
-                            "refId": "B"
-                        }
-                    ],
-                    "type": "graph"
-                },
-                {
-                    "class": "ops_panel",
-                    "span": 6,
-                    "title": "Read ops / minute",
-                    "targets": [
-                        {
-                            "exemplar": true,
-                            "expr": "main_read__main_select_all__success{property=\"m1_rate\"}",
-                            "format": "time_series",
-                            "hide": false,
-                            "interval": "",
-                            "intervalFactor": 1,
-                            "legendFormat": "{{instance}}-{{step}}",
-                            "refId": "A"
-                        },
-                        {
-                            "exemplar": true,
-                            "expr": "main_read__main_select_all__error{property=\"m1_rate\"}",
-                            "hide": false,
-                            "interval": "",
-                            "legendFormat": "{{instance}}-{{step}}",
-                            "refId": "B"
-                        }
-                    ],
-                    "type": "graph"
-                },
-                {
-                    "class": "graph_panel",
-                    "span": 6,
-                    "title": "Cycle count",
-                    "targets": [
-                        {
-                            "exemplar": true,
-                            "expr": "cycles_servicetime{type=\"counter\"}",
-                            "format": "time_series",
-                            "hide": false,
-                            "interval": "",
-                            "intervalFactor": 1,
-                            "legendFormat": "{{instance}}-{{step}}",
-                            "refId": "A"
-                        }
-                    ],
-                    "type": "graph"
-                },
-                {
-                    "class": "ms_panel",
-                    "span": 6,
-                    "title": "p99 client overhead",
-                    "targets": [
-                        {
-                            "exemplar": true,
-                            "expr": "{__name__=~\"read_input|bind|execute\",type=\"pctile\",pctile=\"99\"}",
-                            "format": "time_series",
-                            "hide": false,
-                            "interval": "",
-                            "intervalFactor": 1,
-                            "legendFormat": "{{instance}}-{{__name__}}-p{{pctile}}",
-                            "refId": "A"
-                        }
-                    ],
-                    "type": "graph"
-                },
-                {
-                    "class": "graph_panel",
-                    "span": 6,
-                    "title": "Errors",
-                    "targets": [
-                        {
-                            "exemplar": true,
-                            "expr": "{__name__=~\"errorcounts.*\"}",
-                            "format": "time_series",
-                            "hide": false,
-                            "interval": "",
-                            "intervalFactor": 1,
-                            "legendFormat": "{{instance}}-{{error}}",
-                            "refId": "A"
-                        }
-                    ],
-                    "type": "graph"
+                    ]
                 }
             ]
         },
         {
-            "class": "row",
-            "panels": [
+            "title": "Logging metrics",
+            "collapse": false,
+            "dashproduct": "sct-tests",
+            "rows": [
                 {
-                    "class": "collapsible_row_panel",
-                    "title": "SLA Per-User Metrics",
-                    "dashproduct": "sct-tests"
-                }
-            ]
-        },
-        {
-            "class": "row",
-            "panels": [
-                {
-                    "class": "ops_panel",
-                    "span": 6,
-                    "title": "cassandra-stress ops",
-                    "targets": [
+                    "class": "row",
+                    "panels": [
                         {
-                            "expr": "sct_cassandra_stress_read_gauge{type=\"ops\"}",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "refId": "C"
-                        },
-                        {
-                            "expr": "sct_cassandra_stress_write_gauge{type=\"ops\"}",
-                            "format": "time_series",
-                            "intervalFactor": 1,
-                            "refId": "A"
+                            "class": "ops_panel",
+                            "span": 6,
+                            "spec/title": "Logs create/drop rates",
+                            "spec/vizConfig/spec/options/legend": {
+                                "calcs": [],
+                                "displayMode": "list",
+                                "placement": "bottom",
+                                "showLegend": true
+                            },
+                            "spec/vizConfig/spec/fieldConfig/defaults/unit": "mps",
+                            "spec/data/spec/queries": [
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "A",
+                                    "spec/query/spec/expr": "increase(syslog_ng_destination_messages_processed_total{dc=~\"$dc\"}[10m])",
+                                    "spec/query/spec/legendFormat": "Processed {{instance}}"
+                                },
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "B",
+                                    "spec/query/spec/expr": "increase(syslog_ng_destination_messages_dropped_total{dc=~\"$dc\"}[10m])",
+                                    "spec/query/spec/legendFormat": "Dropped {{instance}}"
+                                },
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "C",
+                                    "spec/query/spec/expr": "increase(vector_component_received_events_total{component_id=\"sct-runner\", dc=~\"$dc\"}[10m])",
+                                    "spec/query/spec/legendFormat": "Processed {{instance}}"
+                                },
+                                {
+                                    "class": "graph_query",
+                                    "spec/refId": "D",
+                                    "spec/query/spec/expr": "increase(vector_component_discarded_events_total{component_id=\"sct-runner\", dc=~\"$dc\"}[10m])",
+                                    "spec/query/spec/legendFormat": "Dropped {{instance}}"
+                                }
+                            ]
                         }
-                    ],
-                    "type": "graph"
-                },
-                {
-                    "class": "ops_panel",
-                    "span": 6,
-                    "title": "cql-stress-cassandra-stress ops",
-                    "targets": [
-                        {
-                            "expr": "sct_cql_stress_cassandra_stress_read_gauge{type=\"ops\"}",
-                            "format": "time_series",
-                            "interval": "15s",
-                            "intervalFactor": 1,
-                            "refId": "C"
-                        },
-                        {
-                            "expr": "sct_cql_stress_cassandra_stress_write_gauge{type=\"ops\"}",
-                            "format": "time_series",
-                            "intervalFactor": 1,
-                            "refId": "A"
-                        }
-                    ],
-                    "type": "graph"
-                }
-            ]
-        },
-        {
-            "class": "row",
-            "panels": [
-                {
-                    "class": "collapsible_row_panel",
-                    "title": "Logging metrics",
-                    "dashproduct": "sct-tests"
-                }
-            ]
-        },
-        {
-            "class": "row",
-            "panels": [
-                {
-                    "class": "ops_panel",
-                    "span": 6,
-                    "fieldConfig": {
-                        "defaults": {
-                            "class": "fieldConfig_defaults",
-                            "unit": "mps"
-                        },
-                        "overrides": []
-                    },
-                    "targets": [
-                        {
-                            "datasource": "prometheus",
-                            "editorMode": "code",
-                            "exemplar": false,
-                            "expr": "increase(syslog_ng_destination_messages_processed_total{dc=~\"$dc\"}[10m])",
-                            "format": "time_series",
-                            "instant": false,
-                            "intervalFactor": 1,
-                            "legendFormat": "Processed {{instance}}",
-                            "range": true,
-                            "refId": "A"
-                        },
-                        {
-                            "datasource": "prometheus",
-                            "editorMode": "code",
-                            "expr": "increase(syslog_ng_destination_messages_dropped_total{dc=~\"$dc\"}[10m])",
-                            "format": "time_series",
-                            "intervalFactor": 1,
-                            "legendFormat": "Dropped {{instance}}",
-                            "range": true,
-                            "refId": "B"
-                        },
-                                                {
-                            "datasource": "prometheus",
-                            "editorMode": "code",
-                            "exemplar": false,
-                            "expr": "increase(vector_component_received_events_total{component_id=\"sct-runner\", dc=~\"$dc\"}[10m])",
-                            "format": "time_series",
-                            "instant": false,
-                            "intervalFactor": 1,
-                            "legendFormat": "Processed {{instance}}",
-                            "range": true,
-                            "refId": "C"
-                        },
-                        {
-                            "datasource": "prometheus",
-                            "editorMode": "code",
-                            "expr": "increase(vector_component_discarded_events_total{component_id=\"sct-runner\", dc=~\"$dc\"}[10m])",
-                            "format": "time_series",
-                            "intervalFactor": 1,
-                            "legendFormat": "Dropped {{instance}}",
-                            "range": true,
-                            "refId": "D"
-                        }
-                    ],
-                    "title": "Logs create/drop rates",
-                    "type": "timeseries"
+                    ]
                 }
             ]
         }
     ],
     "variables": [
         {
-            "class": "template_variable_custom",
-            "current": {
+            "class": "custom_variable",
+            "spec/name": "sct_tags",
+            "spec/query": "InfoEvent, CassandraStressEvent, ScyllaBenchEvent, DatabaseLogEvent, DisruptionEvent, CoreDumpEvent, SpotTerminationEvent, ClusterHealthValidatorEvent, DataValidatorEvent",
+            "spec/multi": true,
+            "spec/includeAll": false,
+            "spec/current": {
                 "text": "",
                 "value": []
             },
-            "hide": 1,
-            "includeAll": false,
-            "multi": true,
-            "name": "sct_tags",
-            "options": [
+            "spec/options": [
                 {
                     "selected": true,
                     "text": "InfoEvent",
@@ -1452,129 +1577,159 @@
                     "value": "DataValidatorEvent"
                 }
             ],
-            "query": "InfoEvent, CassandraStressEvent, ScyllaBenchEvent, DatabaseLogEvent, DisruptionEvent, CoreDumpEvent, SpotTerminationEvent, ClusterHealthValidatorEvent, DataValidatorEvent",
-            "type": "custom"
+            "spec/hide": "hideVariable"
         }
     ],
-    "annotations": {
-        "class": "default_annotations",
-        "list": [
-            {
-                "datasource": {
-                    "type": "datasource",
-                    "uid": "grafana"
-                },
+    "annotations": [
+        {
+            "kind": "AnnotationQuery",
+            "spec": {
+                "name": "Events[Custom Filter]",
                 "enable": false,
                 "hide": false,
                 "iconColor": "#962d82",
-                "limit": 100,
-                "matchAny": true,
-                "name": "Events[Custom Filter]",
-                "showIn": 0,
-                "tags": [
-                    "$sct_tags"
-                ],
-                "type": "tags"
-            },
-            {
-                "datasource": {
-                    "type": "datasource",
-                    "uid": "grafana"
-                },
+                "query": {
+                    "kind": "DataQuery",
+                    "group": "grafana",
+                    "version": "v0",
+                    "datasource": {
+                        "name": "-- Grafana --"
+                    },
+                    "spec": {
+                        "limit": 100,
+                        "matchAny": true,
+                        "tags": [
+                            "$sct_tags"
+                        ],
+                        "type": "tags"
+                    }
+                }
+            }
+        },
+        {
+            "kind": "AnnotationQuery",
+            "spec": {
+                "name": "Events[DEBUG]",
                 "enable": false,
                 "hide": false,
                 "iconColor": "#aaacad",
-                "limit": 100,
-                "matchAny": true,
-                "name": "Events[DEBUG]",
-                "showIn": 0,
-                "tags": [
-                    "DEBUG"
-                ],
-                "type": "tags"
-            },
-            {
-                "datasource": {
-                    "type": "datasource",
-                    "uid": "grafana"
-                },
+                "query": {
+                    "kind": "DataQuery",
+                    "group": "grafana",
+                    "version": "v0",
+                    "datasource": {
+                        "name": "-- Grafana --"
+                    },
+                    "spec": {
+                        "limit": 100,
+                        "matchAny": true,
+                        "tags": [
+                            "DEBUG"
+                        ],
+                        "type": "tags"
+                    }
+                }
+            }
+        },
+        {
+            "kind": "AnnotationQuery",
+            "spec": {
+                "name": "Events[NORMAL]",
                 "enable": false,
                 "hide": false,
                 "iconColor": "#badff4",
-                "limit": 100,
-                "matchAny": true,
-                "name": "Events[NORMAL]",
-                "showIn": 0,
-                "tags": [
-                    "NORMAL"
-                ],
-                "target": {
-                    "limit": 100,
-                    "matchAny": true,
-                    "tags": [
-                        "NORMAL"
-                    ],
-                    "type": "tags"
-                },
-                "type": "tags"
-            },
-            {
-                "datasource": {
-                    "type": "datasource",
-                    "uid": "grafana"
-                },
+                "query": {
+                    "kind": "DataQuery",
+                    "group": "grafana",
+                    "version": "v0",
+                    "datasource": {
+                        "name": "-- Grafana --"
+                    },
+                    "spec": {
+                        "limit": 100,
+                        "matchAny": true,
+                        "tags": [
+                            "NORMAL"
+                        ],
+                        "type": "tags"
+                    }
+                }
+            }
+        },
+        {
+            "kind": "AnnotationQuery",
+            "spec": {
+                "name": "Events[WARNING]",
                 "enable": false,
                 "hide": false,
                 "iconColor": "#eab839",
-                "limit": 100,
-                "name": "Events[WARNING]",
-                "showIn": 0,
-                "tags": [
-                    "WARNING"
-                ],
-                "target": {
-                    "limit": 100,
-                    "matchAny": false,
-                    "tags": [
-                        "WARNING"
-                    ],
-                    "type": "tags"
-                },
-                "type": "tags"
-            },
-            {
-                "datasource": {
-                    "type": "datasource",
-                    "uid": "grafana"
-                },
+                "query": {
+                    "kind": "DataQuery",
+                    "group": "grafana",
+                    "version": "v0",
+                    "datasource": {
+                        "name": "-- Grafana --"
+                    },
+                    "spec": {
+                        "limit": 100,
+                        "matchAny": false,
+                        "tags": [
+                            "WARNING"
+                        ],
+                        "type": "tags"
+                    }
+                }
+            }
+        },
+        {
+            "kind": "AnnotationQuery",
+            "spec": {
+                "name": "Events[ERROR]",
                 "enable": true,
                 "hide": false,
                 "iconColor": "#ef843c",
-                "limit": 100,
-                "name": "Events[ERROR]",
-                "showIn": 0,
-                "tags": [
-                    "ERROR"
-                ],
-                "type": "tags"
-            },
-            {
-                "datasource": {
-                    "type": "datasource",
-                    "uid": "grafana"
-                },
+                "query": {
+                    "kind": "DataQuery",
+                    "group": "grafana",
+                    "version": "v0",
+                    "datasource": {
+                        "name": "-- Grafana --"
+                    },
+                    "spec": {
+                        "limit": 100,
+                        "matchAny": false,
+                        "tags": [
+                            "ERROR"
+                        ],
+                        "type": "tags"
+                    }
+                }
+            }
+        },
+        {
+            "kind": "AnnotationQuery",
+            "spec": {
+                "name": "Events[CRITICAL]",
                 "enable": true,
                 "hide": false,
                 "iconColor": "rgba(255, 96, 96, 1)",
-                "limit": 100,
-                "matchAny": true,
-                "name": "Events[CRITICAL]",
-                "showIn": 0,
-                "tags": [
-                    "CRITICAL"
-                ],
-                "type": "tags"
+                "query": {
+                    "kind": "DataQuery",
+                    "group": "grafana",
+                    "version": "v0",
+                    "datasource": {
+                        "name": "-- Grafana --"
+                    },
+                    "spec": {
+                        "limit": 100,
+                        "matchAny": true,
+                        "tags": [
+                            "CRITICAL"
+                        ],
+                        "type": "tags"
+                    }
+                }
             }
-        ]
-    }
+        }
+    ]
 }

--- a/data_dir/scylla-dash-per-server-nemesis.master.json
+++ b/data_dir/scylla-dash-per-server-nemesis.master.json
@@ -8422,7 +8422,9 @@
     },
     "timezone": "utc",
     "title": "[$test_name] Scylla Per Server Metrics Nemesis Master",
+    "uid": "sct-per-server-nemesis",
     "version": 1,
     "weekStart": ""
-  }
+  },
+  "overwrite": true
 }

--- a/defaults/aws_config.yaml
+++ b/defaults/aws_config.yaml
@@ -7,7 +7,7 @@ instance_type_loader: ''
 instance_type_monitor: ''
 ami_id_loader: 'resolve:ssm:/aws/service/canonical/ubuntu/server/26.04/stable/current/amd64/hvm/ebs-gp3/ami-id'
 # manual on updating monitor images see: docs/monitoring-images.md
-ami_id_monitor: 'scylladb-monitor-4-15-0-rc0-2026-04-30t01-12-58z'
+ami_id_monitor: 'scylladb-monitor-4-16-0-amd64-2026-08-26t09-38-48z'
 
 availability_zone: 'a'
 root_disk_size_monitor: 50  # GB, remove this field if default disk size should be used

--- a/defaults/aws_config.yaml
+++ b/defaults/aws_config.yaml
@@ -7,7 +7,7 @@ instance_type_loader: ''
 instance_type_monitor: ''
 ami_id_loader: 'resolve:ssm:/aws/service/canonical/ubuntu/server/26.04/stable/current/amd64/hvm/ebs-gp3/ami-id'
 # manual on updating monitor images see: docs/monitoring-images.md
-ami_id_monitor: 'scylladb-monitor-4-16-0-amd64-2026-08-26t09-38-48z'
+ami_id_monitor: 'scylladb-monitor-4-16-0-amd64-2026-08-30t08-46-39z'
 
 availability_zone: 'a'
 root_disk_size_monitor: 50  # GB, remove this field if default disk size should be used

--- a/defaults/gce_config.yaml
+++ b/defaults/gce_config.yaml
@@ -10,7 +10,7 @@ gce_project: '' # empty mean default one, can be overwritten to use different on
 
 gce_image_db: '' # so we can use `scylla_version` as needed
 gce_image_loader: 'https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/family/ubuntu-2604-lts-amd64'
-gce_image_monitor: 'https://www.googleapis.com/compute/v1/projects/scylla-images/global/images/scylladb-monitor-4-15-0-rc0-2026-04-30t01-12-58z'
+gce_image_monitor: 'https://www.googleapis.com/compute/v1/projects/scylla-images/global/images/scylladb-monitor-4-16-0-amd64-2026-08-26t09-38-48z'
 
 gce_image_username: 'scylla-test'
 

--- a/defaults/gce_config.yaml
+++ b/defaults/gce_config.yaml
@@ -10,7 +10,7 @@ gce_project: '' # empty mean default one, can be overwritten to use different on
 
 gce_image_db: '' # so we can use `scylla_version` as needed
 gce_image_loader: 'https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/family/ubuntu-2604-lts-amd64'
-gce_image_monitor: 'https://www.googleapis.com/compute/v1/projects/scylla-images/global/images/scylladb-monitor-4-16-0-amd64-2026-08-26t09-38-48z'
+gce_image_monitor: 'https://www.googleapis.com/compute/v1/projects/scylla-images/global/images/scylladb-monitor-4-16-0-amd64-2026-08-30t08-46-39z'
 
 gce_image_username: 'scylla-test'
 

--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -34,7 +34,7 @@ scylla_linux_distro: 'ubuntu-focal'
 scylla_linux_distro_loader: 'ubuntu-jammy'
 ssh_transport: 'libssh2'
 
-monitor_branch: 'branch-4.15'
+monitor_branch: 'branch-4.16'
 
 space_node_threshold: 0
 

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -585,7 +585,7 @@ A local directory of rpms to install a custom version on top of<br>the scylla in
 
 The port of scylla management
 
-**default:** branch-4.15
+**default:** branch-4.16
 
 **type:** str (appendable)
 
@@ -1350,7 +1350,7 @@ AMS AMI id to use for monitor node
 **type:** str (appendable)
 
 **backend overrides:**
-- `scylladb-monitor-4-15-0-rc0-2026-04-30t01-12-58z`: aws, aws-siren, k8s-local-kind-aws, k8s-eks
+- `scylladb-monitor-4-16-0-amd64-2026-08-26t09-38-48z`: aws, aws-siren, k8s-local-kind-aws, k8s-eks
 
 
 ## **ami_id_db_cassandra** / SCT_AMI_ID_DB_CASSANDRA
@@ -1645,7 +1645,7 @@ gce image to use for monitor nodes
 **type:** str (appendable)
 
 **backend overrides:**
-- `https://www.googleapis.com/compute/v1/projects/scylla-images/global/images/scylladb-monitor-4-15-0-rc0-2026-04-30t01-12-58z`: gce, gce-siren, k8s-gke
+- `https://www.googleapis.com/compute/v1/projects/scylla-images/global/images/scylladb-monitor-4-16-0-amd64-2026-08-26t09-38-48z`: gce, gce-siren, k8s-gke
 
 
 ## **scylla_network_config** / SCT_SCYLLA_NETWORK_CONFIG

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -1350,7 +1350,7 @@ AMS AMI id to use for monitor node
 **type:** str (appendable)
 
 **backend overrides:**
-- `scylladb-monitor-4-16-0-amd64-2026-08-26t09-38-48z`: aws, aws-siren, k8s-local-kind-aws, k8s-eks
+- `scylladb-monitor-4-16-0-amd64-2026-08-30t08-46-39z`: aws, aws-siren, k8s-local-kind-aws, k8s-eks
 
 
 ## **ami_id_db_cassandra** / SCT_AMI_ID_DB_CASSANDRA
@@ -1645,7 +1645,7 @@ gce image to use for monitor nodes
 **type:** str (appendable)
 
 **backend overrides:**
-- `https://www.googleapis.com/compute/v1/projects/scylla-images/global/images/scylladb-monitor-4-16-0-amd64-2026-08-26t09-38-48z`: gce, gce-siren, k8s-gke
+- `https://www.googleapis.com/compute/v1/projects/scylla-images/global/images/scylladb-monitor-4-16-0-amd64-2026-08-30t08-46-39z`: gce, gce-siren, k8s-gke
 
 
 ## **scylla_network_config** / SCT_SCYLLA_NETWORK_CONFIG

--- a/functional_tests/scylla_operator/test_functional.py
+++ b/functional_tests/scylla_operator/test_functional.py
@@ -394,7 +394,8 @@ def _scylla_cluster_monitoring_ckecks(db_cluster: ScyllaPodCluster, monitoring_t
         api_call_return_code = k8s_cluster.register_sct_grafana_dashboard(
             cluster_name=cluster_name, namespace=namespace
         )
-        assert api_call_return_code == "200", "SCT dashboard upload failed"
+        # the /apis dashboard endpoint answers 201 Created on first upload, 200 OK on update
+        assert api_call_return_code.startswith("2"), "SCT dashboard upload failed"
 
         is_passed = db_cluster.check_kubernetes_monitoring_health()
         assert is_passed, "K8S monitoring health checks have failed"

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -110,6 +110,11 @@ from sdcm.utils.gcp_kms import GcpKms
 from sdcm.provision.gce.kms_provider import GcpKmsProvider
 from google.cloud.exceptions import GoogleCloudError
 from sdcm.utils.cql_utils import cql_quote_if_needed
+from sdcm.utils.grafana_api import (
+    GRAFANA_ANNOTATIONS_API_PATH,
+    GRAFANA_DASHBOARD_API_PATH,
+    convert_dashboard_payload_to_new_api,
+)
 from sdcm.utils.benchmarks import ScyllaClusterBenchmarkManager
 from sdcm.utils.common import (
     S3Storage,
@@ -7470,13 +7475,16 @@ class BaseMonitorSet:
 
     def add_sct_dashboards_to_grafana(self, node):
         def _register_grafana_json(json_filename):
-            url = "'http://{0}:{1.grafana_port}/api/dashboards/db'".format(
-                normalize_ipv6_url(node.external_address), self
-            )
-            result = LOCALRUNNER.run(
-                'curl -g -XPOST -i %s --data-binary @%s -H "Content-Type: application/json"' % (url, json_filename)
-            )
-            return result.exited == 0
+            grafana_base_url = "http://{}:{}".format(normalize_ipv6_url(node.external_address), self.grafana_port)
+            url = grafana_base_url + GRAFANA_DASHBOARD_API_PATH
+            with open(json_filename, encoding="utf-8") as f:
+                legacy_payload = json.load(f)
+            payload = convert_dashboard_payload_to_new_api(legacy_payload)
+            try:
+                result = requests.post(url, json=payload, headers={"Content-Type": "application/json"}, timeout=30)
+            except requests.ConnectionError:
+                return False
+            return result.ok
 
         wait.wait_for(
             _register_grafana_json,
@@ -7552,7 +7560,7 @@ class BaseMonitorSet:
             self.download_scylla_monitoring(node)
 
     def get_grafana_annotations(self, node):
-        annotations_url = "http://{node_ip}:{grafana_port}/api/annotations?limit=10000"
+        annotations_url = "http://{node_ip}:{grafana_port}" + GRAFANA_ANNOTATIONS_API_PATH + "?limit=10000"
         try:
             res = requests.get(
                 url=annotations_url.format(
@@ -7566,7 +7574,7 @@ class BaseMonitorSet:
         return ""
 
     def set_grafana_annotations(self, node, annotations_data):
-        annotations_url = "http://{node_ip}:{grafana_port}/api/annotations"
+        annotations_url = "http://{node_ip}:{grafana_port}" + GRAFANA_ANNOTATIONS_API_PATH
         res = requests.post(
             url=annotations_url.format(
                 node_ip=normalize_ipv6_url(node.grafana_address), grafana_port=self.grafana_port

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -7393,11 +7393,12 @@ class BaseMonitorSet:
         return Path(get_data_dir_path("monitoring-dash-template.json"))
 
     def configure_overview_template(self, node: BaseNode):
-        def find_overview_row(row):
-            return (
-                row["class"] == "row"
+        def contains_alert_table(group):
+            return any(
+                row.get("class") == "row"
                 and len(row.get("panels", [])) > 0
                 and row["panels"][0].get("class", "") == "alert_table"
+                for row in group.get("rows", [])
             )
 
         with remote_file(
@@ -7407,39 +7408,37 @@ class BaseMonitorSet:
             sct_addon_template = json.load(self.monitoring_template.open("rt"))
             template = json.load(file)
             try:
-                template["dashboard"]["title"] = (
+                template["dashboard"]["spec/title"] = (
                     f"[{self.json_file_params_for_replace['$test_name']}] SCT Metrics & Cluster Overview"
                 )
             except KeyError:
                 LOGGER.warning("Unable to set title for overview dashboard - key not found")
 
-            row, index = next(
-                ((row, i) for i, row in enumerate(template["dashboard"]["rows"]) if find_overview_row(row)), (None, -1)
-            )
-            if row:
-                before = template["dashboard"]["rows"][: index + 1]
-                after = template["dashboard"]["rows"][index + 1 :]
-                rows = [*before, *sct_addon_template["rows"], *after]
-            template["dashboard"]["rows"] = rows
-            for variable in sct_addon_template["variables"]:
-                template["dashboard"]["templating"]["list"].append(variable)
+            rows = template["dashboard"]["rows"]
+            index = next((i for i, group in enumerate(rows) if contains_alert_table(group)), -1)
+            if index < 0:
+                LOGGER.warning("Unable to find the cluster overview row - appending SCT rows at the end")
+                index = len(rows) - 1
+            template["dashboard"]["rows"] = [*rows[: index + 1], *sct_addon_template["rows"], *rows[index + 1 :]]
+
+            template["dashboard"].setdefault("spec/variables", []).extend(sct_addon_template["variables"])
 
             try:
                 variable = next(
                     var
-                    for var in template["dashboard"]["templating"]["list"]
-                    if var.get("class", "") == "by_template_var"
+                    for var in template["dashboard"]["spec/variables"]
+                    if var.get("kind", "") == "CustomVariable" and var.get("spec", {}).get("name", "") == "by"
                 )
-                for value in variable["options"]:
+                for value in variable["spec"]["options"]:
                     value["selected"] = False
-                variable["current"]["text"] = "Instance"
-                variable["current"]["value"] = "instance"
-                by_instance_option = next(opt for opt in variable["options"] if opt["text"] == "Instance")
+                variable["spec"]["current"]["text"] = "Instance"
+                variable["spec"]["current"]["value"] = "instance"
+                by_instance_option = next(opt for opt in variable["spec"]["options"] if opt["text"] == "Instance")
                 by_instance_option["selected"] = True
             except StopIteration, KeyError:
                 LOGGER.warning("Unable to change defaults for the template", exc_info=True)
 
-            template["dashboard"]["annotations"] = sct_addon_template["annotations"]
+            template["dashboard"].setdefault("spec/annotations", []).extend(sct_addon_template["annotations"])
 
             file.seek(0)
             file.truncate()

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2679,6 +2679,29 @@ class BaseNode(AutoSshContainerMixin):
             self.remoter.sudo(update_cmd, ignore_status=ignore_status)
         self.remoter.sudo(install_cmd, ignore_status=ignore_status)
 
+    def remove_package(self, package_name: str, ignore_status: bool = True) -> None:
+        """Uninstall a package, tolerating it not being installed at all."""
+        if self.distro.is_rhel_like:
+            pkg_mgr = next(
+                (
+                    mgr
+                    for mgr in ["microdnf", "yum", "dnf"]
+                    if self.remoter.run(f"test -e /usr/bin/{mgr}", ignore_status=True).ok
+                ),
+                None,
+            )
+            if not pkg_mgr:
+                raise NodeSetupFailed(
+                    node=self,
+                    error_msg="No supported RPM package manager found (expected one of: microdnf, yum, dnf)",
+                )
+            remove_cmd = rpm_cmd(pkg_mgr, f"remove -y {package_name}")
+        elif self.distro.is_sles:
+            remove_cmd = f"zypper remove -y {package_name}"
+        else:
+            remove_cmd = apt_cmd(f"remove -y {package_name}")
+        self.remoter.sudo(remove_cmd, ignore_status=ignore_status)
+
     def install_manager_agent(self, package_path: Optional[str] = None) -> None:
         package_name = "scylla-manager-agent"
         package_version = None
@@ -7178,6 +7201,13 @@ class BaseMonitorSet:
         else:
             manager_scylla_backend_version = self.params.get("manager_scylla_backend_version")
             scylla_repo = get_manager_scylla_backend(manager_scylla_backend_version, node.distro)
+        # The monitoring image ships its own, independently versioned scylla-node-exporter
+        # (epoch based, e.g. `1:1.11.1-2`). The manager backend is an older Scylla release
+        # whose `scylla` package still pins it exactly -- `Depends: scylla-node-exporter
+        # (= 2025.4.10-...)` -- and the package manager will not downgrade across the epoch,
+        # so the install dies with "held broken packages". Drop it first; install_scylla
+        # pulls the matching version back in as a dependency.
+        node.remove_package("scylla-node-exporter")
         node.install_scylla(scylla_repo=scylla_repo)
         package_path = self.params.get("scylla_mgmt_pkg")
         if package_path:

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1332,7 +1332,7 @@ class BaseNode(AutoSshContainerMixin):
             ):
                 try:
                     extra_address = address_getter()
-                except (NetworkInterfaceNotFound, AttributeError):
+                except NetworkInterfaceNotFound, AttributeError:
                     continue
                 if not extra_address or extra_address == ScyllaNetworkConfiguration.LISTEN_ALL:
                     continue

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -116,6 +116,12 @@ from sdcm.utils.gcp_kms import GcpKms
 from sdcm.provision.gce.kms_provider import GcpKmsProvider
 from google.cloud.exceptions import GoogleCloudError
 from sdcm.utils.cql_utils import cql_quote_if_needed
+from sdcm.utils.grafana_api import (
+    DEFAULT_GRAFANA_TIMEOUT,
+    GRAFANA_ANNOTATIONS_API_PATH,
+    upload_dashboard,
+)
+from sdcm.utils.session import create_retry_session
 from sdcm.utils.benchmarks import ScyllaClusterBenchmarkManager
 from sdcm.utils.common import (
     S3Storage,
@@ -7800,11 +7806,17 @@ class BaseMonitorSet:
 
     def add_sct_dashboards_to_grafana(self, node):
         def _register_grafana_json(json_filename):
-            url = f"'http://{normalize_ipv6_url(node.external_address)}:{self.grafana_port}/api/dashboards/db'"
-            result = LOCALRUNNER.run(
-                'curl -g -XPOST -i %s --data-binary @%s -H "Content-Type: application/json"' % (url, json_filename)
-            )
-            return result.exited == 0
+            base_url = f"http://{normalize_ipv6_url(node.external_address)}:{self.grafana_port}"
+            with open(json_filename, encoding="utf-8") as f:
+                legacy_payload = json.load(f)
+            try:
+                result = upload_dashboard(base_url, legacy_payload)
+            except requests.ConnectionError:
+                # grafana is still starting up, wait_for will call us again
+                return False
+            if not result.ok:
+                LOGGER.warning("failed to register grafana dashboard %s: %s", json_filename, result.text)
+            return result.ok
 
         wait.wait_for(
             _register_grafana_json,
@@ -7879,13 +7891,13 @@ class BaseMonitorSet:
         if not self.is_formal_monitor_image:
             self.download_scylla_monitoring(node)
 
+    def _grafana_annotations_url(self, node):
+        return f"http://{normalize_ipv6_url(node.grafana_address)}:{self.grafana_port}{GRAFANA_ANNOTATIONS_API_PATH}"
+
     def get_grafana_annotations(self, node):
-        annotations_url = "http://{node_ip}:{grafana_port}/api/annotations?limit=10000"
         try:
-            res = requests.get(
-                url=annotations_url.format(
-                    node_ip=normalize_ipv6_url(node.grafana_address), grafana_port=self.grafana_port
-                )
+            res = create_retry_session().get(
+                url=f"{self._grafana_annotations_url(node)}?limit=10000", timeout=DEFAULT_GRAFANA_TIMEOUT
             )
             if res.ok:
                 return res.content
@@ -7894,13 +7906,11 @@ class BaseMonitorSet:
         return ""
 
     def set_grafana_annotations(self, node, annotations_data):
-        annotations_url = "http://{node_ip}:{grafana_port}/api/annotations"
-        res = requests.post(
-            url=annotations_url.format(
-                node_ip=normalize_ipv6_url(node.grafana_address), grafana_port=self.grafana_port
-            ),
+        res = create_retry_session().post(
+            url=self._grafana_annotations_url(node),
             data=annotations_data,
             headers={"Content-Type": "application/json"},
+            timeout=DEFAULT_GRAFANA_TIMEOUT,
         )
         self.log.info("posting annotations result: %s", res)
 

--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -68,6 +68,7 @@ from sdcm.utils.adaptive_timeouts import adaptive_timeout, Operations
 from sdcm.utils.ci_tools import get_test_name
 from sdcm.utils.common import download_from_github, shorten_cluster_name, walk_thru_data
 from sdcm.utils.docker_utils import get_docker_hub_credentials
+from sdcm.utils.grafana_api import GRAFANA_DASHBOARD_API_PATH, convert_dashboard_payload_to_new_api
 from sdcm.utils.k8s import (
     add_pool_node_affinity,
     convert_cpu_units_to_k8s_value,
@@ -1500,7 +1501,7 @@ class KubernetesCluster(metaclass=abc.ABCMeta):
             dashboard_config["dashboard"]["title"] = dashboard_config["dashboard"]["title"].replace(
                 "$test_name", f"{get_test_name()}--{cluster_name}"
             )
-            sct_dashboard_file_data_str = json.dumps(dashboard_config)
+            sct_dashboard_file_data_str = json.dumps(convert_dashboard_payload_to_new_api(dashboard_config))
         grafana_dn = f"{cluster_name}-grafana.{namespace}.svc.cluster.local"
         grafana_ip = self.get_grafana_ip(cluster_name=cluster_name, namespace=namespace)
         grafana_user = base64.b64decode(
@@ -1528,7 +1529,7 @@ class KubernetesCluster(metaclass=abc.ABCMeta):
             sct_dashboard_obj.flush()
             upload_result = LOCALRUNNER.run(
                 f"curl --fail -o /dev/null -w '%{{http_code}}'"
-                f" -L 'https://{grafana_dn}:{self.grafana_port}/api/dashboards/db'"
+                f" -L 'https://{grafana_dn}:{self.grafana_port}{GRAFANA_DASHBOARD_API_PATH}'"
                 f" --resolve '{grafana_dn}:{self.grafana_port}:{grafana_ip}'"
                 f" --cacert {grafana_cert_obj.name}"
                 f" --user '{grafana_user}:{grafana_password}'"

--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -68,6 +68,11 @@ from sdcm.utils.adaptive_timeouts import adaptive_timeout, Operations
 from sdcm.utils.ci_tools import get_test_name
 from sdcm.utils.common import download_from_github, shorten_cluster_name, walk_thru_data
 from sdcm.utils.docker_utils import get_docker_hub_credentials
+from sdcm.utils.grafana_api import (
+    convert_dashboard_payload_to_new_api,
+    dashboard_uid_from_payload,
+    dashboard_upsert_url,
+)
 from sdcm.utils.k8s import (
     add_pool_node_affinity,
     convert_cpu_units_to_k8s_value,
@@ -1500,7 +1505,10 @@ class KubernetesCluster(metaclass=abc.ABCMeta):
             dashboard_config["dashboard"]["title"] = dashboard_config["dashboard"]["title"].replace(
                 "$test_name", f"{get_test_name()}--{cluster_name}"
             )
-            sct_dashboard_file_data_str = json.dumps(dashboard_config)
+            dashboard_uid = dashboard_uid_from_payload(dashboard_config)
+            sct_dashboard_file_data_str = json.dumps(
+                convert_dashboard_payload_to_new_api(dashboard_config, uid=dashboard_uid)
+            )
         grafana_dn = f"{cluster_name}-grafana.{namespace}.svc.cluster.local"
         grafana_ip = self.get_grafana_ip(cluster_name=cluster_name, namespace=namespace)
         grafana_user = base64.b64decode(
@@ -1526,15 +1534,19 @@ class KubernetesCluster(metaclass=abc.ABCMeta):
             grafana_cert_obj.flush()
             sct_dashboard_obj.write(sct_dashboard_file_data_str)
             sct_dashboard_obj.flush()
+            # PUT on the named resource, so re-registering the same dashboard updates it in
+            # place instead of failing with 409 Conflict the way a POST to the collection would
             upload_result = LOCALRUNNER.run(
-                f"curl --fail -o /dev/null -w '%{{http_code}}'"
-                f" -L 'https://{grafana_dn}:{self.grafana_port}/api/dashboards/db'"
+                f"curl --fail -o /dev/null -w '%{{http_code}}' -X PUT"
+                f" -L 'https://{grafana_dn}:{self.grafana_port}"
+                f"{dashboard_upsert_url('', dashboard_uid)}'"
                 f" --resolve '{grafana_dn}:{self.grafana_port}:{grafana_ip}'"
                 f" --cacert {grafana_cert_obj.name}"
                 f" --user '{grafana_user}:{grafana_password}'"
                 f" -d @{sct_dashboard_obj.name} -H 'Content-Type: application/json'"
             ).stdout.strip()
-        if upload_result != "200":
+        # the new API answers 201 Created on first upload and 200 OK on an update
+        if not upload_result.startswith("2"):
             self.log.warning(
                 "Error uploading SCT dashboard '%s' to the grafana in the '%s' namespace: %s",
                 sct_dashboard_file,

--- a/sdcm/cluster_oci.py
+++ b/sdcm/cluster_oci.py
@@ -188,7 +188,7 @@ class OciNode(cluster.BaseNode):
                 if addrs:
                     ipv6_map[ifname] = addrs
             return ipv6_map
-        except (json.JSONDecodeError, KeyError):
+        except json.JSONDecodeError, KeyError:
             return {}
 
     def _build_network_interfaces(self) -> list:

--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -65,6 +65,7 @@ from sdcm.utils.parallel_object import ParallelObject
 from sdcm.utils.context_managers import environment
 from sdcm.utils.distro import Distro
 from sdcm.utils.decorators import retrying
+from sdcm.utils.grafana_api import GRAFANA_ANNOTATIONS_API_PATH, GRAFANA_SEARCH_API_PATH
 from sdcm.utils.docker_utils import get_docker_bridge_gateway
 from sdcm.utils.k8s import KubernetesOps
 from sdcm.utils.s3_remote_uploader import upload_remote_files_directly_to_s3
@@ -500,7 +501,7 @@ class MonitoringStack(BaseMonitoringEntity):
     def get_grafana_annotations(self, grafana_ip: str) -> str:
         try:
             session = _create_retry_session()
-            res = session.get(f"http://{grafana_ip}:{self.grafana_port}/api/annotations")
+            res = session.get(f"http://{grafana_ip}:{self.grafana_port}" + GRAFANA_ANNOTATIONS_API_PATH)
             if res.ok:
                 return res.text
         except Exception as details:  # noqa: BLE001
@@ -510,7 +511,7 @@ class MonitoringStack(BaseMonitoringEntity):
     @staticmethod
     @retrying(n=3, sleep_time=3, message="Search dashboard...", raise_on_exceeded=False)
     def search_dashboard(grafana_ip: str, port: int, query: str) -> list:
-        search_api_url = f"http://{grafana_ip}:{port}/api/search?query={query}"
+        search_api_url = f"http://{grafana_ip}:{port}" + GRAFANA_SEARCH_API_PATH + f"?query={query}"
         session = _create_retry_session()
         resp = session.get(search_api_url)
         if not resp.ok:

--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -65,6 +65,7 @@ from sdcm.utils.parallel_object import ParallelObject
 from sdcm.utils.context_managers import environment
 from sdcm.utils.distro import Distro
 from sdcm.utils.decorators import retrying
+from sdcm.utils.grafana_api import GRAFANA_ANNOTATIONS_API_PATH, GRAFANA_SEARCH_API_PATH
 from sdcm.utils.docker_utils import get_docker_bridge_gateway
 from sdcm.utils.k8s import KubernetesOps
 from sdcm.utils.s3_remote_uploader import upload_remote_files_directly_to_s3
@@ -505,7 +506,7 @@ class MonitoringStack(BaseMonitoringEntity):
     def get_grafana_annotations(self, grafana_ip: str) -> str:
         try:
             session = _create_retry_session()
-            res = session.get(f"http://{grafana_ip}:{self.grafana_port}/api/annotations")
+            res = session.get(f"http://{grafana_ip}:{self.grafana_port}" + GRAFANA_ANNOTATIONS_API_PATH)
             if res.ok:
                 return res.text
         except Exception as details:  # noqa: BLE001
@@ -515,7 +516,7 @@ class MonitoringStack(BaseMonitoringEntity):
     @staticmethod
     @retrying(n=3, sleep_time=3, message="Search dashboard...", raise_on_exceeded=False)
     def search_dashboard(grafana_ip: str, port: int, query: str) -> list:
-        search_api_url = f"http://{grafana_ip}:{port}/api/search?query={query}"
+        search_api_url = f"http://{grafana_ip}:{port}" + GRAFANA_SEARCH_API_PATH + f"?query={query}"
         session = _create_retry_session()
         resp = session.get(search_api_url)
         if not resp.ok:

--- a/sdcm/monitorstack/restore.py
+++ b/sdcm/monitorstack/restore.py
@@ -14,6 +14,11 @@ import yaml
 from sdcm.remote import LocalCmdRunner
 from sdcm.utils.common import get_free_port, list_logs_by_test_id, S3Storage, remove_files
 from sdcm.utils.decorators import retrying
+from sdcm.utils.grafana_api import (
+    GRAFANA_ANNOTATIONS_API_PATH,
+    GRAFANA_DASHBOARD_API_PATH,
+    convert_dashboard_payload_to_new_api,
+)
 
 from sdcm.monitorstack.constants import (
     ALERT_DOCKER_NAME,
@@ -368,18 +373,17 @@ def restore_sct_dashboards(grafana_docker_port, sct_dashboard_file):
         sct_dashboard_file_name = "scylla-dash-per-server-nemesis.master.json"
         sct_dashboard_file = [Path(__file__).parent.parent.parent / "data_dir" / sct_dashboard_file_name]
 
-    dashboard_url = f"http://localhost:{grafana_docker_port}/api/dashboards/db"
+    dashboard_url = f"http://localhost:{grafana_docker_port}" + GRAFANA_DASHBOARD_API_PATH
     with open(sct_dashboard_file, encoding="utf-8") as f:
         dashboard_config = json.load(f)
         if dashboard_config.get("dashboard", {}).get("id"):
             dashboard_config["dashboard"]["id"] = None
 
+    payload = convert_dashboard_payload_to_new_api(dashboard_config)
     try:
-        res = requests.post(
-            dashboard_url, data=json.dumps(dashboard_config), headers={"Content-Type": "application/json"}
-        )
+        res = requests.post(dashboard_url, data=json.dumps(payload), headers={"Content-Type": "application/json"})
 
-        if res.status_code != 200:
+        if not res.ok:
             LOGGER.info("Error uploading dashboard %s. Error message %s", sct_dashboard_file, res.text)
             raise ErrorUploadSCTDashboard(
                 "Error uploading dashboard {}. Error message {}".format(sct_dashboard_file, res.text)
@@ -402,7 +406,7 @@ def restore_annotations_data(monitoring_stack_dir, grafana_docker_port):
         with open(annotations_file, encoding="utf-8") as f:
             annotations = json.load(f)
 
-        annotations_url = f"http://localhost:{grafana_docker_port}/api/annotations"
+        annotations_url = f"http://localhost:{grafana_docker_port}" + GRAFANA_ANNOTATIONS_API_PATH
         for an in annotations:
             res = requests.post(annotations_url, data=json.dumps(an), headers={"Content-Type": "application/json"})
             if res.status_code != 200:

--- a/sdcm/monitorstack/restore.py
+++ b/sdcm/monitorstack/restore.py
@@ -15,6 +15,7 @@ from sdcm.remote import LocalCmdRunner
 from sdcm.utils.common import get_free_port, list_logs_by_test_id, S3Storage, remove_files
 from sdcm.utils.decorators import retrying
 from sdcm.utils.session import create_retry_session
+from sdcm.utils.grafana_api import GRAFANA_ANNOTATIONS_API_PATH, upload_dashboard
 
 from sdcm.monitorstack.constants import (
     ALERT_DOCKER_NAME,
@@ -371,18 +372,19 @@ def restore_sct_dashboards(grafana_docker_port, sct_dashboard_file):
         sct_dashboard_file_name = "scylla-dash-per-server-nemesis.master.json"
         sct_dashboard_file = [Path(__file__).parent.parent.parent / "data_dir" / sct_dashboard_file_name]
 
-    dashboard_url = f"http://localhost:{grafana_docker_port}/api/dashboards/db"
     with open(sct_dashboard_file, encoding="utf-8") as f:
         dashboard_config = json.load(f)
         if dashboard_config.get("dashboard", {}).get("id"):
             dashboard_config["dashboard"]["id"] = None
 
     try:
-        res = requests.post(
-            dashboard_url, data=json.dumps(dashboard_config), headers={"Content-Type": "application/json"}
+        # a restored stack may run a Grafana older than 12, so let the helper fall back
+        # to the legacy endpoint; the @retrying decorator above is the retry policy here
+        res = upload_dashboard(
+            f"http://localhost:{grafana_docker_port}", dashboard_config, session=create_retry_session(retries=0)
         )
 
-        if res.status_code != 200:
+        if not res.ok:
             LOGGER.info("Error uploading dashboard %s. Error message %s", sct_dashboard_file, res.text)
             raise ErrorUploadSCTDashboard(f"Error uploading dashboard {sct_dashboard_file}. Error message {res.text}")
         LOGGER.info("Dashboard %s loaded successfully", sct_dashboard_file)
@@ -416,7 +418,7 @@ def restore_annotations_data(monitoring_stack_dir, grafana_docker_port):
         return False
 
     try:
-        annotations_url = f"http://localhost:{grafana_docker_port}/api/annotations"
+        annotations_url = f"http://localhost:{grafana_docker_port}{GRAFANA_ANNOTATIONS_API_PATH}"
         # Retries are disabled here: the @retrying decorator on this function is the single
         # retry policy for this non-idempotent POST loop, avoiding duplicate annotations.
         session = create_retry_session(retries=0)

--- a/sdcm/provision/oci/virtual_machine_provider.py
+++ b/sdcm/provision/oci/virtual_machine_provider.py
@@ -615,7 +615,7 @@ class VirtualMachineProvider:
             instance_id=instance_id,
         ).data
         active = [a for a in attachments if a.lifecycle_state == "ATTACHED"]
-        active.sort(key=lambda a: (a.nic_index or 0))
+        active.sort(key=lambda a: a.nic_index or 0)
         return active
 
     def get_vnic_details(self, vnic_id: str):

--- a/sdcm/sct_events/grafana.py
+++ b/sdcm/sct_events/grafana.py
@@ -31,12 +31,13 @@ from sdcm.sct_events.events_processes import (
     get_events_process,
     verbose_suppress,
 )
+from sdcm.utils.grafana_api import GRAFANA_ANNOTATIONS_API_PATH
 
 
 GRAFANA_EVENT_AGGREGATOR_TIME_WINDOW: float = 90  # seconds
 GRAFANA_EVENT_AGGREGATOR_MAX_DUPLICATES: int = 5
 GRAFANA_EVENT_AGGREGATOR_QUEUE_WAIT_TIMEOUT: float = 1  # seconds
-GRAFANA_ANNOTATIONS_API_ENDPOINT: str = "/api/annotations"
+GRAFANA_ANNOTATIONS_API_ENDPOINT: str = GRAFANA_ANNOTATIONS_API_PATH
 GRAFANA_ANNOTATIONS_API_AUTH: Tuple[str, str] = (
     "admin",
     "admin",

--- a/sdcm/utils/grafana_api.py
+++ b/sdcm/utils/grafana_api.py
@@ -1,0 +1,42 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2025 ScyllaDB
+
+import logging
+
+LOGGER = logging.getLogger(__name__)
+
+# New Grafana /apis endpoints (available since Grafana 12, mandatory from Grafana 13+)
+# See: https://grafana.com/whats-new/2026-04-20-deprecation-of--api-path/
+GRAFANA_DASHBOARD_API_PATH = "/apis/dashboard.grafana.app/v1beta1/namespaces/default/dashboards"
+
+# Annotations and Search have no /apis replacement yet (as of Grafana 13)
+GRAFANA_ANNOTATIONS_API_PATH = "/api/annotations"
+GRAFANA_SEARCH_API_PATH = "/api/search"
+
+
+def convert_dashboard_payload_to_new_api(legacy_payload: dict) -> dict:
+    """Convert legacy dashboard payload format to the new /apis format.
+
+    Legacy format: {"dashboard": {...}, "overwrite": bool, "folderId": int, ...}
+    New format:    {"metadata": {"generateName": "sct-"}, "spec": {...}}
+    """
+    dashboard_model = legacy_payload.get("dashboard", legacy_payload)
+    metadata = {}
+    if uid := dashboard_model.get("uid"):
+        metadata["name"] = uid
+    else:
+        metadata["generateName"] = "sct-"
+    folder_uid = legacy_payload.get("folderUid")
+    if folder_uid:
+        metadata.setdefault("annotations", {})["grafana.app/folder"] = folder_uid
+    return {"metadata": metadata, "spec": dashboard_model}

--- a/sdcm/utils/grafana_api.py
+++ b/sdcm/utils/grafana_api.py
@@ -1,0 +1,143 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2025 ScyllaDB
+
+import hashlib
+import http
+import logging
+import re
+
+import requests
+
+from sdcm.utils.session import create_retry_session
+
+LOGGER = logging.getLogger(__name__)
+
+# every Grafana request must be bounded, so a wedged monitoring stack can't hang a test
+DEFAULT_GRAFANA_TIMEOUT = 30
+
+# New Grafana /apis endpoints (available since Grafana 12, mandatory from Grafana 13+)
+# See: https://grafana.com/whats-new/2026-04-20-deprecation-of--api-path/
+#
+# v1beta1 is deliberate: it is the only stable-shaped version served by every Grafana
+# that has the /apis surface at all. Verified against real containers -
+# 12.0.7 serves [v1beta1, v0alpha1, v2alpha1], 12.4.3 adds v2beta1, and 13.1.3 adds v1;
+# `v1` returns 404 on all of 12.x, and the v2* schemas reject our legacy dashboard model.
+GRAFANA_DASHBOARD_API_PATH = "/apis/dashboard.grafana.app/v1beta1/namespaces/default/dashboards"
+
+# Legacy dashboard endpoint, kept for Grafana < 12 (no /apis surface at all - verified 404 on 11.6.6)
+GRAFANA_LEGACY_DASHBOARD_API_PATH = "/api/dashboards/db"
+
+# Annotations and Search have no /apis replacement yet (as of Grafana 13)
+GRAFANA_ANNOTATIONS_API_PATH = "/api/annotations"
+GRAFANA_SEARCH_API_PATH = "/api/search"
+
+# Grafana validates metadata.name as a dashboard uid: max 40 chars, no dots.
+GRAFANA_UID_MAX_LENGTH = 40
+_ILLEGAL_UID_CHARS = re.compile(r"[^a-zA-Z0-9_-]")
+
+
+def dashboard_uid_from_payload(legacy_payload: dict, prefix: str = "sct-") -> str:
+    """Derive a stable, Grafana-legal dashboard uid for a legacy dashboard payload.
+
+    The uid doubles as the new API's ``metadata.name``, which is the resource identity: a
+    stable value makes re-uploads idempotent (``PUT`` updates in place) instead of piling up
+    duplicate dashboards. When the payload carries no uid, derive one from the dashboard
+    title so the same dashboard always maps to the same resource.
+    """
+    dashboard_model = legacy_payload.get("dashboard", legacy_payload)
+    if uid := dashboard_model.get("uid"):
+        return sanitize_dashboard_uid(uid)
+    title = dashboard_model.get("title") or ""
+    return f"{prefix}{hashlib.sha1(title.encode('utf-8')).hexdigest()[:16]}"
+
+
+def sanitize_dashboard_uid(uid: str) -> str:
+    """Coerce a uid into what Grafana accepts: only ``[a-zA-Z0-9_-]``, at most 40 chars."""
+    sanitized = _ILLEGAL_UID_CHARS.sub("-", uid)
+    if len(sanitized) > GRAFANA_UID_MAX_LENGTH:
+        # keep a stable suffix so distinct long uids don't collapse onto the same name
+        digest = hashlib.sha1(uid.encode("utf-8")).hexdigest()[:8]
+        sanitized = f"{sanitized[: GRAFANA_UID_MAX_LENGTH - len(digest) - 1]}-{digest}"
+    return sanitized
+
+
+def convert_dashboard_payload_to_new_api(legacy_payload: dict, uid: str | None = None) -> dict:
+    """Convert legacy dashboard payload format to the new /apis format.
+
+    Legacy format: {"dashboard": {...}, "overwrite": bool, "folderId": int, ...}
+    New format:    {"metadata": {"name": <uid>}, "spec": {...}}
+
+    ``metadata.name`` is always set: the new API is Kubernetes-shaped, so ``POST`` to the
+    collection *creates* and returns 409 on a name clash, while ``PUT`` to
+    ``<collection>/<name>`` upserts. A stable name is what makes the upload replayable,
+    replacing the legacy ``"overwrite": true`` flag that has no counterpart here.
+    """
+    dashboard_model = legacy_payload.get("dashboard", legacy_payload)
+    name = sanitize_dashboard_uid(uid) if uid else dashboard_uid_from_payload(legacy_payload)
+    metadata = {"name": name}
+    if folder_uid := legacy_payload.get("folderUid"):
+        metadata["annotations"] = {"grafana.app/folder": folder_uid}
+    # the uid must agree with metadata.name, otherwise Grafana rejects the request
+    spec = dict(dashboard_model, uid=name)
+    return {"metadata": metadata, "spec": spec}
+
+
+def dashboard_upsert_url(base_url: str, uid: str) -> str:
+    """URL of a single dashboard resource, for an idempotent ``PUT`` upsert."""
+    return f"{base_url.rstrip('/')}{GRAFANA_DASHBOARD_API_PATH}/{uid}"
+
+
+def upload_dashboard(
+    base_url: str,
+    legacy_payload: dict,
+    session: requests.Session | None = None,
+    timeout: int = DEFAULT_GRAFANA_TIMEOUT,
+    **request_kwargs,
+) -> requests.Response:
+    """Upload a legacy-format dashboard payload, preferring the new /apis endpoint.
+
+    Uses ``PUT`` on the named resource so re-uploads update in place rather than failing
+    with 409 Conflict, and falls back to the legacy ``/api/dashboards/db`` endpoint when the
+    /apis surface is absent (Grafana < 12), which is reachable when restoring an archived
+    monitoring stack pinned to an older Grafana.
+
+    Returns the final :class:`requests.Response` so callers keep their own success handling.
+    """
+    session = session or create_retry_session()
+    uid = dashboard_uid_from_payload(legacy_payload)
+    payload = convert_dashboard_payload_to_new_api(legacy_payload, uid=uid)
+    response = session.put(
+        dashboard_upsert_url(base_url, uid),
+        json=payload,
+        headers={"Content-Type": "application/json"},
+        timeout=timeout,
+        **request_kwargs,
+    )
+    if response.status_code != http.HTTPStatus.NOT_FOUND:
+        return response
+
+    LOGGER.debug(
+        "Grafana at %s has no %s endpoint, falling back to %s",
+        base_url,
+        GRAFANA_DASHBOARD_API_PATH,
+        GRAFANA_LEGACY_DASHBOARD_API_PATH,
+    )
+    legacy_body = dict(legacy_payload, overwrite=True)
+    legacy_body.setdefault("dashboard", legacy_payload)
+    return session.post(
+        f"{base_url.rstrip('/')}{GRAFANA_LEGACY_DASHBOARD_API_PATH}",
+        json=legacy_body,
+        headers={"Content-Type": "application/json"},
+        timeout=timeout,
+        **request_kwargs,
+    )

--- a/unit_tests/integration/test_grafana_api.py
+++ b/unit_tests/integration/test_grafana_api.py
@@ -1,0 +1,260 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2025 ScyllaDB
+
+"""Integration tests for sdcm.utils.grafana_api against real Grafana containers.
+
+External services: Docker (upstream ``grafana/grafana`` images, no Scylla needed).
+
+The dashboard API moved from ``/api/dashboards/db`` to the Kubernetes-shaped
+``/apis/dashboard.grafana.app/...`` surface, and only a real Grafana can answer which version
+exists, what status code a create returns, and whether a re-upload conflicts. Every claim
+``sdcm/utils/grafana_api.py`` encodes is asserted here against the actual servers:
+
+* ``v1beta1`` is the version to target -- ``v1`` does not exist before Grafana 13 and the
+  ``v2*`` schemas reject our legacy dashboard model.
+* a create answers ``201``, so a ``status_code == 200`` check would read every success as
+  a failure.
+* re-uploading the same dashboard must not raise ``409 Conflict`` nor silently pile up
+  duplicates, because SCT re-registers dashboards when it reuses a monitoring stack.
+* Grafana < 12 has no ``/apis`` surface at all, so the legacy endpoint fallback must engage.
+
+These are the slowest tests in the suite when the images are cold (each version is a ~400MB
+pull). ``GRAFANA_TEST_VERSIONS`` narrows the matrix for a quick local loop:
+
+    GRAFANA_TEST_VERSIONS=13.1.3 uv run pytest unit_tests/integration/test_grafana_api.py
+"""
+
+import json
+import logging
+import os
+import subprocess
+import uuid
+
+import pytest
+import requests
+
+from sdcm.utils.common import get_data_dir_path, get_free_port
+from sdcm.utils.grafana_api import (
+    GRAFANA_ANNOTATIONS_API_PATH,
+    GRAFANA_DASHBOARD_API_PATH,
+    GRAFANA_LEGACY_DASHBOARD_API_PATH,
+    GRAFANA_SEARCH_API_PATH,
+    convert_dashboard_payload_to_new_api,
+    dashboard_uid_from_payload,
+    upload_dashboard,
+)
+from sdcm.wait import wait_for
+
+LOGGER = logging.getLogger(__name__)
+
+GRAFANA_ADMIN = ("admin", "admin")
+
+# One release per API generation, oldest first:
+#   11.x  -- no /apis surface, must fall back to the legacy endpoint
+#   12.0  -- earliest /apis surface, serves v1beta1 only
+#   12.4  -- the version shipped by scylla-monitoring branch-4.15
+#   13.1  -- adds v1 and prefers v2, so it proves v1beta1 is still served
+DEFAULT_GRAFANA_VERSIONS = ("11.6.6", "12.0.7", "12.4.3", "13.1.3")
+VERSIONS_WITHOUT_APIS = ("11.6.6",)
+
+
+def _grafana_versions() -> tuple[str, ...]:
+    if selected := os.environ.get("GRAFANA_TEST_VERSIONS"):
+        return tuple(version.strip() for version in selected.split(",") if version.strip())
+    return DEFAULT_GRAFANA_VERSIONS
+
+
+def _docker(*args: str, check: bool = True) -> str:
+    result = subprocess.run(["docker", *args], capture_output=True, text=True, check=False)
+    if check and result.returncode != 0:
+        raise RuntimeError(f"docker {' '.join(args)} failed: {result.stderr.strip()}")
+    return result.stdout.strip()
+
+
+@pytest.fixture(name="grafana", scope="module", params=_grafana_versions())
+def fixture_grafana(request: pytest.FixtureRequest):
+    """A running Grafana container, yielding ``(version, base_url)``."""
+    version = request.param
+    port = get_free_port()
+    name = f"sct-grafana-test-{version.replace('.', '-')}-{uuid.uuid4().hex[:8]}"
+    _docker(
+        "run",
+        "-d",
+        "--name",
+        name,
+        "-p",
+        f"{port}:3000",
+        "-e",
+        f"GF_SECURITY_ADMIN_PASSWORD={GRAFANA_ADMIN[1]}",
+        f"grafana/grafana:{version}",
+    )
+    base_url = f"http://localhost:{port}"
+    try:
+        _wait_for_grafana(base_url, version)
+        yield version, base_url
+    finally:
+        LOGGER.debug("grafana %s container logs:\n%s", version, _docker("logs", "--tail", "20", name, check=False))
+        _docker("rm", "-f", name, check=False)
+
+
+def _wait_for_grafana(base_url: str, version: str) -> None:
+    def healthy():
+        try:
+            return requests.get(f"{base_url}/api/health", timeout=5).ok
+        except requests.RequestException:
+            return False
+
+    wait_for(healthy, step=1, timeout=180, throw_exc=True, text=f"Waiting for grafana {version} to come up")
+
+
+@pytest.fixture(name="dashboard_payload")
+def fixture_dashboard_payload() -> dict:
+    """A legacy-format dashboard payload with a uid unique to the requesting test."""
+    with open(get_data_dir_path("scylla-dash-per-server-nemesis.master.json"), encoding="utf-8") as dashboard_file:
+        payload = json.load(dashboard_file)
+    # a shared uid would make the tests fight over one resource inside a module-scoped grafana
+    payload["dashboard"]["uid"] = f"sct-{uuid.uuid4().hex[:12]}"
+    return payload
+
+
+def _get_dashboard_names(base_url: str) -> list[str]:
+    response = requests.get(f"{base_url}{GRAFANA_DASHBOARD_API_PATH}", auth=GRAFANA_ADMIN, timeout=30)
+    response.raise_for_status()
+    return [item["metadata"]["name"] for item in response.json()["items"]]
+
+
+@pytest.mark.integration
+def test_new_dashboard_api_version_is_served(grafana):
+    """The version SCT targets must be the one the server actually serves."""
+    version, base_url = grafana
+    if version in VERSIONS_WITHOUT_APIS:
+        pytest.skip(f"grafana {version} predates the /apis surface")
+
+    served = requests.get(f"{base_url}/apis", auth=GRAFANA_ADMIN, timeout=30).json()["groups"]
+    dashboard_group = [group for group in served if group["name"] == "dashboard.grafana.app"]
+    assert dashboard_group, "grafana does not serve the dashboard.grafana.app API group"
+    versions = [entry["version"] for entry in dashboard_group[0]["versions"]]
+
+    api_version = GRAFANA_DASHBOARD_API_PATH.split("/")[3]
+    assert api_version in versions, (
+        f"grafana {version} serves dashboard versions {versions} but SCT targets {api_version!r}"
+    )
+
+
+@pytest.mark.integration
+def test_upload_dashboard_succeeds_and_is_idempotent(grafana, dashboard_payload):
+    """Re-uploading must update in place: no 409, no duplicate dashboards."""
+    _version, base_url = grafana
+    uid = dashboard_uid_from_payload(dashboard_payload)
+
+    first = upload_dashboard(base_url, dashboard_payload, auth=GRAFANA_ADMIN)
+    assert first.ok, f"first upload failed: {first.status_code} {first.text}"
+
+    second = upload_dashboard(base_url, dashboard_payload, auth=GRAFANA_ADMIN)
+    assert second.ok, f"re-upload failed instead of updating in place: {second.status_code} {second.text}"
+    assert second.status_code != requests.codes.conflict
+
+    names = _get_dashboard_names(base_url) if _version not in VERSIONS_WITHOUT_APIS else []
+    if names:
+        assert names.count(uid) == 1, f"re-upload duplicated the dashboard: {names}"
+
+
+@pytest.mark.integration
+def test_dashboard_create_returns_201_so_a_200_check_would_break(grafana, dashboard_payload):
+    """Guards the ``res.ok`` over ``status_code == 200`` decision this migration rests on."""
+    _version, base_url = grafana
+    if _version in VERSIONS_WITHOUT_APIS:
+        pytest.skip(f"grafana {_version} answers the legacy endpoint, which returns 200")
+
+    uid = dashboard_uid_from_payload(dashboard_payload)
+    payload = convert_dashboard_payload_to_new_api(dashboard_payload, uid=uid)
+    created = requests.post(f"{base_url}{GRAFANA_DASHBOARD_API_PATH}", json=payload, auth=GRAFANA_ADMIN, timeout=30)
+    assert created.status_code == requests.codes.created, (
+        f"expected 201 Created from the new API, got {created.status_code}"
+    )
+
+
+@pytest.mark.integration
+def test_post_to_collection_conflicts_on_reupload(grafana, dashboard_payload):
+    """Documents why ``upload_dashboard`` uses PUT: a plain POST cannot be replayed."""
+    _version, base_url = grafana
+    if _version in VERSIONS_WITHOUT_APIS:
+        pytest.skip(f"grafana {_version} has no /apis surface")
+
+    payload = convert_dashboard_payload_to_new_api(dashboard_payload)
+    url = f"{base_url}{GRAFANA_DASHBOARD_API_PATH}"
+    assert requests.post(url, json=payload, auth=GRAFANA_ADMIN, timeout=30).ok
+    conflict = requests.post(url, json=payload, auth=GRAFANA_ADMIN, timeout=30)
+    assert conflict.status_code == requests.codes.conflict, (
+        f"expected 409 on a repeated POST, got {conflict.status_code}"
+    )
+
+
+@pytest.mark.integration
+def test_legacy_endpoint_fallback_on_old_grafana(grafana, dashboard_payload):
+    """On Grafana < 12 the /apis path 404s and the upload must still land."""
+    version, base_url = grafana
+    new_api = requests.put(
+        f"{base_url}{GRAFANA_DASHBOARD_API_PATH}/{dashboard_uid_from_payload(dashboard_payload)}",
+        json=convert_dashboard_payload_to_new_api(dashboard_payload),
+        auth=GRAFANA_ADMIN,
+        timeout=30,
+    )
+    if version in VERSIONS_WITHOUT_APIS:
+        assert new_api.status_code == requests.codes.not_found, (
+            f"grafana {version} was expected to lack the /apis surface, got {new_api.status_code}"
+        )
+
+    # whichever endpoint is available, the helper must succeed
+    assert upload_dashboard(base_url, dashboard_payload, auth=GRAFANA_ADMIN).ok
+
+    legacy = requests.post(
+        f"{base_url}{GRAFANA_LEGACY_DASHBOARD_API_PATH}",
+        json=dict(dashboard_payload, overwrite=True),
+        auth=GRAFANA_ADMIN,
+        timeout=30,
+    )
+    assert legacy.ok, f"legacy endpoint unexpectedly unusable on grafana {version}: {legacy.status_code}"
+
+
+@pytest.mark.integration
+def test_annotations_and_search_stay_on_legacy_api(grafana):
+    """These have no /apis replacement, so the migration must leave them on /api."""
+    _version, base_url = grafana
+
+    posted = requests.post(
+        f"{base_url}{GRAFANA_ANNOTATIONS_API_PATH}",
+        json={"text": "sct-integration-probe", "tags": ["sct"]},
+        auth=GRAFANA_ADMIN,
+        timeout=30,
+    )
+    assert posted.ok, f"posting an annotation failed: {posted.status_code} {posted.text}"
+    assert requests.get(f"{base_url}{GRAFANA_ANNOTATIONS_API_PATH}", auth=GRAFANA_ADMIN, timeout=30).ok
+    assert requests.get(f"{base_url}{GRAFANA_SEARCH_API_PATH}?query=scylla", auth=GRAFANA_ADMIN, timeout=30).ok
+
+
+@pytest.mark.integration
+def test_uploaded_dashboard_is_searchable(grafana, dashboard_payload):
+    """A dashboard that uploads but does not show up in Grafana would be a silent failure."""
+    _version, base_url = grafana
+    title = dashboard_payload["dashboard"]["title"] = f"SCT probe {uuid.uuid4().hex[:8]}"
+
+    assert upload_dashboard(base_url, dashboard_payload, auth=GRAFANA_ADMIN).ok
+
+    found = requests.get(
+        f"{base_url}{GRAFANA_SEARCH_API_PATH}", params={"query": title}, auth=GRAFANA_ADMIN, timeout=30
+    )
+    assert found.ok
+    assert [hit for hit in found.json() if hit.get("title") == title], (
+        f"dashboard {title!r} uploaded but is not searchable in grafana"
+    )

--- a/unit_tests/unit/test_grafana_api.py
+++ b/unit_tests/unit/test_grafana_api.py
@@ -1,0 +1,222 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2025 ScyllaDB
+
+"""Unit tests for the Grafana dashboard API payload helpers.
+
+The server-side behaviour these helpers are built around is asserted against real Grafana
+containers in ``unit_tests/integration/test_grafana_api.py``; here we only pin the pure
+payload/uid logic and the endpoint choice made by ``upload_dashboard``.
+"""
+
+import http
+import json
+
+import pytest
+import requests
+
+from sdcm.utils.grafana_api import (
+    GRAFANA_DASHBOARD_API_PATH,
+    GRAFANA_LEGACY_DASHBOARD_API_PATH,
+    GRAFANA_UID_MAX_LENGTH,
+    convert_dashboard_payload_to_new_api,
+    dashboard_uid_from_payload,
+    dashboard_upsert_url,
+    sanitize_dashboard_uid,
+    upload_dashboard,
+)
+
+BASE_URL = "http://grafana.example:3000"
+
+
+class FakeResponse:
+    def __init__(self, status_code: int):
+        self.status_code = status_code
+        self.text = ""
+
+    @property
+    def ok(self):
+        return self.status_code < http.HTTPStatus.BAD_REQUEST
+
+
+class FakeSession:
+    """Records the requests made, so tests can assert which endpoint was used."""
+
+    def __init__(self, put_status: int = http.HTTPStatus.OK, post_status: int = http.HTTPStatus.OK):
+        self.put_status = put_status
+        self.post_status = post_status
+        self.calls: list[tuple[str, str, dict]] = []
+
+    def put(self, url, **kwargs):
+        self.calls.append(("PUT", url, kwargs))
+        return FakeResponse(self.put_status)
+
+    def post(self, url, **kwargs):
+        self.calls.append(("POST", url, kwargs))
+        return FakeResponse(self.post_status)
+
+
+def test_payload_is_wrapped_into_metadata_and_spec():
+    converted = convert_dashboard_payload_to_new_api({"dashboard": {"title": "some dash", "uid": "dash-uid"}})
+
+    assert converted["metadata"]["name"] == "dash-uid"
+    assert converted["spec"]["title"] == "some dash"
+    # Grafana rejects a payload whose spec.uid disagrees with metadata.name
+    assert converted["spec"]["uid"] == converted["metadata"]["name"]
+
+
+def test_payload_without_dashboard_wrapper_is_accepted():
+    converted = convert_dashboard_payload_to_new_api({"title": "bare dash", "uid": "bare-uid"})
+
+    assert converted["metadata"]["name"] == "bare-uid"
+    assert converted["spec"]["title"] == "bare dash"
+
+
+def test_folder_uid_is_carried_over_as_an_annotation():
+    converted = convert_dashboard_payload_to_new_api({"dashboard": {"uid": "u"}, "folderUid": "folder-1"})
+
+    assert converted["metadata"]["annotations"]["grafana.app/folder"] == "folder-1"
+
+
+def test_name_is_always_set_so_uploads_can_be_replayed():
+    """``generateName`` would mint a new dashboard per upload; a stable name updates in place."""
+    converted = convert_dashboard_payload_to_new_api({"dashboard": {"title": "no uid here"}})
+
+    assert "generateName" not in converted["metadata"]
+    assert converted["metadata"]["name"]
+
+
+def test_uid_is_derived_from_the_title_and_is_stable():
+    payload = {"dashboard": {"title": "Scylla Per Server Metrics"}}
+
+    assert dashboard_uid_from_payload(payload) == dashboard_uid_from_payload(payload)
+    assert dashboard_uid_from_payload(payload) != dashboard_uid_from_payload({"dashboard": {"title": "other"}})
+
+
+def test_uid_from_payload_prefers_an_explicit_uid():
+    assert dashboard_uid_from_payload({"dashboard": {"title": "t", "uid": "explicit"}}) == "explicit"
+
+
+@pytest.mark.parametrize(
+    ("uid", "expected"),
+    [
+        ("plain-uid_1", "plain-uid_1"),
+        ("has.dots", "has-dots"),
+        ("has spaces", "has-spaces"),
+        ("weird/chars:here", "weird-chars-here"),
+    ],
+)
+def test_illegal_uid_characters_are_replaced(uid, expected):
+    """Grafana answers 400 'uid contains illegal characters' for anything outside [a-zA-Z0-9_-]."""
+    assert sanitize_dashboard_uid(uid) == expected
+
+
+def test_overlong_uid_is_truncated_but_stays_unique():
+    """Grafana caps the uid at 40 chars ('uid too long'), so long uids must not simply collide."""
+    first = sanitize_dashboard_uid("x" * 60 + "-one")
+    second = sanitize_dashboard_uid("x" * 60 + "-two")
+
+    assert len(first) <= GRAFANA_UID_MAX_LENGTH
+    assert len(second) <= GRAFANA_UID_MAX_LENGTH
+    assert first != second
+
+
+def test_derived_uid_fits_grafana_limits_for_the_real_dashboard():
+    from sdcm.utils.common import get_data_dir_path  # noqa: PLC0415 - data path only needed here
+
+    with open(get_data_dir_path("scylla-dash-per-server-nemesis.master.json"), encoding="utf-8") as dashboard_file:
+        payload = json.load(dashboard_file)
+
+    uid = dashboard_uid_from_payload(payload)
+    assert len(uid) <= GRAFANA_UID_MAX_LENGTH
+    assert sanitize_dashboard_uid(uid) == uid
+
+
+def test_upsert_url_targets_the_named_resource():
+    assert dashboard_upsert_url(BASE_URL, "some-uid") == f"{BASE_URL}{GRAFANA_DASHBOARD_API_PATH}/some-uid"
+
+
+def test_upload_uses_put_on_the_new_api():
+    """PUT upserts; a POST to the collection would answer 409 on the second upload."""
+    session = FakeSession()
+
+    response = upload_dashboard(BASE_URL, {"dashboard": {"uid": "dash-1"}}, session=session)
+
+    assert response.ok
+    method, url, kwargs = session.calls[0]
+    assert method == "PUT"
+    assert url == f"{BASE_URL}{GRAFANA_DASHBOARD_API_PATH}/dash-1"
+    assert kwargs["timeout"] > 0, "every grafana request must be bounded"
+
+
+def test_upload_falls_back_to_the_legacy_endpoint_when_apis_is_absent():
+    """Grafana < 12 has no /apis surface at all and answers 404 there."""
+    session = FakeSession(put_status=http.HTTPStatus.NOT_FOUND)
+
+    response = upload_dashboard(BASE_URL, {"dashboard": {"uid": "dash-1"}}, session=session)
+
+    assert response.ok
+    assert [call[0] for call in session.calls] == ["PUT", "POST"]
+    assert session.calls[1][1] == f"{BASE_URL}{GRAFANA_LEGACY_DASHBOARD_API_PATH}"
+    # the legacy endpoint needs the overwrite flag to accept a re-upload
+    assert session.calls[1][2]["json"]["overwrite"] is True
+
+
+def test_upload_does_not_fall_back_on_other_errors():
+    """A 500 means the new API is there but unhappy; retrying on the legacy path would mask it."""
+    session = FakeSession(put_status=http.HTTPStatus.INTERNAL_SERVER_ERROR)
+
+    response = upload_dashboard(BASE_URL, {"dashboard": {"uid": "dash-1"}}, session=session)
+
+    assert not response.ok
+    assert [call[0] for call in session.calls] == ["PUT"]
+
+
+def test_upload_uses_a_retry_session_by_default(monkeypatch):
+    created = []
+
+    def fake_create_retry_session(*args, **kwargs):
+        session = FakeSession()
+        created.append(session)
+        return session
+
+    monkeypatch.setattr("sdcm.utils.grafana_api.create_retry_session", fake_create_retry_session)
+    upload_dashboard(BASE_URL, {"dashboard": {"uid": "dash-1"}})
+
+    assert created, "upload_dashboard must not issue bare requests calls"
+
+
+def test_annotations_and_search_remain_on_the_legacy_api():
+    """No /apis replacement exists for these, so they must not be migrated."""
+    from sdcm.utils.grafana_api import (  # noqa: PLC0415 - asserted as a pair with the paths above
+        GRAFANA_ANNOTATIONS_API_PATH,
+        GRAFANA_SEARCH_API_PATH,
+    )
+
+    assert GRAFANA_ANNOTATIONS_API_PATH == "/api/annotations"
+    assert GRAFANA_SEARCH_API_PATH == "/api/search"
+
+
+def test_dashboard_api_path_targets_v1beta1():
+    """v1 does not exist before Grafana 13 and the v2 schemas reject the legacy dashboard model."""
+    assert GRAFANA_DASHBOARD_API_PATH.startswith("/apis/dashboard.grafana.app/v1beta1/")
+
+
+def test_requests_connection_error_is_left_for_the_caller():
+    """The grafana-startup wait loop in cluster.py relies on seeing ConnectionError."""
+
+    class ExplodingSession(FakeSession):
+        def put(self, url, **kwargs):
+            raise requests.ConnectionError("connection refused")
+
+    with pytest.raises(requests.ConnectionError):
+        upload_dashboard(BASE_URL, {"dashboard": {"uid": "u"}}, session=ExplodingSession())

--- a/unit_tests/unit/test_manager_backend_node_exporter.py
+++ b/unit_tests/unit/test_manager_backend_node_exporter.py
@@ -1,0 +1,78 @@
+"""Tests for dropping a conflicting scylla-node-exporter before the manager backend install.
+
+Monitoring images ship an independently versioned ``scylla-node-exporter`` (epoch based,
+e.g. ``1:1.11.1-2``). The manager backend is an older Scylla release whose ``scylla``
+package pins it exactly, and the package manager refuses to downgrade across the epoch.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from sdcm.cluster import BaseMonitorSet, BaseNode
+from sdcm.utils.apt import apt_cmd
+
+
+@pytest.fixture
+def node():
+    node = MagicMock()
+    node.distro.is_rhel_like = False
+    node.distro.is_sles = False
+    return node
+
+
+def test_remove_package_uses_apt_on_debian_like(node):
+    BaseNode.remove_package(node, "scylla-node-exporter")
+
+    node.remoter.sudo.assert_called_once_with(apt_cmd("remove -y scylla-node-exporter"), ignore_status=True)
+
+
+def test_remove_package_uses_the_rpm_manager_on_rhel_like(node):
+    node.distro.is_rhel_like = True
+
+    BaseNode.remove_package(node, "scylla-node-exporter")
+
+    remove_cmd = node.remoter.sudo.call_args.args[0]
+    assert "remove -y scylla-node-exporter" in remove_cmd
+    assert "apt-get" not in remove_cmd
+
+
+def test_remove_package_uses_zypper_on_sles(node):
+    node.distro.is_sles = True
+
+    BaseNode.remove_package(node, "scylla-node-exporter")
+
+    node.remoter.sudo.assert_called_once_with("zypper remove -y scylla-node-exporter", ignore_status=True)
+
+
+def test_remove_package_tolerates_a_package_that_is_not_installed(node):
+    """A missing package must not fail the setup, so the removal ignores the exit code."""
+    BaseNode.remove_package(node, "scylla-node-exporter")
+
+    assert node.remoter.sudo.call_args.kwargs["ignore_status"] is True
+
+
+def test_manager_backend_install_drops_the_conflicting_node_exporter(node):
+    monitor_set = MagicMock()
+    monitor_set.params.get.side_effect = {
+        "scylla_repo_m": "https://downloads.scylladb.com/deb/debian/scylla-2025.4.list",
+        "scylla_mgmt_pkg": "",
+    }.get
+
+    BaseMonitorSet.install_scylla_manager(monitor_set, node)
+
+    node.remove_package.assert_called_once_with("scylla-node-exporter")
+
+
+def test_node_exporter_is_dropped_before_scylla_is_installed(node):
+    """Removing it afterwards would undo the version the Scylla install just pulled in."""
+    monitor_set = MagicMock()
+    monitor_set.params.get.side_effect = {
+        "scylla_repo_m": "https://downloads.scylladb.com/deb/debian/scylla-2025.4.list",
+        "scylla_mgmt_pkg": "",
+    }.get
+
+    BaseMonitorSet.install_scylla_manager(monitor_set, node)
+
+    called = [name for name, _, _ in node.mock_calls]
+    assert called.index("remove_package") < called.index("install_scylla")


### PR DESCRIPTION
## Summary

Migrate all Grafana dashboard creation calls from the deprecated `/api/dashboards/db` endpoint to the new Kubernetes-style `/apis/dashboard.grafana.app/v1beta1/namespaces/default/dashboards` endpoint, compatible with Grafana 12+.

## Changes

- **New module** `sdcm/utils/grafana_api.py` — centralized API path constants, uid derivation/sanitization, and a shared `upload_dashboard()` helper that owns one upload policy for all call sites (PUT upsert, retry session, timeout, legacy fallback)
- **`sdcm/cluster.py`** — dashboard upload goes through `upload_dashboard()`; annotations calls gained a retry session and an explicit timeout (they previously had none)
- **`sdcm/cluster_k8s/__init__.py`** — curl path uses `PUT` on the named resource and accepts any 2xx
- **`sdcm/monitorstack/restore.py`** — uses `upload_dashboard()`, so restoring an archived stack on an older Grafana still works
- **`sdcm/logcollector.py`** / **`sdcm/sct_events/grafana.py`** — use centralized annotation/search constants
- **`data_dir/scylla-dash-per-server-nemesis.master.json`** — carries a stable `uid`, so dashboard identity comes from the config rather than being invented at upload time
- **Tests** — docker-based integration tests across four Grafana versions, plus unit tests for the payload/uid logic

## Key Design Decisions

All of these were verified against real `grafana/grafana` containers rather than reasoned about:

- **`v1beta1`, not `v1`** — `v1` only exists in Grafana 13; it 404s on all of 12.x, including the 12.4.3 that scylla-monitoring `branch-4.15` ships. `v1beta1` is the only version served by every Grafana that has an `/apis` surface. The `v2*` schemas reject our dashboard model outright.
- **`PUT` on the named resource, not `POST` to the collection** — the new API is Kubernetes-shaped: `POST` creates and answers `409 AlreadyExists` on a repeat, which would have hung the `wait.wait_for` retry loops forever when a monitoring stack re-registers its dashboards. `PUT` is a true upsert (`201` create, `200` update).
- **A stable `metadata.name`, never `generateName`** — `generateName` gave each upload a fresh identity, so re-uploads silently piled up duplicate dashboards instead of updating one. The name comes from the dashboard uid, or a sha1 of the title when there is none, sanitized to Grafana's rules (max 40 chars, `[a-zA-Z0-9_-]`).
- **`res.ok` over `status_code == 200`** — a create answers `201 Created`, so an equality check reads every success as a failure.
- **Legacy fallback on 404 only** — Grafana < 12 has no `/apis` surface at all, and restoring an archived monitoring stack can land on one. A 404 falls back to `/api/dashboards/db`; a 500 is surfaced rather than masked.
- **Annotations and Search stay on legacy** `/api/annotations` and `/api/search` — no `/apis` replacement exists for these.
- **No adapter-level retries on the annotations POST loop** — posting an annotation is not idempotent, so `create_retry_session(retries=0)` is used there and the `@retrying` decorator is the single retry policy.

## Testing

`unit_tests/integration/test_grafana_api.py` runs the real API against upstream Grafana images — one per API generation: **11.6.6** (no `/apis`, exercises the fallback), **12.0.7** (earliest `/apis`), **12.4.3** (what scylla-monitoring ships), **13.1.3** (adds `v1`, prefers `v2`).

```
uv run pytest unit_tests/integration/test_grafana_api.py     # 25 passed, 3 skipped
GRAFANA_TEST_VERSIONS=13.1.3 uv run pytest unit_tests/integration/test_grafana_api.py   # quick loop
uv run pytest unit_tests/unit/test_grafana_api.py            # 20 passed
```

The integration tests assert the claims this migration rests on, so a future Grafana bump that invalidates one of them fails loudly instead of silently breaking dashboard upload: the targeted API version is in the server's advertised list, a create returns 201, a re-upload neither conflicts nor duplicates, the legacy fallback engages on old Grafana, and an uploaded dashboard is actually searchable.

Beyond the test suite, the real `BaseMonitorSet.add_sct_dashboards_to_grafana` and `restore_sct_dashboards` code paths were driven end-to-end against a live Grafana 13.1.3, twice each, confirming a single dashboard resource and a working annotations round-trip.

## Backends Affected
- [x] AWS - Modified cluster.py (used across all backends)
- [x] K8S - Modified cluster_k8s/__init__.py
