### PR TITLE
fix(config): treat blank required params as missing and unblock pipeline linting

### DIFF
--- a/configurations/nemesis/longevity-5gb-1h-nemesis.yaml
+++ b/configurations/nemesis/longevity-5gb-1h-nemesis.yaml
@@ -22,6 +22,7 @@ gce_instance_type_loader: 'e2-standard-2'
 azure_instance_type_db: 'Standard_L8s_v3'
 instance_type_loader: 'c6i.large'
 azure_instance_type_loader: 'Standard_F2s_v2'
+oci_instance_type_db: "VM.DenseIO.E5.Flex:8" # <shape-name>:<ocpus>:<ram>:<nvmes>
 
 nemesis_interval: 3
 

--- a/jenkins-pipelines/oss/features/features-google-cloud-snitch-mutli-dc.jenkinsfile
+++ b/jenkins-pipelines/oss/features/features-google-cloud-snitch-mutli-dc.jenkinsfile
@@ -7,5 +7,5 @@ longevityPipeline(
     backend: 'gce',
     gce_datacenter: '''["us-east1", "us-west1"]''',
     test_name: 'snitch_test.SnitchTest.test_cloud_snitch',
-    test_config: 'test-cases/features/google-cloud-snitch-multi-dc.yaml'
+    test_config: '''["test-cases/features/google-cloud-snitch-multi-dc.yaml", "configurations/gce/z3-highmem-8-highlssd.yaml"]'''
 )

--- a/jenkins-pipelines/oss/rolling-upgrade/rolling-upgrade-alternator.jenkinsfile
+++ b/jenkins-pipelines/oss/rolling-upgrade/rolling-upgrade-alternator.jenkinsfile
@@ -10,5 +10,5 @@ rollingUpgradePipeline(
     gce_image_db: 'https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/family/ubuntu-2204-lts',
 
     test_name: 'upgrade_test.UpgradeTest.test_generic_cluster_upgrade',
-    test_config: '''["test-cases/upgrades/generic-rolling-upgrade.yaml", "configurations/rolling-upgrade-alternator.yaml", "configurations/auth_cassandra.yaml"]'''
+    test_config: '''["test-cases/upgrades/generic-rolling-upgrade.yaml", "configurations/rolling-upgrade-alternator.yaml", "configurations/gce/z3-highmem-8-highlssd.yaml", "configurations/auth_cassandra.yaml"]'''
 )

--- a/jenkins-pipelines/oss/rolling-upgrade/rolling-upgrade-ubuntu22.04-ldap-authorization.jenkinsfile
+++ b/jenkins-pipelines/oss/rolling-upgrade/rolling-upgrade-ubuntu22.04-ldap-authorization.jenkinsfile
@@ -10,6 +10,6 @@ rollingUpgradePipeline(
     gce_image_db: 'https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/family/ubuntu-2204-lts',
 
     test_name: 'upgrade_test.UpgradeTest.test_rolling_upgrade',
-    test_config: '''["test-cases/upgrades/rolling-upgrade.yaml", "configurations/ldap-authorization.yaml", "configurations/auth_cassandra.yaml"]''',
+    test_config: '''["test-cases/upgrades/rolling-upgrade.yaml", "configurations/ldap-authorization.yaml", "configurations/gce/z3-highmem-8-highlssd.yaml", "configurations/auth_cassandra.yaml"]''',
     internode_compression: 'all'
 )

