### PR TITLE
[Backport 2025.1] fix(nemesis): remove 128KB chunk_length_kb from ModifyTableCompressionMonkey

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -2898,7 +2898,7 @@ class Nemesis:
         algo = random.choice(algos)
         prop_val = {"sstable_compression": algo}
         if algo:
-            prop_val["chunk_length_kb"] = random.choice(["4K", "64KB", "128KB"])
+            prop_val["chunk_length_kb"] = random.choice(["4K", "16KB", "64KB"])
             prop_val["crc_check_chance"] = random.random()
         self._modify_table_property(name="compression", val=str(prop_val))
 


### PR DESCRIPTION
`ModifyTableCompressionMonkey` randomly sets `chunk_length_kb=128KB`, which causes seastar oversized allocation warnings (~135KB = chunk + compression overhead > 128KB threshold). Ref: scylladb/scylladb#24872.

- Replaced `128KB` with `16KB` in chunk_length choices: `["4K", "16KB", "64KB"]`
- Keeps compression nemesis variety while staying below seastar's allocation threshold
- Can be restored once the upstream issue is resolved

### Testing
- [ ] N/A — single constant change in nemesis config; no new logic to test

### PR pre-checks (self review)
- [ ] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)

- (cherry picked from commit eab431165abedb8db74dae6f967891ce439aab00)

Parent PR: #14515