### PR TITLE
improvement(azure-provision): add stuck-VM detection and redeploy

### DIFF
--- a/defaults/azure_config.yaml
+++ b/defaults/azure_config.yaml
@@ -8,6 +8,9 @@ user_credentials_path: '~/.ssh/scylla_test_id_ed25519'
 azure_instance_type_db: ''
 azure_instance_type_loader: ''
 azure_instance_type_monitor: ''
+
+azure_provision_stuck_vm_timeout: 900  # seconds before VM in 'creating' status is treated as stuck
+azure_provision_stuck_vm_recreate_attempts: 3
 azure_image_loader: 'Canonical:ubuntu-24_04-lts:server:latest'
 azure_image_monitor: 'Canonical:ubuntu-24_04-lts:server:latest'
 

--- a/defaults/severities.yaml
+++ b/defaults/severities.yaml
@@ -114,6 +114,7 @@ SoftTimeoutEvent: ERROR
 HardTimeoutEvent: CRITICAL
 ElasticsearchEvent: ERROR
 SpotTerminationEvent: CRITICAL
+InstanceProvisionStuckEvent: WARNING
 AwsKmsEvent: ERROR
 ScyllaRepoEvent: WARNING
 InfoEvent: ERROR

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -2367,6 +2367,30 @@ The username for the Azure image.
 - `scyllaadm`: azure
 
 
+## **azure_provision_stuck_vm_timeout** / SCT_AZURE_PROVISION_STUCK_VM_TIMEOUT
+
+Seconds to wait for an Azure VM to reach the 'Succeeded' provisioning state before<br>treating it as stuck (accepted by Azure but never started by the host - SCT-434) and<br>recreating it. Detection is gated on the polled instanceView provisioning state.
+
+**default:** N/A
+
+**type:** int
+
+**backend overrides:**
+- `900`: azure
+
+
+## **azure_provision_stuck_vm_recreate_attempts** / SCT_AZURE_PROVISION_STUCK_VM_RECREATE_ATTEMPTS
+
+How many times to recreate a stuck Azure VM (full node: VM, NIC and public IP) onto<br>fresh capacity before giving up with a non-retryable error.
+
+**default:** N/A
+
+**type:** int
+
+**backend overrides:**
+- `3`: azure
+
+
 ## **oci_region_name** / SCT_OCI_REGION_NAME
 
 OCI region where the resources will be deployed

--- a/sdcm/provision/azure/provisioner.py
+++ b/sdcm/provision/azure/provisioner.py
@@ -16,6 +16,7 @@ import string
 from datetime import datetime, timezone
 from typing import Dict, List
 
+from azure.core.exceptions import AzureError, ResourceNotFoundError
 from azure.mgmt.compute.models import VirtualMachine, VirtualMachinePriorityTypes
 from azure.mgmt.resource.resources.models import ResourceGroup
 from invoke import Result
@@ -25,7 +26,11 @@ from sdcm.provision.azure.network_interface_provider import NetworkInterfaceProv
 from sdcm.provision.azure.network_security_group_provider import NetworkSecurityGroupProvider
 from sdcm.provision.azure.resource_group_provider import ResourceGroupProvider
 from sdcm.provision.azure.subnet_provider import SubnetProvider
-from sdcm.provision.azure.virtual_machine_provider import VirtualMachineProvider
+from sdcm.provision.azure.virtual_machine_provider import (
+    VirtualMachineProvider,
+    DEFAULT_STUCK_VM_TIMEOUT,
+    DEFAULT_STUCK_VM_POLL_INTERVAL,
+)
 from sdcm.provision.azure.virtual_network_provider import VirtualNetworkProvider
 from sdcm.provision.provisioner import (
     Provisioner,
@@ -33,11 +38,18 @@ from sdcm.provision.provisioner import (
     VmInstance,
     PricingModel,
     OperationPreemptedError,
+    StuckVMProvisioningError,
+    ProvisionUnrecoverableError,
 )
 from sdcm.provision.security import ScyllaOpenPorts
+from sdcm.sct_events import Severity
+from sdcm.sct_events.system import InstanceProvisionStuckEvent
 from sdcm.utils.azure_utils import AzureService
 
 LOGGER = logging.getLogger(__name__)
+
+DEFAULT_STUCK_VM_RECREATE_ATTEMPTS = 3
+DEFAULT_REDEPLOY_TIMEOUT = 300
 
 
 class AzureProvisioner(Provisioner):
@@ -50,6 +62,12 @@ class AzureProvisioner(Provisioner):
         super().__init__(test_id, region, availability_zone)
         # NOTE: Enable Azure KMS by default, disable only if configured explicitly
         self._enable_azure_kms = not config.get("enterprise_disable_kms")
+        stuck_vm_timeout = config.get("azure_provision_stuck_vm_timeout")
+        self._stuck_vm_timeout = stuck_vm_timeout if stuck_vm_timeout is not None else DEFAULT_STUCK_VM_TIMEOUT
+        stuck_vm_recreate_attempts = config.get("azure_provision_stuck_vm_recreate_attempts")
+        self._stuck_vm_recreate_attempts = (
+            stuck_vm_recreate_attempts if stuck_vm_recreate_attempts is not None else DEFAULT_STUCK_VM_RECREATE_ATTEMPTS
+        )
         self._azure_service: AzureService = azure_service
         self._cache: Dict[str, VmInstance] = {}
         LOGGER.debug("getting resources for %s...", self._resource_group_name)
@@ -65,9 +83,7 @@ class AzureProvisioner(Provisioner):
         self._subnet_provider = SubnetProvider(self._resource_group_name, self._azure_service)
         self._ip_provider = IpAddressProvider(self._resource_group_name, self._region, self._az, self._azure_service)
         self._nic_provider = NetworkInterfaceProvider(self._resource_group_name, self._region, self._azure_service)
-        self._vm_provider = VirtualMachineProvider(
-            self._resource_group_name, self._region, self._az, self._enable_azure_kms, self._azure_service
-        )
+        self._vm_provider = self._make_vm_provider()
         for v_m in self._vm_provider.list():
             try:
                 self._cache[v_m.name] = self._vm_to_instance(v_m)
@@ -76,6 +92,17 @@ class AzureProvisioner(Provisioner):
 
     def __str__(self):
         return f"{self.__class__.__name__}(region={self.region}, az={self.availability_zone})"
+
+    def _make_vm_provider(self) -> VirtualMachineProvider:
+        return VirtualMachineProvider(
+            self._resource_group_name,
+            self._region,
+            self._az,
+            self._enable_azure_kms,
+            self._azure_service,
+            _stuck_vm_timeout=self._stuck_vm_timeout,
+            _stuck_vm_poll_interval=DEFAULT_STUCK_VM_POLL_INTERVAL,
+        )
 
     @staticmethod
     def _convert_az_to_zone(availability_zone: str) -> str:
@@ -139,45 +166,123 @@ class AzureProvisioner(Provisioner):
     ) -> List[VmInstance]:
         """Create a set of instances specified by a list of InstanceDefinition.
         If instances already exist, returns them."""
