### PR TITLE
fix(platform-migration): move weekend test run to us-east-2

### DIFF
--- a/jenkins-pipelines/oss/platform-migration/platform-migration-50perc-batched.jenkinsfile
+++ b/jenkins-pipelines/oss/platform-migration/platform-migration-50perc-batched.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    region: 'eu-west-1',
+    region: 'us-east-2',
     test_name: 'platform_migration_test.PlatformMigrationTest.test_migrate_platform_batched',
     test_config: '''["test-cases/platform-migration/x86-to-arm-single-dc-50-perc.yaml", "test-cases/platform-migration/x86-to-arm-batched.yaml"]'''
 )


### PR DESCRIPTION
Running the test setup for batched migration - 8 DB nodes at peak plus loaders and monitor - in eu-west-1 competes with the weekend jobs, causing regular insufficient-capacity failures of this test. us-east-2 carries no other SCT load and offers all instance types in every AZ.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
