### PR TITLE
fix(events): broaden raft topology closed_error filter to match node-info variant

### DIFF
--- a/sdcm/sct_events/setup.py
+++ b/sdcm/sct_events/setup.py
@@ -197,7 +197,7 @@ def enable_default_filters(sct_config: SCTConfiguration):
         db_event=DatabaseLogEvent.RUNTIME_ERROR,
         line=r".*raft_topology - topology change coordinator fiber got error std::runtime_error"
         r" \(raft topology: exec_global_command\(barrier(?:_and_drain)?\) failed with seastar::rpc::closed_error"
-        r" \(connection is closed\)\)",
+        r" \(.*connection is closed\)\)",
     ).publish()
 
 


### PR DESCRIPTION
Closes https://scylladb.atlassian.net/browse/SCT-470

The DbEventsFilter regex for raft topology barrier errors only matched `(connection is closed)` but not the variant that includes node details: `(got error from node <uuid>/<ip>: connection is closed)`.

Example unfiltered event:
```
raft_topology - topology change coordinator fiber got error std::runtime_error
(raft topology: exec_global_command(barrier) failed with seastar::rpc::closed_error
(got error from node 6ce02a67-21e7-4ba5-900f-1036de9e03ad/2600:1f18:7f4:3c00:b3d2:1896:d209:e8fe:
connection is closed))
```

Change `\(connection is closed\)` to `\(.*connection is closed\)` to cover both forms.