### PR TITLE
fix(scylla-doctor): search for bundled python3 under $HOME instead of /tmp

### DIFF
--- a/unit_tests/test_scylla_doctor.py
+++ b/unit_tests/test_scylla_doctor.py
@@ -502,6 +502,37 @@ def test_find_scylla_bundled_python3_raises_when_not_found(doctor, is_nonroot, r
         doctor.find_scylla_bundled_python3("/home/user")
 
 
+# --- scylla_install_home tests ---
+
+
+def test_scylla_install_home_returns_remote_home(doctor):
+    """scylla_install_home should return $HOME from the remote node."""
+    home_result = MagicMock(stdout="/home/ubuntu\n")
+    doctor.node.remoter.run.return_value = home_result
+
+    assert doctor.scylla_install_home == "/home/ubuntu"
+    doctor.node.remoter.run.assert_called_with("echo $HOME", verbose=False)
+
+
+def test_install_scylla_doctor_uses_scylla_install_home_for_python3(mock_node, mock_test_config):
+    """install_scylla_doctor should search for python3 under $HOME, not /tmp/scylla_doctor."""
+    test_config, _params = mock_test_config
+    mock_node.is_nonroot_install = True
+    doc = ScyllaDoctor(node=mock_node, test_config=test_config, offline_install=True)
+
+    with (
+        patch.object(doc, "download_scylla_doctor"),
+        patch.object(
+            doc, "find_scylla_bundled_python3", return_value="/home/ubuntu/scylladb/python3/bin/python3"
+        ) as mock_find,
+        patch.object(doc, "update_scylla_doctor_config"),
+        patch.object(type(doc), "scylla_install_home", new_callable=lambda: property(lambda self: "/home/ubuntu")),
+    ):
+        doc.install_scylla_doctor()
+
+    mock_find.assert_called_once_with("/home/ubuntu")
+
+
 # --- run_analysis_phase tests ---
 
 

--- a/utils/scylla_doctor.py
+++ b/utils/scylla_doctor.py
@@ -150,6 +150,17 @@ class ScyllaDoctor:
         return sd_dir
 
     @cached_property
+    def scylla_install_home(self) -> str:
+        """Return the user's home directory where Scylla is installed.
+
+        For nonroot offline installs Scylla lives under ``$HOME/scylladb``.
+        This property returns ``$HOME`` so that searches for bundled binaries
+        and scylla-doctor config paths point at the correct location, rather
+        than the temporary working directory used for tarball extraction.
+        """
+        return self.node.remoter.run("echo $HOME", verbose=False).stdout.strip()
+
+    @cached_property
     def version(self):
         version = self.run(f"{self.scylla_doctor_exec} --version")
         LOGGER.info("Scylla doctor version: %s", version)
@@ -489,7 +500,7 @@ class ScyllaDoctor:
         # Always download from S3 — package repos are not updated at the same
         # time as S3 releases, and specific versions may not be available via repo.
         self.download_scylla_doctor()
-        self.python3_path = self.find_scylla_bundled_python3(self.current_dir)
+        self.python3_path = self.find_scylla_bundled_python3(self.scylla_install_home)
 
         additional_config = ""
         if self.node.is_nonroot_install:
@@ -498,7 +509,7 @@ class ScyllaDoctor:
             additional_config += self.SCYLLA_DOCTOR_ANALYZER_CONFIG
 
         if additional_config:
-            self.update_scylla_doctor_config(self.current_dir, additional_config=additional_config)
+            self.update_scylla_doctor_config(self.scylla_install_home, additional_config=additional_config)
 
         # TODO: optionally install via package manager (apt/yum/dnf) instead of S3
         #  download. Needs an SCT configuration toggle to enable this path.


### PR DESCRIPTION
The current_dir property was changed to /tmp/scylla_doctor for tarball extraction (Docker writability fix), but find_scylla_bundled_python3() and update_scylla_doctor_config() were still using it as the Scylla install root. For nonroot offline installs, python3 lives under $HOME (e.g. /home/ubuntu/scylladb/python3/bin/python3), not under /tmp.

Add a scylla_install_home property that returns the remote node's $HOME and use it for python3 search and [DefaultPaths] config generation.

Fixes: https://scylladb.atlassian.net/browse/SCT-477

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [root install + basic SD](https://argus.scylladb.com/tests/scylla-cluster-tests/992abd35-1878-4d7c-99f6-21ee8c9e33bf)
- [x] [root install + full SD](https://argus.scylladb.com/tests/scylla-cluster-tests/5898f19e-5b9b-44db-b6d7-ef4f6f845ce5)
- [x]  [root install = basic SD, GCE](https://argus.scylladb.com/tests/scylla-cluster-tests/9b1c7485-a5ad-42d5-a7a4-59deca251f8f)
- [x]  [root install = full SD, GCE](https://argus.scylladb.com/tests/scylla-cluster-tests/f6b3af89-4d6c-4bd0-85b7-2a4dfefd5179)
- [x]  [nonroot + basic SD, ubuntu2404](https://argus.scylladb.com/tests/scylla-cluster-tests/263e8dc3-68d9-48a5-bb9a-bd31e7768941)
- [x]  [nonroot + basic SD, rocky9](https://argus.scylladb.com/tests/scylla-cluster-tests/8788e59f-7119-45b9-ab7d-2da0b5ec46cb)
- [x]  [docker](https://argus.scylladb.com/tests/scylla-cluster-tests/0fa0bd8a-aa0c-4281-b8da-a2ca6626f3ad)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
