### PR TITLE
fix(nemesis): fix ModifyTableCompactionMonkey TWCS window/TTL conflict

### DIFF
--- a/sdcm/nemesis/monkey/modify_table.py
+++ b/sdcm/nemesis/monkey/modify_table.py
@@ -195,12 +195,26 @@ class ModifyTableCompactionMonkey(ModifyTableBaseMonkey):
         prop_val = self.random.choice(strategies)()
 
         if prop_val["class"] == "TimeWindowCompactionStrategy":
-            # Max allowed TTL - 49 days (4300000) (to be compatible with default TWCS settings)
-            self.modify_table_property(
-                name="default_time_to_live", val=str(4300000), filter_out_table_with_counter=True
+            # Pick the table upfront so both the compaction and TTL changes target the same table.
+            ks_cfs = self.runner.cluster.get_non_system_ks_cf_list(
+                db_node=self.runner.target_node,
+                filter_out_table_with_counter=True,
+                filter_out_mv=True,
             )
+            if not ks_cfs:
+                raise UnsupportedNemesis("No non-system user tables found")
+            keyspace_table = self.random.choice(ks_cfs)
 
-        self.modify_table_property(name="compaction", val=str(prop_val))
+            # Max allowed TTL - 49 days (4300000) (to be compatible with default TWCS settings)
+            # Set compaction BEFORE default_time_to_live.  The table may currently have TWCS
+            # with a smaller window (e.g. 1 h from a previous nemesis run).  Setting
+            # TTL=4_300_000 against a 1-hour window would exceed twcs_max_window_count=50
+            # (4_300_000 / 3_600 ≈ 1194).  After switching to a DAYS-based window the TTL
+            # is always within the limit (4_300_000 / 86_400 ≈ 49.8 < 50).
+            self.modify_table_property(name="compaction", val=str(prop_val), keyspace_table=keyspace_table)
+            self.modify_table_property(name="default_time_to_live", val=4_300_000, keyspace_table=keyspace_table)
+        else:
+            self.modify_table_property(name="compaction", val=str(prop_val))
 
 
 class ModifyTableCompressionMonkey(ModifyTableBaseMonkey):

--- a/unit_tests/unit/nemesis/monkey/test_modify_table.py
+++ b/unit_tests/unit/nemesis/monkey/test_modify_table.py
@@ -103,8 +103,10 @@ def test_comment_monkey(runner):
     assert monkey.runner.executed[-1] == "ALTER TABLE ks1.tbl1 WITH comment = 'abc123';"
 
 
-def test_compaction_twcs_sets_ttl_before_compaction(runner):
-    """When TimeWindowCompactionStrategy is chosen, default_time_to_live must be set first."""
+def test_compaction_twcs_sets_compaction_before_ttl(runner):
+    """When TimeWindowCompactionStrategy is chosen, compaction must be set before
+    default_time_to_live so that the new DAYS-based window is active when ScyllaDB
+    validates the TTL against twcs_max_window_count."""
     monkey = ModifyTableCompactionMonkey(runner)
     # Force the TWCS lambda to be picked
     monkey.random.choice = lambda seq: seq[2] if callable(seq[0]) else seq[0]
@@ -113,8 +115,8 @@ def test_compaction_twcs_sets_ttl_before_compaction(runner):
 
     stmts = monkey.runner.executed
     assert len(stmts) == 2
-    assert "default_time_to_live = 4300000" in stmts[0]
-    assert "'class': 'TimeWindowCompactionStrategy'" in stmts[1]
+    assert "'class': 'TimeWindowCompactionStrategy'" in stmts[0]
+    assert "default_time_to_live = 4300000" in stmts[1]
 
 
 def test_default_ttl_non_twcs(runner):


### PR DESCRIPTION
When switching to TWCS, the old code set default_time_to_live=4_300_000 before applying the new compaction strategy. If the table already had TWCS with a small window (e.g. 1 h) from a prior nemesis run, ScyllaDB rejected the ALTER TABLE with:

> ConfigurationException: default_time_to_live=4300000 and compaction window=3600(s) can lead to 1194 windows, which is larger than twcs_max_window_count (50)

Two bugs fixed:

1. Order: set compaction first, then default_time_to_live.  After switching to a DAYS-based window (minimum 86 400 s) the TTL is always within the limit: 4_300_000 / 86_400 ≈ 49.8 < 50.

2. Same table: previously each modify_table_property call picked a random table independently, so the TTL change and the compaction change could land on different tables.  The table is now selected upfront and passed explicitly to both calls.

Fixes: #12505

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