--- a/jenkins-pipelines/oss/rolling-upgrade/rolling-upgrade-with-null-inserts.jenkinsfile
+++ b/jenkins-pipelines/oss/rolling-upgrade/rolling-upgrade-with-null-inserts.jenkinsfile
@@ -9,5 +9,5 @@ rollingUpgradePipeline(
     linux_distro: 'ubuntu-focal',
     use_preinstalled_scylla: true,
     test_name: 'upgrade_test.UpgradeTest.test_generic_cluster_upgrade',
-    test_config: '''["test-cases/upgrades/generic-rolling-upgrade.yaml", "configurations/rolling-upgrade-with-null-inserts.yaml", "configurations/auth_cassandra.yaml"]'''
+    test_config: '''["test-cases/upgrades/generic-rolling-upgrade.yaml", "configurations/rolling-upgrade-with-null-inserts.yaml", "configurations/gce/z3-highmem-8-highlssd.yaml", "configurations/auth_cassandra.yaml"]'''
 )

--- a/jenkins-pipelines/oss/rolling-upgrade/rolling-upgrade-with-sla-no-shares.jenkinsfile
+++ b/jenkins-pipelines/oss/rolling-upgrade/rolling-upgrade-with-sla-no-shares.jenkinsfile
@@ -9,5 +9,5 @@ rollingUpgradePipeline(
     linux_distro: 'ubuntu-jammy',
     gce_image_db: 'https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/family/ubuntu-2204-lts',
     test_name: 'upgrade_test.UpgradeTest.test_generic_cluster_upgrade',
-    test_config: '''["test-cases/upgrades/generic-rolling-upgrade.yaml", "configurations/rolling-upgrade-with-sla-no-shares.yaml", "configurations/auth_cassandra.yaml"]'''
+    test_config: '''["test-cases/upgrades/generic-rolling-upgrade.yaml", "configurations/rolling-upgrade-with-sla-no-shares.yaml", "configurations/gce/z3-highmem-8-highlssd.yaml", "configurations/auth_cassandra.yaml"]'''
 )

--- a/jenkins-pipelines/oss/rolling-upgrade/rolling-upgrade-with-sla.jenkinsfile
+++ b/jenkins-pipelines/oss/rolling-upgrade/rolling-upgrade-with-sla.jenkinsfile
@@ -9,5 +9,5 @@ rollingUpgradePipeline(
     linux_distro: 'ubuntu-jammy',
     gce_image_db: 'https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/family/ubuntu-2204-lts',
     test_name: 'upgrade_test.UpgradeTest.test_generic_cluster_upgrade',
-    test_config: '''["test-cases/upgrades/generic-rolling-upgrade.yaml", "configurations/rolling-upgrade-with-sla.yaml", "configurations/auth_cassandra.yaml"]'''
+    test_config: '''["test-cases/upgrades/generic-rolling-upgrade.yaml", "configurations/rolling-upgrade-with-sla.yaml", "configurations/gce/z3-highmem-8-highlssd.yaml", "configurations/auth_cassandra.yaml"]'''
 )

--- a/jenkins-pipelines/oss/vnodes/rolling_upgrades/rolling-upgrade-with-sla.jenkinsfile
+++ b/jenkins-pipelines/oss/vnodes/rolling_upgrades/rolling-upgrade-with-sla.jenkinsfile
@@ -9,5 +9,5 @@ rollingUpgradePipeline(
     linux_distro: 'ubuntu-jammy',
     gce_image_db: 'https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/family/ubuntu-2204-lts',
     test_name: 'upgrade_test.UpgradeTest.test_generic_cluster_upgrade',
-    test_config: '''["test-cases/upgrades/generic-rolling-upgrade.yaml", "configurations/rolling-upgrade-with-sla.yaml","configurations/tablets_disabled.yaml", "configurations/auth_cassandra.yaml"]'''
+    test_config: '''["test-cases/upgrades/generic-rolling-upgrade.yaml", "configurations/rolling-upgrade-with-sla.yaml","configurations/tablets_disabled.yaml", "configurations/gce/z3-highmem-8-highlssd.yaml", "configurations/auth_cassandra.yaml"]'''
 )

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -3993,8 +3993,11 @@ class SCTConfiguration(BaseModel):
             for field_name, field in self.__class__.model_fields.items()
             if field_name in required_params and not is_ignored_field(field)
         ]
