### PR TITLE
fix(manager): remove cron schedule from backup task creation

### DIFF
--- a/mgmt_upgrade_test.py
+++ b/mgmt_upgrade_test.py
@@ -167,7 +167,6 @@ class ManagerUpgradeTest(ManagerTestFunctionsMixIn, ClusterTester):
         with self.subTest("Creating a backup task and stopping it"):
             self.generate_load_and_wait_for_results(keyspace_name="keyspace2")
             stopped_backup_task = mgr_cluster.create_backup_task(
-                cron=create_cron_list_from_timedelta(minutes=1),
                 location_list=self.locations,
                 keyspace_list=["keyspace2"],
                 method=self.backup_method,


### PR DESCRIPTION
Closes https://scylladb.atlassian.net/browse/SCT-469

There is no reason to schedule this task and then wait for it to start running. It can be triggered immediately instead, thus, eliminating the need for a wait.

### Testing

- [x] [ubuntu24-upgrade-test](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/mikita/job/manager-master-clone/job/ubuntu24-upgrade-test/16/)