### PR TITLE
fix(cache-issues): increase label fetch limit in GraphQL queries

### DIFF
--- a/.github/workflows/cache-issues.yaml
+++ b/.github/workflows/cache-issues.yaml
@@ -39,7 +39,7 @@ jobs:
                       nodes {
                         number
                         state
-                        labels(first: 10) { nodes { name } }
+                        labels(first: 100) { nodes { name } }
                         title
                       }
                     }
@@ -75,7 +75,7 @@ jobs:
                       nodes {
                         number
                         state
-                        labels(first: 10) { nodes { name } }
+                        labels(first: 100) { nodes { name } }
                         title
                       }
                     }


### PR DESCRIPTION
## Problem

The `cache-issues.yaml` workflow uses GraphQL to fetch issue/PR labels with `labels(first: 10)`, which silently truncates labels for issues that have more than 10 labels.

For example, [scylladb/scylladb#16317](https://github.com/scylladb/scylladb/issues/16317) has 14 labels (including multiple `sct-*-skip` labels), but only the first 10 are cached. The remaining `sct-2025.3-skip`, `sct-2025.4-skip`, `sct-6.2-skip`, and `type/epic` labels are silently dropped.

## Fix

Increase the label pagination limit from `10` to `100` in both `fetch_issues_graphql()` and `fetch_prs_graphql()` functions. 100 is the GitHub GraphQL API maximum for nested connections and covers any realistic number of labels.

## Verification

After this fix deploys, the next scheduled run (every 2h) will correctly cache all labels for issues like #16317.