-        for field in fields:
-            assert self.get(field) is not None, f"{field} missing from config for {backend}"
+        for field_name in fields:
+            value = self.get(field_name)
+            assert value is not None and not (isinstance(value, str) and not value.strip()), (
+                f"{field_name} missing from config for {backend}"
+            )
 
     def _instance_type_validation(self):
         if instance_type := self.get("nemesis_grow_shrink_instance_type"):

--- a/sdcm/utils/lint/env_builder.py
+++ b/sdcm/utils/lint/env_builder.py
@@ -7,11 +7,37 @@ SCTConfiguration expects, mirroring the logic in vars/runSctTest.groovy.
 import json
 import logging
 
-from sdcm.sct_config import BACKEND_IMAGE_FIELD
+from sdcm.sct_config import BACKEND_IMAGE_FIELD, SCTConfiguration
 from sdcm.sct_config import count_regions as count_regions_from_string
 from sdcm.utils.lint.jenkins_parser import PipelineConfig
 
 logger = logging.getLogger(__name__)
+
+# Required params that Jenkins injects at runtime (their default in the pipeline
+# definition is empty), so they are never pinned in the pipeline file itself.
+# During linting we fill a working placeholder for any backend that lists them as
+# required, so the check validates config structure instead of failing on a
+# runtime-only param. Keyed by param name -> (SCT_* env var, placeholder value).
+#   - scylla_version: chosen so resolution stays offline —
+#     get_scylla_docker_repo_from_version() maps it to a nightly repo and
+#     _replace_docker_image_latest_tag() only hits the network for "latest".
+#   - k8s_scylla_operator_docker_image: only k8s-eks requires it; a plain image
+#     reference is enough for the structural check.
+_RUNTIME_REQUIRED_PARAM_PLACEHOLDERS: dict[str, tuple[str, str]] = {
+    "scylla_version": ("SCT_SCYLLA_VERSION", "0.0.0-lint-placeholder"),
+    "k8s_scylla_operator_docker_image": (
+        "SCT_K8S_SCYLLA_OPERATOR_DOCKER_IMAGE",
+        "scylladb/scylla-operator:lint-placeholder",
+    ),
+}
+
+# Precompute, per backend, the placeholder env vars to inject — derived from
+# backend_required_params so it stays in sync as required params change.
+_BACKEND_RUNTIME_PLACEHOLDERS: dict[str, dict[str, str]] = {}
+for _param, (_env_var, _value) in _RUNTIME_REQUIRED_PARAM_PLACEHOLDERS.items():
+    for _backend, _required in SCTConfiguration.model_fields["backend_required_params"].default.items():
+        if _param in _required:
+            _BACKEND_RUNTIME_PLACEHOLDERS.setdefault(_backend, {})[_env_var] = _value
 
 # Mapping from pipeline parameter names to SCT_* environment variable names.
 # "Direct" means the env var name follows the SCT_ + UPPER(param) convention.
@@ -265,6 +291,9 @@ def _add_image_placeholders(env: dict[str, str], backend: str, num_regions: int)
     ):
         env["SCT_SCYLLA_REPO"] = _SCYLLA_REPO_PLACEHOLDER
 
-    # xcloud backend requires scylla_version at runtime — provide obviously invalid placeholder
-    if backend == "xcloud" and "SCT_SCYLLA_VERSION" not in env:
-        env["SCT_SCYLLA_VERSION"] = "0.0.0-lint-placeholder"
+    # Some required params (scylla_version, k8s_scylla_operator_docker_image, ...)
+    # are supplied by Jenkins at runtime and never pinned in the pipeline file.
+    # Inject placeholders for those so linting validates config structure instead
+    # of failing on a runtime-only param — they stay mandatory for the actual check.
+    for env_var, value in _BACKEND_RUNTIME_PLACEHOLDERS.get(backend, {}).items():
+        env.setdefault(env_var, value)

