### PR TITLE
improvement(sct-runner): add retries for checking SSH connectivity

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -71,6 +71,7 @@ from sdcm.sct_runner import (
 )
 
 from sdcm.utils.ci_tools import get_job_name, get_job_url
+from sdcm.utils.decorators import retrying
 from sdcm.utils.git import get_git_commit_id, get_git_status_info, clone_repo
 from sdcm.utils.argus import (
     argus_offline_collect_events,
@@ -2445,11 +2446,17 @@ def create_runner_instance(
     LOGGER.info("Verifying SSH connectivity...")
     runner_public_ip = sct_runner.get_instance_public_ip(instance=instance)
     remoter = sct_runner.get_remoter(host=runner_public_ip, connect_timeout=240)
-    if remoter.run("true", timeout=200, verbose=False, ignore_status=True).ok:
+
+    @retrying(n=3, sleep_time=30, message=f"Retrying SSH connection to {runner_public_ip}")
+    def verify_ssh():
+        assert remoter.run("true", timeout=200, verbose=False, ignore_status=True).ok
+
+    try:
+        verify_ssh()
         LOGGER.info("Successfully connected the SCT Runner. Public IP: %s", runner_public_ip)
         with sct_runner_ip_path.open(mode="w", encoding="utf-8") as sct_runner_ip_file:
             sct_runner_ip_file.write(runner_public_ip)
-    else:
+    except Exception:  # noqa: BLE001
         LOGGER.error("Unable to SSH to %s! Exiting...", runner_public_ip)
         sys.exit(1)
 


### PR DESCRIPTION
It may happen that one of SSH attempts may fail due to various reasons. So, add several retries to workaround following situation:

```
  Verifying SSH connectivity...
  Connected (version 2.0, client OpenSSH_9.6p1)
  Authentication (publickey) successful!
  Connected (version 2.0, client OpenSSH_9.6p1)
  Authentication (publickey) failed.
  Authentication failed.
  ...
  paramiko.ssh_exception.AuthenticationException: Authentication failed.
```

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
