### PR TITLE
ci(oci): wait for rpm lock on rhel-based distros

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -97,6 +97,7 @@ from sdcm.remote.remote_file import remote_file, yaml_file_to_dict, dict_to_yaml
 from sdcm import wait, mgmt
 from sdcm.sct_config import SCTConfiguration
 from sdcm.utils.apt import apt_cmd
+from sdcm.utils.rpm import rpm_cmd
 from sdcm.sct_events.continuous_event import ContinuousEventsRegistry
 from sdcm.sct_events.system import AwsKmsEvent
 from sdcm.snitch_configuration import SnitchConfig
@@ -2263,7 +2264,7 @@ class BaseNode(AutoSshContainerMixin):
 
         if debug_install:
             if self.distro.is_rhel_like:
-                self.remoter.sudo("yum install -y scylla-gdb", verbose=True, ignore_status=True)
+                self.remoter.sudo(rpm_cmd("yum", "install -y scylla-gdb"), verbose=True, ignore_status=True)
             elif self.distro.is_sles:
                 self.remoter.sudo("zypper install -y scylla-gdb", verbose=True, ignore_status=True)
 
@@ -2467,15 +2468,23 @@ class BaseNode(AutoSshContainerMixin):
     )
     def install_package(self, package_name: str, package_version: str = None, ignore_status: bool = False) -> None:
         if self.distro.is_rhel_like:
-            pkg_cmd = next(
+            pkg_mgr = next(
                 mgr
                 for mgr in ["microdnf", "yum", "dnf"]
                 if self.remoter.run(f"test -e /usr/bin/{mgr}", ignore_status=True).ok
             )
+            if not pkg_mgr:
+                raise NodeSetupFailed(
+                    node=self,
+                    error_msg="No supported RPM package manager found (expected one of: microdnf, yum, dnf)",
+                )
             package_name = f"{package_name}-{package_version}*" if package_version else package_name
+            install_cmd = rpm_cmd(pkg_mgr, f"install -y {package_name}")
+            update_cmd = rpm_cmd(pkg_mgr, "update -y")
         elif self.distro.is_sles:
-            pkg_cmd = "zypper"
             package_name = f"{package_name}-{package_version}" if package_version else package_name
+            install_cmd = f"zypper install -y {package_name}"
+            update_cmd = "zypper update -y"
         else:
             pkg_cmd = apt_cmd()
             version_prefix = f"={package_version}*" if package_version else ""
@@ -2489,11 +2498,13 @@ class BaseNode(AutoSshContainerMixin):
                     f"{pkg}{version_prefix}" for pkg in [package_name] + list(set(result.stdout.splitlines()))
                 ]
                 package_name = " ".join(packages_to_install)
+            install_cmd = f"{pkg_cmd} install -y {package_name}"
+            update_cmd = f"{pkg_cmd} update"
         if self.is_kubernetes():
             # NOTE: run "update" command because on K8S after each pod recreation we lose previous "update" results.
             #       And running some old Scylla docker images we may get errors refering to old/removed mirrors.
-            self.remoter.sudo(f"{pkg_cmd} update", ignore_status=ignore_status)
-        self.remoter.sudo(f"{pkg_cmd} install -y {package_name}", ignore_status=ignore_status)
+            self.remoter.sudo(update_cmd, ignore_status=ignore_status)
+        self.remoter.sudo(install_cmd, ignore_status=ignore_status)
 
     def install_manager_agent(self, package_path: Optional[str] = None) -> None:
         package_name = "scylla-manager-agent"
@@ -2658,10 +2669,10 @@ class BaseNode(AutoSshContainerMixin):
                 self.install_epel()
             self.remoter.run("sudo yum remove -y abrt")  # https://docs.scylladb.com/operating-scylla/admin/#core-dumps
             version = f"-{scylla_version}*" if scylla_version else ""
-            self.remoter.run(f"sudo yum install -y {self.scylla_pkg()}{version}")
+            self.remoter.run(f"sudo {rpm_cmd('yum', f'install -y {self.scylla_pkg()}{version}')}", retry=3, timeout=600)
             # scylla-node-exporter is now independently versioned and may not be pulled
             # as a dependency of the scylla meta-package, so install it explicitly.
