### PR TITLE
fix(nemesis): retry ModifyTable ALTER on CQL timeout

### DIFF
--- a/sdcm/nemesis/monkey/modify_table.py
+++ b/sdcm/nemesis/monkey/modify_table.py
@@ -10,10 +10,13 @@ import logging
 import time
 from typing import Any, Dict
 
+from cassandra import OperationTimedOut
+
 from sdcm.exceptions import UnsupportedNemesis
 from sdcm.nemesis import NemesisBaseClass
 from sdcm.sct_events.system import InfoEvent
 from sdcm.utils.common import generate_random_string
+from sdcm.utils.decorators import retrying
 from test_lib.compaction import (
     CompactionStrategy,
     calculate_allowed_twcs_ttl,
@@ -65,8 +68,22 @@ class ModifyTableBaseMonkey(NemesisBaseClass, abc.ABC):
 
         cmd = f"ALTER TABLE {keyspace_table} WITH {name} = {val};"
         self.runner.actions_log.info(f"Modify table property on {keyspace_table}: {name} = {val}")
-        with self.runner.cluster.cql_connection_patient(self.runner.target_node) as session:
-            session.execute(cmd)
+
+        # Schema changes can time out when topology-changing nemeses run concurrently (e.g. an isolated
+        # node stalling raft topology operations). Retry the ALTER TABLE on CQL timeout with an increased
+        # per-request timeout to give the operation enough headroom to complete.
+        @retrying(
+            n=3,
+            sleep_time=30,
+            allowed_exceptions=(OperationTimedOut,),
+            message=f"Retrying ALTER TABLE on {keyspace_table} after CQL timeout",
+        )
+        def _execute_alter():
+            with self.runner.cluster.cql_connection_patient(self.runner.target_node) as session:
+                session.default_timeout = 300  # increase timeout for schema changes during parallel topology operation
+                session.execute(cmd)
+
+        _execute_alter()
 
 
 # ---------------------------------------------------------------------------

--- a/unit_tests/unit/nemesis/monkey/test_modify_table.py
+++ b/unit_tests/unit/nemesis/monkey/test_modify_table.py
@@ -5,8 +5,9 @@ method delegation, and the pure arithmetic in set_new_twcs_settings.
 Randomly-generated values are not asserted on.
 """
 
-from unittest.mock import patch
+from unittest.mock import call, patch
 
+from cassandra import OperationTimedOut
 import pytest
 
 from sdcm.exceptions import UnsupportedNemesis
@@ -86,6 +87,29 @@ def test_modify_table_property_forwards_filter_out_counter(runner):
         filter_out_table_with_counter=True,
         filter_out_mv=True,
     )
+
+
+def test_modify_table_property_retries_operation_timed_out_and_sets_session_timeout(runner):
+    """Retry ALTER TABLE after CQL timeout and use a longer per-request timeout."""
+    monkey = ModifyTableCommentMonkey(runner)
+    # Grab the mocked CQL session returned by the patient connection context manager.
+    session = runner.cluster.cql_connection_patient.return_value.__enter__.return_value
+    # First execute() raises OperationTimedOut (simulating a CQL timeout), the second succeeds.
+    session.execute.side_effect = [OperationTimedOut(errors={}, last_host="127.0.0.1"), None]
+
+    # Patch the retry decorator's sleep so the 30s backoff between attempts is skipped in the test.
+    with patch("sdcm.utils.decorators.time.sleep", return_value=None):
+        # Trigger the ALTER TABLE; the first attempt times out and the retry logic re-runs it.
+        monkey.modify_table_property(name="comment", val="'retry-test'", keyspace_table="ks1.tbl1")
+
+    expected_cmd = "ALTER TABLE ks1.tbl1 WITH comment = 'retry-test';"
+    # The same ALTER must be executed exactly twice: the timed-out attempt and the successful retry.
+    assert session.execute.call_args_list == [
+        call(expected_cmd),
+        call(expected_cmd),
+    ], "ALTER TABLE should be retried once after OperationTimedOut, yielding exactly two identical executes"
+    # The retry path must raise the per-request timeout to 300s to give schema changes more headroom.
+    assert session.default_timeout == 300, "session.default_timeout should be increased to 300s for schema changes"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
ModifyTable* nemeses could fail with cassandra.OperationTimedOut when an ALTER TABLE schema change ran concurrently with topology-changing nemeses (e.g. an isolated node stalling raft topology operations), as seen in SCT-249 where ModifyTableReadRepairChanceMonkey timed out.

Wrap the ALTER TABLE execution in the shared retrying decorator (3 attempts, 30s apart) with a 300s per-request timeout. The CQL command and its value are computed once before the retry loop, so re-applying an ALTER that already succeeded server-side but timed out client-side is idempotent and safe.

Fixes: SCT-249

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [Passed with specific nemesis ](https://argus.scylladb.com/tests/scylla-cluster-tests/4fc23ead-8f62-4673-b893-0fa3f385d3db)
- [job with all table modified nemesis](https://argus.scylladb.com/tests/scylla-cluster-tests/ec111ed6-856c-4e6c-b20e-0ea6961988cb)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
