### PR TITLE
feature(scylla-doctor): add analysis phase support for full edition

### DIFF
--- a/artifacts_test.py
+++ b/artifacts_test.py
@@ -358,6 +358,13 @@ class ArtifactsTest(ClusterTester):
 
         backend = self.params.get("cluster_backend")
 
+        if self.params.get("run_scylla_doctor_only"):
+            with self.logged_subtest("verify node health"):
+                self.verify_node_health()
+            with self.logged_subtest("check scylla_doctor results"):
+                self.run_scylla_doctor()
+            return
+
         if backend == "aws":
             with self.logged_subtest("check ENA support"):
                 assert self.node.ena_support, "ENA support is not enabled"

--- a/artifacts_test.py
+++ b/artifacts_test.py
@@ -563,6 +563,9 @@ class ArtifactsTest(ClusterTester):
                 scylla_doctor.run_scylla_doctor_and_collect_results()
                 scylla_doctor.analyze_vitals()
                 scylla_doctor.analyze_and_verify_results()
+                if scylla_doctor.is_full_edition:
+                    scylla_doctor.run_analysis_phase()
+                    scylla_doctor.analyze_and_verify_analysis_results()
 
     def get_email_data(self):
         self.log.info("Prepare data for email")

--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -275,6 +275,7 @@ kafka_connectors: []
 
 run_scylla_doctor: true
 scylla_doctor_version: "1.10"
+scylla_doctor_full_tarball_url: null
 run_scylla_doctor_only: false
 scylla_doctor_edition: "basic"
 nemesis_double_load_during_grow_shrink_duration: 0

--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -275,6 +275,7 @@ kafka_connectors: []
 
 run_scylla_doctor: true
 scylla_doctor_version: "1.10"
