### PR TITLE
feature(oci): add resolve:platform: mechanism for OCI platform images

### DIFF
--- a/jenkins-pipelines/oss/artifacts-offline-install/artifacts-oel8.jenkinsfile
+++ b/jenkins-pipelines/oss/artifacts-offline-install/artifacts-oel8.jenkinsfile
@@ -5,9 +5,9 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 artifactsPipeline(
     test_config: 'test-cases/artifacts/oel8.yaml',
-    backend: 'aws',
-    region: 'eu-west-1',
-    provision_type: 'spot',
+    backend: 'oci',
+    region: 'us-ashburn-1',
+    provision_type: 'on_demand',
 
     timeout: [time: 60, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy'

--- a/jenkins-pipelines/oss/artifacts/artifacts-oel8.jenkinsfile
+++ b/jenkins-pipelines/oss/artifacts/artifacts-oel8.jenkinsfile
@@ -5,9 +5,9 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 artifactsPipeline(
     test_config: 'test-cases/artifacts/oel8.yaml',
-    backend: 'aws',
-    region: 'eu-west-1',
-    provision_type: 'spot',
+    backend: 'oci',
+    region: 'us-ashburn-1',
+    provision_type: 'on_demand',
 
     timeout: [time: 60, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy'

--- a/jenkins-pipelines/oss/artifacts/artifacts-oel9.jenkinsfile
+++ b/jenkins-pipelines/oss/artifacts/artifacts-oel9.jenkinsfile
@@ -5,9 +5,9 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 artifactsPipeline(
     test_config: 'test-cases/artifacts/oel9.yaml',
-    backend: 'aws',
-    region: 'eu-west-1',
-    provision_type: 'spot',
+    backend: 'oci',
+    region: 'us-ashburn-1',
+    provision_type: 'on_demand',
 
     timeout: [time: 60, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy'

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -3911,7 +3911,7 @@ class SCTConfiguration(BaseModel):
     def _validate_zero_token_backend_support(backend: str):
         assert backend == "aws", "Only AWS supports zero nodes configuration"
 
-    def verify_configuration_urls_validity(self):
+    def verify_configuration_urls_validity(self):  # noqa: PLR0914
         """
         Check if ami_id and repo urls are valid
         """
@@ -3967,15 +3967,41 @@ class SCTConfiguration(BaseModel):
                 self["user_data_format_version"] = tags.get("user_data_format_version", "2")
 
         if backend == "oci":
-            oci_image_db = self.get("oci_image_db").split()
-            oci_region_names = self.get("oci_region_name") or []
-            if not isinstance(oci_region_names, list):
-                oci_region_names = [oci_region_names]
-            for image, region in zip(oci_image_db, oci_region_names):
-                tags = oci_utils.get_image_tags(region, image, "scylla")
-                if "user_data_format_version" not in tags.keys():
-                    logging.warning("'user_data_format_version' tag missing from [%s]: existing tags: %s", image, tags)
-                self["user_data_format_version"] = tags.get("user_data_format_version", "3")
+            oci_image_db = self.get("oci_image_db")
+            if oci_image_db.startswith("resolve:platform:"):
+                # NOTE: Resolve platform image to actual OCID
+                parts = oci_image_db.replace("resolve:platform:", "").split(":")
+                os_name = parts[0]
+                os_version = parts[1] if len(parts) > 1 else "n/a"
+                oci_region_names = self.get("oci_region_name") or []
+                if not isinstance(oci_region_names, list):
+                    oci_region_names = [oci_region_names]
+                shape_name = (self.get("oci_instance_type_db") or "").split(":")[0] or None
+                resolved_images = []
+                for region in oci_region_names:
+                    resolved_images.append(
+                        oci_utils.get_platform_image_ocid(
+                            compartment_id=oci_utils.get_oci_compartment_id(),
+                            region=region,
+                            operating_system=os_name,
+                            version=os_version,
+                            shape=shape_name,
+                        )
+                    )
+                self["oci_image_db"] = " ".join(resolved_images)
+                # NOTE: use default format version because platform images don't have scylla tags
+                self["user_data_format_version"] = "3"
+            else:
+                oci_region_names = self.get("oci_region_name") or []
+                if not isinstance(oci_region_names, list):
+                    oci_region_names = [oci_region_names]
+                for image, region in zip(oci_image_db.split(), oci_region_names):
+                    tags = oci_utils.get_image_tags(region, image, "scylla")
+                    if "user_data_format_version" not in tags.keys():
+                        logging.warning(
+                            "'user_data_format_version' tag missing from [%s]: existing tags: %s", image, tags
+                        )
+                    self["user_data_format_version"] = tags.get("user_data_format_version", "3")
 
         # For each Scylla repo file we will check that there is at least one valid URL through which to download a
         # version of SCYLLA, otherwise we will get an error.

--- a/sdcm/sct_provision/oci/oci_region_definition_builder.py
+++ b/sdcm/sct_provision/oci/oci_region_definition_builder.py
@@ -80,7 +80,7 @@ class OciDefinitionBuilder(DefinitionBuilder):
             LOGGER.info("Image ID for the '%s' was not provided, using latest ubuntu-%s", node_type, ubuntu_version)
             definition.image_id = get_ubuntu_image_ocid(
                 compartment_id=get_oci_compartment_id(),
-                region=(self.regions[0] if self.regions else ""),
+                region=region,
                 version=ubuntu_version,
             )
 

--- a/sdcm/utils/oci_utils.py
+++ b/sdcm/utils/oci_utils.py
@@ -210,6 +210,69 @@ def resolve_availability_domain(compartment_id: str, short_name: str, region: st
     raise ValueError(f"Could not resolve availability domain '{short_name}' in region. Available: {ads}")
 
 
+def get_platform_image_ocid(
+    compartment_id: str,
+    region: str | None = None,
+    operating_system: str = "Oracle Linux",
+    version: str = "8",
+    shape: str | None = None,
+) -> str:
+    """Get the latest platform image OCID for the specified OS and version.
+
+    Args:
+        compartment_id: The compartment OCID (used for API call context)
+        region: OCI region name
+        operating_system: OS name as recognized by OCI (e.g. "Oracle Linux", "Canonical Ubuntu")
+        version: OS version string (e.g. "8", "9", "24.04")
+        shape: OCI shape name to filter compatible images (e.g. "VM.DenseIO.E5.Flex")
+
+    Returns:
+        OCID of the latest matching platform image
+
+    Raises:
+        ValueError: If no matching image is found
+    """
+    compute_client = OciService().get_compute_client(region=region)
+
+    kwargs = {
+        "compartment_id": compartment_id,
+        "operating_system": operating_system,
+        "operating_system_version": version,
+        "sort_by": "TIMECREATED",
+        "sort_order": "DESC",
+        "lifecycle_state": "AVAILABLE",
+    }
+    if shape:
+        kwargs["shape"] = shape
+
+    images = oci.pagination.list_call_get_all_results_generator(
+        compute_client.list_images,
+        yield_mode="record",
+        **kwargs,
+    )
+
+    amd64_images = []
+    while current_image := next(images, None):
+        current_image_name = current_image.display_name.lower()
+        # Filter for amd64/x86_64 images (exclude ARM)
+        if "aarch64" not in current_image_name and "arm" not in current_image_name:
+            amd64_images.append(current_image)
+    if not amd64_images:
+        shape_msg = f" compatible with shape {shape}" if shape else ""
+        raise ValueError(f"No {operating_system} {version} amd64 image{shape_msg} found in region {region}")
+
+    latest_image = amd64_images[0]
+    LOGGER.info(
+        "Found %d images. Pick latest %s %s image: %s (OCID: %s)",
+        len(amd64_images),
+        operating_system,
+        version,
+        latest_image.display_name,
+        latest_image.id,
+    )
+    return latest_image.id
+
+
 def get_ubuntu_image_ocid(compartment_id: str, region: str | None = None, version: str = "24.04") -> str:
     """Get the latest Ubuntu image OCID for the specified region.
 
@@ -224,39 +287,12 @@ def get_ubuntu_image_ocid(compartment_id: str, region: str | None = None, versio
     Raises:
         ValueError: If no matching image is found
     """
-    compute_client = OciService().get_compute_client(region=region)
-
-    # List images with Ubuntu filter
-    # OCI provides official Ubuntu images from Canonical
-    images = oci.pagination.list_call_get_all_results_generator(
-        compute_client.list_images,
-        yield_mode="record",
+    return get_platform_image_ocid(
         compartment_id=compartment_id,
+        region=region,
         operating_system="Canonical Ubuntu",
-        operating_system_version=version,
-        sort_by="TIMECREATED",
-        sort_order="DESC",
-        lifecycle_state="AVAILABLE",
+        version=version,
     )
-
-    amd64_images = []
-    while current_image := next(images, None):
-        current_image_name = current_image.display_name.lower()
-        # Filter for amd64/x86_64 images (exclude ARM)
-        if "aarch64" not in current_image_name and "arm" not in current_image_name:
-            amd64_images.append(current_image)
-    if not amd64_images:
-        raise ValueError(f"No Ubuntu {version} amd64 image found in region {region}")
-
-    latest_image = amd64_images[0]
-    LOGGER.info(
-        "Found total images: %s. Pick latest Ubuntu %s image: %s (OCID: %s)",
-        len(amd64_images),
-        version,
-        latest_image.display_name,
-        latest_image.id,
-    )
-    return latest_image.id
 
 
 def list_instances_oci(

--- a/test-cases/artifacts/oel8.yaml
+++ b/test-cases/artifacts/oel8.yaml
@@ -1,18 +1,22 @@
-ami_db_scylla_user: 'ec2-user'
-ami_id_db_scylla: 'resolve:owner:131827586825/x86_64/OL8.*'
+user_prefix: "artifacts-oel8-oci"
+
+cluster_backend: "oci"
+instance_provision: "on_demand" # NOTE: DenseIO shapes cannot be 'spot'
+oci_instance_type_db: "VM.DenseIO.E5.Flex:8"
+oci_image_db: "resolve:platform:Oracle Linux:8"
+oci_image_username: "opc"
+oci_region_name:
+  - us-ashburn-1
+
+ami_db_scylla_user: "opc"
+scylla_linux_distro: "centos"
+
 root_disk_size_db: 50
 backtrace_decoding: false
-cluster_backend: 'aws'
-instance_type_db: 'i4i.large'
-instance_provision: "spot"
-instance_provision_fallback_on_demand: true
 n_db_nodes: 1
 n_loaders: 0
 n_monitor_nodes: 0
 nemesis_class_name: 'NoOpMonkey'
-region_name: 'eu-west-1'
-scylla_linux_distro: 'centos'
 test_duration: 60
 use_preinstalled_scylla: false
-user_prefix: 'artifacts-oel8'
 fallback_to_next_availability_zone: true

--- a/test-cases/artifacts/oel9.yaml
+++ b/test-cases/artifacts/oel9.yaml
@@ -1,18 +1,22 @@
-ami_db_scylla_user: 'ec2-user'
-ami_id_db_scylla: 'resolve:owner:131827586825/x86_64/OL9.*'
+user_prefix: "artifacts-oel9-oci"
+
+cluster_backend: "oci"
+instance_provision: "on_demand" # NOTE: DenseIO shapes cannot be 'spot'
+oci_instance_type_db: "VM.DenseIO.E5.Flex:8"
+oci_image_db: "resolve:platform:Oracle Linux:9"
+oci_image_username: "opc"
+oci_region_name:
+  - us-ashburn-1
+
+ami_db_scylla_user: "opc"
+scylla_linux_distro: "centos"
+
 root_disk_size_db: 50
 backtrace_decoding: false
-cluster_backend: 'aws'
-instance_type_db: 'i4i.large'
-instance_provision: "spot"
-instance_provision_fallback_on_demand: true
 n_db_nodes: 1
 n_loaders: 0
 n_monitor_nodes: 0
 nemesis_class_name: 'NoOpMonkey'
-region_name: 'eu-west-1'
-scylla_linux_distro: 'centos'
 test_duration: 60
 use_preinstalled_scylla: false
-user_prefix: 'artifacts-oel9'
 fallback_to_next_availability_zone: true

--- a/unit_tests/unit/test_oci_utils.py
+++ b/unit_tests/unit/test_oci_utils.py
@@ -182,7 +182,7 @@ def test_get_ubuntu_image_ocid_not_found(mock_page_iterator, mock_get_client):
     mock_client = MagicMock()
     mock_page_iterator.return_value = iter([])
     mock_get_client.return_value = mock_client
-    with pytest.raises(ValueError, match="No Ubuntu"):
+    with pytest.raises(ValueError, match="No Canonical Ubuntu"):
         get_ubuntu_image_ocid("compartment-id")
     mock_page_iterator.assert_called_once()
 

--- a/utils/lint_test_cases.sh
+++ b/utils/lint_test_cases.sh
@@ -4,16 +4,15 @@
 # Use instead: ./sct.py lint-pipelines
 
 OUT=0
-SCT_AMI_ID_DB_SCYLLA=ami-1234 ./sct.py lint-yamls -i '.yaml' -e 'azure,oci,multi-dc,multiDC,multidc,multiple-dc,3dcs,5dcs,rolling,docker,artifacts,private-repo,ics/long,scylla-operator,gce,custom-d3,jepsen,repair-based-operations,add-new-dc,baremetal,x86-to-arm,cassandra'
+SCT_AMI_ID_DB_SCYLLA=ami-1234 ./sct.py lint-yamls -i '.yaml' -e 'azure,oci,multi-dc,multiDC,multidc,multiple-dc,3dcs,5dcs,rolling,docker,artifacts,private-repo,ics/long,scylla-operator,gce,custom-d3,jepsen,repair-based-operations,add-new-dc,baremetal,x86-to-arm,cassandra,oel'
 OUT=$(($OUT + $?))
 
 SCT_AZURE_IMAGE_DB=image SCT_AZURE_REGION_NAME="eastus" ./sct.py lint-yamls --backend azure -i azure
 OUT=$(($OUT + $?))
 
-SCT_OCI_IMAGE_DB=image SCT_OCI_REGION_NAME="us-ashburn-1" ./sct.py lint-yamls --backend oci -i oci
+SCT_OCI_IMAGE_DB=image SCT_OCI_REGION_NAME="us-ashburn-1" ./sct.py lint-yamls --backend oci -i 'oci,oel'
 OUT=$(($OUT + $?))
 
-# oel test cases are excluded from linting due to https://scylladb.atlassian.net/browse/SCT-109
 SCT_GCE_IMAGE_DB=image SCT_SCYLLA_REPO='http://downloads.scylladb.com.s3.amazonaws.com/rpm/centos/scylla-2021.1.repo' ./sct.py lint-yamls -b gce -i 'rolling,artifacts,private-repo,gce,custom-d3,jepsen' -e 'multi-dc,multiDC,docker,azure,oci,5dcs,oel'
 OUT=$(($OUT + $?))
 


### PR DESCRIPTION
Implement a `resolve:platform:` config mechanism that dynamically resolves OCI platform images (e.g. Oracle Linux 8/9) to their actual OCIDs at config validation time.
This enables artifacts tests on OCI using bare OS images without hardcoding region-specific image IDs.

Changes:
- Refactor `get_ubuntu_image_ocid()` into generic `get_platform_image_ocid()` with OS name, version, and shape compatibility filtering parameters
- Resolve `resolve:platform:Oracle Linux:8` strings in sct_config.py during `verify_configuration_urls_validity()` so Argus and downstream consumers receive the actual OCID rather than the placeholder
- Fix ubuntu image region selection bug in oci_region_definition_builder (was using `self.regions[0]` instead of the current region)
- Add OEL8 and OEL9 artifacts tests based on the OCI backend.

Closes: #SCT-109

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [scylla-staging/valerii/vp-artifacts-oel8-oci#6](https://argus.scylladb.com/tests/scylla-cluster-tests/0eaa14a7-14fc-4669-bde1-cecf4b1c413f) (ok)
- [scylla-staging/valerii/vp-artifacts-oel9-oci#4](https://argus.scylladb.com/tests/scylla-cluster-tests/7e77723e-a181-40a4-a3db-fabbbe1bf738) (failed on the Scylla installation step - unrelated to this PR)
- Regression testing: [scylla-staging/valerii/vp-artifacts-oci-image#16](https://argus.scylladb.com/tests/scylla-cluster-tests/aca2a0a7-24bb-4afc-989e-f2656ab7ed2b) (ok)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