-        provisioned_vm_instances = []
-        definitions_to_provision = []
-        for definition in definitions:
-            if definition.name in self._cache:
-                provisioned_vm_instances.append(self._cache[definition.name])
-            else:
-                definitions_to_provision.append(definition)
-        if not definitions_to_provision:
-            return provisioned_vm_instances
+        definitions_to_provision = [definition for definition in definitions if definition.name not in self._cache]
+        if definitions_to_provision:
+            v_ms = self._provision_with_stuck_recreate(definitions_to_provision, pricing_model)
+            v_ms_by_name = {v_m.name: v_m for v_m in v_ms}
+            for definition in definitions_to_provision:
+                self._cache[definition.name] = self._vm_to_instance(v_ms_by_name[definition.name])
+        return [self._cache[definition.name] for definition in definitions]
 
+    def _provision_with_stuck_recreate(
+        self, definitions: List[InstanceDefinition], pricing_model: PricingModel
+    ) -> List[VirtualMachine]:
+        """Provision VMs and recover any that get stuck until retries are exhausted.
+
+        A stuck VM is first redeployed to a new node (move of the VM onto another host that keeps,
+        its NIC and public IP). If redeploy does not succeed, the VM is deleted and provisioned
+        again from scratch.
+        """
+        attempt = 0
+        while True:
+            try:
+                return self._provision_resources(definitions, pricing_model)
+            except OperationPreemptedError:
+                self._reset_resource_providers()
+                raise
+            except StuckVMProvisioningError as exc:
+                if attempt >= self._stuck_vm_recreate_attempts:
+                    for vm_name in exc.vm_names:
+                        InstanceProvisionStuckEvent(
+                            vm_name=vm_name,
+                            attempt=attempt,
+                            provisioning_state="Creating",
+                            message=f"giving up after {self._stuck_vm_recreate_attempts} recovery attempts",
+                            severity=Severity.WARNING,
+                        ).publish_or_dump(default_logger=LOGGER)
+                    raise ProvisionUnrecoverableError(
+                        f"Azure VM(s) {', '.join(exc.vm_names)} stuck in provisioning after "
+                        f"{self._stuck_vm_recreate_attempts} recovery attempts"
+                    ) from exc
+                attempt += 1
+                for vm_name in exc.vm_names:
+                    InstanceProvisionStuckEvent(
+                        vm_name=vm_name,
+                        attempt=attempt,
+                        provisioning_state="Creating",
+                        message="recovering stuck VM (redeploy, recreate on failure)",
+                        severity=Severity.NORMAL,
+                    ).publish_or_dump(default_logger=LOGGER)
+                    if not self._redeploy_stuck_node(vm_name):
+                        LOGGER.warning(
+                            "Redeploy did not rescue VM %s; deleting it to recreate on fresh capacity", vm_name
+                        )
+                        self._delete_stuck_node(vm_name)
+
+    def _redeploy_stuck_node(self, name: str) -> bool:
+        """Redeploy VM to a new node.
+
+        Returns True if the VM reached the 'Succeeded' provisioning state; False if the redeploy
+        failed or did not complete within the timeout.
+        """
+        try:
+            LOGGER.info("Redeploying stuck VM %s to a new node", name)
+            poller = self._azure_service.compute.virtual_machines.begin_redeploy(self._resource_group_name, name)
+            poller.wait(timeout=DEFAULT_REDEPLOY_TIMEOUT)
+        except AzureError as err:
+            LOGGER.warning("Redeploy of stuck VM %s failed: %s", name, err)
+            return False
+        if not poller.done():
+            LOGGER.warning("Redeploy of stuck VM %s did not complete within %ss", name, DEFAULT_REDEPLOY_TIMEOUT)
+            return False
+        return self._vm_provider.recheck_provisioned(name) is not None
+
+    def _delete_stuck_node(self, name: str) -> None:
+        """Delete a stuck VM and its network resources."""
+        self._vm_provider.delete(name, wait=True)
+        self._cache.pop(name, None)
+
+        try:
+            nic = self._nic_provider.get(name)
+        except KeyError:
+            nic = None
+        if nic is not None:
+            self._azure_service.network.network_interfaces.begin_delete(self._resource_group_name, nic.name).wait()
+            self._nic_provider.delete(nic)
+
+        ip_address = self._ip_provider.get(name)
+        if getattr(ip_address, "id", None):
+            try:
+                self._azure_service.network.public_ip_addresses.begin_delete(
+                    self._resource_group_name, ip_address.name
+                ).wait()
+            except ResourceNotFoundError:
+                pass
+        self._ip_provider.delete(ip_address)
+
+    def _provision_resources(
+        self, definitions: List[InstanceDefinition], pricing_model: PricingModel
+    ) -> List[VirtualMachine]:
+        """Provision all Azure resources needed for the given VM definitions."""
         self._rg_provider.get_or_create()
         sec_group_id = self._network_sec_group_provider.get_or_create(security_rules=ScyllaOpenPorts).id
         vnet_name = self._vnet_provider.get_or_create().name
         subnet_id = self._subnet_provider.get_or_create(vnet_name, sec_group_id).id
