### PR TITLE
fix(perf-regression): replace eu-west-3 region for tests using i8g instances

### DIFF
--- a/vars/perfRegressionParallelPipelinebyRegion.groovy
+++ b/vars/perfRegressionParallelPipelinebyRegion.groovy
@@ -9,7 +9,7 @@ Master 3-weeks (master-3weeks):
 
 Master monthly (master-monthly):
 - predefined-throughput-steps-i8g-vnodes — eu-west-2, versions: ['master'], labels: ['master-monthly'], all 4 sub tests
-- latency-650gb-with-nemesis-i8g-vnodes — eu-west-3, versions: ['master'], labels: ['master-monthly'], all 3 sub tests (mixed, read, write)
+- latency-650gb-with-nemesis-i8g-vnodes — eu-north-1, versions: ['master'], labels: ['master-monthly'], all 3 sub tests (mixed, read, write)
 
 < Scylla version 2025.3 (non-master, versions 2025.2, 2025.1, 2024.2, 2024.1):
 - predefined-throughput-steps-vnodes — us-east-1, versions: ['2025.2', '2025.1', '2024.2', '2024.1'], all sub tests (read, mixed, disk_only)
@@ -23,7 +23,7 @@ Master monthly (master-monthly):
 
 >= Scylla version 2025.3 (non-master/release):
 - predefined-throughput-steps-i8g-tablets — us-west-2, ignore_versions: ['2025.2', '2025.1', '2024.1', '2024.2', 'master'], all sub tests
-- latency-650gb-during-rolling-upgrade-i8g-tablets — eu-west-3, ignore_versions: ['2025.2', '2025.1', '2024.2', '2024.1', 'master'], mixed load
+- latency-650gb-during-rolling-upgrade-i8g-tablets — eu-west-2, ignore_versions: ['2025.2', '2025.1', '2024.2', '2024.1', 'master'], mixed load
 - latency-650gb-with-nemesis-i8g-tablets — eu-west-2, ignore_versions: ['2025.2', '2025.1', '2024.2', '2024.1', 'master'], read + mixed
 - predefined-throughput-steps-i8g-vnodes — eu-west-2, ignore_versions: ['2025.2', '2025.1', '2024.2', '2024.1', 'master'], mixed only
 - latency-650gb-with-nemesis-i8g-vnodes — eu-west-1, ignore_versions: ['2025.2', '2025.1', '2024.2', '2024.1', 'master'], mixed only
@@ -153,12 +153,12 @@ def call(Map pipelineParams) {
                             ],
                             [
                                 job_name: 'scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-with-nemesis-i8g-vnodes',
-                                region: 'eu-west-3',
+                                region: 'eu-north-1',
                                 versions: ['master'],
                                 pre_release: [],
                                 sub_tests: ['"test_latency_mixed_with_nemesis"', '"test_latency_read_with_nemesis"', '"test_latency_write_with_nemesis"'],
                                 labels: ['master-monthly'],
-                                job_throttle_category: 'SCT-perf-eu-west-3-i8g',
+                                job_throttle_category: 'SCT-perf-eu-north-1-i8g',
                                 arch: 'aarch64'
                             ],
                             [
@@ -310,13 +310,13 @@ def call(Map pipelineParams) {
                             ],
                             [
                                 job_name: 'scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-during-rolling-upgrade-i8g-tablets',
-                                region: 'eu-west-3',
+                                region: 'eu-west-2',
                                 ignore_versions: ['2025.2', '2025.1', '2024.2', '2024.1', 'master'],
                                 pre_release: [],
                                 sub_tests: ['"test_latency_mixed_with_upgrade"'],
                                 labels: [],
                                 rolling_upgrade_test: true,
-                                job_throttle_category: 'SCT-perf-eu-west-3-i8g',
+                                job_throttle_category: 'SCT-perf-eu-west-2-i8g',
                                 arch: 'aarch64'
                             ],
                             [


### PR DESCRIPTION
The i8g instance type is not available in the eu-west-3 region, causing provisioning failures in performance regression tests. Replaced the region with one that supports i8g instances for affected test configurations

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
