### PR TITLE
ci(oci): add analog of the tier2 multidc test for the OCI backend

### DIFF
--- a/jenkins-pipelines/oss/tier2/longevity-cdc-8h-multi-dc-topology-changes-streaming-oci.jenkinsfile
+++ b/jenkins-pipelines/oss/tier2/longevity-cdc-8h-multi-dc-topology-changes-streaming-oci.jenkinsfile
@@ -1,0 +1,12 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+// Runs LongevityTest for topology changes with streaming instead of RBNO
+longevityPipeline(
+    backend: 'oci',
+    oci_region_name: '''["us-ashburn-1", "us-phoenix-1"]''',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: '''["test-cases/longevity/longevity-cdc-100gb-8h-multi-dc-topology-changes.yaml", "configurations/disable_rbno.yaml"]''',
+)

--- a/test-cases/longevity/longevity-cdc-100gb-8h-multi-dc-topology-changes.yaml
+++ b/test-cases/longevity/longevity-cdc-100gb-8h-multi-dc-topology-changes.yaml
@@ -7,11 +7,14 @@ stress_cmd: [ "cassandra-stress user no-warmup profile=/tmp/cdc_profile_multidc.
              ]
 
 n_db_nodes: '6 6'
-instance_type_db: 'i4i.4xlarge'
 n_loaders: '2 2'
+
+instance_type_db: 'i4i.4xlarge'
+oci_instance_type_db: "VM.DenseIO.E5.Flex:8" # <shape-name>:<ocpus>:<ram>:<nvmes>
 
 rack_aware_loader: true
 region_aware_loader: true
+availability_zone: "a,b,c"
 simulated_racks: 0
 
 nemesis_class_name: 'SisyphusMonkey'


### PR DESCRIPTION
### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [scylla-staging/valerii/vp-longevity-cdc-8h-multi-dc-topology-changes-streaming-oci-test#3](https://argus.scylladb.com/tests/scylla-cluster-tests/6f2c365f-8067-4ba5-8f9b-de0837c11fa4) (failed, but error is unrelated to the PR)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
