### PR TITLE
Fix mgr test issues

### DIFF
--- a/mgmt_upgrade_test.py
+++ b/mgmt_upgrade_test.py
@@ -167,7 +167,6 @@ class ManagerUpgradeTest(ManagerTestFunctionsMixIn, ClusterTester):
         with self.subTest("Creating a backup task and stopping it"):
             self.generate_load_and_wait_for_results(keyspace_name="keyspace2")
             stopped_backup_task = mgr_cluster.create_backup_task(
-                cron=create_cron_list_from_timedelta(minutes=1),
                 location_list=self.locations,
                 keyspace_list=["keyspace2"],
                 method=self.backup_method,

--- a/sdcm/sct_events/setup.py
+++ b/sdcm/sct_events/setup.py
@@ -197,7 +197,7 @@ def enable_default_filters(sct_config: SCTConfiguration):
         db_event=DatabaseLogEvent.RUNTIME_ERROR,
         line=r".*raft_topology - topology change coordinator fiber got error std::runtime_error"
         r" \(raft topology: exec_global_command\(barrier(?:_and_drain)?\) failed with seastar::rpc::closed_error"
-        r" \(connection is closed\)\)",
+        r" \(.*connection is closed\)\)",
     ).publish()
 
 


### PR DESCRIPTION
Closes https://scylladb.atlassian.net/browse/SCT-469
Closes https://scylladb.atlassian.net/browse/SCT-470

## Changes

1. fix(manager): remove cron schedule from backup task creation

There is no reason to schedule this task and then wait for its RUNNING state. It can be triggered immediately instead, thus, eliminating the need to wait for it to start running.

2. fix(events): broaden raft topology closed_error filter to match node-info variant

The DbEventsFilter regex for raft topology barrier errors only matched `(connection is closed)` but not the variant that includes node details: `(got error from node <uuid>/<ip>: connection is closed)`.

Example unfiltered event:
```
  raft_topology - topology change coordinator fiber got error std::runtime_error
  (raft topology: exec_global_command(barrier) failed with seastar::rpc::closed_error
  (got error from node 6ce02a67-21e7-4ba5-900f-1036de9e03ad/2600:1f18:7f4:3c00:b3d2:1896:d209:e8fe:
  connection is closed))
```

Change `\(connection is closed\)` to `\(.*connection is closed\)` to cover both forms.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] [ubuntu24-upgrade-test](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/mikita/job/manager-master-clone/job/ubuntu24-upgrade-test/16/)