### PR TITLE
improvement(test-cases): retune longevity-mv-si-4days

### DIFF
--- a/jenkins-pipelines/oss/tier1/longevity-mv-si-4days-streaming-oci.jenkinsfile
+++ b/jenkins-pipelines/oss/tier1/longevity-mv-si-4days-streaming-oci.jenkinsfile
@@ -8,5 +8,5 @@ longevityPipeline(
     region: 'us-ashburn-1',
     provision_type: 'on_demand', // DenseIO OCI shapes cannot be 'spot'
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: '''["test-cases/longevity/longevity-mv-si-4days.yaml", "configurations/disable_rbno.yaml", "configurations/oci/longevity-mv-si-4days.yaml"]'''
+    test_config: '''["test-cases/longevity/longevity-mv-si-4days.yaml", "configurations/oci/longevity-mv-si-4days.yaml"]'''
 )

--- a/jenkins-pipelines/oss/tier1/longevity-mv-si-4days-streaming-oci.jenkinsfile
+++ b/jenkins-pipelines/oss/tier1/longevity-mv-si-4days-streaming-oci.jenkinsfile
@@ -8,5 +8,5 @@ longevityPipeline(
     oci_region_name: 'us-phoenix-1',
     provision_type: 'on_demand', // DenseIO OCI shapes cannot be 'spot'
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: '''["test-cases/longevity/longevity-mv-si-4days.yaml", "configurations/disable_rbno.yaml", "configurations/oci/longevity-mv-si-4days.yaml"]'''
+    test_config: '''["test-cases/longevity/longevity-mv-si-4days.yaml", "configurations/oci/longevity-mv-si-4days.yaml"]'''
 )

--- a/jenkins-pipelines/oss/tier1/longevity-mv-si-4days-streaming.jenkinsfile
+++ b/jenkins-pipelines/oss/tier1/longevity-mv-si-4days-streaming.jenkinsfile
@@ -7,6 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: '''["test-cases/longevity/longevity-mv-si-4days.yaml", "configurations/disable_rbno.yaml", "configurations/adaptive_timeout_multipliers.yaml"]'''
+    test_config: '''["test-cases/longevity/longevity-mv-si-4days.yaml", "configurations/adaptive_timeout_multipliers.yaml"]'''
 
 )

--- a/jenkins-pipelines/oss/tier1/longevity-mv-si-4days-streaming.jenkinsfile
+++ b/jenkins-pipelines/oss/tier1/longevity-mv-si-4days-streaming.jenkinsfile
@@ -7,6 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: '''["test-cases/longevity/longevity-mv-si-4days.yaml", "configurations/disable_rbno.yaml", "configurations/adaptive_timeout_multipliers.yaml", "configurations/auto-repair-1h.yaml"]'''
+    test_config: '''["test-cases/longevity/longevity-mv-si-4days.yaml", "configurations/adaptive_timeout_multipliers.yaml", "configurations/auto-repair-1h.yaml"]'''
 
 )