--- a/templates/test_config/template-longevity-5gb-1h-base.yaml.j2
+++ b/templates/test_config/template-longevity-5gb-1h-base.yaml.j2
@@ -22,6 +22,7 @@ gce_instance_type_loader: 'e2-standard-2'
 azure_instance_type_db: 'Standard_L8s_v3'
 instance_type_loader: 'c6i.large'
 azure_instance_type_loader: 'Standard_F2s_v2'
+oci_instance_type_db: "VM.DenseIO.E5.Flex:8" # <shape-name>:<ocpus>:<ram>:<nvmes>
 
 nemesis_interval: 3
 

--- a/unit_tests/integration/test_config.py
+++ b/unit_tests/integration/test_config.py
@@ -41,6 +41,10 @@ def fixture_env(monkeypatch):
     monkeypatch.setenv("SCT_USE_MGMT", "false")
     monkeypatch.setenv("SCT_SCYLLA_VERSION", _get_latest_scylla_release())
     monkeypatch.setenv("SCT_CONFIG_FILES", "unit_tests/test_configs/minimal_test_case.yaml")
+    # gce/azure instance_type_db default to empty and are now required; set them so
+    # gce/azure/gce-siren backends pass the per-backend required-params check.
+    monkeypatch.setenv("SCT_GCE_INSTANCE_TYPE_DB", "n2-highmem-2")
+    monkeypatch.setenv("SCT_AZURE_INSTANCE_TYPE_DB", "Standard_L8s_v3")
 
 
 @pytest.mark.integration

--- a/unit_tests/integration/test_config_get_version_based_on_conf.py
+++ b/unit_tests/integration/test_config_get_version_based_on_conf.py
@@ -47,6 +47,10 @@ def latest_release():
 @pytest.fixture(scope="function", autouse=True)
 def function_setup(monkeypatch):
     monkeypatch.setenv("SCT_CONFIG_FILES", "unit_tests/test_configs/minimal_test_case.yaml")
