### PR TITLE
fix(ycsb): fix AWS SDK v2 credential loading for alternator

### DIFF
--- a/sdcm/ycsb_thread.py
+++ b/sdcm/ycsb_thread.py
@@ -133,7 +133,6 @@ class YcsbStressThread(DockerBasedStressThread):
             dynamodb_teample = dedent(
                 """
                 measurementtype=hdrhistogram
-                dynamodb.awsCredentialsFile = /tmp/aws_dummy_credentials_file
                 dynamodb.endpoint = {0}://{1}:{2}
                 dynamodb.connectMax = 200
                 requestdistribution = uniform
@@ -156,26 +155,29 @@ class YcsbStressThread(DockerBasedStressThread):
                     dynamodb.primaryKey = {alternator.consts.HASH_KEY_NAME}
                     dynamodb.primaryKeyType = {alternator.enums.YCSBSchemaTypes.HASH_SCHEMA.value}
                 """)
+            access_key = self.params.get("alternator_access_key_id")
             if self.params.get("alternator_enforce_authorization"):
-                aws_credentials_content = dedent(f"""
-                    accessKey = {self.params.get("alternator_access_key_id")}
-                    secretKey = {alternator.api.Alternator.get_salted_hash(node=self.node_list[0], username=self.params.get("alternator_access_key_id"))}
-                """)
+                secret_key = alternator.api.Alternator.get_salted_hash(node=self.node_list[0], username=access_key)
             else:
-                aws_credentials_content = dedent(f"""
-                    accessKey = {self.params.get("alternator_access_key_id")}
-                    secretKey = {self.params.get("alternator_secret_access_key")}
-                """)
+                secret_key = self.params.get("alternator_secret_access_key")
+
+            if access_key is None or access_key == "":
+                access_key = "test"
+            if secret_key is None or secret_key == "":
+                secret_key = "test"
 
             with tempfile.NamedTemporaryFile(mode="w+", encoding="utf-8") as tmp_file:
                 tmp_file.write(dynamodb_teample)
+                tmp_file.write(
+                    dedent(f"""
+                    dynamodb.awsAccessKey = {access_key}
+                    dynamodb.awsSecretKey = {secret_key}
+                    aws.accessKeyId = {access_key}
+                    aws.secretKey = {secret_key}
+                """)
+                )
                 tmp_file.flush()
                 cmd_runner.send_files(tmp_file.name, os.path.join("/tmp", "dynamodb.properties"))
-
-            with tempfile.NamedTemporaryFile(mode="w+", encoding="utf-8") as tmp_file:
-                tmp_file.write(aws_credentials_content)
-                tmp_file.flush()
-                cmd_runner.send_files(tmp_file.name, os.path.join("/tmp", "aws_dummy_credentials_file"))
             if is_kubernetes:
                 if web_protocol == "https":
                     if ca_bundle_path := getattr(self.node_list[0], "alternator_ca_bundle_path", None):


### PR DESCRIPTION
Remove dynamodb.awsCredentialsFile from the properties template (SDK v1 only) and write credentials inline as dynamodb.awsAccessKey/awsSecretKey and aws.accessKeyId/aws.secretKey, which AWS SDK v2 actually reads. Fall back to dummy "test" values when credentials are empty to satisfy SDK v2's non-empty requirement.

Backport of relevant credential changes from #13482.

Fixes https://scylladb.atlassian.net/browse/SCT-485

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://jenkins.scylladb.com/job/scylla-staging/job/jsmolar/job/longevity-alternator-3h-test/3/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