-        ip_addresses = self._ip_provider.get_or_create(instance_definitions=definitions_to_provision, version="IPV4")
-        nics = self._nic_provider.get_or_create(
+        self._ip_provider.get_or_create(instance_definitions=definitions, version="IPV4")
+        ip_addresses_ids = [self._ip_provider.get(definition.name).id for definition in definitions]
+        self._nic_provider.get_or_create(
             subnet_id,
-            ip_addresses_ids=[address.id for address in ip_addresses],
-            names=[definition.name for definition in definitions_to_provision],
+            ip_addresses_ids=ip_addresses_ids,
+            names=[definition.name for definition in definitions],
         )
-        try:
-            v_ms = self._vm_provider.get_or_create(
-                definitions=definitions_to_provision, nics_ids=[nic.id for nic in nics], pricing_model=pricing_model
-            )
-        except OperationPreemptedError:
-            # upon preemption error, need to recreate providers to rediscover resources as cache might be invalid.
-            self._ip_provider = IpAddressProvider(
-                self._resource_group_name, self._region, self._az, self._azure_service
-            )
-            self._nic_provider = NetworkInterfaceProvider(self._resource_group_name, self._region, self._azure_service)
-            self._vm_provider = VirtualMachineProvider(
-                self._resource_group_name, self._region, self._az, self._enable_azure_kms, self._azure_service
-            )
-            raise
-        for definition, v_m in zip(definitions, v_ms):
-            instance = self._vm_to_instance(v_m)
-            self._cache[definition.name] = instance
-            provisioned_vm_instances.append(instance)
-        return provisioned_vm_instances
+        nics_ids = [self._nic_provider.get(definition.name).id for definition in definitions]
+        return self._vm_provider.get_or_create(definitions=definitions, nics_ids=nics_ids, pricing_model=pricing_model)
+
+    def _reset_resource_providers(self) -> None:
+        """Rebuild IP/NIC/VM providers so they rediscover live resources (caches may be stale)."""
+        self._ip_provider = IpAddressProvider(self._resource_group_name, self._region, self._az, self._azure_service)
+        self._nic_provider = NetworkInterfaceProvider(self._resource_group_name, self._region, self._azure_service)
+        self._vm_provider = self._make_vm_provider()
 
     def terminate_instance(self, name: str, wait: bool = True) -> None:
         """Terminates virtual machine, cleaning attached ip address and network interface."""

--- a/sdcm/provision/azure/virtual_machine_provider.py
+++ b/sdcm/provision/azure/virtual_machine_provider.py
@@ -25,13 +25,24 @@ from azure.mgmt.compute.models import VirtualMachine, RunCommandInput
 from invoke import Result
 
 from sdcm.provision.azure.kms_provider import AzureKmsProvider
-from sdcm.provision.provisioner import InstanceDefinition, PricingModel, ProvisionError, OperationPreemptedError
+from sdcm.provision.provisioner import (
+    InstanceDefinition,
+    PricingModel,
+    ProvisionError,
+    OperationPreemptedError,
+    StuckVMProvisioningError,
+)
 from sdcm.provision.user_data import UserDataBuilder
 from sdcm.utils.azure_utils import AzureService
+from sdcm.wait import wait_for
+from sdcm.exceptions import WaitForTimeoutError
 
 LOGGER = logging.getLogger(__name__)
 
 SCT_RESOURCE_GROUP_PREFIX = "SCT-"
+
+DEFAULT_STUCK_VM_TIMEOUT = 900
+DEFAULT_STUCK_VM_POLL_INTERVAL = 30
 
 
 @dataclass
@@ -42,6 +53,8 @@ class VirtualMachineProvider:
     _enable_azure_kms: bool = False
     _azure_service: AzureService = AzureService()
     _cache: Dict[str, VirtualMachine] = field(default_factory=dict)
+    _stuck_vm_timeout: int = DEFAULT_STUCK_VM_TIMEOUT
+    _stuck_vm_poll_interval: int = DEFAULT_STUCK_VM_POLL_INTERVAL
 
     def __post_init__(self):
         """Discover existing virtual machines for resource group."""
@@ -49,8 +62,14 @@ class VirtualMachineProvider:
             v_ms = self._azure_service.compute.virtual_machines.list(self._resource_group_name)
             for _v_m in v_ms:
                 v_m = self._azure_service.compute.virtual_machines.get(self._resource_group_name, _v_m.name)
-                if v_m.provisioning_state != "Deleting":
+                if v_m.provisioning_state == "Succeeded":
                     self._cache[v_m.name] = v_m
+                elif v_m.provisioning_state != "Deleting":
+                    LOGGER.warning(
+                        "Discovered VM %s in non-final provisioning state '%s'; not caching it as ready",
+                        v_m.name,
+                        v_m.provisioning_state,
+                    )
         except ResourceNotFoundError:
             pass
 
@@ -146,31 +165,74 @@ class VirtualMachineProvider:
             except AzureError as err:
                 LOGGER.error("Error when sending create vm request for VM %s: %s", definition.name, str(err))
                 error_to_raise = err
+        stuck_vm_names = []
         for definition, poller in pollers:
             try:
-                poller.wait(timeout=900)
-                v_m = self._azure_service.compute.virtual_machines.get(
-                    self._resource_group_name, definition.name, expand="instanceView"
-                )
-                if v_m.instance_view and v_m.instance_view.statuses:
-                    statuses = ", ".join(
-                        f"{status.code}: {status.display_status}" for status in v_m.instance_view.statuses
-                    )
-                    LOGGER.debug("Provisioned VM %s instance state: %s", v_m.name, statuses)
-                else:
-                    LOGGER.warning("Instance view is not available for VM %s", v_m.name)
-                self._cache[v_m.name] = v_m
-                v_ms.append(v_m)
+                # check for create-time errors quickly
+                poller.wait(timeout=self._stuck_vm_poll_interval)
             except ODataV4Error as err:
                 LOGGER.error("Error when waiting for VM %s: %s", definition.name, str(err))
                 if err.code == "OperationPreempted":
                     raise OperationPreemptedError(err)  # spot instance preemption, abort provision immediately
+                error_to_raise = err
+                continue
             except AzureError as err:
                 LOGGER.error("Error when waiting for creation of VM %s: %s", definition.name, str(err))
                 error_to_raise = err
+                continue
+            v_m = self._wait_until_provisioned(definition.name)
+            if v_m is None:
+                # accepted by Azure but never reached Succeeded within the timeout (i.e. stuck);
+                # do NOT cache or return it; the provisioner will redeploy it to a new node
+                LOGGER.warning("VM %s is stuck in provisioning, will be redeployed to a new node", definition.name)
+                stuck_vm_names.append(definition.name)
+                continue
+            self._cache[v_m.name] = v_m
+            v_ms.append(v_m)
         if error_to_raise:
             raise ProvisionError(error_to_raise)
+        if stuck_vm_names:
+            raise StuckVMProvisioningError(stuck_vm_names)
         return v_ms
+
+    def _wait_until_provisioned(self, name: str) -> Optional[VirtualMachine]:
+        """Wait until the VM reaches ProvisioningState=Succeeded.
+
+        Returns the VM on success, or None if the stuck-VM timeout expires first.
+        """
+
+        def get_provisioned_vm() -> Optional[VirtualMachine]:
+            vm = self._azure_service.compute.virtual_machines.get(
+                self._resource_group_name,
+                name,
+                expand="instanceView",
+            )
+            if vm.instance_view and vm.instance_view.statuses:
+                status_summary = ", ".join(
+                    f"{status.code}: {status.display_status}" for status in vm.instance_view.statuses
+                )
+                LOGGER.debug("VM %s instance state: %s", name, status_summary)
+            if vm.provisioning_state == "Succeeded":
+                return vm
+            return None
+
+        try:
+            return wait_for(
+                get_provisioned_vm,
+                step=self._stuck_vm_poll_interval,
+                timeout=self._stuck_vm_timeout,
+                throw_exc=True,
+                text=f"Waiting for VM {name} to reach Succeeded provisioning state",
+            )
+        except WaitForTimeoutError:
+            return None
+
+    def recheck_provisioned(self, name: str) -> Optional[VirtualMachine]:
+        """Re-poll a VM after an unplanned action (e.g. redeploy); cache and return it if it reaches 'Succeeded'."""
+        v_m = self._wait_until_provisioned(name)
+        if v_m is not None:
+            self._cache[v_m.name] = v_m
+        return v_m
 
     def list(self):
         return list(self._cache.values())
@@ -188,7 +250,7 @@ class VirtualMachineProvider:
             LOGGER.info("Waiting for termination of instance: %s...", name)
             task.wait()
             LOGGER.info("Instance %s has been terminated.", name)
-        del self._cache[name]
+        self._cache.pop(name, None)
 
     def reboot(self, name: str, wait: bool = True, hard: bool = False) -> None:
         LOGGER.info("Triggering reboot of instance: %s", name)

--- a/sdcm/provision/provisioner.py
+++ b/sdcm/provision/provisioner.py
@@ -66,6 +66,18 @@ class OperationPreemptedError(Exception):
     pass
 
 
+class StuckVMProvisioningError(Exception):
+    """Raised when one or more accepted VMs never finish provisioning.
+
+    Stores the names of the stuck VMs so the provisioner can recreate only those
+    nodes. It intentionally does not inherit from ``ProvisionError``.
+    """
+
+    def __init__(self, vm_names: List[str]):
+        self.vm_names = vm_names
+        super().__init__(f"VMs stuck during provisioning: {', '.join(vm_names)}")
+
+
 class ProvisionUnrecoverableError(Exception):
     """Base class for provisioning failures that retrying cannot fix (e.g. zone capacity)."""
 

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1412,6 +1412,21 @@ class SCTConfiguration(BaseModel):
     azure_image_username: String = SctField(
         description="The username for the Azure image.",
     )
+    azure_provision_stuck_vm_timeout: int = SctField(
+        gt=0,
+        description="""
+              Seconds to wait for an Azure VM to reach the 'Succeeded' provisioning state before
+              treating it as stuck (accepted by Azure but never started by the host - SCT-434) and
+              recreating it. Detection is gated on the polled instanceView provisioning state.
+        """,
+    )
+    azure_provision_stuck_vm_recreate_attempts: int = SctField(
+        ge=0,
+        description="""
+              How many times to recreate a stuck Azure VM (full node: VM, NIC and public IP) onto
+              fresh capacity before giving up with a non-retryable error.
+        """,
+    )
 
     # Oracle Cloud (OCI) options
     oci_region_name: StringOrList = SctField(

--- a/sdcm/sct_events/system.py
+++ b/sdcm/sct_events/system.py
@@ -126,6 +126,29 @@ class SpotTerminationEvent(InformationalEvent):
         return super().msgfmt + ": node={0.node} message={0.message}"
 
 
+class InstanceProvisionStuckEvent(InformationalEvent):
+    """Published when a VM is accepted by the cloud but stays in a non-Succeeded
+    provisioning state past the configured timeout.
+
+    Uses NORMAL severity while the stuck node is being recreated, and WARNING
+    when recreate attempts are exhausted.
+    """
+
+    def __init__(self, vm_name: str, attempt: int, provisioning_state: str, message: str, severity: Severity):
+        super().__init__(severity=severity)
+        self.vm_name = vm_name
+        self.attempt = attempt
+        self.provisioning_state = provisioning_state
+        self.message = message
+
+    @property
+    def msgfmt(self) -> str:
+        return (
+            f"{super().msgfmt}: vm_name={{0.vm_name}} attempt={{0.attempt}} "
+            f"provisioning_state={{0.provisioning_state}} message={{0.message}}"
+        )
+
+
 class KernelPanicEvent(InformationalEvent):
     """Published when a kernel panic is detected on a node."""
 

--- a/sdcm/sct_provision/azure/azure_region_definition_builder.py
+++ b/sdcm/sct_provision/azure/azure_region_definition_builder.py
@@ -10,7 +10,7 @@
 # See LICENSE for more details.
 #
 # Copyright (c) 2022 ScyllaDB
-from typing import Dict
+from typing import Any, Dict
 
 from sdcm.sct_provision.common.types import NodeTypeType
 from sdcm.sct_provision.region_definition_builder import ConfigParamsMap, DefinitionBuilder
@@ -52,3 +52,10 @@ class AzureDefinitionBuilder(DefinitionBuilder):
         """
         node_prefix = f"{user_prefix}-{node_type_short}-node-{short_test_id}"
         return f"{node_prefix}-{region}-{index}".lower()
+
+    def get_provisioner_config(self) -> Dict[str, Any]:
+        """Pass Azure stuck-VM timeout and recreate-attempt settings to the provisioner."""
+        return {
+            "azure_provision_stuck_vm_timeout": self.params.get("azure_provision_stuck_vm_timeout"),
+            "azure_provision_stuck_vm_recreate_attempts": self.params.get("azure_provision_stuck_vm_recreate_attempts"),
+        }

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1727,6 +1727,10 @@ class ClusterTester(unittest.TestCase):
                     test_id=test_id,
                     region=region,
                     availability_zone=self.params.get("availability_zone"),
+                    azure_provision_stuck_vm_timeout=self.params.get("azure_provision_stuck_vm_timeout"),
+                    azure_provision_stuck_vm_recreate_attempts=self.params.get(
+                        "azure_provision_stuck_vm_recreate_attempts"
+                    ),
                 )
             )
         if db_info["n_nodes"] is None:

--- a/unit_tests/unit/provisioner/conftest.py
+++ b/unit_tests/unit/provisioner/conftest.py
@@ -21,7 +21,15 @@ from sdcm.utils.sct_cmd_helpers import get_test_config
 from sdcm.sct_config import SCTConfiguration
 from sdcm.test_config import TestConfig
 from sdcm.utils.azure_utils import AzureService
-from unit_tests.unit.provisioner.fake_azure_service import FakeAzureService
+from unit_tests.unit.provisioner.fake_azure_service import FakeAzureService, FakeVirtualMachines
+
+
+@pytest.fixture(autouse=True)
+def _reset_fake_vm_simulation():
+    """Reset fake VM scripts before and after each test."""
+    FakeVirtualMachines.clear_scripts()
+    yield
+    FakeVirtualMachines.clear_scripts()
 
 
 @pytest.fixture(scope="session")

--- a/unit_tests/unit/provisioner/fake_azure_service.py
+++ b/unit_tests/unit/provisioner/fake_azure_service.py
@@ -16,6 +16,7 @@ import os
 import shutil
 import subprocess
 
+from dataclasses import dataclass
 from pathlib import Path
 from typing import List, Any, Dict
 
@@ -46,6 +47,9 @@ class WaitableObject:
     def wait(self, timeout=None):
         if self.error:
             raise self.error
+
+    def done(self) -> bool:
+        return True
 
 
 class ResultableObject:
@@ -337,7 +341,10 @@ class FakeIpAddress:
             raise ResourceNotFoundError("Public IP address not found") from None
 
     def begin_delete(self, resource_group_name: str, public_ip_address_name: str) -> WaitableObject:
-        os.remove(self.path / resource_group_name / f"ip-{public_ip_address_name}.json")
+        try:
+            os.remove(self.path / resource_group_name / f"ip-{public_ip_address_name}.json")
+        except FileNotFoundError:
+            pass
         return WaitableObject()
 
 
@@ -440,7 +447,10 @@ class FakeNetworkInterface:
             raise ResourceNotFoundError("NIC not found") from None
 
     def begin_delete(self, resource_group_name: str, network_interface_name: str) -> WaitableObject:
-        os.remove(self.path / resource_group_name / f"nic-{network_interface_name}.json")
+        try:
+            os.remove(self.path / resource_group_name / f"nic-{network_interface_name}.json")
+        except FileNotFoundError:
+            pass
         return WaitableObject()
 
 
@@ -454,9 +464,126 @@ class FakeNetwork:
         self.network_interfaces = FakeNetworkInterface(self.path)
 
 
+@dataclass
+class VMCreateBehavior:
+    """Describe how a fake VM creation should behave in tests.
+
+    If ``stuck`` is True, the VM stays in the Azure stuck state instead of succeeding.
+    If ``recover_after_polls`` is set, the VM recovers after that many instance-view polls.
+    If it is ``None``, the VM stays stuck until it is deleted and recreated.
+    If ``redeploy_fails`` is True, a redeploy of this VM raises an error.
+    """
+
+    stuck: bool = False
+    recover_after_polls: int | None = None
+    redeploy_fails: bool = False
+
+
 class FakeVirtualMachines:
+    _scripts: Dict[str, Dict[str, Any]] = {}
+
     def __init__(self, path: Path) -> None:
         self.path = path
+
+    @classmethod
+    def set_provision_script(
+        cls, vm_name: str, behaviors: List[VMCreateBehavior] | None = None, default: VMCreateBehavior | None = None
+    ) -> None:
+        """Store the scripted create behavior for a VM name."""
+        cls._scripts[vm_name] = {
+            "queue": list(behaviors or []),
+            "default": default,
+        }
+
+    @classmethod
+    def clear_scripts(cls) -> None:
+        """Remove all scripted VM behaviors."""
+        cls._scripts = {}
+
+    @classmethod
+    def _next_behavior(cls, vm_name: str) -> VMCreateBehavior:
+        """Return the next scripted behavior for a VM, or the default healthy one."""
+        script = cls._scripts.get(vm_name)
+        if not script:
+            return VMCreateBehavior()
+        if script["queue"]:
+            return script["queue"].pop(0)
+        return script["default"] or VMCreateBehavior()
+
+    def _vm_path(self, resource_group_name: str, vm_name: str) -> Path:
+        """Build the JSON file path for a fake VM."""
+        return self.path / resource_group_name / f"vm-{vm_name}.json"
+
+    def _read_raw(self, resource_group_name: str, vm_name: str) -> Dict[str, Any]:
+        """Load raw fake VM data from disk."""
+        try:
+            with open(self._vm_path(resource_group_name, vm_name), "r", encoding="utf-8") as file:
+                return json.load(file)
+        except FileNotFoundError:
+            raise ResourceNotFoundError("Virtual Machine not found") from None
+
+    def _write_raw(self, resource_group_name: str, vm_name: str, data: Dict[str, Any]) -> None:
+        """Write raw fake VM data to disk."""
+        with open(self._vm_path(resource_group_name, vm_name), "w", encoding="utf-8") as file:
+            json.dump(data, fp=file, indent=2)
+
+    @staticmethod
+    def _build_instance_view(provisioning_state: str) -> Dict[str, Any]:
+        """Build the fake Azure instance view for the VM state."""
+        if provisioning_state == "Succeeded":
+            return {
+                "vmAgent": {
+                    "vmAgentVersion": "2.9.1.1",
+                    "statuses": [
+                        {
+                            "code": "ProvisioningState/succeeded",
+                            "level": "Info",
+                            "displayStatus": "Ready",
+                            "message": "Guest Agent is running",
+                        }
+                    ],
+                },
+                "statuses": [
+                    {
+                        "code": "ProvisioningState/succeeded",
+                        "level": "Info",
+                        "displayStatus": "Provisioning succeeded",
+                    },
+                    {
+                        "code": "PowerState/running",
+                        "level": "Info",
+                        "displayStatus": "VM running",
+                    },
+                ],
+            }
+        return {
+            "statuses": [
+                {
+                    "code": "ProvisioningState/creating",
+                    "level": "Info",
+                    "displayStatus": "Creating",
+                },
+                {
+                    "code": "PowerState/starting",
+                    "level": "Info",
+                    "displayStatus": "VM starting",
+                },
+            ],
+        }
+
+    def _advance_simulation(self, resource_group_name: str, vm_name: str, raw: Dict[str, Any]) -> Dict[str, Any]:
+        """Advance stuck-VM simulation by one poll and mark it succeeded when ready."""
+        sim = raw.get("_simulation")
+        if not sim or not sim.get("stuck"):
+            return raw
+
+        sim["polls_seen"] += 1
+        recover_after = sim.get("recover_after_polls")
+        if recover_after is not None and sim["polls_seen"] >= recover_after:
+            sim["stuck"] = False
+            raw["properties"]["provisioningState"] = "Succeeded"
+        self._write_raw(resource_group_name, vm_name, raw)
+        return raw
 
     def list(self, resource_group_name: str) -> List[VirtualMachine]:
         try:
@@ -466,7 +593,9 @@ class FakeVirtualMachines:
         elements = []
         for fle in files:
             with open(self.path / resource_group_name / fle, "r", encoding="utf-8") as file:
-                elements.append(VirtualMachine.deserialize(json.load(file)))
+                raw = json.load(file)
+            raw.pop("_simulation", None)
+            elements.append(VirtualMachine.deserialize(raw))
         return elements
 
     def begin_create_or_update(
@@ -559,45 +688,80 @@ class FakeVirtualMachines:
         }
         base["properties"].update(**parameters)
         base["tags"] = tags
+        behavior = self._next_behavior(vm_name)
+        if behavior.stuck:
+            base["properties"]["provisioningState"] = "Creating"
+            base["_simulation"] = {
+                "stuck": True,
+                "recover_after_polls": behavior.recover_after_polls,
+                "polls_seen": 0,
+            }
         with open(self.path / resource_group_name / f"vm-{vm_name}.json", "w", encoding="utf-8") as file:
             json.dump(base, fp=file, indent=2)
         return WaitableObject()
 
     def begin_update(self, resource_group_name: str, vm_name: str, parameters: Dict[str, Any]) -> WaitableObject:
-        try:
-            with open(self.path / resource_group_name / f"vm-{vm_name}.json", "r", encoding="utf-8") as file:
-                v_m = json.loads(file.read())
-        except FileNotFoundError:
-            raise ResourceNotFoundError("Virtual Machine not found") from None
-
+        v_m = self._read_raw(resource_group_name, vm_name)
         tags = parameters.pop("tags") if "tags" in parameters else {}
         v_m["properties"].update(**dict_keys_to_camel_case(parameters))
-        v_m["tags"].update(**tags)
+        v_m.setdefault("tags", {}).update(**tags)
+        sim = v_m.pop("_simulation", None)
         VirtualMachine.deserialize(v_m)
-        with open(self.path / resource_group_name / f"vm-{vm_name}.json", "w", encoding="utf-8") as file:
-            json.dump(v_m, fp=file, indent=2)
+        if sim is not None:
+            v_m["_simulation"] = sim
+        self._write_raw(resource_group_name, vm_name, v_m)
         return WaitableObject()
 
     def begin_delete(self, resource_group_name: str, vm_name: str) -> WaitableObject:
-        network_svc = FakeNetwork(self.path)
-        v_m = self.get(resource_group_name, vm_name)
-        os.remove(self.path / resource_group_name / f"vm-{vm_name}.json")
-        nic_name = v_m.network_profile.network_interfaces[0].id.split("/", -1)[-1]
-        nic = network_svc.network_interfaces.get(resource_group_name, nic_name)
-        network_svc.network_interfaces.begin_delete(resource_group_name, nic_name)
-        network_svc.public_ip_addresses.begin_delete(
-            resource_group_name, nic.ip_configurations[0].public_ip_address.name
-        )
+        raw = self._read_raw(resource_group_name, vm_name)
+        os.remove(self._vm_path(resource_group_name, vm_name))
+        nic_ref = (raw["properties"].get("networkProfile") or {}).get("networkInterfaces") or [{}]
+        delete_option = (nic_ref[0].get("properties") or {}).get("deleteOption", "Detach")
+        if delete_option == "Delete" and nic_ref[0].get("id"):
+            network_svc = FakeNetwork(self.path)
+            nic_name = nic_ref[0]["id"].split("/")[-1]
+            try:
+                nic = network_svc.network_interfaces.get(resource_group_name, nic_name)
+                network_svc.network_interfaces.begin_delete(resource_group_name, nic_name)
+                public_ip = nic.ip_configurations[0].public_ip_address
+                if public_ip is not None and getattr(public_ip, "name", None):
+                    network_svc.public_ip_addresses.begin_delete(resource_group_name, public_ip.name)
+            except ResourceNotFoundError:
+                pass
         return WaitableObject()
 
     def get(self, resource_group_name: str, vm_name: str, expand: str = "") -> VirtualMachine:
-        try:
-            with open(self.path / resource_group_name / f"vm-{vm_name}.json", "r", encoding="utf-8") as file:
-                return VirtualMachine.deserialize(json.load(file))
-        except FileNotFoundError:
-            raise ResourceNotFoundError("Virtual Machine not found") from None
+        raw = self._read_raw(resource_group_name, vm_name)
+        if expand and "instanceview" in expand.lower():
+            raw = self._advance_simulation(resource_group_name, vm_name, raw)
+            raw = {**raw, "properties": {**raw["properties"]}}
+            raw["properties"]["instanceView"] = self._build_instance_view(raw["properties"]["provisioningState"])
+        raw.pop("_simulation", None)
+        return VirtualMachine.deserialize(raw)
+
+    def instance_view(self, resource_group_name: str, vm_name: str):
+        return self.get(resource_group_name, vm_name, expand="instanceView").instance_view
 
     def begin_restart(self, resource_group_name, vm_name) -> WaitableObject:
+        return WaitableObject()
+
+    def begin_redeploy(self, resource_group_name, vm_name) -> WaitableObject:
+        behavior = self._next_behavior(vm_name)
+        if behavior.redeploy_fails:
+            return WaitableObject(
+                error=AzureError("VMRedeploymentFailed: redeployment failed due to an internal error")
+            )
+        raw = self._read_raw(resource_group_name, vm_name)
+        raw["properties"]["provisioningState"] = "Creating" if behavior.stuck else "Succeeded"
+        if behavior.stuck:
+            raw["_simulation"] = {
+                "stuck": True,
+                "recover_after_polls": behavior.recover_after_polls,
+                "polls_seen": 0,
+            }
+        else:
+            raw.pop("_simulation", None)
+        self._write_raw(resource_group_name, vm_name, raw)
         return WaitableObject()
 
     def begin_run_command(self, resource_group_name, vm_name, parameters) -> ResultableObject:

--- a/unit_tests/unit/provisioner/test_stuck_vm_recreate.py
+++ b/unit_tests/unit/provisioner/test_stuck_vm_recreate.py
@@ -1,0 +1,167 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2026 ScyllaDB
+
+"""Tests for Azure stuck-VM detection and whole-node recreate (SCT-434)"""
+
+import uuid
+from unittest.mock import patch
+
+import pytest
+
+from sdcm.keystore import KeyStore
+from sdcm.provision.azure.virtual_machine_provider import VirtualMachineProvider
+from sdcm.provision.provisioner import (
+    InstanceDefinition,
+    ProvisionError,
+    ProvisionUnrecoverableError,
+    provisioner_factory,
+)
+from unit_tests.unit.provisioner.fake_azure_service import FakeVirtualMachines, VMCreateBehavior
+
+
+@pytest.fixture(autouse=True)
+def _no_nic_propagation_sleep():
+    """Skip NIC propagation sleep so recreate attempts stay fast in tests."""
+    with patch("sdcm.provision.azure.network_interface_provider.time.sleep"):
+        yield
+
+
+def _make_provisioner(azure_service, recreate_attempts: int = 2, timeout: float = 0.5, poll: float = 0.01):
+    provisioner = provisioner_factory.create_provisioner(
+        backend="azure",
+        test_id=str(uuid.uuid4()),
+        region="eastus",
+        availability_zone="",
+        azure_service=azure_service,
+        azure_provision_stuck_vm_recreate_attempts=recreate_attempts,
+    )
+    provisioner._vm_provider._stuck_vm_timeout = timeout
+    provisioner._vm_provider._stuck_vm_poll_interval = poll
+    return provisioner
+
+
+def _definition(name: str) -> InstanceDefinition:
+    return InstanceDefinition(
+        name=name,
+        image_id="OpenLogic:CentOS:7_9:latest",
+        type="Standard_L8s_v4",
+        user_name="tester",
+        ssh_key=KeyStore().get_ec2_ssh_key_pair(),
+        tags={"NodeType": "scylla-db"},
+        user_data=None,
+        use_public_ip=True,
+    )
+
+
+def _stuck_events(events, severity_name: str) -> list[str]:
+    by_category = events.get_events_by_category()
+    return [line for line in by_category.get(severity_name, []) if "InstanceProvisionStuckEvent" in line]
+
+
+def test_slow_but_recovering_vm_is_not_redeployed(azure_service):
+    """A VM that recovers before the timeout must not be redeployed."""
+    FakeVirtualMachines.set_provision_script("node-slow", [VMCreateBehavior(stuck=True, recover_after_polls=3)])
+    provisioner = _make_provisioner(azure_service)
+    with patch.object(provisioner, "_redeploy_stuck_node", wraps=provisioner._redeploy_stuck_node) as redeploy_spy:
+        instances = provisioner.get_or_create_instances([_definition("node-slow")])
+    assert [instance.name for instance in instances] == ["node-slow"]
+    redeploy_spy.assert_not_called()
+
+
+def test_stuck_vm_is_redeployed_and_succeeds(azure_service, events_function_scope):
+    """A stuck VM should be redeployed once and then succeed (no delete/recreate needed)."""
+    FakeVirtualMachines.set_provision_script("node-stuck", [VMCreateBehavior(stuck=True)])
+    provisioner = _make_provisioner(azure_service, recreate_attempts=2)
+    with (
+        patch.object(provisioner, "_redeploy_stuck_node", wraps=provisioner._redeploy_stuck_node) as redeploy_spy,
+        patch.object(provisioner, "_delete_stuck_node", wraps=provisioner._delete_stuck_node) as delete_spy,
+    ):
+        instances = provisioner.get_or_create_instances([_definition("node-stuck")])
+
+    assert [instance.name for instance in instances] == ["node-stuck"]
+    redeploy_spy.assert_called_once_with("node-stuck")
+    delete_spy.assert_not_called()
+    assert len(_stuck_events(events_function_scope, "NORMAL")) == 1
+    assert _stuck_events(events_function_scope, "WARNING") == []
+
+
+def test_stuck_vm_redeploy_fails_then_recreated_and_succeeds(azure_service, events_function_scope):
+    """When redeploy fails, the stuck VM is deleted and recreated, then succeeds."""
+    FakeVirtualMachines.set_provision_script(
+        "node-x",
+        [VMCreateBehavior(stuck=True), VMCreateBehavior(redeploy_fails=True), VMCreateBehavior()],
+    )
+    provisioner = _make_provisioner(azure_service, recreate_attempts=2)
+    with (
+        patch.object(provisioner, "_redeploy_stuck_node", wraps=provisioner._redeploy_stuck_node) as redeploy_spy,
+        patch.object(provisioner, "_delete_stuck_node", wraps=provisioner._delete_stuck_node) as delete_spy,
+    ):
+        instances = provisioner.get_or_create_instances([_definition("node-x")])
+
+    assert [instance.name for instance in instances] == ["node-x"]
+    redeploy_spy.assert_called_once_with("node-x")
+    delete_spy.assert_called_once_with("node-x")
+    assert len(_stuck_events(events_function_scope, "NORMAL")) == 1
+    assert _stuck_events(events_function_scope, "WARNING") == []
+
+
+def test_permanently_stuck_vm_raises_unrecoverable_after_configured_attempts(azure_service, events_function_scope):
+    FakeVirtualMachines.set_provision_script("node-dead", default=VMCreateBehavior(stuck=True))
+    provisioner = _make_provisioner(azure_service, recreate_attempts=2)
+    with (
+        patch.object(provisioner, "_redeploy_stuck_node", wraps=provisioner._redeploy_stuck_node) as redeploy_spy,
+        patch.object(provisioner, "_delete_stuck_node", wraps=provisioner._delete_stuck_node) as delete_spy,
+    ):
+        with pytest.raises(ProvisionUnrecoverableError) as exc_info:
+            provisioner.get_or_create_instances([_definition("node-dead")])
+
+    assert not isinstance(exc_info.value, ProvisionError)
+    assert redeploy_spy.call_count == 2
+    assert delete_spy.call_count == 2
+    assert len(_stuck_events(events_function_scope, "NORMAL")) == 2
+    assert len(_stuck_events(events_function_scope, "WARNING")) == 1
+
+
+def test_only_stuck_vm_in_mixed_batch_is_redeployed(azure_service, events_function_scope):
+    FakeVirtualMachines.set_provision_script("node-bad", [VMCreateBehavior(stuck=True)])
+    provisioner = _make_provisioner(azure_service, recreate_attempts=2)
+    definitions = [_definition("node-good-1"), _definition("node-bad"), _definition("node-good-2")]
+    with patch.object(provisioner, "_redeploy_stuck_node", wraps=provisioner._redeploy_stuck_node) as redeploy_spy:
+        instances = provisioner.get_or_create_instances(definitions)
+
+    assert [instance.name for instance in instances] == ["node-good-1", "node-bad", "node-good-2"]
+    redeploy_spy.assert_called_once_with("node-bad")
+    assert len(_stuck_events(events_function_scope, "NORMAL")) == 1
+
+
+def test_discovery_does_not_cache_still_creating_vm(azure_service):
+    """A VM still in Creating state must not be rediscovered as ready."""
+    vm_name = "ghost"
+    resource_group = f"SCT-{uuid.uuid4()}-eastus"
+    vm_parameters = {
+        "location": "eastus",
+        "tags": {"NodeType": "scylla-db"},
+        "hardware_profile": {"vm_size": "Standard_L8s_v4"},
+        "network_profile": {
+            "network_interfaces": [{"id": "/fake/nic/ghost-nic", "properties": {"deleteOption": "Detach"}}]
+        },
+        "priority": "Regular",
+    }
+
+    azure_service.resource.resource_groups.create_or_update(resource_group, {"location": "eastus"})
+    FakeVirtualMachines.set_provision_script(vm_name, [VMCreateBehavior(stuck=True)])
+    azure_service.compute.virtual_machines.begin_create_or_update(resource_group, vm_name, vm_parameters)
+
+    provider = VirtualMachineProvider(resource_group, "eastus", "", False, azure_service)
+    assert vm_name not in provider._cache
+    assert provider.list() == []

--- a/vars/longevityPipeline.groovy
+++ b/vars/longevityPipeline.groovy
@@ -347,7 +347,7 @@ def call(Map pipelineParams) {
                     script {
                         wrap([$class: 'BuildUser']) {
                             dir('scylla-cluster-tests') {
-                                timeout(time: params.backend == 'azure' ? 60 : 30, unit: 'MINUTES') {
+                                timeout(time: params.backend == 'azure' ? 90 : 30, unit: 'MINUTES') {
                                     provisionResources(params, builder.region)
                                     completed_stages['provision_resources'] = true
                                 }


### PR DESCRIPTION
Ocassionbally, VM provisioning request is accepted by Azure but the VM never start (SCT-434).
The change improves provisioning process by detecting such VMs and redeploying the instance on another Azure node (number of attempts to re-deploy a VM is configurable).

Fixes: SCT-434

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [longevity-10gb-3h-azure-test](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/longevity-10gb-3h-azure-test/13)

The node-6 provisioning failed on the first attempt:
```
18:16:26  last error: RetryError(<Future at 0x701d100e81b0 state=finished returned NoneType>)
18:16:26  VM longevity-10gb-3h-azure-st-db-node-fc3655a0-eastus-6 is stuck in provisioning, will be recreated
18:16:26  Triggering termination of instance: longevity-10gb-3h-azure-st-db-node-fc3655a0-eastus-6
18:16:26  Waiting for termination of instance: longevity-10gb-3h-azure-st-db-node-fc3655a0-eastus-6...
18:16:36  Instance longevity-10gb-3h-azure-st-db-node-fc3655a0-eastus-6 has been terminated.
```
Then the node is successfully recreated on the second attempt:
```
18:16:38  (InstanceProvisionStuckEvent Severity.NORMAL) period_type=one-time event_id=07a9d29f-7a20-42b3-b7ef-17bc54c5eec0: vm_name=longevity-10gb-3h-azure-st-db-node-fc3655a0-eastus-6 attempt=1 provisioning_state=Creating message=recreating stuck VM on fresh capacity
...
18:17:10  Waiting for cloud-init to complete on node longevity-10gb-3h-azure-st-db-node-fc3655a0-eastus-6...
...
18:21:35  < t:2026-06-10 16:21:35,570 f:cluster.py      l:952  c:sdcm.cluster_azure   p:INFO  > Node longevity-10gb-3h-azure-st-db-node-fc3655a0-eastus-6 [None | 10.0.0.10] (Type: Standard_L8s_v4): Detected Linux distribution: UBUNTU26
```

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
