### PR TITLE
fix(provision): set oracle db instance size default

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -130,7 +130,9 @@ run_gemini_in_rolling_upgrade: false
 
 # cloud-agnostic instance sizing constraints (resolved per-cloud by _resolve_instance_sizes)
 sizing_db: null
-sizing_db_oracle: null
+sizing_db_oracle:
+  vcpu: 8
+  memory: '>=60'
 sizing_loader:
   vcpu: 4
   memory: '>=8'

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -1190,7 +1190,7 @@ Cloud-agnostic instance sizing constraints for db nodes
 
 Cloud-agnostic instance sizing constraints for db_oracle nodes
 
-**default:** N/A
+**default:** {'vcpu': 8, 'memory': '>=60'}
 
 **type:** dict
 


### PR DESCRIPTION
After recent change we forgot to specify default oracle instance size and now most of gemini tests fail.
Set 8cpu's 60GB memory (previous default, i8g.2xlarge). In case bigger one is needed, tests can override.

fixes: SCT-478

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