-            self.remoter.run("sudo yum install -y scylla-node-exporter", ignore_status=True)
+            self.remoter.run(f"sudo {rpm_cmd('yum', 'install -y scylla-node-exporter')}", ignore_status=True)
         elif self.distro.is_sles15:
             self.remoter.sudo("SUSEConnect --product sle-module-legacy/15.3/x86_64")
             self.remoter.sudo("SUSEConnect --product sle-module-python2/15.3/x86_64")
@@ -3769,12 +3780,13 @@ class BaseNode(AutoSshContainerMixin):
 
         if self.distro.is_rhel8:
             self.remoter.run(
-                "sudo yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm"
+                f"sudo {rpm_cmd('yum', 'install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm')}",
+                retry=3,
             )
         elif self.distro.is_oel8:
-            self.remoter.run("sudo yum install -y oracle-epel-release-el8")
+            self.remoter.run(f"sudo {rpm_cmd('yum', 'install -y oracle-epel-release-el8')}", retry=3)
         else:
-            self.remoter.run("sudo yum install -y epel-release", retry=3)
+            self.remoter.run(f"sudo {rpm_cmd('yum', 'install -y epel-release')}", retry=3)
 
     def is_machine_image_configured(self):
         smi_configured_path = "/etc/scylla/machine_image_configured"

--- a/sdcm/utils/rpm.py
+++ b/sdcm/utils/rpm.py
@@ -1,0 +1,47 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2026 ScyllaDB
+
+
+def rpm_cmd(pkg_manager: str, subcommand: str, lock_timeout: int = 120) -> str:
+    """Build a yum/dnf/microdnf command string with rpm lock tolerance baked in.
+
+    Analogous to sdcm/utils/apt.py:apt_cmd() which uses DPkg::Lock::Timeout.
+    Since yum/dnf have no native lock-wait flag, we prefix the command with a
+    shell loop that polls fuser on the rpm lock file.
+
+    On OCI, oracle-cloud-agent holds the lock at boot while installing monitoring
+    plugins.  Other transient holders: yum-cron, dnf-automatic, PackageKit.
+
+    The returned string is wrapped in ``bash -c '...'`` so that it works correctly
+    with both ``remoter.sudo()`` (which prepends ``sudo``) and
+    ``remoter.run("sudo ...")``.
+
+    Args:
+        pkg_manager: The RPM package manager binary name ("yum", "dnf", or "microdnf").
+        subcommand: The subcommand with arguments (e.g. "install -y nginx").
+        lock_timeout: Max seconds to wait for rpm lock (default 120, polls every 2s).
+
+    Returns:
+        Shell command string ready for remoter.run() / remoter.sudo().
+    """
+    iterations = lock_timeout // 2
+    wait = (
+        f"for i in $(seq 1 {iterations}); do "
+        "fuser /var/lib/rpm/.rpm.lock &>/dev/null || break; "
+        f'echo "rpm lock held, waiting... ($i/{iterations})"; sleep 2; done'
+    )
+
+    # Escape single quotes in the command portion to prevent shell injection.
+    # The wait loop is static (no external input), only pkg_manager+subcommand need escaping.
+    cmd = f"{pkg_manager} {subcommand}".replace("'", r"'\''")
+    return f"bash -c '{wait} && {cmd}'"


### PR DESCRIPTION
Running Artifacts tests on the OCI backend may lead to the following error:

```
        > Command: 'sudo yum install -y scylla'
        >
        > Exit code: 1
        >
        > Stdout:
            ...
        > Error: GPG check FAILED
```

It is caused by the `rpm.lock` being held by the OCI agent installation
process which starts after the DB node startup.
    
So, tolerate rpm.lock holdings in SCT.
Do it by adding an additional bash checker for that lock before
executing package management commands.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- https://jenkins.scylladb.com/job/scylla-staging/job/valerii/job/vp-artifacts-oel8-oci/12

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