+run_scylla_doctor_only: false
 scylla_doctor_edition: "basic"
 nemesis_double_load_during_grow_shrink_duration: 0
 

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -1957,6 +1957,15 @@ Scylla Doctor version to use for artifact tests. Set to specific version (e.g., 
 * appendable
 
 
+## **run_scylla_doctor_only** / SCT_RUN_SCYLLA_DOCTOR_ONLY
+
+When true, the artifact test runs only the Scylla Doctor validation<br>(install, collect vitals, analyze, verify) and skips all other artifact checks<br>such as stop/start, cassandra-stress, housekeeping, etc. Useful for fast SD<br>release gating. Implies run_scylla_doctor=true.
+
+**default:** N/A
+
+**type:** bool
+
+
 ## **scylla_doctor_edition** / SCT_SCYLLA_DOCTOR_EDITION
 
 Scylla Doctor edition to use. Allowed values: 'basic', 'full'.<br>'basic' fetches the free/open-source edition via HTTP.<br>'full' fetches the full/enterprise edition from a private S3 bucket.

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -1957,6 +1957,16 @@ Scylla Doctor version to use for artifact tests. Set to specific version (e.g., 
 * appendable
 
 
+## **scylla_doctor_full_tarball_url** / SCT_SCYLLA_DOCTOR_FULL_TARBALL_URL
+
+Direct URL to a full edition Scylla Doctor tarball in S3. When set, bypasses the<br>standard version-based S3 lookup and downloads SD directly from this URL.<br>Use for testing unofficial or pre-release SD versions.<br>Example: 'https://s3.amazonaws.com/my-bucket/scylla-doctor-1.11-rc1.tar.gz'
+
+**default:** N/A
+
+**type:** str
+* appendable
+
+
 ## **run_scylla_doctor_only** / SCT_RUN_SCYLLA_DOCTOR_ONLY
 
 When true, the artifact test runs only the Scylla Doctor validation<br>(install, collect vitals, analyze, verify) and skips all other artifact checks<br>such as stop/start, cassandra-stress, housekeeping, etc. Useful for fast SD<br>release gating. Implies run_scylla_doctor=true.

--- a/docs/plans/mini-plans/scylla-doctor-release-gating-suite.md
+++ b/docs/plans/mini-plans/scylla-doctor-release-gating-suite.md
@@ -1,0 +1,330 @@
+# Scylla Doctor Release Gating Suite — Implementation Plan
+
+**Date:** 2026-04-06
+**Updated:** 2026-04-12
+**Status:** Draft
+**Scope:** Integrate the full SD test suite into existing artifact tests for validating Scylla Doctor releases
+
+---
+
+## Background
+
+After a detailed chat with Israel, here's the plan to run the full SD test suites. The approach integrates SD validation into the existing artifact test infrastructure to keep things efficient and simple, rather than creating a separate standalone suite.
+
+---
+
+## Plan Summary
+
+### 1. Integration with Artifact Tests
+
+The full SD suite will be added into the **current artifact tests** (`artifacts_test.py`). No separate test file or test configs are needed. The existing `run_scylla_doctor()` method and `utils/scylla_doctor.py` utility class already provide the core SD validation flow (install → collect vitals → analyze → verify). The changes extend this to support new modes and parameters.
+
+### 2. SD Installation
+
+SD will be installed using a **tarball from S3**. The SD tarball must be stored in an S3 bucket that the QA user can access, so the installation goes smoothly. The existing `download_scylla_doctor()` method in `utils/scylla_doctor.py` already handles S3-based tarball downloads from `downloads.scylladb.com/downloads/scylla-doctor/tar/`.
+
+---
+
+## Required Actions
+
+### Action 1: Merge PR #14051 — Full Edition Download from Private S3 Bucket
+
+**PR:** [feature(scylla-doctor): support full edition download from private S3 bucket](https://github.com/scylladb/scylla-cluster-tests/pull/14051)
+
+This PR correctly identifies the SD release version and adds support for downloading the full SD edition (Collectors + Analyzers) instead of just the Collectors-only tarball. This is a prerequisite for the remaining actions.
+
+**Status:** Awaiting merge.
+
+### Action 2: New Parameter for Custom S3 Full Edition Tarball URL
+
+Add a new SCT configuration parameter that provides a **direct link to an S3 tarball** for the full SD edition (Collectors + Analyzers) that is not an official release. This enables testing pre-release or unofficial SD full edition builds.
+
+#### 2.1 New Config Parameter
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `scylla_doctor_full_tarball_url` | str | Direct URL to a Scylla Doctor full edition tarball (Collectors + Analyzers) in S3. When set, bypasses the standard version-based S3 lookup and downloads the full SD edition directly from this URL. Use for testing unofficial or pre-release SD builds. |
+
+Environment variable: `SCT_SCYLLA_DOCTOR_FULL_TARBALL_URL`
+
+#### 2.2 Implementation in `sdcm/sct_config.py`
+
+Add the new parameter alongside the existing SD config options (`run_scylla_doctor`, `scylla_doctor_version`):
+
+```python
+scylla_doctor_full_tarball_url: String = SctField(
+    description="""Direct URL to a Scylla Doctor full edition tarball (Collectors + Analyzers)
+            in S3. When set, bypasses the standard version-based S3 lookup and downloads the
+            full SD edition directly from this URL. Use for testing unofficial or pre-release
+            SD builds.
+            Example: 'https://s3.amazonaws.com/my-bucket/scylla-doctor-full-1.11-rc1.tar.gz'""",
+)
+```
+
+
+### Action 3: Auto-Discover Supported Scylla Versions
+
+Pick the **latest minor (patch) version** from each currently supported official Scylla release branch and run SD against all of them. This ensures SD is validated across the full range of Scylla versions that customers may be running.
+
+#### 3.1 Version Discovery
+
+SCT already has infrastructure for discovering supported Scylla versions:
+
+- `get_s3_scylla_repos_mapping()` in `sdcm/utils/version_utils.py` — enumerates all published release branches from S3 repo files
+- `UpgradeBaseVersion.get_version_list()` in `utils/get_supported_scylla_base_versions.py` — returns all supported release version prefixes (e.g., `2025.4`, `2026.1`)
+- `get_all_versions()` in `sdcm/utils/version_utils.py` — can resolve all patch versions for a given branch repo
+
+The gating pipeline will use this to automatically determine which Scylla versions to test, selecting the latest patch of each supported branch.
+
+#### 3.2 Scylla Version Matrix
+
+| Branch | Type | Example Latest Patch |
+|--------|------|----------------------|
+| 2025.4.x | LTS | 2025.4.3 |
+| 2026.1.x | Latest | 2026.1.1 |
+
+*Versions are auto-discovered at pipeline runtime — no manual maintenance required.*
+
+#### 3.3 Implementation
+
+The Jenkins pipeline will call a helper script (or Groovy function in `vars/`) that:
+1. Calls `get_s3_scylla_repos_mapping()` to enumerate all supported release branches
+2. For each branch, resolves the latest available patch version
+3. Feeds each version as a parameter (`SCT_SCYLLA_VERSION`) into the parallel artifact test runs
+
+This means a single SD release gating trigger produces tests across **all supported Scylla versions × all OS variants**.
+
+### Action 4: SD-Only Test Mode Flag
+
+Add a flag that runs **SD validation only**, skipping the full artifact test flow (scylla stop/start, cassandra-stress, housekeeping checks, perftune, etc.). This provides a fast path for SD release gating.
+
+#### 4.1 New Config Parameter
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `run_scylla_doctor_only` | bool | When true, the artifact test runs only the Scylla Doctor validation subtests (install, collect, analyze, verify) and skips all other artifact checks. Default: false. |
+
+Environment variable: `SCT_RUN_SCYLLA_DOCTOR_ONLY`
+
+#### 4.2 Implementation in `sdcm/sct_config.py`
+
+```python
+run_scylla_doctor_only: Boolean = SctField(
+    description="""When true, the artifact test runs only the Scylla Doctor validation
+            (install, collect vitals, analyze, verify) and skips all other artifact checks
+            such as stop/start, cassandra-stress, housekeeping, etc. Useful for fast SD
+            release gating. Implies run_scylla_doctor=true.""",
+)
+```
+
+#### 4.3 Default in `defaults/test_default.yaml`
+
+```yaml
+run_scylla_doctor_only: false
+```
+
+#### 4.4 Implementation in `artifacts_test.py`
+
+Modify `test_scylla_service()` to support the SD-only mode. When `run_scylla_doctor_only` is set, the test performs minimal Scylla validation (verify it's running via `nodetool status`) and then runs only the SD subtests:
+
+```python
+def test_scylla_service(self):
+    self.run_pre_create_schema()
+    backend = self.params.get("cluster_backend")
+
+    if self.params.get("run_scylla_doctor_only"):
+        # SD-only mode: minimal Scylla validation, then full SD test
+        with self.logged_subtest("verify node health"):
+            self.verify_node_health()
+        with self.logged_subtest("check scylla_doctor results"):
+            self.run_scylla_doctor()
+        return
+
+    # ... existing full artifact test flow unchanged ...
+```
+
+### Action 5: Trigger to Run All Artifact Tests in Parallel
+
+Create a Jenkins pipeline that triggers **all artifact tests simultaneously**, waits for all of them to finish, and produces **detailed failure reports** so issues can be fixed quickly.
+
+#### 5.1 Pipeline Shared Library
+
+**File:** `vars/sdReleaseGatingPipeline.groovy`
+
+This pipeline:
+1. Accepts `sd_tarball_url` as a **required** parameter — the direct URL to the SD full edition tarball under test
+2. Auto-discovers the latest patch version for each supported Scylla release branch (Action 3)
+3. Triggers all existing artifact test jobs in parallel — one per OS/backend × Scylla version
+4. Passes `scylla_doctor_full_tarball_url` and `run_scylla_doctor_only=true` as **direct parameters** to each artifact job (no `extra_environment_variables`)
+5. `run_scylla_doctor` is always `true` by default (from `test_default.yaml`), so it is not explicitly passed
+6. Waits for all jobs to complete
+7. Aggregates results and produces a summary report with per-OS, per-Scylla-version pass/fail status
+
+#### 5.2 Pipeline Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `sd_tarball_url` | string | **Yes** | Direct URL to a Scylla Doctor full edition tarball in S3 |
+| `scylla_versions` | string | No | Space-separated Scylla versions to test. Auto-discovered when empty |
+| `os_filter` | string | No | Comma-separated OS labels to test. Tests all OS variants when empty |
+| `post_behavior_db_nodes` | string | No | `keep\|keep-on-failure\|destroy` (default: `destroy`) |
+| `provision_type` | string | No | `on_demand\|spot\|spot_fleet` (default: `spot`) |
+| `email_recipients` | string | No | Email recipients for gating report (default: `qa@scylladb.com`) |
+| `requested_by_user` | string | No | User requesting the job |
+
+**Removed parameters** (compared to initial plan):
+- ~~`sd_version`~~ — Not needed; the tarball URL is the only way to specify the SD build
+- ~~`sd_only_mode`~~ — Always `true`; the gating pipeline always runs SD-only mode
+
+#### 5.3 Artifact Pipeline Changes
+
+**File:** `vars/artifactsPipeline.groovy` (modified)
+
+Two new parameters added to the artifact test pipeline so the gating pipeline can pass them directly:
+
+```groovy
+separator(name: 'SCYLLA_DOCTOR', sectionHeader: 'Scylla Doctor Configuration')
+string(defaultValue: '', name: 'scylla_doctor_full_tarball_url',
+       description: 'Direct URL to a Scylla Doctor full edition tarball in S3.')
+booleanParam(defaultValue: false, name: 'run_scylla_doctor_only',
+       description: 'When true, runs only Scylla Doctor validation.')
+```
+
+These are exported as SCT environment variables in the sctScript:
+
+```bash
+if [[ ! -z "${params.scylla_doctor_full_tarball_url}" ]]; then
+    export SCT_SCYLLA_DOCTOR_FULL_TARBALL_URL="${params.scylla_doctor_full_tarball_url}"
+fi
+if [[ "${params.run_scylla_doctor_only}" == "true" ]]; then
+    export SCT_RUN_SCYLLA_DOCTOR_ONLY=true
+fi
+```
+
+This avoids using `extra_environment_variables` for SD parameters.
+
+#### 5.4 How Jobs Are Triggered
+
+Each artifact test is triggered with direct parameters (no `extra_environment_variables`):
+
+```groovy
+build(
+    job: fullJobPath,
+    wait: true,
+    propagate: false,
+    parameters: [
+        string(name: 'scylla_version', value: scyllaVersion),
+        string(name: 'scylla_doctor_full_tarball_url', value: params.sd_tarball_url.trim()),
+        booleanParam(name: 'run_scylla_doctor_only', value: true),
+        string(name: 'post_behavior_db_nodes', value: params.post_behavior_db_nodes),
+        string(name: 'provision_type', value: params.provision_type),
+        string(name: 'email_recipients', value: ''),  // Suppress per-job emails
+        string(name: 'requested_by_user', value: params.requested_by_user),
+    ]
+)
+```
+
+#### 5.5 Failure Reporting
+
+The pipeline collects results from all parallel jobs and produces:
+- A **summary table** showing pass/fail per OS variant × Scylla version
+- **Links to individual job logs** for failed runs
+- The specific SD version and tarball URL used
+- **Notification** to the SD team (email or Slack) on any failure
+
+Example summary output:
+
+```
+SD Version: 1.11 | Status: FAILED
+
+                    2025.4.3   2026.1.1
+CentOS 9            ✅          ✅
+Rocky 9             ✅          ✅
+Ubuntu 22.04        ✅          ❌
+Ubuntu 24.04        ✅          ✅
+Debian 12           ✅          ✅
+AMI                 ✅          ✅
+Docker              ✅          ✅
+
+Failed: Ubuntu 22.04 × 2026.1.1 — FirewallRulesCollector (new failure)
+  → [Job Link]
+```
+
+---
+
+## Files to Create or Modify
+
+| File | Action | Description |
+|------|--------|-------------|
+| `sdcm/sct_config.py` | Modify | Add `scylla_doctor_full_tarball_url` and `run_scylla_doctor_only` parameters |
+| `defaults/test_default.yaml` | Modify | Add default values for new parameters |
+| `utils/scylla_doctor.py` | Modify | Support custom full edition tarball URL in `download_scylla_doctor()` |
+| `artifacts_test.py` | Modify | Add SD-only mode early-return path in `test_scylla_service()` |
+| `vars/artifactsPipeline.groovy` | Modify | Add `scylla_doctor_full_tarball_url` and `run_scylla_doctor_only` as direct pipeline parameters |
+| `jenkins-pipelines/scylla-doctor/_display_name` | Create | Jenkins folder display name |
+| `jenkins-pipelines/scylla-doctor/sd-release-gating.jenkinsfile` | Create | Pipeline entry point that invokes `sdReleaseGatingPipeline` shared library |
+| `vars/sdReleaseGatingPipeline.groovy` | Create | Shared library: parallel trigger pipeline with version discovery and failure reporting |
+
+---
+
+## Test Matrix
+
+The SD gating pipeline combines:
+- **Rows:** Auto-discovered latest patch of each supported Scylla release branch (e.g., 2025.4.x, 2026.1.x)
+- **Columns:** Existing artifact test OS configs from `test-cases/artifacts/`
+
+OS coverage from existing artifact tests:
+
+| OS | Config File | Backend |
+|----|-------------|---------|
+| CentOS 9 | `test-cases/artifacts/centos9.yaml` | GCE |
+| Rocky 9 | `test-cases/artifacts/rocky9.yaml` | GCE |
+| Ubuntu 22.04 | `test-cases/artifacts/ubuntu2204.yaml` | GCE |
+| Ubuntu 24.04 | `test-cases/artifacts/ubuntu2404.yaml` | GCE |
+| Debian 12 | `test-cases/artifacts/debian12.yaml` | GCE |
+| AMI (Amazon Linux) | via AWS artifact pipelines | AWS |
+| Docker | `test-cases/artifacts/docker.yaml` | Docker |
+| RHEL 8 | `test-cases/artifacts/rhel8.yaml` | GCE |
+| RHEL 10 | `test-cases/artifacts/rhel10.yaml` | GCE |
+| OEL 9 | `test-cases/artifacts/oel9.yaml` | GCE |
+| + ARM variants | via `-arm` pipelines | AWS |
+
+**Total combinations per SD release:** ~2 Scylla versions × ~10 OS variants = **~20 test runs** (all executed in parallel).
+
+---
+
+## Pass/Fail Criteria
+
+The SD release is **approved** if all artifact tests pass the SD subtests:
+
+1. SD installs successfully from S3 tarball on all OS variants
+2. All collectors pass (excluding documented known exceptions in `filter_out_failed_collectors()`)
+3. Analyzer runs without errors
+4. Vitals JSON and scylla_logs archive are created (non-Docker)
+5. No version-specific failures across any supported Scylla release
+
+A failure in **any** cell of the matrix blocks the SD release.
+
+---
+
+## Estimated Effort
+
+| Component | Effort |
+|-----------|--------|
+| Merge PR #14051 (prerequisite) | External dependency |
+| `scylla_doctor_full_tarball_url` parameter + `scylla_doctor.py` changes | 1 day |
+| `run_scylla_doctor_only` flag + `artifacts_test.py` changes | 1 day |
+| Scylla version auto-discovery in pipeline | 1-2 days |
+| `sdReleaseGatingPipeline.groovy` + `artifactsPipeline.groovy` changes | 2-3 days |
+| End-to-end testing & validation | 1-2 days |
+| **Total** | **~6-9 days** |
+
+---
+
+## Open Questions
+
+| # | Question | Impact | Decision Needed By |
+|---|----------|--------|--------------------|
+| 1 | Should the approved SD version auto-update `scylla_doctor_version` in `defaults/test_default.yaml` via automated PR? | CI/CD integration | During implementation |
+| 2 | Where should the gating pass/fail result be published (Argus, email, Slack)? | Notification setup | During implementation |
+| 3 | Should the S3 bucket for pre-release SD tarballs require specific IAM permissions beyond QA user access? | Access setup | Before implementation |

--- a/jenkins-pipelines/scylla-doctor/_display_name
+++ b/jenkins-pipelines/scylla-doctor/_display_name
@@ -1,0 +1,1 @@
+Scylla Doctor

--- a/jenkins-pipelines/scylla-doctor/sd-release-gating.jenkinsfile
+++ b/jenkins-pipelines/scylla-doctor/sd-release-gating.jenkinsfile
@@ -1,0 +1,6 @@
+#! groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+sdReleaseGatingPipeline()

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1277,6 +1277,12 @@ class SCTConfiguration(BaseModel):
                 to hardcode the version, or leave empty to use the latest available version. For stability,
                 artifact tests should use a hardcoded version to avoid issues from newer scylla-doctor releases.""",
     )
+    scylla_doctor_full_tarball_url: String = SctField(
+        description="""Direct URL to a full edition Scylla Doctor tarball in S3. When set, bypasses the
+                standard version-based S3 lookup and downloads SD directly from this URL.
+                Use for testing unofficial or pre-release SD versions.
+                Example: 'https://s3.amazonaws.com/my-bucket/scylla-doctor-1.11-rc1.tar.gz'""",
+    )
     run_scylla_doctor_only: Boolean = SctField(
         description="""When true, the artifact test runs only the Scylla Doctor validation
                 (install, collect vitals, analyze, verify) and skips all other artifact checks

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1277,6 +1277,12 @@ class SCTConfiguration(BaseModel):
                 to hardcode the version, or leave empty to use the latest available version. For stability,
                 artifact tests should use a hardcoded version to avoid issues from newer scylla-doctor releases.""",
     )
+    run_scylla_doctor_only: Boolean = SctField(
+        description="""When true, the artifact test runs only the Scylla Doctor validation
+                (install, collect vitals, analyze, verify) and skips all other artifact checks
+                such as stop/start, cassandra-stress, housekeeping, etc. Useful for fast SD
+                release gating. Implies run_scylla_doctor=true.""",
+    )
     scylla_doctor_edition: Literal["basic", "full"] = SctField(
         description="""Scylla Doctor edition to use. Allowed values: 'basic', 'full'.
                 'basic' fetches the free/open-source edition via HTTP.

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1294,6 +1294,7 @@ class SCTConfiguration(BaseModel):
                 'basic' fetches the free/open-source edition via HTTP.
                 'full' fetches the full/enterprise edition from a private S3 bucket.""",
     )
+
     skip_test_stages: DictOrStr = SctField(
         description="Skip selected stages of a test scenario",
     )

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -3975,6 +3975,22 @@ class ClusterTester(unittest.TestCase):
                             )
                             self.log.debug("Downloaded scylla-doctor logs from %s to %s", node.name, local_logs_path)
 
+                        if doctor.is_full_edition:
+                            self.log.info("Running scylla-doctor analysis phase (full edition) on %s...", node.name)
+                            doctor.run_analysis_phase()
+                            if doctor.analysis_report_file:
+                                local_analysis_path = os.path.join(
+                                    self.logdir, f"scylla_doctor_{node.name}_analysis.json"
+                                )
+                                node.remoter.receive_files(
+                                    src=doctor.analysis_report_file, dst=local_analysis_path, sudo=download_with_sudo
+                                )
+                                self.log.debug(
+                                    "Downloaded scylla-doctor analysis from %s to %s",
+                                    node.name,
+                                    local_analysis_path,
+                                )
+
                         self.log.info("Scylla-doctor completed for node %s", node.name)
                     except (ScyllaDoctorException, UnexpectedExit, Failure, AssertionError) as exc:
                         self.log.warning("Failed to run scylla-doctor on node %s: %s", node.name, exc)

--- a/sdcm/utils/aws_utils.py
+++ b/sdcm/utils/aws_utils.py
@@ -616,6 +616,23 @@ def get_by_owner_ami(parameter: str, region_name) -> str:
         ],
     )
     images = sorted(images, key=lambda x: x.creation_date, reverse=True)
+    if not images:
+        # List available images from the owner to help debug naming issues
+        available_names_info = ""
+        try:
+            all_images = ec2_resource.images.filter(
+                Owners=[owner],
+                Filters=[{"Name": "architecture", "Values": [arch]}],
+            )
+            available_names = sorted([img.name or "<unnamed>" for img in all_images], reverse=True)[:10]
+            available_names_info = f" Available image names (top 10): {available_names}"
+
+        except Exception as exc:  # noqa: BLE001
+            LOGGER.debug("Failed to list available images for debugging: %s", exc)
+        raise ValueError(
+            f"No AMI found for owner={owner}, architecture={arch}, name_filter={name_filter} "
+            f"in region {region_name}.{available_names_info}"
+        )
     LOGGER.debug(f'found image "{images[0].name}" - {images[0].id}')
     return images[0].id
 

--- a/unit_tests/test_scylla_doctor.py
+++ b/unit_tests/test_scylla_doctor.py
@@ -325,6 +325,17 @@ def test_download_basic_edition_skips_full(mock_boto_client, mock_node, mock_tes
     }
     mock_boto_client.return_value = mock_s3
 
+    def _run_side_effect(cmd, **kwargs):
+        result = MagicMock()
+        result.ok = True
+        if "file " in cmd:
+            result.stdout = "/tmp/scylla_doctor_download.tar.gz: gzip compressed data\n"
+        else:
+            result.stdout = "/home/testuser\n"
+        return result
+
+    mock_node.remoter.run.side_effect = _run_side_effect
+
     doc = ScyllaDoctor(node=mock_node, test_config=test_config, offline_install=True)
 
     with patch.object(ScyllaDoctor, "download_full_scylla_doctor") as mock_full:
@@ -489,3 +500,81 @@ def test_find_scylla_bundled_python3_raises_when_not_found(doctor, is_nonroot, r
 
     with pytest.raises(ScyllaDoctorException, match="No Scylla-bundled python3"):
         doctor.find_scylla_bundled_python3("/home/user")
+
+
+# --- run_analysis_phase tests ---
+
+
+def test_run_analysis_phase_skips_when_not_full_edition(mock_node, mock_test_config):
+    """When edition is not full, run_analysis_phase should skip without error."""
+    test_config, params = mock_test_config
+    params["scylla_doctor_edition"] = "basic"
+    doc = ScyllaDoctor(node=mock_node, test_config=test_config)
+    doc.json_result_file = "test-node.local.vitals.json"
+
+    doc.run_analysis_phase()
+
+    # No remoter calls should have been made for the analysis phase
+    mock_node.remoter.sudo.assert_not_called()
+
+
+def test_run_analysis_phase_full_edition_success(mock_node, mock_test_config):
+    """When edition is full, run_analysis_phase should run analysis and store the report file."""
+    test_config, params = mock_test_config
+    params["scylla_doctor_edition"] = "full"
+    doc = ScyllaDoctor(node=mock_node, test_config=test_config)
+    doc._full_edition_downloaded = True
+    doc.json_result_file = "test-node.local.vitals.json"
+    doc.scylla_doctor_exec = "/home/testuser/scylla_doctor.pyz"
+
+    # First sudo call is from run() — returns the JSON analysis output
+    run_result = MagicMock()
+    run_result.stdout = '{"SomeAnalyzer": {"status": 0}}'
+    # Second sudo call is to write the file via base64
+    write_result = MagicMock()
+    write_result.stdout = ""
+    mock_node.remoter.sudo.side_effect = [run_result, write_result]
+
+    check_result = MagicMock()
+    check_result.ok = True
+    check_result.stdout = "test-node.local.analysis.json\n"
+    mock_node.remoter.run.return_value = check_result
+
+    doc.run_analysis_phase()
+
+    # Verify sudo was called with --output json to produce JSON output
+    first_sudo_cmd = mock_node.remoter.sudo.call_args_list[0][0][0]
+    assert "--load-vitals test-node.local.vitals.json" in first_sudo_cmd
+    assert "--output json" in first_sudo_cmd
+
+    assert doc.analysis_report_file == "test-node.local.analysis.json"
+
+
+def test_run_analysis_phase_report_not_created(mock_node, mock_test_config):
+    """When the analysis report file is not created, ScyllaDoctorException should be raised."""
+    test_config, params = mock_test_config
+    params["scylla_doctor_edition"] = "full"
+    doc = ScyllaDoctor(node=mock_node, test_config=test_config)
+    doc._full_edition_downloaded = True
+    doc.json_result_file = "test-node.local.vitals.json"
+    doc.scylla_doctor_exec = "/home/testuser/scylla_doctor.pyz"
+
+    # First sudo call is from run() — returns JSON output
+    run_result = MagicMock()
+    run_result.stdout = '{"SomeAnalyzer": {"status": 0}}'
+    # Second sudo call is to write the file via base64
+    write_result = MagicMock()
+    write_result.stdout = ""
+    # Third sudo call is from self.version (accessed in exception message)
+    version_result = MagicMock()
+    version_result.stdout = "1.9.0"
+    mock_node.remoter.sudo.side_effect = [run_result, write_result, version_result]
+
+    # test -s check fails — file was not created
+    check_result = MagicMock()
+    check_result.ok = False
+    check_result.stdout = ""
+    mock_node.remoter.run.return_value = check_result
+
+    with pytest.raises(ScyllaDoctorException, match="Analysis report file"):
+        doc.run_analysis_phase()

--- a/utils/scylla_doctor.py
+++ b/utils/scylla_doctor.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import base64
 import json
 import logging
 import pprint
@@ -70,6 +71,43 @@ class ScyllaDoctor:
         ; skip until https://scylladb.atlassian.net/browse/DOCTOR-19 is figured out
         run = no
     """)
+    SCYLLA_DOCTOR_ANALYZER_CONFIG = dedent("""
+        [RAMAnalyzer]
+        ; change recommended ram value for this analyzer as it is not relevant for the test and should not cause test failures
+        ram_recommended_total = 7340032
+        ram_recommended_per_lcore = 3145728
+        [SwapAnalyzer]
+        ; change Recommended RAM to swap ratio for this analyzer as it is not relevant for the test and should not cause test failures
+        ram_swap_ratio = 3.5
+        [StorageRAMRatioAnalyzer]
+        ; Maximum recommended Disk to RAM ratio
+        ratio = 120
+        [ScyllaServicesAnalyzer]
+        ; disable this analyzer
+        run = no
+        [CPUScalingAnalyzer]
+        ; @Vladislav Zolotarov request
+        run = no
+        [RsyslogAnalyzer]
+        ; do not need to configure it, SD check that /etc/rsyslog.d/scylla.conf file exists only
+        run = no
+        [ScyllaInternodeCompressionAnalyzer]
+        ; not relevant for this test
+        run = no
+        [ScyllaSnitchAnalyzer]
+        ; It's default snitch, not relevant to change for this test. Scylla issue https://github.com/scylladb/scylladb/issues/2370
+        run = no
+        [ScyllaUpdateAnalyzer]
+        ; not relevant for this test
+        run = no
+        [ScyllaClusterSystemKeyspacesReplicationAnalyzer]
+        ; in the production the NetworkTopologyStrategy has to be configured, skip for now with Switch internal distributed keyspaces from SimpleStrategy to NetworkTopologyStrategy / EverywhereStrategy / Raft Group 0  · Issue #1796 · scylladb/scylladb
+        run = no
+        [ScyllaConfigurationConsistencyAnalyzer]
+        ; skip
+        skip_source_validation_keys = abort_on_ebadf, abort_on_internal_error, abort_on_lsa_bad_alloc, enable_sstable_key_validation
+        skip_persisted_validation_keys = kms_hosts
+    """)
 
     def __init__(self, node: BaseNode, test_config: TestConfig, offline_install=False):
         self.node = node
@@ -78,7 +116,21 @@ class ScyllaDoctor:
         self.scylla_doctor_exec = "scylla-doctor"
         self.json_result_file = ""
         self.scylla_logs_file = ""
+        self.analysis_report_file = ""
         self.python3_path = ""
+        self._full_edition_downloaded = False
+
+    @property
+    def is_full_edition(self):
+        """Check whether the full (enterprise) edition of Scylla Doctor is actually installed.
+
+        Returns True only when the edition is configured as ``"full"`` AND the
+        full edition binary was successfully downloaded.  If the download failed
+        and fell back to basic, this returns False — preventing the analysis
+        phase from running with a basic edition binary that cannot produce the
+        expected JSON output.
+        """
+        return self.configured_edition == "full" and self._full_edition_downloaded
 
     def run(self, sd_command):
         if self.python3_path:
@@ -91,8 +143,11 @@ class ScyllaDoctor:
 
     @cached_property
     def current_dir(self):
-        result = self.node.remoter.run("pwd", verbose=False)
-        return result.stdout.strip()
+        # Use a dedicated writable directory instead of relying on pwd,
+        # which may point to a non-writable location in Docker containers.
+        sd_dir = "/tmp/scylla_doctor"
+        self.node.remoter.run(f"mkdir -p {sd_dir}", verbose=False)
+        return sd_dir
 
     @cached_property
     def version(self):
@@ -183,8 +238,12 @@ class ScyllaDoctor:
         """Parse an S3 reference into ``(bucket_name, object_key)``.
 
         Supported formats:
+        - ``https://s3.amazonaws.com/BUCKET/KEY`` — path-style URL.
+        - ``https://s3.REGION.amazonaws.com/BUCKET/KEY`` — path-style with region.
+        - ``https://BUCKET.s3.amazonaws.com/KEY`` — virtual-hosted style.
+        - ``https://BUCKET.s3.REGION.amazonaws.com/KEY`` — virtual-hosted with region.
         - ``https://BUCKET/KEY`` — bucket name extracted from host,
-          key from the path.
+          key from the path (legacy/simple format).
         - ``prefix/path/file.tar.gz`` (bare S3 key, no scheme) — uses
           *default_bucket*.
 
@@ -201,9 +260,25 @@ class ScyllaDoctor:
         if not parsed.scheme:
             return default_bucket, url
 
-        # https://BUCKET/KEY
         host = parsed.hostname or ""
         path = parsed.path.lstrip("/")
+
+        # Path-style: https://s3.amazonaws.com/BUCKET/KEY
+        #          or https://s3.REGION.amazonaws.com/BUCKET/KEY
+        if re.match(r"s3([.-][a-z0-9-]+)?\.amazonaws\.com$", host):
+            # First path segment is the bucket, rest is the key
+            parts = path.split("/", 1)
+            bucket = parts[0]
+            key = parts[1] if len(parts) > 1 else ""
+            return bucket, key
+
+        # Virtual-hosted style: https://BUCKET.s3.amazonaws.com/KEY
+        #                     or https://BUCKET.s3.REGION.amazonaws.com/KEY
+        match = re.match(r"(.+)\.s3([.-][a-z0-9-]+)?\.amazonaws\.com$", host)
+        if match:
+            return match.group(1), path
+
+        # Fallback: treat host as bucket name, path as key
         return host, path
 
     @staticmethod
@@ -243,6 +318,10 @@ class ScyllaDoctor:
         Downloads to a temporary file first so that HTTP errors (e.g. S3
         returning a short XML error page) are detected before ``tar`` runs.
 
+        Extraction always targets ``self.current_dir`` via ``-C`` so that
+        it works even when the remoter's working directory is not writable
+        (common in Docker containers).
+
         Args:
             url: Full URL (may be a pre-signed S3 URL).
             description: Human-readable label for log messages.
@@ -275,7 +354,20 @@ class ScyllaDoctor:
                 f"Downloaded {description} file is not a valid gzip tarball. First 500 bytes of response:\n{body_head}"
             )
         LOGGER.info("Extracting %s tarball...", description)
-        self.node.remoter.run(f"tar -xvzf {tmp_tarball} && rm -f {tmp_tarball}")
+        # --no-same-owner: avoid chown failures in Docker containers running as non-root
+        # --no-same-permissions: avoid permission restore issues in restricted environments
+        extract_result = self.node.remoter.run(
+            f"tar -xzf {tmp_tarball} -C {self.current_dir} --no-same-owner --no-same-permissions 2>&1",
+            ignore_status=True,
+        )
+        if extract_result.ok:
+            self.node.remoter.run(f"rm -f {tmp_tarball}", verbose=False, ignore_status=True)
+        else:
+            stderr_output = extract_result.stdout.strip() or extract_result.stderr.strip()
+            self.node.remoter.run(f"rm -f {tmp_tarball}", verbose=False, ignore_status=True)
+            raise ScyllaDoctorException(
+                f"Failed to extract {description} tarball (exit code {extract_result.exited}): {stderr_output}"
+            )
 
     def download_full_scylla_doctor(self):
         """Download the full scylla-doctor edition using an S3 pre-signed URL.
@@ -344,14 +436,6 @@ class ScyllaDoctor:
             LOGGER.info("curl already installed, proceeding...")
         else:
             self.node.install_package("curl")
-
-        tarball_url = self.test_config.tester_obj().params.get("scylla_doctor_tarball_url")
-        if tarball_url:
-            LOGGER.info("Using custom SD tarball URL: %s", tarball_url)
-            self.node.remoter.run(f"curl -JL {tarball_url} | tar -xvz")
-            self.scylla_doctor_exec = f"{self.current_dir}/{self.SCYLLA_DOCTOR_OFFLINE_BIN}"
-            return
-
         if self.configured_version:
             LOGGER.info("Using configured scylla-doctor version: %s", self.configured_version)
             package = self.locate_scylla_doctor_package(version=self.configured_version)
@@ -374,15 +458,20 @@ class ScyllaDoctor:
 
     def update_scylla_doctor_config(self, prefix: str, additional_config=""):
         with remote_file(self.node.remoter, f"{self.current_dir}/{self.SCYLLA_DOCTOR_OFFLINE_CONF}") as f:
-            config = dedent(f"""
-                [DefaultPaths]
-                scylla_directory = {prefix}/scylladb
-                scylla_directory_config = {prefix}/scylladb/etc/scylla
-                scylla_directory_configs = {prefix}/scylladb/etc/scylla.d
-                scylla_directory_var = {prefix}/scylladb
+            # Only override DefaultPaths for nonroot installs where Scylla
+            # lives under $HOME/scylladb instead of system paths.
+            if self.node.is_nonroot_install:
+                default_paths = dedent(f"""
+                    [DefaultPaths]
+                    scylla_directory = {prefix}/scylladb
+                    scylla_directory_config = {prefix}/scylladb/etc/scylla
+                    scylla_directory_configs = {prefix}/scylladb/etc/scylla.d
+                    scylla_directory_var = {prefix}/scylladb
+                """)
+            else:
+                default_paths = ""
 
-                {additional_config}
-            """)
+            config = f"{default_paths}\n{additional_config}\n"
             LOGGER.info("Updating scylla-doctor-config file...\n%s", config)
 
             f.seek(0)
@@ -394,15 +483,22 @@ class ScyllaDoctor:
         if self.node.parent_cluster.cluster_backend == "docker":
             self.node.install_package("ethtool")
             self.node.install_package("tar")
+            self.node.install_package("gzip")
+            self.node.install_package("file")
 
         # Always download from S3 — package repos are not updated at the same
         # time as S3 releases, and specific versions may not be available via repo.
         self.download_scylla_doctor()
         self.python3_path = self.find_scylla_bundled_python3(self.current_dir)
+
+        additional_config = ""
         if self.node.is_nonroot_install:
-            self.update_scylla_doctor_config(
-                self.current_dir, additional_config=self.SCYLLA_DOCTOR_DISABLED_OFFLINE_COLLECTORS
-            )
+            additional_config += self.SCYLLA_DOCTOR_DISABLED_OFFLINE_COLLECTORS
+        if self.is_full_edition:
+            additional_config += self.SCYLLA_DOCTOR_ANALYZER_CONFIG
+
+        if additional_config:
+            self.update_scylla_doctor_config(self.current_dir, additional_config=additional_config)
 
         # TODO: optionally install via package manager (apt/yum/dnf) instead of S3
         #  download. Needs an SCT configuration toggle to enable this path.
@@ -471,7 +567,24 @@ class ScyllaDoctor:
             f"Scylla doctor requires the python3 executable bundled with the Scylla installation."
         )
 
+    def _ensure_lspci(self):
+        """Install pciutils (provides lspci) if not already present."""
+        result = self.node.remoter.sudo("which lspci", ignore_status=True, verbose=False)
+        if result.ok:
+            LOGGER.info("lspci already installed, proceeding...")
+            return
+        LOGGER.info("lspci not found, installing pciutils...")
+        self.node.install_package("pciutils")
+
+    def _ensure_iptables(self):
+        """Install and start iptables service before SD Analyzer run."""
+        self.node.install_package("iptables")
+        self.node.start_service("iptables", ignore_status=True)
+
     def run_scylla_doctor_and_collect_results(self):
+        self._ensure_lspci()
+        self._ensure_iptables()
+
         auth_options = ""
         if credentials := self.node.parent_cluster.get_db_auth():
             auth_options = "-sov CQL,user,{} -sov CQL,password,{} ".format(*credentials)
@@ -501,12 +614,166 @@ class ScyllaDoctor:
         result = self.run(sd_command=f"{self.scylla_doctor_exec} --load-vitals {self.json_result_file} --verbose")
         LOGGER.debug(pprint.pformat(result))
 
+    def run_analysis_phase(self):
+        """Run the analysis phase of Scylla Doctor (full edition only).
+
+        Loads previously collected vitals and runs analyzers to produce
+        findings and recommendations about the cluster health.
+
+        Uses ``--output json`` to get the analysis report in JSON format
+        from stdout, then saves it to a file for later verification.
+        """
+        if not self.is_full_edition:
+            LOGGER.info("Skipping analysis phase — only available for the full edition")
+            return
+
+        if not self.json_result_file:
+            LOGGER.warning("Cannot run analysis phase: no vitals file collected")
+            return
+
+        json_report_name = f"{self.node.public_dns_name}.analysis.json"
+        LOGGER.info("Running Scylla Doctor analysis phase (full edition)...")
+
+        sd_cmd = f"{self.scylla_doctor_exec} --load-vitals {self.json_result_file} --output json"
+        LOGGER.info("Run scylla-doctor command: %s", sd_cmd)
+        stdout_content = self.run(sd_command=sd_cmd)
+
+        # Save the JSON output from stdout to a file
+        if not stdout_content:
+            raise ScyllaDoctorException(f"Analysis phase produced no output. Scylla doctor version: {self.version}")
+        # Use base64 to safely write JSON that may contain special characters
+        encoded = base64.b64encode(stdout_content.encode()).decode()
+        self.node.remoter.sudo(f"bash -c 'echo {encoded} | base64 -d > {json_report_name}'")
+
+        # Verify the JSON report was created
+        verify_result = self.node.remoter.run(
+            f"test -s {json_report_name} && echo {json_report_name}", verbose=False, ignore_status=True
+        )
+        self.analysis_report_file = verify_result.stdout.strip() if verify_result.ok else ""
+        if not self.analysis_report_file:
+            raise ScyllaDoctorException(
+                f"Analysis report file {json_report_name} has not been created. Scylla doctor version: {self.version}"
+            )
+        LOGGER.info("Analysis JSON report saved to: %s", self.analysis_report_file)
+
+    @staticmethod
+    def _extract_json_from_output(content: str) -> dict:
+        """Extract a JSON object from content that may contain non-JSON text.
+
+        Scylla-doctor may prepend human-readable text (ASCII banner, progress
+        markers) before the actual JSON output.  This method first tries direct
+        parsing; if that fails it locates the first ``{`` and uses
+        ``raw_decode`` to parse the JSON object starting there.
+
+        Args:
+            content: Raw output that should contain a JSON object.
+
+        Returns:
+            Parsed JSON as a dict.
+
+        Raises:
+            ScyllaDoctorException: If no valid JSON object can be found.
+        """
+        content = content.strip()
+        if not content:
+            raise ScyllaDoctorException("Analysis output is empty — nothing to parse")
+
+        # Fast path: content is pure JSON
+        try:
+            return json.loads(content)
+        except json.JSONDecodeError:
+            pass
+
+        # Slow path: look for JSON embedded in non-JSON output
+        idx = content.find("{")
+        if idx == -1:
+            raise ScyllaDoctorException(f"No JSON object found in analysis output (first 500 chars): {content[:500]}")
+
+        decoder = json.JSONDecoder()
+        try:
+            obj, _ = decoder.raw_decode(content, idx)
+            return obj
+        except json.JSONDecodeError as exc:
+            raise ScyllaDoctorException(
+                f"Failed to parse JSON from analysis output at position {idx} (first 500 chars): {content[:500]}"
+            ) from exc
+
+    def analyze_vitals_report_known_issues(self, analyzer, value):
+        known_issue = None
+        if (
+            analyzer == "DriverVersionAnalyzer"
+            and "API call error occurred to retrieve the minimum or latest driver version" in value["message"]
+        ):
+            known_issue = "https://scylladb.atlassian.net/browse/SCT-420"
+
+        elif (
+            analyzer == "NodeInstanceTypeAnalyzer"
+            and "'n2-standard-2' instance type is not listed as recommended" in value["message"]
+        ):
+            known_issue = "https://scylladb.atlassian.net/browse/SCT-415"
+
+        elif (
+            analyzer == "NICsAnalyzer"
+            and "EC2 instance class does not support enhanced networking." in value["message"]
+        ):
+            known_issue = "https://scylladb.atlassian.net/browse/SCT-422"
+
+        elif (
+            analyzer == "NodeInstanceTypeAnalyzer"
+            and "'im4gn.xlarge' instance type is not listed as recommended" in value["message"]
+        ):
+            known_issue = "https://scylladb.atlassian.net/browse/SCT-421"
+
+        elif analyzer == "ScyllaSSTablesAnalyzer" and "SSTable format is not 'me'" in value["message"]:
+            known_issue = "https://scylladb.atlassian.net/browse/SCT-455"
+
+        return known_issue
+
+    def analyze_and_verify_analysis_results(self):
+        """Parse the JSON analysis report and verify that no analyzer failed.
+
+        The analysis report is a JSON file produced by ``run_analysis_phase()``
+        (parsed from scylla-doctor's human-readable output).  Each top-level
+        key is an analyzer name mapped to a dict with at least a ``status``
+            PASSED = 0
+            SKIPPED = 1
+            WARNING = 2
+            FAILED = 3
+        """
+        if not self.analysis_report_file:
+            LOGGER.warning("No analysis report file to verify")
+            return
+
+        raw_content = self.node.remoter.sudo(f"cat {self.analysis_report_file}").stdout.strip()
+        analysis_result = self._extract_json_from_output(raw_content)
+        LOGGER.info("Loaded %d analyzer results from JSON report", len(analysis_result))
+
+        LOGGER.debug("Scylla-doctor analysis output: %s", pprint.pformat(analysis_result))
+
+        failed_analyzers = {}
+        for analyzer, value in analysis_result.items():
+            LOGGER.info("Analyzer %s status: %s (%s)", analyzer, value.get("status"), value)
+            if isinstance(value, dict) and value.get("status") not in [0, 1]:  # PASSED, SKIPPED
+                # TODO: temporary workaround. Will be fixed in SD and then this if block should be removed.
+                #  See https://scylladb.atlassian.net/browse/SCT-115
+                if known_issue := self.analyze_vitals_report_known_issues(analyzer, value):
+                    value["known issue"] = known_issue
+                failed_analyzers[analyzer] = value
+
+        LOGGER.info("Failed analyzers: %s", pprint.pformat(failed_analyzers))
+
+        assert not failed_analyzers, (
+            f"Failed analyzers: {pprint.pformat(failed_analyzers)}. Scylla doctor version: {self.version}"
+        )
+
     def filter_out_failed_collectors(self, collector):
         # FirewallRulesCollector return empty result - https://github.com/scylladb/field-engineering/issues/2248
         if collector == "FirewallRulesCollector":
             return True
 
         # https://github.com/scylladb/field-engineering/issues/2288
+        # Docker containers lack many OS-level utilities (ip, iptables, ss, dmesg, timedatectl)
+        # and don't have access to /proc/interrupts or cloud metadata endpoints.
         if self.node.parent_cluster.cluster_backend == "docker" and collector in [
             "StorageConfigurationCollector",
             "PerftuneSystemConfigurationCollector",

--- a/utils/scylla_doctor.py
+++ b/utils/scylla_doctor.py
@@ -5,6 +5,7 @@ import pprint
 import re
 from functools import cached_property
 from textwrap import dedent
+from urllib.parse import urlparse
 
 import boto3
 
@@ -178,6 +179,34 @@ class ScyllaDoctor:
         return package, bucket_name
 
     @staticmethod
+    def _parse_s3_url(url: str, default_bucket: str) -> tuple[str, str]:
+        """Parse an S3 reference into ``(bucket_name, object_key)``.
+
+        Supported formats:
+        - ``https://BUCKET/KEY`` — bucket name extracted from host,
+          key from the path.
+        - ``prefix/path/file.tar.gz`` (bare S3 key, no scheme) — uses
+          *default_bucket*.
+
+        Args:
+            url: The URL or key path to parse.
+            default_bucket: Bucket name to use when *url* is a bare key.
+
+        Returns:
+            Tuple of (bucket_name, object_key).
+        """
+        parsed = urlparse(url)
+
+        # No scheme → treat as a bare S3 key
+        if not parsed.scheme:
+            return default_bucket, url
+
+        # https://BUCKET/KEY
+        host = parsed.hostname or ""
+        path = parsed.path.lstrip("/")
+        return host, path
+
+    @staticmethod
     def _get_bucket_region(bucket_name: str) -> str:
         """Determine the AWS region of an S3 bucket.
 
@@ -253,11 +282,16 @@ class ScyllaDoctor:
 
         Generates a pre-signed URL on the SCT runner side (which has AWS credentials)
         and passes it to curl on the remote node, avoiding the need for AWS credentials on the node.
+
+        If ``scylla_doctor_full_tarball_url`` is configured, it is used directly
+        instead of locating the package in S3.
         """
         if self.node.remoter.run("curl --version", ignore_status=True).ok:
             LOGGER.info("curl already installed, proceeding...")
         else:
             self.node.install_package("curl")
+
+        full_tarball_url = self.test_config.tester_obj().params.get("scylla_doctor_full_tarball_url")
 
         version = self.configured_version
         if version:
@@ -271,6 +305,14 @@ class ScyllaDoctor:
             version_msg = f"version {version}" if version else "latest version"
             raise ScyllaDoctorException(f"Unable to find full scylla-doctor package for {version_msg}")
 
+        if full_tarball_url:
+            custom_bucket, custom_key = self._parse_s3_url(full_tarball_url, default_bucket=bucket_name)
+            if custom_bucket != bucket_name:
+                bucket_name = custom_bucket
+                LOGGER.info("Overriding bucket from full_tarball_url: %s", bucket_name)
+            package["Key"] = custom_key
+            LOGGER.info("Using custom full SD tarball — bucket: %s, key: %s", bucket_name, custom_key)
+
         package_key = package["Key"]
         package_filename = package_key.split("/")[-1]
         LOGGER.info("Downloading full scylla-doctor package %s from bucket %s...", package_filename, bucket_name)
@@ -283,13 +325,13 @@ class ScyllaDoctor:
         bucket_region = self._get_bucket_region(bucket_name)
         LOGGER.info("Bucket %s is in region %s", bucket_name, bucket_region)
         s3 = boto3.client("s3", region_name=bucket_region)
-        presigned_url = s3.generate_presigned_url(
+        download_url = s3.generate_presigned_url(
             ClientMethod="get_object",
             Params={"Bucket": bucket_name, "Key": package_key},
             ExpiresIn=300,
         )
 
-        self._download_and_extract_tarball(presigned_url, description=f"full scylla-doctor ({package_filename})")
+        self._download_and_extract_tarball(download_url, description=f"full scylla-doctor ({package_filename})")
         self.scylla_doctor_exec = f"{self.current_dir}/{self.SCYLLA_DOCTOR_OFFLINE_BIN}"
         self._full_edition_downloaded = True
 
@@ -302,6 +344,14 @@ class ScyllaDoctor:
             LOGGER.info("curl already installed, proceeding...")
         else:
             self.node.install_package("curl")
+
+        tarball_url = self.test_config.tester_obj().params.get("scylla_doctor_tarball_url")
+        if tarball_url:
+            LOGGER.info("Using custom SD tarball URL: %s", tarball_url)
+            self.node.remoter.run(f"curl -JL {tarball_url} | tar -xvz")
+            self.scylla_doctor_exec = f"{self.current_dir}/{self.SCYLLA_DOCTOR_OFFLINE_BIN}"
+            return
+
         if self.configured_version:
             LOGGER.info("Using configured scylla-doctor version: %s", self.configured_version)
             package = self.locate_scylla_doctor_package(version=self.configured_version)

--- a/vars/artifactsPipeline.groovy
+++ b/vars/artifactsPipeline.groovy
@@ -107,6 +107,9 @@ def call(Map pipelineParams) {
             booleanParam(defaultValue: "${pipelineParams.get('run_scylla_doctor_only', false)}",
                    description: 'When true, runs only Scylla Doctor validation and skips the full artifact test flow.',
                    name: 'run_scylla_doctor_only')
+            choice(choices: ["${pipelineParams.get('scylla_doctor_edition', 'basic')}", 'basic', 'full'],
+                   description: "Scylla Doctor edition: 'basic' (collectors only) or 'full' (collectors + analyzers).",
+                   name: 'scylla_doctor_edition')
             separator(name: 'EXTRA_ENVIRONMENTAL_VARIABLES', sectionHeader: 'Extra environment variables Configuration')
             text(defaultValue: "${pipelineParams.get('extra_environment_variables', '')}",
                     description: (
@@ -283,6 +286,9 @@ def call(Map pipelineParams) {
                                                     fi
                                                     if [[ "${params.run_scylla_doctor_only}" == "true" ]]; then
                                                         export SCT_RUN_SCYLLA_DOCTOR_ONLY=true
+                                                    fi
+                                                    if [[ ! -z "${params.scylla_doctor_edition}" ]]; then
+                                                        export SCT_SCYLLA_DOCTOR_EDITION="${params.scylla_doctor_edition}"
                                                     fi
 
                                                     echo "start test ......."

--- a/vars/artifactsPipeline.groovy
+++ b/vars/artifactsPipeline.groovy
@@ -100,6 +100,13 @@ def call(Map pipelineParams) {
             string(defaultValue: "${pipelineParams.get('billing_project', '')}",
                    description: 'Billing project for the test run',
                    name: 'billing_project')
+            separator(name: 'SCYLLA_DOCTOR', sectionHeader: 'Scylla Doctor Configuration')
+            string(defaultValue: "${pipelineParams.get('scylla_doctor_full_tarball_url', '')}",
+                   description: 'Direct URL to a full edition Scylla Doctor tarball in S3. When set, bypasses the standard version-based S3 lookup.',
+                   name: 'scylla_doctor_full_tarball_url')
+            booleanParam(defaultValue: "${pipelineParams.get('run_scylla_doctor_only', false)}",
+                   description: 'When true, runs only Scylla Doctor validation and skips the full artifact test flow.',
+                   name: 'run_scylla_doctor_only')
             separator(name: 'EXTRA_ENVIRONMENTAL_VARIABLES', sectionHeader: 'Extra environment variables Configuration')
             text(defaultValue: "${pipelineParams.get('extra_environment_variables', '')}",
                     description: (
@@ -269,6 +276,13 @@ def call(Map pipelineParams) {
                                                     fi
                                                     if [[ -n "${params.availability_zone ? params.availability_zone : ''}" ]] ; then
                                                         export SCT_AVAILABILITY_ZONE="${params.availability_zone}"
+                                                    fi
+
+                                                    if [[ ! -z "${params.scylla_doctor_full_tarball_url}" ]]; then
+                                                        export SCT_SCYLLA_DOCTOR_FULL_TARBALL_URL="${params.scylla_doctor_full_tarball_url}"
+                                                    fi
+                                                    if [[ "${params.run_scylla_doctor_only}" == "true" ]]; then
+                                                        export SCT_RUN_SCYLLA_DOCTOR_ONLY=true
                                                     fi
 
                                                     echo "start test ......."

--- a/vars/sdReleaseGatingPipeline.groovy
+++ b/vars/sdReleaseGatingPipeline.groovy
@@ -1,0 +1,579 @@
+#!groovy
+
+import groovy.json.JsonSlurperClassic
+import groovy.json.JsonOutput
+
+/**
+ * Builds the HTML gating report from aggregated test results.
+ *
+ * @param results       Map of "os_label/version" → result map (os, version, status, url, error)
+ * @param scyllaVersions Array of Scylla version strings tested
+ * @param sdVersionDisplay Human-readable SD version string
+ * @return Full HTML document as a String
+ */
+def buildHtmlReport(Map results, String[] scyllaVersions, String sdVersionDisplay) {
+    def osLabels = results.values().collect { it.os }.unique()
+    def hasFailures = results.values().any { it.status != 'SUCCESS' }
+    def overallStatus = hasFailures ? 'FAILED' : 'PASSED'
+    def overallColor = hasFailures ? '#d32f2f' : '#388e3c'
+
+    def report = new StringBuilder()
+    report.append(buildHtmlHead())
+    report.append(buildHtmlSummary(sdVersionDisplay, overallStatus, overallColor, scyllaVersions))
+    report.append(buildHtmlResultsTable(results, scyllaVersions, osLabels))
+    report.append(buildHtmlFailuresSection(results))
+    report.append('</body></html>')
+    return report.toString()
+}
+
+/** Returns the HTML doctype, head with styles, and opening body/h1 tags. */
+def buildHtmlHead() {
+    return '''<!DOCTYPE html>
+<html>
+<head>
+<style>
+  body { font-family: Arial, Helvetica, sans-serif; margin: 20px; color: #333; }
+  h1 { color: #1a237e; border-bottom: 2px solid #1a237e; padding-bottom: 8px; }
+  .summary { margin: 16px 0; padding: 12px 16px; background: #f5f5f5; border-radius: 6px; }
+  .summary dt { font-weight: bold; display: inline; }
+  .summary dd { display: inline; margin: 0 24px 0 4px; }
+  .status-badge { display: inline-block; padding: 4px 12px; border-radius: 4px; color: #fff; font-weight: bold; }
+  table { border-collapse: collapse; margin: 20px 0; width: auto; }
+  th, td { border: 1px solid #ccc; padding: 8px 14px; text-align: center; }
+  th { background: #1a237e; color: #fff; }
+  td:first-child { text-align: left; font-weight: bold; }
+  tr:nth-child(even) { background: #fafafa; }
+  .pass { color: #388e3c; font-weight: bold; }
+  .fail { color: #d32f2f; font-weight: bold; }
+  .unstable { color: #f57c00; font-weight: bold; }
+  .aborted { color: #757575; font-weight: bold; }
+  .na { color: #9e9e9e; }
+  .failures { margin-top: 24px; }
+  .failures h2 { color: #d32f2f; }
+  .failure-item { background: #fff3f3; border-left: 4px solid #d32f2f; padding: 8px 12px; margin: 8px 0; border-radius: 0 4px 4px 0; }
+  .failure-item .label { font-weight: bold; }
+  .approved { margin-top: 24px; padding: 12px; background: #e8f5e9; border-left: 4px solid #388e3c; border-radius: 0 4px 4px 0; font-weight: bold; color: #388e3c; }
+</style>
+</head>
+<body>
+<h1>Scylla Doctor Release Gating Report</h1>
+'''
+}
+
+/** Returns the summary section with SD version, overall status badge, and tested versions. */
+def buildHtmlSummary(String sdVersionDisplay, String overallStatus, String overallColor, String[] scyllaVersions) {
+    return """<div class="summary">
+  <dl>
+    <dt>SD Version:</dt><dd>${sdVersionDisplay}</dd>
+    <dt>Overall Status:</dt><dd><span class="status-badge" style="background:${overallColor}">${overallStatus}</span></dd>
+    <dt>Scylla Versions:</dt><dd>${scyllaVersions.join(', ')}</dd>
+  </dl>
+</div>
+"""
+}
+
+/** Returns an HTML table cell with a status icon/link for the given job result. */
+def buildStatusCell(Map result) {
+    if (!result) {
+        return '<span class="na">N/A</span>'
+    }
+    def url = result.url ?: ''
+    def statusMap = [
+        'SUCCESS' : [css: 'pass',     icon: '✅ PASS'],
+        'FAILURE' : [css: 'fail',     icon: '❌ FAIL'],
+        'UNSTABLE': [css: 'unstable', icon: '⚠️ UNSTABLE'],
+        'ABORTED' : [css: 'aborted',  icon: '⏹️ ABORTED'],
+    ]
+    def entry = statusMap[result.status]
+    if (entry) {
+        return url ? "<a class=\"${entry.css}\" href=\"${url}\">${entry.icon}</a>"
+                   : "<span class=\"${entry.css}\">${entry.icon}</span>"
+    }
+    return "<span>${result.status}</span>"
+}
+
+/** Returns the full OS × version results table as HTML. */
+def buildHtmlResultsTable(Map results, String[] scyllaVersions, List osLabels) {
+    def table = new StringBuilder()
+    table.append('<table>\n<tr><th>OS</th>')
+    for (def ver in scyllaVersions) {
+        table.append("<th>${ver}</th>")
+    }
+    table.append('</tr>\n')
+
+    for (def os in osLabels) {
+        table.append('<tr>')
+        table.append("<td>${os}</td>")
+        for (def ver in scyllaVersions) {
+            def result = results["${os}/${ver}"]
+            table.append("<td>${buildStatusCell(result)}</td>")
+        }
+        table.append('</tr>\n')
+    }
+    table.append('</table>\n')
+    return table.toString()
+}
+
+/** Returns the failures detail section, or an approval banner if all passed. */
+def buildHtmlFailuresSection(Map results) {
+    def failedJobs = results.findAll { k, v -> v.status != 'SUCCESS' }
+    if (!failedJobs) {
+        return '<div class="approved">All tests PASSED. SD release is approved. ✅</div>\n'
+    }
+    def section = new StringBuilder()
+    section.append('<div class="failures"><h2>Failures</h2>\n')
+    failedJobs.each { key, result ->
+        section.append('<div class="failure-item">')
+        section.append("<span class=\"label\">${result.os} &times; ${result.version}</span> &mdash; ${result.status}")
+        if (result.url) {
+            section.append(" &nbsp;<a href=\"${result.url}\">View Job</a>")
+        }
+        if (result.error) {
+            section.append("<br/><small>${result.error}</small>")
+        }
+        section.append('</div>\n')
+    }
+    section.append('</div>\n')
+    return section.toString()
+}
+
+/**
+ * Builds a plain-text gating report for Jenkins console output.
+ */
+def buildTextReport(Map results, String[] scyllaVersions, String sdVersionDisplay) {
+    def osLabels = results.values().collect { it.os }.unique()
+    def hasFailures = results.values().any { it.status != 'SUCCESS' }
+    def overallStatus = hasFailures ? 'FAILED' : 'PASSED'
+
+    def colWidth = 15
+    def osColWidth = 20
+    def report = new StringBuilder()
+    report.append('=' * 80 + '\n')
+    report.append("SCYLLA DOCTOR RELEASE GATING REPORT\n")
+    report.append('=' * 80 + '\n\n')
+    report.append("SD Version: ${sdVersionDisplay}\n")
+    report.append("Overall Status: ${overallStatus}\n")
+    report.append("Scylla Versions Tested: ${scyllaVersions.join(', ')}\n\n")
+
+    report.append(String.format("%-${osColWidth}s", 'OS'))
+    for (def ver in scyllaVersions) {
+        report.append(String.format("%-${colWidth}s", ver))
+    }
+    report.append('\n')
+    report.append('-' * (osColWidth + colWidth * scyllaVersions.length) + '\n')
+
+    for (def os in osLabels) {
+        def osUrl = scyllaVersions.collect { ver -> results["${os}/${ver}"] }.find { it?.url }?.url ?: ''
+        def osCell = osUrl ? "${os} (${osUrl})" : os
+        report.append(String.format("%-${osColWidth}s", osCell))
+        for (def ver in scyllaVersions) {
+            def key = "${os}/${ver}"
+            def result = results[key]
+            def statusIcon = 'N/A'
+            if (result) {
+                switch (result.status) {
+                    case 'SUCCESS':  statusIcon = '✅ PASS'; break
+                    case 'FAILURE':  statusIcon = '❌ FAIL'; break
+                    case 'UNSTABLE': statusIcon = '⚠️  UNSTABLE'; break
+                    case 'ABORTED':  statusIcon = '⏹️  ABORTED'; break
+                    default:         statusIcon = "? ${result.status}"; break
+                }
+            }
+            report.append(String.format("%-${colWidth}s", statusIcon))
+        }
+        report.append('\n')
+    }
+    report.append('\n')
+
+    def failedJobs = results.findAll { k, v -> v.status != 'SUCCESS' }
+    if (failedJobs) {
+        report.append("FAILURES:\n")
+        report.append('-' * 80 + '\n')
+        failedJobs.each { key, result ->
+            report.append("  ${result.os} × ${result.version} — ${result.status}\n")
+            if (result.url) {
+                report.append("    → ${result.url}\n")
+            }
+            if (result.error) {
+                report.append("    Error: ${result.error}\n")
+            }
+        }
+    } else {
+        report.append("All tests PASSED. SD release is approved.\n")
+    }
+    report.append('\n' + '=' * 80 + '\n')
+    return report.toString()
+}
+
+/**
+ * Scylla Doctor Release Gating Pipeline
+ *
+ * Triggers all artifact tests in parallel for each supported Scylla version × OS variant
+ * combination, passing SD-specific parameters (version or tarball URL) and the SD-only mode flag.
+ *
+ * After all jobs complete, aggregates results into a summary table showing pass/fail per
+ * OS variant × Scylla version, with links to individual job logs for failed runs.
+ */
+def call(Map pipelineParams = [:]) {
+    List discoveredVersions = []
+
+    // Artifact test job definitions: each entry maps a human-readable OS label to the
+    // Jenkins job path (relative to the current folder) and backend-specific settings.
+    // The job paths use '..' prefix to reference sibling folders in the Jenkins job tree.
+
+    def ARTIFACT_TEST_JOBS = [
+        [
+            os_label: 'centos9',
+            job_path: 'oss/artifacts/artifacts-centos9-test',
+            backend: 'gce',
+        ],
+        [
+            os_label: 'rocky9',
+            job_path: 'oss/artifacts/artifacts-rocky9-test',
+            backend: 'gce',
+        ],
+        [
+            os_label: 'ubuntu2404',
+            job_path: 'oss/artifacts/artifacts-ubuntu2404-test',
+            backend: 'gce',
+        ],
+        [
+            os_label: 'debian12',
+            job_path: 'oss/artifacts/artifacts-debian12-test',
+            backend: 'gce',
+        ],
+        [
+            os_label: 'ami',
+            job_path: 'oss/artifacts/artifacts-ami-test',
+            backend: 'aws',
+        ],
+        [
+            os_label: 'amazon2023-arm',
+            job_path: 'oss/artifacts/artifacts-amazon2023-arm-test',
+            backend: 'aws',
+        ],
+        [
+            os_label: 'ubuntu2204',
+            job_path: 'oss/artifacts/artifacts-ubuntu2204-test',
+            backend: 'gce',
+        ],
+        [
+            os_label: 'rhel10',
+            job_path: 'oss/artifacts/artifacts-rhel10-test',
+            backend: 'aws',
+        ],
+        // AMI is not found for OEL9, so we are skipping it for now. We can re-enable it later when the AMI will be available.
+//         [
+//             os_label: 'oel9',
+//             job_path: 'oss/artifacts/artifacts-oel9-test',
+//             backend: 'aws',
+//         ],
+        [
+            os_label: 'amazon2023',
+            job_path: 'oss/artifacts/artifacts-amazon2023-test',
+            backend: 'aws',
+        ],
+        [
+            os_label: 'centos9-arm',
+            job_path: 'oss/artifacts/artifacts-centos9-arm-test',
+            backend: 'aws',
+        ],
+        [
+            os_label: 'ubuntu2204-arm',
+            job_path: 'oss/artifacts/artifacts-ubuntu2204-arm-test',
+            backend: 'aws',
+        ],
+        [
+            os_label: 'ubuntu2404-arm',
+            job_path: 'oss/artifacts/artifacts-ubuntu2404-arm-test',
+            backend: 'aws',
+        ],
+        [
+            os_label: 'ami-arm',
+            job_path: 'oss/artifacts/artifacts-ami-arm-test',
+            backend: 'aws',
+        ],
+        [
+            os_label: 'docker',
+            job_path: 'oss/artifacts/artifacts-docker-test',
+            backend: 'docker',
+        ],
+    ]
+
+    def builder = getJenkinsLabels('aws', 'eu-west-1')
+
+    pipeline {
+        agent {
+            label {
+                label builder.label
+            }
+        }
+
+        environment {
+            AWS_ACCESS_KEY_ID     = credentials('qa-aws-secret-key-id')
+            AWS_SECRET_ACCESS_KEY = credentials('qa-aws-secret-access-key')
+        }
+
+        parameters {
+            separator(name: 'SD_CONFIG', sectionHeader: 'Scylla Doctor Configuration')
+            string(name: 'sd_tarball_url', defaultValue: '',
+                   description: '(Required) Direct URL to a Scylla Doctor tarball in S3. Downloads SD directly from this URL, bypassing the standard version-based S3 lookup.')
+
+            separator(name: 'SCYLLA_CONFIG', sectionHeader: 'Scylla Version Configuration')
+            string(name: 'scylla_versions', defaultValue: '',
+                   description: 'Space-separated list of Scylla versions to test (e.g., "2025.1.12 2026.1.1"). Leave empty to auto-discover the latest patch of each supported enterprise release branch.')
+
+            separator(name: 'JOB_CONFIG', sectionHeader: 'Job Configuration')
+            string(name: 'os_filter', defaultValue: '',
+                   description: 'Comma-separated list of OS labels to test (e.g., "centos9,ubuntu2204,docker"). Leave empty to test all OS variants.')
+            string(name: 'post_behavior_db_nodes', defaultValue: 'destroy',
+                   description: 'keep|keep-on-failure|destroy')
+            string(name: 'provision_type', defaultValue: 'spot',
+                   description: 'on_demand|spot|spot_fleet')
+
+            separator(name: 'NOTIFICATION_CONFIG', sectionHeader: 'Notification Configuration')
+            string(name: 'email_recipients', defaultValue: 'vladz@scylladb.com',
+                   description: 'Email recipients for the gating summary report')
+            string(name: 'requested_by_user', defaultValue: 'scylla-doctor',
+                   description: 'Actual user requesting job start, for automated job builds')
+        }
+
+        options {
+            timestamps()
+            buildDiscarder(logRotator(numToKeepStr: '30'))
+            timeout(time: 180, unit: 'MINUTES')
+        }
+
+        stages {
+            stage('Preparation') {
+                when { expression { env.BUILD_NUMBER == '1' } }
+                steps {
+                    script {
+                        if (currentBuild.getBuildCauses('hudson.model.Cause$UserIdCause') != null) {
+                            currentBuild.description = ('Aborted build#1 not having parameters loaded. \n'
+                              + 'Build#2 is ready to run')
+                            currentBuild.result = 'ABORTED'
+                            error('Abort build#1 which only loads params')
+                        }
+                    }
+                }
+            }
+
+            stage('Validate Parameters') {
+                steps {
+                    script {
+                        if (!params.sd_tarball_url?.trim()) {
+                            error("'sd_tarball_url' is required. Provide a direct URL to a Scylla Doctor tarball in S3.")
+                        }
+                    }
+                }
+            }
+
+            stage('Checkout') {
+                steps {
+                    dir('scylla-cluster-tests') {
+                        timeout(time: 5, unit: 'MINUTES') {
+                            checkout scm
+                        }
+                    }
+                }
+            }
+
+            stage('Discover Scylla Versions') {
+                steps {
+                    catchError(stageResult: 'FAILURE') {
+                        timeout(time: 10, unit: 'MINUTES') {
+                            script {
+                                if (params.scylla_versions?.trim()) {
+                                    // Use explicitly provided versions
+                                    discoveredVersions = params.scylla_versions.trim().split('\\s+') as List
+                                    println("Using explicitly provided Scylla versions: ${discoveredVersions}")
+                                } else {
+                                    // Auto-discover supported enterprise release versions using sct.py
+                                    dir('scylla-cluster-tests') {
+                                        dockerLogin(params)
+
+                                        def output = sh(
+                                            returnStdout: true,
+                                            script: './docker/env/hydra.sh get-official-supported-versions --only-print-versions true'
+                                        ).trim()
+
+                                        println("Hydra version discovery output:\n${output}")
+                                        // The last line contains space-separated versions
+                                        def versionLine = output.split('\n').last().trim()
+                                        if (versionLine) {
+                                            discoveredVersions = versionLine.split('\\s+') as List
+                                            println("Auto-discovered Scylla versions: ${discoveredVersions}")
+                                        } else {
+                                            error("Failed to auto-discover Scylla versions. Output: ${output}")
+                                        }
+                                    }
+                                }
+
+                                if (!discoveredVersions) {
+                                    error("No Scylla versions discovered or provided. Cannot proceed.")
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            stage('Run Artifact Tests') {
+                steps {
+                    script {
+                        def scyllaVersions = discoveredVersions as String[]
+                        println("Scheduling artifact tests for Scylla versions: ${scyllaVersions}")
+                        def osFilter = params.os_filter?.trim() ? params.os_filter.trim().split(',').collect { it.trim() } : []
+
+                        // Filter OS variants if os_filter is specified
+                        def jobsToRun = ARTIFACT_TEST_JOBS
+                        if (osFilter) {
+                            jobsToRun = ARTIFACT_TEST_JOBS.findAll { osFilter.contains(it.os_label) }
+                            println("Filtered OS variants: ${jobsToRun*.os_label}")
+                        }
+
+                        // Track results: key = "os_label/scylla_version", value = result map
+                        def results = Collections.synchronizedMap([:])
+                        def parallelJobs = [:]
+
+                        for (def jobDef in jobsToRun) {
+                            for (def version in scyllaVersions) {
+                                println("Scheduling job for OS=${jobDef.os_label}, Scylla version=${version}")
+                                def osLabel = jobDef.os_label
+                                def jobPath = jobDef.job_path
+                                def stageKey = "${osLabel}/${version}"
+                                def scyllaVersion = version
+
+                                parallelJobs[stageKey] = {
+                                    def jobResult = [
+                                        os: osLabel,
+                                        version: scyllaVersion,
+                                        status: 'NOT_RUN',
+                                        url: '',
+                                    ]
+                                    try {
+                                        // Resolve job path relative to current folder
+                                        def currentJobDir = JOB_NAME.substring(0, JOB_NAME.lastIndexOf('/'))
+                                        def fullJobPath = "${currentJobDir}/${jobPath}"
+                                        println("Triggering job at path: ${fullJobPath} with parameters: scylla_version=${scyllaVersion}, sd_tarball_url=${params.sd_tarball_url.trim()}, post_behavior_db_nodes=${params.post_behavior_db_nodes}, provision_type=${params.provision_type}, requested_by_user=${params.requested_by_user}")
+
+                                        def triggered = build(
+                                            job: fullJobPath,
+                                            wait: true,
+                                            propagate: false,
+                                            parameters: [
+                                                string(name: 'scylla_version', value: scyllaVersion),
+                                                string(name: 'scylla_doctor_full_tarball_url', value: params.sd_tarball_url.trim()),
+                                                string(name: 'scylla_doctor_edition', value: 'full'),
+                                                booleanParam(name: 'run_scylla_doctor_only', value: true),
+                                                string(name: 'post_behavior_db_nodes', value: params.post_behavior_db_nodes),
+                                                string(name: 'provision_type', value: params.provision_type),
+                                                string(name: 'email_recipients', value: ''),  // Suppress per-job emails
+                                                string(name: 'requested_by_user', value: params.requested_by_user),
+                                            ]
+                                        )
+                                        jobResult.status = triggered.result ?: 'UNKNOWN'
+                                        jobResult.url = triggered.absoluteUrl ?: ''
+
+                                        // Capture error details from failed builds
+                                        if (triggered.result && triggered.result != 'SUCCESS') {
+                                            try {
+                                                def description = triggered.rawBuild?.description ?: ''
+                                                def failureCause = triggered.rawBuild?.getLog(50)?.join('\n') ?: ''
+                                                jobResult.error = description ?: "Job finished with ${triggered.result}. Check ${jobResult.url} for details."
+                                            } catch (Exception logEx) {
+                                                jobResult.error = "Job finished with ${triggered.result}. Check ${jobResult.url} for details."
+                                            }
+                                        }
+                                    } catch (Exception e) {
+                                        jobResult.status = 'FAILURE'
+                                        jobResult.url = ''
+                                        jobResult.error = "Error triggering job: ${e.message}"
+                                        println("Error triggering ${stageKey}: ${e.message}")
+                                    }
+                                    results[stageKey] = jobResult
+
+                                    // Print errors to trigger console for immediate visibility
+                                    if (jobResult.status != 'SUCCESS') {
+                                        println("=" * 60)
+                                        println("FAILED: ${stageKey} — ${jobResult.status}")
+                                        if (jobResult.url) {
+                                            println("  Job URL: ${jobResult.url}")
+                                        }
+                                        if (jobResult.error) {
+                                            println("  Error: ${jobResult.error}")
+                                        }
+                                        println("=" * 60)
+                                    }
+                                }
+                            }
+                        }
+
+                        // Execute all jobs in parallel
+                        parallel parallelJobs
+
+                        // Store results for the report stage
+                        env.GATING_RESULTS_JSON = JsonOutput.toJson(results)
+                    }
+                }
+            }
+
+            stage('Generate Report') {
+                steps {
+                    script {
+                        def results = new JsonSlurperClassic().parseText(env.GATING_RESULTS_JSON)
+                        def scyllaVersions = discoveredVersions as String[]
+                        def sdVersionDisplay = "tarball: ${params.sd_tarball_url}"
+
+                        // Print plain-text report to Jenkins console
+                        println(buildTextReport(results, scyllaVersions, sdVersionDisplay))
+
+                        // Write HTML report for email notification and archiving
+                        writeFile file: 'sd-gating-report.html', text: buildHtmlReport(results, scyllaVersions, sdVersionDisplay)
+
+                        // Set build description with summary
+                        def hasFailures = results.values().any { it.status != 'SUCCESS' }
+                        def overallStatus = hasFailures ? 'FAILED' : 'PASSED'
+                        def passCount = results.count { k, v -> v.status == 'SUCCESS' }
+                        def totalCount = results.size()
+                        currentBuild.description = "SD ${sdVersionDisplay} | ${overallStatus} | ${passCount}/${totalCount} passed"
+
+                        if (hasFailures) {
+                            currentBuild.result = 'FAILURE'
+                        }
+                    }
+                }
+            }
+
+            stage('Send Notification') {
+                when {
+                    expression { params.email_recipients?.trim() }
+                }
+                steps {
+                    script {
+                        def results = new JsonSlurperClassic().parseText(env.GATING_RESULTS_JSON)
+                        def hasFailures = results.values().any { it.status != 'SUCCESS' }
+                        def status = hasFailures ? 'FAILED' : 'PASSED'
+
+                        def sdFileName = params.sd_tarball_url.trim().tokenize('/').last()
+                        def dateTime = new Date().format("yyyy-MM-dd HH:mm", TimeZone.getTimeZone('UTC'))
+
+                        emailext(
+                            subject: "SD Release Gating ${status}: ${sdFileName} (${dateTime} UTC)",
+                            body: readFile('sd-gating-report.html'),
+                            to: params.email_recipients,
+                            mimeType: 'text/html'
+                        )
+                    }
+                }
+            }
+        }
+
+        post {
+            always {
+                archiveArtifacts artifacts: 'sd-gating-report.html', allowEmptyArchive: true
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add support for running the Scylla Doctor analysis phase when scylla_doctor_edition=full. The analysis phase loads previously collected vitals and runs analyzers to produce findings and recommendations about cluster health.


### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [sd-release-gating](https://jenkins.scylladb.com/job/scylla-doctor/job/sd-release-gating/14/)
- [x] [GCE - artifacts-debian12-test with Scylla version parameter](https://argus.scylladb.com/tests/scylla-cluster-tests/dda06b89-49ca-4930-a1cc-5c3a24046887)
- [x] [GCE - artifacts-debian12-test with Scylla repo parameter](https://argus.scylladb.com/tests/scylla-cluster-tests/e0d697d8-1b34-41d9-8f9c-5398659a2a5c)
- [x] [AWS - artifacts-amazon2023-arm-test with Scylla repo parameter](https://argus.scylladb.com/tests/scylla-cluster-tests/7bd1281c-a2f0-49d8-9296-8946e99d1a50)
- [x] [Docker - artifacts-docker-test](https://argus.scylladb.com/tests/scylla-cluster-tests/9ed6aef3-a885-4fcc-8552-e107cf93f3c9)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
