### PR TITLE
fix(nemesis): always add node after removal even if repair fails

### DIFF
--- a/sdcm/nemesis/__init__.py
+++ b/sdcm/nemesis/__init__.py
@@ -3780,9 +3780,17 @@ class NemesisRunner:
 
         # full cluster repair
         # Repairing will result in a best effort repair due to the terminated node,
-        # and as a result requires ignoring repair errors
-        with DbEventsFilter(db_event=DatabaseLogEvent.RUNTIME_ERROR, line="failed to repair"):
-            self.run_repair(ignore_down_hosts=True)
+        # and as a result requires ignoring repair errors.
+        # Even if repair fails, we must still add a replacement node so the
+        # cluster is left with the original number of nodes.
+        try:
+            with DbEventsFilter(db_event=DatabaseLogEvent.RUNTIME_ERROR, line="failed to repair"):
+                self.run_repair(ignore_down_hosts=True)
+        except Exception as exc:  # noqa: BLE001
+            InfoEvent(
+                message=f"Repair failed after removing node {node_to_remove.name}: {exc}",
+                severity=Severity.ERROR,
+            ).publish()
 
         # add new node with same type (data node / zero token node)
         new_node_args = {"count": 1, "rack": self.target_node.rack}


### PR DESCRIPTION
In `_remove_node_add_node`, wrap the best-effort repair call in a try/except so that `_add_and_init_new_cluster_nodes` is always reached, keeping the cluster at its original node count.

Fixes: SCT-190

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
