### PR TITLE
ci(renovate): show semver versions in GitHub Actions digest PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,10 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    "helpers:pinGitHubActionDigestsToSemver"
   ],
+  "commitBodyTable": true,
   "ignorePresets": [
     "group:monorepos",
     "group:recommended"


### PR DESCRIPTION
## Problem

Renovate digest update PRs (e.g. #14948) only show opaque SHA fragments like `de0fac2` → `df4cb1c` without stating the actual version change or linking to meaningful release notes.

## Solution

Add two Renovate configuration improvements:

1. **`helpers:pinGitHubActionDigestsToSemver` preset** — Tells Renovate to extract the actual semver tag from GitHub Actions digests. Future PRs will show `v6.0.2 → v6.0.3` instead of bare SHA changes.

2. **`commitBodyTable: true`** — Adds a structured table to commit messages showing datasource, package, and version change.

## What changes

```diff
 "extends": [
-    "config:recommended"
+    "config:recommended",
+    "helpers:pinGitHubActionDigestsToSemver"
 ],
+"commitBodyTable": true,
```

## Expected result

**Before** (current PR #14948):
| Package | Update | Change |
|---|---|---|
| actions/checkout | digest | `de0fac2` → `df4cb1c` |

**After** (future PRs):
| Package | Update | Change |
|---|---|---|
| actions/checkout | patch | `v6.0.2` → `v6.0.3` |

With release notes links and proper GitHub diff URLs.

## Notes

- SHA pinning is preserved (security requirement)
- Existing open digest PRs will be updated on next Renovate run
- The preset handles `extractVersion` and `versioning` regex internally
- No workflow file changes needed — Renovate will update version comments automatically on next pin