### PR TITLE
fix(test-config): skip baremetal in test_18 version/repo check

### DIFF
--- a/unit_tests/integration/test_config.py
+++ b/unit_tests/integration/test_config.py
@@ -269,6 +269,8 @@ def test_18_error_if_no_version_repo_ami_selected(monkeypatch):
             continue
         if "siren" in backend:
             continue
+        if backend == "baremetal":
+            continue
         if backend == "xcloud":
             monkeypatch.setenv("SCT_XCLOUD_PROVIDER", "aws")
         monkeypatch.setenv("SCT_CLUSTER_BACKEND", backend)


### PR DESCRIPTION
## Problem

`test_18_error_if_no_version_repo_ami_selected` fails with:

```
AssertionError: Regex pattern did not match.
  Expected regex: "scylla version/repos wasn't configured correctly"
  Actual message: 's3_baremetal_config missing from config for baremetal'
```

## Root Cause

Commit 868b3ff0ce ("fix(sct-config): apply backend required params validation for all backends") started enforcing required backend params for all backends. For `baremetal`, `s3_baremetal_config` is a required field checked in `_check_per_backend_required_values()`.

Since `_check_version_supplied()` explicitly skips baremetal (line 3988: `and not backend == "baremetal"` — it uses pre-installed scylla), the version/repos assertion the test expects is never reached for that backend. Instead, the backend required params check fires first with a different error.

## Fix

Skip `baremetal` in the test loop, matching the production code's intentional design that baremetal does not require version/repos configuration.

## Manual Testing Required

- [ ] Run integration test: `uv run python -m pytest unit_tests/integration/test_config.py::test_18_error_if_no_version_repo_ami_selected -x`
