### PR TITLE
fix(aws): validate instance type availability in target region

### DIFF
--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -4000,8 +4000,28 @@ class SCTConfiguration(BaseModel):
             )
 
     def _instance_type_validation(self):
+        backend = self.get("cluster_backend")
+
+        # Validate main instance types (db, loader, monitor) are available in the target region
+        if backend == "aws":
+            instance_type_params = [
+                "instance_type_db",
+                "instance_type_loader",
+                "instance_type_monitor",
+                "instance_type_db_target",
+            ]
+            if self.get("db_type") in ("mixed_scylla", "mixed_cassandra"):
+                instance_type_params.append("instance_type_db_oracle")
+            for param_name in instance_type_params:
+                if instance_type := self.get(param_name):
+                    for region in self.region_names:
+                        assert aws_check_instance_type_supported(instance_type, region), (
+                            f"Instance type '{instance_type}' (param: {param_name}) "
+                            f"is not supported in region '{region}'"
+                        )
+
+        # Validate nemesis_grow_shrink_instance_type
         if instance_type := self.get("nemesis_grow_shrink_instance_type"):
-            backend = self.get("cluster_backend")
             match backend:
                 case "aws":
                     for region in self.region_names:

--- a/sdcm/utils/aws_utils.py
+++ b/sdcm/utils/aws_utils.py
@@ -508,7 +508,15 @@ def get_arch_from_instance_type(instance_type: str, region_name: str) -> AwsArch
     arch = "x86_64"
     if instance_type:
         client: EC2Client = boto3.client("ec2", region_name=region_name)
-        instance_type_info = client.describe_instance_types(InstanceTypes=[instance_type])
+        try:
+            instance_type_info = client.describe_instance_types(InstanceTypes=[instance_type])
+        except ClientError as exc:
+            if exc.response["Error"]["Code"] == "InvalidInstanceType":
+                raise ValueError(
+                    f"Instance type '{instance_type}' is not available in region '{region_name}'. "
+                    f"Please verify the instance type exists in this region or use a different one."
+                ) from exc
+            raise
 
         try:
             arch = instance_type_info["InstanceTypes"][0].get("ProcessorInfo", {}).get("SupportedArchitectures")[0]

--- a/unit_tests/test_perf_gradual_config.py
+++ b/unit_tests/test_perf_gradual_config.py
@@ -1,5 +1,7 @@
 """Unit tests for perf_gradual_throttle_steps dict format validation."""
 
+from unittest.mock import patch
+
 import pytest
 
 from sdcm.sct_config import SCTConfiguration
@@ -10,6 +12,8 @@ def _set_env(monkeypatch):
     monkeypatch.setenv("SCT_CLUSTER_BACKEND", "aws")
     monkeypatch.setenv("SCT_AMI_ID_DB_SCYLLA", "ami-1234")
     monkeypatch.setenv("SCT_INSTANCE_TYPE_DB", "i4i.large")
+    with patch("sdcm.sct_config.aws_check_instance_type_supported", return_value=True):
+        yield
 
 
 def test_string_format_backward_compatibility():

--- a/unit_tests/unit/conftest.py
+++ b/unit_tests/unit/conftest.py
@@ -103,6 +103,7 @@ def mock_cloud_services(tmp_path_factory):
         patch("sdcm.utils.version_utils.get_s3_scylla_repos_mapping", return_value={}),
         patch("sdcm.utils.aws_utils.get_arch_from_instance_type", return_value="x86_64"),
         patch("sdcm.sct_config.get_arch_from_instance_type", return_value="x86_64"),
+        patch("sdcm.sct_config.aws_check_instance_type_supported", return_value=True),
         patch.object(KeyStore, "get_file_contents", fake_get_file_contents),
         patch.object(KeyStore, "get_json", fake_get_json),
         patch.object(KeyStore, "get_ssh_key_pair", return_value=mock_ssh_key),


### PR DESCRIPTION
Add region availability checks for instance_type_db, instance_type_loader, and instance_type_monitor during config validation. Also handle ClientError in get_arch_from_instance_type to provide a clear error message when an instance type does not exist in the specified region.

Fix for error:
```
15:46:41  Traceback (most recent call last):
15:46:41    File "/home/ubuntu/scylla-cluster-tests/./sct.py", line 2378, in <module>
15:46:41      cli.main(prog_name="hydra")
15:46:41      ~~~~~~~~^^^^^^^^^^^^^^^^^^^
15:46:41    File "/usr/local/lib/python3.13/site-packages/click/core.py", line 1055, in main
15:46:41      rv = self.invoke(ctx)
15:46:41    File "/usr/local/lib/python3.13/site-packages/click/core.py", line 1657, in invoke
15:46:41      return _process_result(sub_ctx.command.invoke(sub_ctx))
15:46:41                             ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
15:46:41    File "/usr/local/lib/python3.13/site-packages/click/core.py", line 1404, in invoke
15:46:41      return ctx.invoke(self.callback, **ctx.params)
15:46:41             ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
15:46:41    File "/usr/local/lib/python3.13/site-packages/click/core.py", line 760, in invoke
15:46:41      return __callback(*args, **kwargs)
15:46:41    File "/home/ubuntu/scylla-cluster-tests/./sct.py", line 260, in provision_resources
15:46:41      params = init_and_verify_sct_config()
15:46:41    File "/home/ubuntu/scylla-cluster-tests/sdcm/sct_config.py", line 4573, in init_and_verify_sct_config
15:46:41      sct_config = SCTConfiguration()
15:46:41    File "/home/ubuntu/scylla-cluster-tests/sdcm/sct_config.py", line 3107, in __init__
15:46:41      aws_arch = get_arch_from_instance_type(self.get("instance_type_db"), region_name=region)
15:46:41    File "/home/ubuntu/scylla-cluster-tests/sdcm/utils/aws_utils.py", line 511, in get_arch_from_instance_type
15:46:41      instance_type_info = client.describe_instance_types(InstanceTypes=[instance_type])
15:46:41    File "/usr/local/lib/python3.13/site-packages/botocore/client.py", line 598, in _api_call
15:46:41      return self._make_api_call(operation_name, kwargs)
15:46:41             ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^
15:46:41    File "/usr/local/lib/python3.13/site-packages/botocore/context.py", line 123, in wrapper
15:46:41      return func(*args, **kwargs)
15:46:41    File "/usr/local/lib/python3.13/site-packages/botocore/client.py", line 1061, in _make_api_call
15:46:41      raise error_class(parsed_response, operation_name)
15:46:41  botocore.exceptions.ClientError: An error occurred (InvalidInstanceType) when calling the DescribeInstanceTypes operation: The following supplied instance types do not exist: [i8g.4xlarge]
```
https://jenkins.scylladb.com/job/scylla-enterprise/job/perf-regression/job/scylla-enterprise-perf-regression-latency-650gb-during-rolling-upgrade-i8g-tablets/20/execution/node/219/log/

Fixes: https://scylladb.atlassian.net/browse/SCT-476 

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] provision AWS test

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