--- a/test-cases/longevity/longevity-mv-si-4days.yaml
+++ b/test-cases/longevity/longevity-mv-si-4days.yaml
@@ -1,27 +1,77 @@
-test_duration: 6550
-prepare_write_cmd: ["cassandra-stress user profile=/tmp/c-s_profile_4mv_5queries.yaml ops'(insert=15,read1=1,read2=1,read3=1,read4=1,read5=1)' cl=QUORUM n=100000000 -mode cql3 native -rate threads=200",
-                    "cassandra-stress user profile=/tmp/c-s_profile_3si_5queries.yaml ops'(insert=25,si_read1=1,si_read2=1,si_read3=1,si_read4=1,si_read5=1)' cl=QUORUM n=100000000 -mode cql3 native -rate threads=200"
-                   ]
-stress_read_cmd: ["cassandra-stress user profile=/tmp/c-s_profile_4mv_5queries.yaml ops'(insert=15,read1=1,read2=1,read3=1,read4=1,read5=1)' cl=QUORUM duration=5760m -mode cql3 native -rate threads=10",
-                  "cassandra-stress user profile=/tmp/c-s_profile_2mv_2queries.yaml ops'(insert=6,mv_p_read1=1,mv_p_read2=1)' cl=QUORUM duration=5760m -mode cql3 native -rate threads=10",
-                  "cassandra-stress user profile=/tmp/c-s_profile_3si_5queries.yaml ops'(insert=25,si_read1=1,si_read2=1,si_read3=1,si_read4=1,si_read5=1)' cl=QUORUM duration=5760m -mode cql3 native -rate threads=10",
-                  "cassandra-stress user profile=/tmp/c-s_profile_2si_2queries.yaml ops'(insert=10,si_p_read1=1,si_p_read2=1)' cl=QUORUM duration=5760m -mode cql3 native -rate threads=10"
+test_duration: 6600
+prepare_stress_duration: 900
+prepare_write_cmd:
+  - >-
+    cassandra-stress user profile=/tmp/c-s_profile_4mv_5queries.yaml
+    ops'(insert=15,read1=1,read2=1,read3=1,read4=1,read5=1)'
+    cl=QUORUM
+    n=200M
+    -mode cql3 native
+    -rate threads=30
+  - >-
+    cassandra-stress user profile=/tmp/c-s_profile_3si_5queries.yaml
+    ops'(insert=25,si_read1=1,si_read2=1,si_read3=1,si_read4=1,si_read5=1)'
+    cl=QUORUM
+    n=200M
+    -mode cql3 native
+    -rate threads=30
 
-                 ]
+post_prepare_cql_cmds:
+  - >-
+    ALTER TABLE mview.users
+    WITH compression = {
+      'sstable_compression': 'LZ4WithDictsCompressor'
+    }
+    AND speculative_retry = 'NONE';
+  - >-
+    ALTER TABLE sec_index.users
+    WITH compression = {
+      'sstable_compression': 'LZ4WithDictsCompressor'
+    }
+    AND speculative_retry = 'NONE';
+
+stress_read_cmd:
+  - >-
+    cassandra-stress user profile=/tmp/c-s_profile_4mv_5queries.yaml
+    ops'(insert=15,read1=1,read2=1,read3=1,read4=1,read5=1)'
+    cl=QUORUM
+    duration=5760m
+    -mode cql3 native
+    -rate threads=15
+  - >-
+    cassandra-stress user profile=/tmp/c-s_profile_2mv_2queries.yaml
+    ops'(insert=6,mv_p_read1=1,mv_p_read2=1)'
+    cl=QUORUM
+    duration=5760m
+    -mode cql3 native
+    -rate threads=15
+  - >-
+    cassandra-stress user profile=/tmp/c-s_profile_3si_5queries.yaml
+    ops'(insert=25,si_read1=1,si_read2=1,si_read3=1,si_read4=1,si_read5=1)'
+    cl=QUORUM
+    duration=5760m
+    -mode cql3 native
+    -rate threads=15
+  - >-
+    cassandra-stress user profile=/tmp/c-s_profile_2si_2queries.yaml
+    ops'(insert=10,si_p_read1=1,si_p_read2=1)'
+    cl=QUORUM
+    duration=5760m
+    -mode cql3 native
+    -rate threads=15
+
 run_fullscan: ['{"mode": "table", "ks_cf": "random", "interval": 15}']
 
 n_db_nodes: 6
-n_loaders: 2
+n_loaders: 4
 
 sizing_db:
-  vcpu: 32
-  # OCI DenseIO.E5 at 32 vCPUs provides only 192 GB (12 GB/OCPU fixed ratio).
-  # Lowered from >=256 to >=192 so OCI can match; other clouds still pick >=256 naturally.
-  memory: '>=192'
-
-sizing_monitor:
-  vcpu: 4
-  memory: '>=16'
+  # Use >=8 (not exact 8) so OCI can match: OCI DenseIO starts at 16 vCPUs (min 8 OCPUs).
+  # AWS/GCE/Azure still resolve to their 8-vCPU instances (smallest fitting).
+  vcpu: ">=8"
+  memory: ">=64"
+  # disk size needed to ensure usage never goes above 50%
+  local_disk_gb: ">=1200"
 
 root_disk_size_runner: 120
 
@@ -31,6 +81,6 @@ nemesis_interval: 30
 
 user_prefix: 'longevity-mv-si-4d'
 
-space_node_threshold: 644245
+space_node_threshold: 644245094
 
 use_preinstalled_scylla: true

--- a/test-cases/longevity/longevity-mv-si-4days.yaml
+++ b/test-cases/longevity/longevity-mv-si-4days.yaml
@@ -1,5 +1,5 @@
-test_duration: 6600
-prepare_stress_duration: 900
+test_duration: 6800
+prepare_stress_duration: 1000
 prepare_write_cmd:
   - >-
     cassandra-stress user profile=/tmp/c-s_profile_4mv_5queries.yaml

--- a/test-cases/longevity/longevity-mv-si-4days.yaml
+++ b/test-cases/longevity/longevity-mv-si-4days.yaml
@@ -1,23 +1,69 @@
 test_duration: 6550
