### PR TITLE
fix(mgmt-restore): exclude CDC table from restore keyspace list by default

### DIFF
--- a/sdcm/mgmt/cli.py
+++ b/sdcm/mgmt/cli.py
@@ -11,6 +11,7 @@
 #
 # Copyright (c) 2021 ScyllaDB
 
+from functools import cached_property
 import time
 import logging
 import datetime
@@ -40,6 +41,7 @@ from sdcm.provision.helpers.certificate import TLSAssets
 from sdcm.utils.context_managers import DbNodeLogger
 from sdcm.utils.database_query_utils import is_system_keyspace
 from sdcm.utils.replication_strategy_utils import ReplicationStrategy
+from sdcm.utils.version_utils import ComparableScyllaVersion
 from sdcm.wait import WaitForTimeoutError
 
 LOGGER = logging.getLogger(__name__)
@@ -674,6 +676,44 @@ class ManagerCluster(ScyllaManagerBase):
     def set_cluster_id(self, value: str):
         self.id = value
 
+    # Temporary workaround for https://scylladb.atlassian.net/browse/SCT-363
+    # In Scylla >= 2026.2, system_distributed_everywhere.cdc_generation_descriptions_v2 was removed
+    # (https://github.com/scylladb/scylladb/pull/29482), but it may still be present in backup snapshots
+    # taken from older versions. Excluding it prevents SM from failing on restore.
+    # Remove this once Scylla Manager excludes CDC tables from backup/restore automatically
+    # (https://scylladb.atlassian.net/browse/CLOUD-1519).
+    CDC_LEGACY_TABLE_EXCLUSION = ["*", "!system_distributed_everywhere.cdc_generation_descriptions_v2"]
+
+    @cached_property
+    def scylla_version(self) -> str | None:
+        """Get the Scylla version from 'sctool status' output.
+
+        Parses the 'Scylla' column from the status table. Returns the version
+        of the first node found, or None if the column is not present (older SM versions).
+
+        Example 'sctool status' output:
+        # ╭────┬──────────┬──────────┬──────────────┬─────────┬──────┬───────────┬───────────┬───────┬─────────────────────╮
+        # │    │ CQL      │ REST     │ Address      │ Uptime  │ CPUs │ Memory    │ Scylla    │ Agent │ Host ID             │
+        # ├────┼──────────┼──────────┼──────────────┼─────────┼──────┼───────────┼───────────┼───────┼─────────────────────┤
+        # │ UN │ UP (0ms) │ UP (1ms) │ 10.12.10.234 │ 5h3m44s │ 4    │ 30.750GiB │ 2025.4.10 │ 3.8.1 │ 5debe5b1-a823-...   │
+        # │ UN │ UP (2ms) │ UP (2ms) │ 10.12.11.9   │ 5h3m43s │ 4    │ 30.750GiB │ 2025.4.10 │ 3.8.1 │ b33de7c9-3d00-...   │
+        # ╰────┴──────────┴──────────┴──────────────┴─────────┴──────┴───────────┴───────────┴───────┴─────────────────────╯
+        """
+        try:
+            dict_status_tables = self.sctool.run(
+                cmd=f"status -c {self.id}", is_verify_errorless_result=True, is_multiple_tables=True
+            )
+            for _dc_name, hosts_table in dict_status_tables.items():
+                if len(hosts_table) < 2:
+                    continue
+                if "Scylla" not in hosts_table[0]:
+                    return None
+                versions = self.sctool.get_all_column_values_from_table(hosts_table, "Scylla")
+                return versions[0].strip() if versions else None
+        except Exception as exc:  # noqa: BLE001
+            LOGGER.warning("Failed to get Scylla version from sctool status: %s", exc)
+        return None
+
     def create_restore_task(
         self,
         restore_schema=False,
@@ -682,6 +722,7 @@ class ManagerCluster(ScyllaManagerBase):
         snapshot_tag=None,
         dc_mapping=None,
         manager_backup_restore_method=None,
+        keyspace_list=None,
         extra_params=None,
     ):
         cmd = f"restore -c {self.id}"
@@ -689,6 +730,14 @@ class ManagerCluster(ScyllaManagerBase):
             cmd += " --restore-schema"
         if restore_data:
             cmd += " --restore-tables"
+            # Apply version-aware CDC table exclusion if no explicit keyspace filter provided
+            if keyspace_list is None and self.scylla_version:
+                if ComparableScyllaVersion(self.scylla_version) >= "2026.2.0~dev":
+                    keyspace_list = self.CDC_LEGACY_TABLE_EXCLUSION
+            # --keyspace flag is only applicable for --restore-tables mode
+            if keyspace_list:
+                keyspaces_names = ",".join(keyspace_list)
+                cmd += f" --keyspace '{keyspaces_names}'"
         if location_list:
             locations_names = ",".join(location_list)
             cmd += f" --location {locations_names} "


### PR DESCRIPTION
Added a version-aware keyspace exclusion filter to create_restore_task()
that excludes system_distributed_everywhere.cdc_generation_descriptions_v2
on Scylla >= 2026.2. This table was removed in newer Scylla versions but
may still be present in backup snapshots taken from older versions, causing
Scylla Manager restore to fail. The filter is only applied when the target
cluster runs a version where the table no longer exists. This is a
temporary workaround until Scylla Manager handles CDC table exclusion
natively.

Fixes: https://scylladb.atlassian.net/browse/SCT-363
Refs: https://scylladb.atlassian.net/browse/CLOUD-1519

Refs: https://github.com/scylladb/scylladb/pull/29482

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [restore_a_2025_backup](https://argus.scylladb.com/tests/scylla-cluster-tests/ab55fcd3-0af2-4722-86e5-f243ed449127)
--  The test passed the workaround part ok. (Then later it failed for a different non-related SM issue of https://scylladb.atlassian.net/browse/SCYLLADB-2526 )

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
