### PR TITLE
fix(alternator): gate Alternator LWT-tablets on running node version

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1504,8 +1504,9 @@ class ClusterTester(unittest.TestCase):
             # Enable tablets with Alternator TTL requires (#16567).
             tablets_support_ttl = not SkipPerIssues(issues="scylladb/scylladb#16567", params=self.params)
 
-            # Enable tablets for Alternator with LWT requires issue: "[Epic] tablets: support LWT #18068"
-            tablets_support_lwt = not SkipPerIssues(issues="scylladb/scylladb#18068", params=self.params)
+            # LWT with tablets is supported starting from 2025.4 (scylladb/scylladb#18068 resolved).
+            # Check the *running* node version to avoid enabling it on older base versions in upgrade tests.
+            tablets_support_lwt = ComparableScyllaVersion(node.scylla_version) >= "2025.4.0~dev"
 
             tablets_supported_alternator_workload = not is_ttl_in_workload or tablets_support_ttl
             schema = self.params.get("dynamodb_primarykey_type")


### PR DESCRIPTION
The Alternator pre-create logic enabled tablets for the LWT table based solely on whether GitHub issue scylladb/scylladb#18068 was open. Once the issue was closed, tables were created with tablets on any version, but LWT-with-tablets is only supported from 2025.4. In rolling-upgrade tests the base version (e.g. 2025.3.x) rejected LWT on tablet tables, failing the pre-upgrade Alternator workload.

Replace the SkipPerIssues check with a direct version check on the running node so tablets are only enabled when the node actually supports it.

[#SCT-473]

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