-prepare_write_cmd: ["cassandra-stress user profile=/tmp/c-s_profile_4mv_5queries.yaml ops'(insert=15,read1=1,read2=1,read3=1,read4=1,read5=1)' cl=QUORUM n=100000000 -mode cql3 native -rate threads=200",
-                    "cassandra-stress user profile=/tmp/c-s_profile_3si_5queries.yaml ops'(insert=25,si_read1=1,si_read2=1,si_read3=1,si_read4=1,si_read5=1)' cl=QUORUM n=100000000 -mode cql3 native -rate threads=200"
-                   ]
-stress_read_cmd: ["cassandra-stress user profile=/tmp/c-s_profile_4mv_5queries.yaml ops'(insert=15,read1=1,read2=1,read3=1,read4=1,read5=1)' cl=QUORUM duration=5760m -mode cql3 native -rate threads=10",
-                  "cassandra-stress user profile=/tmp/c-s_profile_2mv_2queries.yaml ops'(insert=6,mv_p_read1=1,mv_p_read2=1)' cl=QUORUM duration=5760m -mode cql3 native -rate threads=10",
-                  "cassandra-stress user profile=/tmp/c-s_profile_3si_5queries.yaml ops'(insert=25,si_read1=1,si_read2=1,si_read3=1,si_read4=1,si_read5=1)' cl=QUORUM duration=5760m -mode cql3 native -rate threads=10",
-                  "cassandra-stress user profile=/tmp/c-s_profile_2si_2queries.yaml ops'(insert=10,si_p_read1=1,si_p_read2=1)' cl=QUORUM duration=5760m -mode cql3 native -rate threads=10"
+prepare_stress_duration: 600
+prepare_write_cmd:
+  - >-
+    cassandra-stress user profile=/tmp/c-s_profile_4mv_5queries.yaml ops'(insert=15,read1=1,read2=1,read3=1,read4=1,read5=1)'
+    cl=QUORUM
+    n=100M
+    -mode cql3 native
+    -rate threads=30
+  - >-
+    cassandra-stress user profile=/tmp/c-s_profile_3si_5queries.yaml ops'(insert=25,si_read1=1,si_read2=1,si_read3=1,si_read4=1,si_read5=1)'
+    cl=QUORUM
+    n=100M
+    -mode cql3 native
+    -rate threads=30
 
-                 ]
+post_prepare_cql_cmds:
+  - >-
+    ALTER TABLE mview.users
+    WITH compression = {
+      'sstable_compression': 'LZ4WithDictsCompressor'
+    }
+    AND speculative_retry = 'NONE';
+  - >-
+    ALTER TABLE sec_index.users
+    WITH compression = {
+      'sstable_compression': 'LZ4WithDictsCompressor'
+    }
+    AND speculative_retry = 'NONE';
+
+stress_read_cmd:
+  - >-
+    cassandra-stress user profile=/tmp/c-s_profile_4mv_5queries.yaml ops'(insert=15,read1=1,read2=1,read3=1,read4=1,read5=1)'
+    cl=QUORUM
+    duration=5760m
+    -mode cql3 native
+    -rate threads=15
+  - >-
+    cassandra-stress user profile=/tmp/c-s_profile_2mv_2queries.yaml ops'(insert=6,mv_p_read1=1,mv_p_read2=1)'
+    cl=QUORUM
+    duration=5760m
+    -mode cql3 native
+    -rate threads=15
+  - >-
+    cassandra-stress user profile=/tmp/c-s_profile_3si_5queries.yaml ops'(insert=25,si_read1=1,si_read2=1,si_read3=1,si_read4=1,si_read5=1)'
+    cl=QUORUM
+    duration=5760m
+    -mode cql3 native
+    -rate threads=15
+  - >-
+    cassandra-stress user profile=/tmp/c-s_profile_2si_2queries.yaml ops'(insert=10,si_p_read1=1,si_p_read2=1)'
+    cl=QUORUM
+    duration=5760m
+    -mode cql3 native
+    -rate threads=15
+
 run_fullscan: ['{"mode": "table", "ks_cf": "random", "interval": 15}']
 
 n_db_nodes: 6
-n_loaders: 2
+n_loaders: 4
 
 sizing_db:
-  vcpu: 32
-  # OCI DenseIO.E5 at 32 vCPUs provides only 192 GB (12 GB/OCPU fixed ratio).
-  # Lowered from >=256 to >=192 so OCI can match; other clouds still pick >=256 naturally.
-  memory: '>=192'
+  # OCI DenseIO.E5 at 16 vCPUs provides only 96 GB (12 GB/OCPU fixed ratio).
+  # Lowered from >=128 to >=96 so OCI can match; other clouds still pick >=128 naturally.
+  vcpu: ">=16"
+  memory: ">=96"
 
 sizing_monitor:
   vcpu: 4