+    # gce/azure instance_type_db default to empty and are now required; set them so
+    # gce/azure backends pass the per-backend required-params check.
+    monkeypatch.setenv("SCT_GCE_INSTANCE_TYPE_DB", "n2-highmem-2")
+    monkeypatch.setenv("SCT_AZURE_INSTANCE_TYPE_DB", "Standard_L8s_v3")
 
 
 @pytest.mark.parametrize(

--- a/unit_tests/lint/test_env_builder.py
+++ b/unit_tests/lint/test_env_builder.py
@@ -275,6 +275,53 @@ def test_build_env_xcloud_params():
     env = build_env(config)
     assert env["SCT_XCLOUD_PROVIDER"] == "aws"
     assert env["SCT_XCLOUD_ENV"] == "staging"
+    # xcloud requires scylla_version (injected by Jenkins at runtime) — lint fills a placeholder
+    assert env["SCT_SCYLLA_VERSION"] == "0.0.0-lint-placeholder"
+
+
+@pytest.mark.parametrize(
+    "backend",
+    [
+        pytest.param("docker", id="docker"),
+        pytest.param("k8s-eks", id="k8s-eks"),
+        pytest.param("k8s-gke", id="k8s-gke"),
+        pytest.param("k8s-local-kind", id="k8s-local-kind"),
+        pytest.param("xcloud", id="xcloud"),
+    ],
+)
+def test_build_env_injects_scylla_version_placeholder(backend):
+    """Backends that require scylla_version get a working placeholder for linting."""
+    config = _make_config(params={"backend": backend})
+    env = build_env(config)
+    assert env["SCT_SCYLLA_VERSION"] == "0.0.0-lint-placeholder"
+
+
+def test_build_env_injects_operator_docker_image_for_eks():
+    """k8s-eks requires k8s_scylla_operator_docker_image (Jenkins runtime param) — lint fills it."""
+    config = _make_config(params={"backend": "k8s-eks"})
+    env = build_env(config)
+    assert env["SCT_K8S_SCYLLA_OPERATOR_DOCKER_IMAGE"] == "scylladb/scylla-operator:lint-placeholder"
+
+
+def test_build_env_no_operator_docker_image_for_gke():
+    """k8s-gke requires a helm repo, not the operator docker image — no placeholder injected."""
+    config = _make_config(params={"backend": "k8s-gke"})
+    env = build_env(config)
+    assert "SCT_K8S_SCYLLA_OPERATOR_DOCKER_IMAGE" not in env
+
+
+def test_build_env_keeps_pipeline_scylla_version():
+    """An explicit scylla_version in the pipeline is not overwritten by the placeholder."""
+    config = _make_config(params={"backend": "docker", "scylla_version": "2024.2.0"})
+    env = build_env(config)
+    assert env["SCT_SCYLLA_VERSION"] == "2024.2.0"
+
+
+def test_build_env_no_scylla_version_placeholder_for_aws():
+    """AWS resolves scylla from an AMI/repo, so no scylla_version placeholder is injected."""
+    config = _make_config(params={"backend": "aws", "region": "eu-west-1"})
+    env = build_env(config)
+    assert "SCT_SCYLLA_VERSION" not in env
 
 
 def test_build_env_pytest_addopts():

--- a/unit_tests/unit/test_config.py
+++ b/unit_tests/unit/test_config.py
@@ -26,6 +26,11 @@ def _get_latest_scylla_release(product="scylla"):
     return get_latest_scylla_release(product=product, verify=False)
 
 
+def _set_gce_instance_types(monkeypatch):
+    """gce_instance_type_db defaults to empty and is now required; set it for gce-backend tests."""
+    monkeypatch.setenv("SCT_GCE_INSTANCE_TYPE_DB", "n2-highmem-2")
+
+
 @pytest.fixture(scope="module")
 def monkeymodule():
     """Fixture that provides a monkeypatching with module scope."""
@@ -133,6 +138,7 @@ def test_09_unknown_env(monkeypatch):
 
 def test_12_scylla_version_repo_ubuntu(monkeypatch):
     monkeypatch.setenv("SCT_CLUSTER_BACKEND", "gce")
+    _set_gce_instance_types(monkeypatch)
     monkeypatch.setenv("SCT_SCYLLA_LINUX_DISTRO", "ubuntu-xenial")
     monkeypatch.setenv("SCT_SCYLLA_LINUX_DISTRO_LOADER", "ubuntu-xenial")
     monkeypatch.setenv("SCT_SCYLLA_VERSION", "3.0.3")
@@ -153,6 +159,7 @@ def test_12_scylla_version_repo_ubuntu(monkeypatch):
 
 def test_12_scylla_version_repo_ubuntu_loader_centos(monkeypatch):
     monkeypatch.setenv("SCT_CLUSTER_BACKEND", "gce")
+    _set_gce_instance_types(monkeypatch)
     monkeypatch.setenv("SCT_SCYLLA_LINUX_DISTRO", "ubuntu-xenial")
     monkeypatch.setenv("SCT_SCYLLA_LINUX_DISTRO_LOADER", "centos")
     monkeypatch.setenv("SCT_SCYLLA_VERSION", "3.0.3")
@@ -344,6 +351,7 @@ def test_15_new_scylla_repo(monkeypatch):
 
     monkeypatch.delenv("SCT_SCYLLA_VERSION", raising=False)
     monkeypatch.setenv("SCT_CLUSTER_BACKEND", "gce")
+    _set_gce_instance_types(monkeypatch)
     monkeypatch.setenv("SCT_SCYLLA_REPO", centos_repo)
     monkeypatch.setenv("SCT_NEW_SCYLLA_REPO", centos_repo)
     monkeypatch.setenv("SCT_USER_PREFIX", "testing")
@@ -361,6 +369,7 @@ def test_15_new_scylla_repo(monkeypatch):
 
 def test_15a_new_scylla_repo_by_scylla_version(monkeypatch):
     monkeypatch.setenv("SCT_CLUSTER_BACKEND", "gce")
+    _set_gce_instance_types(monkeypatch)
     monkeypatch.setenv("SCT_SCYLLA_VERSION", "master:latest")
     monkeypatch.setenv("SCT_NEW_VERSION", "master:latest")
     monkeypatch.setenv("SCT_USER_PREFIX", "testing")
@@ -387,6 +396,7 @@ def test_15a_new_scylla_repo_by_scylla_version(monkeypatch):
 
 def test_15b_image_id_by_scylla_version(monkeypatch):
     monkeypatch.setenv("SCT_CLUSTER_BACKEND", "gce")
+    _set_gce_instance_types(monkeypatch)
     monkeypatch.setenv("SCT_SCYLLA_VERSION", "master:latest")
     monkeypatch.setenv("SCT_USER_PREFIX", "testing")
     monkeypatch.setenv("SCT_GCE_IMAGE_DB", "")
@@ -659,6 +669,8 @@ def test_37_raises_error_for_invalid_thread_count_type(monkeypatch):
 def test_38_verify_scylla_version_lookup_k8s(monkeypatch, backend, version, expected_repo):
     monkeypatch.setenv("SCT_CLUSTER_BACKEND", backend)
     monkeypatch.setenv("SCT_SCYLLA_VERSION", version)
+    # k8s-eks requires the operator docker image (a Jenkins runtime param); set it explicitly.
+    monkeypatch.setenv("SCT_K8S_SCYLLA_OPERATOR_DOCKER_IMAGE", "scylladb/scylla-operator:latest")
     conf = sct_config.SCTConfiguration()
     conf.verify_configuration()
     assert "docker_image" in conf.dump_config()


### PR DESCRIPTION
## What

Tightens required-param validation so blank/whitespace values are treated as missing, makes `lint-pipelines` viable across all backends, and fixes the configs/pipelines surfaced by the stricter check.

## Commits

- **fix(config): treat blank strings as missing in required params validation** — `_check_backend_defaults` previously only rejected `None`. A required param set to `""` or whitespace passed validation; now those fail too, which is what surfaces pipelines/configs with effectively-empty `instance_type` definitions.
- **chore(pipelines): add instance_type config to rolling-upgrade jobs** — include `configurations/gce/z3-highmem-8-highlssd.yaml` in the `test_config` of the OSS rolling-upgrade pipelines (plus the vnodes rolling-upgrade-with-sla and the google-cloud-snitch multi-dc feature job) so they define an instance type instead of relying on it implicitly.
- **fix(lint): inject placeholder scylla_version for backends that require it** — some required params are supplied by Jenkins at runtime (empty default in the pipeline definition) and never pinned in the pipeline file: `scylla_version` (`docker`, `k8s-*`, `xcloud`) and `k8s_scylla_operator_docker_image` (`k8s-eks`). With the stricter check, linting these tripped on the runtime-only param and masked genuinely missing params (e.g. `instance_type`). A generic, `backend_required_params`-derived map injects offline placeholders for exactly those backends during linting, keeping the params mandatory for the actual check.
- **chore(config): add oci_instance_type_db to longevity-5gb-1h-nemesis** — define the OCI db instance shape so the config passes the per-backend required-params check.

## Testing

- `unit_tests/lint/test_env_builder.py` — 34 passed (added coverage for placeholder injection across docker/k8s/xcloud, the k8s-eks operator image, explicit-version passthrough, and the AWS/k8s-gke no-placeholder cases)
- `./sct.py lint-pipelines` on docker, k8s-gke and k8s-eks pipelines: passing (previously failed on missing `scylla_version` / `k8s_scylla_operator_docker_image`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes: SCT-480