### PR TITLE
chore(docs): Regenerate docs

### DIFF
--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -2067,15 +2067,14 @@ Direct URL to a full edition Scylla Doctor tarball in S3. When set, bypasses the
 
 **default:** N/A
 
-**type:** str
-* appendable
+**type:** str (appendable)
 
 
 ## **run_scylla_doctor_only** / SCT_RUN_SCYLLA_DOCTOR_ONLY
 
 When true, the artifact test runs only the Scylla Doctor validation<br>(install, collect vitals, analyze, verify) and skips all other artifact checks<br>such as stop/start, cassandra-stress, housekeeping, etc. Useful for fast SD<br>release gating. Implies run_scylla_doctor=true.
 
-**default:** N/A
+**default:** False
 
 **type:** bool
 


### PR DESCRIPTION
Fixes clash between https://github.com/scylladb/scylla-cluster-tests/pull/14960 and https://github.com/scylladb/scylla-cluster-tests/pull/15005

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
