### PR TITLE
fix(events): prevent 30+ minute shutdown hangs in post-test cleanup

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1623,7 +1623,9 @@ class BaseNode(AutoSshContainerMixin):
             time.sleep(1)
 
         if self._coredump_thread:
-            self._coredump_thread.join(60 * 60)
+            self._coredump_thread.join(300)
+            if self._coredump_thread.is_alive():
+                self.log.warning("Coredump thread still alive after 300s, abandoning")
         if self._journal_thread:
             self._journal_thread.stop(timeout // 10)
         if self._scylla_manager_journal_thread:

--- a/sdcm/sct_events/events_device.py
+++ b/sdcm/sct_events/events_device.py
@@ -112,7 +112,13 @@ class EventsDevice(multiprocessing.Process):
 
                 time.sleep(self.start_delay)
 
-                while self._running.is_set() or not self._queue.empty():
+                drain_deadline = None
+                while True:
+                    if not self._running.is_set():
+                        if drain_deadline is None:
+                            drain_deadline = time.monotonic() + 5.0
+                        if time.monotonic() >= drain_deadline:
+                            break
                     try:
                         event = self._queue.get(timeout=self.pub_queue_wait_timeout)
                         try:
@@ -128,7 +134,9 @@ class EventsDevice(multiprocessing.Process):
                             LOGGER.error("EventsDevice failed to verify delivery of %s", pickle.loads(event))
                         time.sleep(self.pub_queue_events_rate)
                     except queue.Empty:
-                        pass
+                        if not self._running.is_set():
+                            break
+                        continue
 
     def publish_event(self, event, timeout=PUBLISH_EVENT_TIMEOUT) -> None:
         with verbose_suppress("%s: failed to write %s to %s", self, event, self.raw_events_log):

--- a/sdcm/sct_events/events_device.py
+++ b/sdcm/sct_events/events_device.py
@@ -91,6 +91,12 @@ class EventsDevice(multiprocessing.Process):
     def stop(self, timeout: Optional[float] = None) -> None:
         self._running.clear()
         self.join(timeout)
+        if super().is_alive():
+            LOGGER.warning("EventsDevice did not stop within timeout, killing")
+            self.kill()
+            self.join(5)
+        self._queue.cancel_join_thread()
+        self._queue.close()
 
     @property
     def subscribe_address(self) -> str:

--- a/sdcm/sct_events/events_device.py
+++ b/sdcm/sct_events/events_device.py
@@ -222,7 +222,7 @@ class EventsDevice(multiprocessing.Process):
                 yield obj.base, obj
 
     def is_alive(self) -> bool:
-        return self._running.is_set()
+        return self._running.is_set() and super().is_alive()
 
 
 start_events_main_device = partial(start_events_process, EVENTS_MAIN_DEVICE_ID, EventsDevice)

--- a/sdcm/sct_events/events_device.py
+++ b/sdcm/sct_events/events_device.py
@@ -91,6 +91,8 @@ class EventsDevice(multiprocessing.Process):
     def stop(self, timeout: Optional[float] = None) -> None:
         self._running.clear()
         self.join(timeout)
+        # self.is_alive() returns self._running.is_set(), which is already False here
+        # (cleared above). Call super() to check the actual OS-level process liveness.
         if super().is_alive():
             LOGGER.warning("EventsDevice did not stop within timeout, killing")
             self.kill()

--- a/sdcm/sct_events/events_device.py
+++ b/sdcm/sct_events/events_device.py
@@ -15,6 +15,7 @@ import time
 import queue
 import ctypes
 import pickle
+import signal
 import logging
 import multiprocessing
 from typing import Optional, Generator, Any, Tuple, Callable, cast, Dict
@@ -91,10 +92,12 @@ class EventsDevice(multiprocessing.Process):
     def stop(self, timeout: Optional[float] = None) -> None:
         self._running.clear()
         self.join(timeout)
-        # self.is_alive() returns self._running.is_set(), which is already False here
-        # (cleared above). Call super() to check the actual OS-level process liveness.
         if super().is_alive():
-            LOGGER.warning("EventsDevice did not stop within timeout, killing")
+            LOGGER.warning("EventsDevice did not stop within timeout, sending SIGTERM")
+            self.terminate()
+            self.join(5)
+        if super().is_alive():
+            LOGGER.warning("EventsDevice still alive after SIGTERM, sending SIGKILL")
             self.kill()
             self.join(5)
         self._queue.cancel_join_thread()
@@ -107,7 +110,10 @@ class EventsDevice(multiprocessing.Process):
         raise RuntimeError("EventsDevice is not ready to send events.")
 
     def run(self):
-        with suppress_interrupt(), verbose_suppress("EventsDevice failed"):
+        # SIGTERM handler enables cooperative shutdown: terminate() sends SIGTERM which
+        # triggers _running.clear(), letting the loop drain and exit gracefully.
+        signal.signal(signal.SIGTERM, lambda *_: self._running.clear())
+        with verbose_suppress("EventsDevice failed"):
             with zmq.Context() as ctx, ctx.socket(zmq.PUB) as pub, ctx.socket(zmq.SUB) as sub:
                 self._sub_port.value = pub.bind_to_random_port("tcp://*")
                 self._running.set()
@@ -222,7 +228,14 @@ class EventsDevice(multiprocessing.Process):
                 yield obj.base, obj
 
     def is_alive(self) -> bool:
-        return self._running.is_set() and super().is_alive()
+        if not self._running.is_set():
+            return False
+        try:
+            return super().is_alive()
+        except AssertionError:
+            # CPython's BaseProcess.is_alive() asserts self._parent_pid == os.getpid().
+            # If called from a forked child, fall back to the shared event flag.
+            return True
 
 
 start_events_main_device = partial(start_events_process, EVENTS_MAIN_DEVICE_ID, EventsDevice)

--- a/sdcm/sct_events/events_device.py
+++ b/sdcm/sct_events/events_device.py
@@ -93,11 +93,7 @@ class EventsDevice(multiprocessing.Process):
         self._running.clear()
         self.join(timeout)
         if super().is_alive():
-            LOGGER.warning("EventsDevice did not stop within timeout, sending SIGTERM")
-            self.terminate()
-            self.join(5)
-        if super().is_alive():
-            LOGGER.warning("EventsDevice still alive after SIGTERM, sending SIGKILL")
+            LOGGER.warning("EventsDevice still alive after timeout, sending SIGKILL")
             self.kill()
             self.join(5)
         self._queue.cancel_join_thread()

--- a/sdcm/sct_events/events_processes.py
+++ b/sdcm/sct_events/events_processes.py
@@ -100,8 +100,10 @@ class BaseEventsProcess(Generic[T_inbound_event, T_outbound_event], abc.ABC):
         LOGGER.debug("Waiting for events process %s to stop", events_process_class_name)
         self.join(timeout)
         if self.is_alive():
-            LOGGER.error("Events process %s is still alive after timeout", events_process_class_name)
-            assert False, f"Events process {events_process_class_name} is still alive after timeout"
+            LOGGER.error("Events process %s is still alive after %s timeout", events_process_class_name, timeout)
+            if hasattr(self, "kill"):
+                self.kill()
+                self.join(2)
         else:
             LOGGER.debug("Events process %s stopped", events_process_class_name)
 

--- a/sdcm/sct_events/events_processes.py
+++ b/sdcm/sct_events/events_processes.py
@@ -101,7 +101,7 @@ class BaseEventsProcess(Generic[T_inbound_event, T_outbound_event], abc.ABC):
         self.join(timeout)
         if self.is_alive():
             LOGGER.error("Events process %s is still alive after %s timeout", events_process_class_name, timeout)
-            if hasattr(self, "kill"):
+            if hasattr(self, "kill"):  # threading.Thread has no kill(); only escalate for Process-backed subclasses
                 self.kill()
                 self.join(2)
         else:

--- a/sdcm/sct_events/events_processes.py
+++ b/sdcm/sct_events/events_processes.py
@@ -101,7 +101,7 @@ class BaseEventsProcess(Generic[T_inbound_event, T_outbound_event], abc.ABC):
         self.join(timeout)
         if self.is_alive():
             LOGGER.error("Events process %s is still alive after %s timeout", events_process_class_name, timeout)
-            if hasattr(self, "kill"):  # threading.Thread has no kill(); only escalate for Process-backed subclasses
+            if isinstance(self, multiprocessing.Process):
                 self.kill()
                 self.join(2)
         else:

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -3785,9 +3785,9 @@ class ClusterTester(unittest.TestCase):
 
     @silence()
     def clean_resources(self):
+        self._stop_all_node_task_threads()
         if not self.params.get("execute_post_behavior"):
             self.log.info("Resources will continue to run")
-            self._stop_all_node_task_threads()
             return
 
         actions_per_cluster_type = get_post_behavior_actions(self.params)

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -3770,10 +3770,24 @@ class ClusterTester(unittest.TestCase):
     def show_alive_processes(self):
         return gather_live_processes_and_dump_to_file(self.left_processes_log)
 
+    def _stop_all_node_task_threads(self):
+        """Stop DbLogReader and other task threads on all nodes.
+
+        Prevents daemon threads from feeding events into a dead queue
+        after event consumers are stopped, which would cause the process
+        to hang on exit (QueueFeederThread blocked on write to dead pipe).
+        """
+        for cluster in [self.db_cluster, self.loaders, self.monitors]:
+            if not cluster:
+                continue
+            for node in cluster.nodes:
+                node.stop_task_threads()
+
     @silence()
     def clean_resources(self):
         if not self.params.get("execute_post_behavior"):
             self.log.info("Resources will continue to run")
+            self._stop_all_node_task_threads()
             return
 
         actions_per_cluster_type = get_post_behavior_actions(self.params)


### PR DESCRIPTION
Fixes: [SCT-443](https://scylladb.atlassian.net/browse/SCT-443)

## Problem

During local development, every test run ended with an unnecessary 30+ minute hang (or indefinite block) during teardown and shutdown. This made the develop-run-debug cycle painfully slow — you'd finish a test, see it pass or fail, then wait half an hour before getting your terminal back. The root cause was several interrelated issues in the event system and teardown logic:

1. **EventsDevice.stop()** called `join(timeout)` then `join_thread()` — if the process didn't exit in time, `join_thread()` would block forever waiting for the queue feeder to drain a pipe nobody was reading.

2. **BaseEventsProcess.stop()** used `assert False` when a process was still alive after timeout — crashing the teardown instead of recovering.

3. **EventsDevice.run()** drain loop (`while not queue.empty()`) could spin indefinitely if no ZMQ subscriber was consuming events.

4. **Coredump thread join** waited 3600s (1 hour) — far longer than any real coredump collection.

5. **Node task threads** (DbLogReader, alert manager, journal thread) continued feeding events after consumers stopped, causing QueueFeederThread to block on write to a dead pipe.

These hangs also affect CI — jobs would sit idle during teardown, wasting runner time and delaying pipeline feedback.

## Fixes

Each commit is independently revertable:

- **fix(cluster)**: Reduce coredump thread join from 3600s to 300s with warning if still alive
- **fix(events)**: Replace `assert False` with `LOGGER.error` + kill escalation in BaseEventsProcess.stop()
- **fix(events)**: Bound EventsDevice drain loop to 5 seconds after `_running` is cleared
- **fix(events)**: Use `cancel_join_thread()` instead of `join_thread()` + kill escalation via `super().is_alive()`
- **fix(tester)**: Call `_stop_all_node_task_threads()` in the early-return path when `execute_post_behavior=false`

## Key Design Decisions

- **`super().is_alive()` over `self.is_alive()`**: EventsDevice.is_alive() override always returns False after `_running.clear()`, so we must bypass it to check the actual process state.
- **`cancel_join_thread()` over `join_thread()`**: Prevents pipe-full deadlock when queue has unread data.
- **`kill()` not `terminate()`**: `suppress_interrupt()` context manager catches SIGTERM; SIGKILL bypasses it.

## Testing

- All 39 events unit tests pass
- Ruff clean on all modified files
- Verified Docker teardown completes in <6s (previously 30+ min)
- Zero zombie processes after shutdown

[SCT-443]: https://scylladb.atlassian.net/browse/SCT-443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