### PR TITLE
fix(monitoring): Backport monitoring 4.15 to 2025.x

### DIFF
--- a/configurations/manager/debian12.yaml
+++ b/configurations/manager/debian12.yaml
@@ -1,0 +1,3 @@
+ami_id_monitor: 'resolve:ssm:/aws/service/debian/release/12/latest/amd64'  # Debian Bookworm latest image
+ami_monitor_user: 'admin'
+monitor_branch: 'branch-4.15'  # Pass it as debian image is not the formal monitor image

--- a/configurations/manager/rocky8.yaml
+++ b/configurations/manager/rocky8.yaml
@@ -1,3 +1,3 @@
 ami_id_monitor: 'ami-011ef2017d41cb239'  # Rocky Linux 8 (Official) image, region - us-east-1
 ami_monitor_user: 'rocky'
-monitor_branch: 'branch-4.7'  # Pass it as rocky image is not the formal monitor image
+monitor_branch: 'branch-4.15'  # Pass it as rocky image is not the formal monitor image

--- a/configurations/manager/rocky9.yaml
+++ b/configurations/manager/rocky9.yaml
@@ -1,3 +1,3 @@
 ami_id_monitor: 'ami-09fb459fad4613d55'  # Rocky Linux 9 (Official) image, region - us-east-1
 ami_monitor_user: 'rocky'
-monitor_branch: 'branch-4.7'  # Pass it as rocky image is not the formal monitor image
+monitor_branch: 'branch-4.15'  # Pass it as rocky image is not the formal monitor image

--- a/configurations/manager/ubuntu24.yaml
+++ b/configurations/manager/ubuntu24.yaml
@@ -1,3 +1,3 @@
 ami_id_monitor: 'resolve:ssm:/aws/service/canonical/ubuntu/server/24.04/stable/current/amd64/hvm/ebs-gp3/ami-id'  # Canonical, Ubuntu, 24.04 LTS, amd64 focal latest image
 ami_monitor_user: 'ubuntu'
-monitor_branch: 'branch-4.7'  # Pass it as the image is not the formal monitor image
+monitor_branch: 'branch-4.15'  # Pass it as the image is not the formal monitor image

--- a/defaults/aws_config.yaml
+++ b/defaults/aws_config.yaml
@@ -7,7 +7,7 @@ instance_type_loader: 'c6i.xlarge'
 instance_type_monitor: 't3.large'
 ami_id_loader: 'resolve:ssm:/aws/service/canonical/ubuntu/server/24.04/stable/current/amd64/hvm/ebs-gp3/ami-id'
 # manual on updating monitor images see: docs/monitoring-images.md
-ami_id_monitor: 'scylladb-monitor-4-8-0-2024-08-06t03-34-43z'
+ami_id_monitor: 'scylladb-monitor-4-15-0-rc0-2026-04-30t01-12-58z'
 
 availability_zone: 'a'
 root_disk_size_monitor: 50  # GB, remove this field if default disk size should be used

--- a/defaults/gce_config.yaml
+++ b/defaults/gce_config.yaml
@@ -5,7 +5,8 @@ gce_project: '' # empty mean default one, can be overwritten to use different on
 
 gce_image_db: '' # so we can use `scylla_version` as needed
 gce_image_loader: 'https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/family/ubuntu-2404-lts-amd64'
-gce_image_monitor: 'https://www.googleapis.com/compute/v1/projects/scylla-images/global/images/scylladb-monitor-4-8-0-2024-08-06t03-34-43z'
+gce_image_monitor: 'https://www.googleapis.com/compute/v1/projects/scylla-images/global/images/scylladb-monitor-4-15-0-rc0-2026-04-30t01-12-58z'
+
 gce_image_username: 'scylla-test'
 
 gce_instance_type_loader: 'e2-standard-2'

--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -34,7 +34,7 @@ scylla_linux_distro: 'ubuntu-focal'
 scylla_linux_distro_loader: 'ubuntu-jammy'
 ssh_transport: 'libssh2'
 
-monitor_branch: 'branch-4.8'
+monitor_branch: 'branch-4.15'
 
 space_node_threshold: 0
 

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -559,7 +559,7 @@ A local directory of rpms to install a custom version on top of<br>the scylla in
 
 The port of scylla management
 
-**default:** branch-4.8
+**default:** branch-4.15
 
 **type:** str (appendable)
 


### PR DESCRIPTION
Due to some bugs with IPAddress parsing in monitoring scripts, backporting newer versions to fix

Fixes SCT-201

### Testing

- [x] [Argus](https://argus.scylladb.com/workspace?state=WyIxZDY1ZWFhZi1jNDVkLTQ1ODEtYmM2OS04ZTQwNzdmMDVkYTgiXQ)
- [x] [Jenkins](https://jenkins.scylladb.com/job/scylla-staging/job/alexey/job/longevity-1tb-5days-azure-test/)