@@ -31,6 +77,6 @@ nemesis_interval: 30
 
 user_prefix: 'longevity-mv-si-4d'
 
-space_node_threshold: 644245
+space_node_threshold: 644245094
 
 use_preinstalled_scylla: true


### PR DESCRIPTION
- use smaller instance types (32 vcpu -> 16 vcpu) (see https://scylladb.atlassian.net/browse/SCYLLADB-1436?focusedCommentId=80933)
- use more loaders (2 -> 4)
- make load consistent across the test (and adjust to new instance types)
  - increase nr of threads in stress_read 10 -> 15
  - reduce nr of treads in prepare_write_cmd 200 -> 30 
- use LZ4 dict compression
- rewrite long lines
- remove streaming override config (see https://scylladb.atlassian.net/browse/SCYLLADB-1436?focusedCommentId=76213)

Fixes: SCYLLADB-1436

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://argus.scylladb.com/tests/scylla-cluster-tests/c2139044-7951-4055-bd91-da36f30687c9
<img width="1054" height="508" alt="image" src="https://github.com/user-attachments/assets/0914197f-78d2-4114-943e-3845dc7fd194" />


Prepare duration `3h29m30s`
> 20:52:51  < t:2026-08-21 17:52:49,892 f:file_logger.py  l:108  c:sdcm.sct_events.file_logger p:INFO  > 2026-08-21 17:52:49.890: (CassandraStressEvent Severity.NORMAL) period_type=end event_id=18dbd0e5-2e30-4e9d-8470-db678341bcd5 duration=3h29m30s: node=Node longevity-mv-si-4d-retune-m-loader-node-c2139044-3 [54.229.236.145 | 10.4.5.163] (Type: c7i.xlarge) (rack: RACK2)


Only let the test for 2 hours after to not waste resources.


Sizing preview
```
Role: db (× 6 nodes)

  Cloud     Resolved Instance          vCPUs  Memory(GB)  Disk(GB)  Arch      Price/hr   Est. Cost  Source
  ────────  ─────────────────────────  ─────  ──────────  ────────  ────────  ────────  ──────────  ────────────────────
  aws       i8g.4xlarge                   16      128.00      3750  arm64      $1.3728     $899.18  sizing_db (test-config) (resolved)
  gce       z3-highmem-16-highlssd        16      128.00  12000 (4d)  x86_64     $2.3039    $1509.03  sizing_db (test-config) (resolved)
  azure     Standard_L16s_v3              16      128.00  3840 (2d)  x86_64     $1.3920     $911.76  sizing_db (test-config) (resolved)
  oci       VM.DenseIO.E5.Flex:16         32      192.00     12800  x86_64     $1.6474    $1079.02  sizing_db (test-config) (resolved)

Role: loader (× 4 nodes)

  Cloud     Resolved Instance          vCPUs  Memory(GB)  Disk(GB)  Arch      Price/hr   Est. Cost  Source
  ────────  ─────────────────────────  ─────  ──────────  ────────  ────────  ────────  ──────────  ────────────────────
  aws       c7i.xlarge                     4        8.00         0  x86_64     $0.1785      $77.94  sizing_loader (defaults) (resolved)
  gce       e2-standard-4                  4       16.00         0  x86_64     $0.1340      $58.52  sizing_loader (defaults) (resolved)
  azure     Standard_F4s_v2                4        8.00         0  x86_64     $0.1690      $73.80  sizing_loader (defaults) (resolved)
  oci       VM.Standard.E4.Flex:2:8        4        8.00         0  x86_64     $0.0980      $42.79  sizing_loader (defaults) (resolved)

Role: monitor (× 1 nodes)

  Cloud     Resolved Instance          vCPUs  Memory(GB)  Disk(GB)  Arch      Price/hr   Est. Cost  Source
  ────────  ─────────────────────────  ─────  ──────────  ────────  ────────  ────────  ──────────  ────────────────────
  aws       t3.xlarge                      4       16.00         0  x86_64     $0.1664      $18.17  sizing_monitor (test-config) (resolved)
  gce       e2-standard-4                  4       16.00         0  x86_64     $0.1340      $14.63  sizing_monitor (test-config) (resolved)
  azure     Standard_D4as_v6               4       16.00         0  x86_64     $0.1820      $19.87  sizing_monitor (test-config) (resolved)
  oci       VM.Standard.E4.Flex:2:16       4       16.00         0  x86_64     $0.0980      $10.70  sizing_monitor (test-config) (resolved)

Estimated Total Cost
  Cloud          Total
  ────────  ──────────
  aws       $   995.29
  gce       $  1582.18
  azure     $  1005.42
  oci       $  1132.51
  ```

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
