### PR TITLE
fix(ycsb): add --entrypoint and fix path for scylladb/ycsb imag

### DIFF
--- a/sdcm/ycsb_thread.py
+++ b/sdcm/ycsb_thread.py
@@ -280,7 +280,8 @@ class YcsbStressThread(DockerBasedStressThread):
             cmd_runner = RemoteDocker(
                 loader,
                 self.docker_image_name,
-                extra_docker_opts=f"{dns_options} {cpu_options} --label shell_marker={self.shell_marker}",
+                command_line="-c 'tail -f /dev/null'",
+                extra_docker_opts=f"{dns_options} {cpu_options} --entrypoint /bin/bash --label shell_marker={self.shell_marker}",
                 docker_network=self.params.get("docker_network"),
             )
             cmd_runner_name = str(loader)
@@ -304,8 +305,8 @@ class YcsbStressThread(DockerBasedStressThread):
                 ).publish()
 
         LOGGER.debug("running: %s", stress_cmd)
-
-        node_cmd = "cd /YCSB && {}".format(stress_cmd)
+        stress_cmd = stress_cmd.replace("bin/ycsb", "bin/ycsb.sh")
+        node_cmd = "cd /usr/local/share/scylla-ycsb && {}".format(stress_cmd)
 
         YcsbStressEvent.start(node=cmd_runner_name, stress_cmd=stress_cmd).publish()
 


### PR DESCRIPTION
[PR#14640](https://github.com/scylladb/scylla-cluster-tests/pull/14640) switched the YCSB image from hydra-loaders:ycsb-jdk8-20220918 to scylladb/ycsb:1.3.2. The new image ships with ENTRYPOINT ['ycsb.sh'], so the default `tail -f /dev/null` command ran `ycsb.sh tail -f /dev/null`, which exited immediately. Every subsequent `docker exec` failed with "container is not running".

The fix `--entrypoint /bin/bash + command_line="-c 'tail -f /dev/null'"` exists on master via [PR#11780](https://github.com/scylladb/scylla-cluster-tests/pull/11780) but was never backported to branch-2025.1.

Also updates the YCSB working directory from `/YCSB` to `/usr/local/share/scylla-ycsb` and the launcher from `bin/ycsb` to `bin/ycsb.sh` to match the new image layout.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
