### PR TITLE
chore(triggers): disable xcloud weekly perf trigger

### DIFF
--- a/jenkins-pipelines/master-triggers/sct_triggers/xcloud-weekly-perf-trigger.xml
+++ b/jenkins-pipelines/master-triggers/sct_triggers/xcloud-weekly-perf-trigger.xml
@@ -8,7 +8,7 @@
   Ref: https://scylladb.atlassian.net/browse/QAINFRA-38
   </description>
   <scm class="hudson.scm.NullSCM"/>
-  <disabled>false</disabled>
+  <disabled>true</disabled>
   <triggers>
     <hudson.triggers.TimerTrigger>
       <spec>0 1 * * 0</spec>


### PR DESCRIPTION
The xcloud performance regression test deployment is costly, so running it weekly is disabled in favor of triggering on demand when needed.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
