### PR TITLE
fix(sct_triggers): longevity-50gb-3days-test should be called with 3 AZs

### DIFF
--- a/jenkins-pipelines/master-triggers/sct_triggers/tier1-custom-time-trigger.xml
+++ b/jenkins-pipelines/master-triggers/sct_triggers/tier1-custom-time-trigger.xml
@@ -30,7 +30,26 @@ stress_duration=1440</properties>
             </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
           </configs>
           <projects>
-            ../tier1/gemini-1tb-10h,../tier1/longevity-1tb-5days-azure-test,../tier1/longevity-large-partition-200k-pks-4days-gce-test,../tier1/longevity-mv-si-4days-streaming-test,../tier1/longevity-schema-topology-changes-12h-test,../tier1/longevity-twcs-48h-test,../tier1/longevity-multidc-schema-topology-changes-12h-test,../tier1/longevity-50gb-3days-test,../tier1/longevity-150gb-asymmetric-cluster-12h-test</projects>
+            ../tier1/gemini-1tb-10h,../tier1/longevity-1tb-5days-azure-test,../tier1/longevity-large-partition-200k-pks-4days-gce-test,../tier1/longevity-mv-si-4days-streaming-test,../tier1/longevity-schema-topology-changes-12h-test,../tier1/longevity-twcs-48h-test,../tier1/longevity-multidc-schema-topology-changes-12h-test,../tier1/longevity-150gb-asymmetric-cluster-12h-test</projects>
+          <condition>SUCCESS</condition>
+          <triggerWithNoParameters>false</triggerWithNoParameters>
+          <triggerFromChildProjects>false</triggerFromChildProjects>
+        </hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
+        <hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
+          <configs>
+            <hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
+              <properties>scylla_version=%(sct_branch)s:latest
+availability_zone=a,b,c
+provision_type=on_demand
+post_behavior_db_nodes=destroy
+post_behavior_monitor_nodes=destroy
+stress_duration=1440
+requested_by_user=pehala
+region=us-east-1</properties>
+              <textParamValueOnNewLine>false</textParamValueOnNewLine>
+            </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
+          </configs>
+          <projects>../tier1/longevity-50gb-3days-test</projects>
           <condition>SUCCESS</condition>
           <triggerWithNoParameters>false</triggerWithNoParameters>
           <triggerFromChildProjects>false</triggerFromChildProjects>

--- a/jenkins-pipelines/oss/sct_triggers/tier1-aws-custom-time-trigger.xml
+++ b/jenkins-pipelines/oss/sct_triggers/tier1-aws-custom-time-trigger.xml
@@ -59,7 +59,26 @@ stress_duration=$stress_duration</properties>
               <textParamValueOnNewLine>false</textParamValueOnNewLine>
             </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
           </configs>
-          <projects>../tier1/longevity-mv-si-4days-streaming-test,../tier1/longevity-schema-topology-changes-12h-test,../tier1/longevity-twcs-48h-test,../tier1/longevity-50gb-3days-test,../tier1/longevity-150gb-asymmetric-cluster-12h-test</projects>
+          <projects>../tier1/longevity-mv-si-4days-streaming-test,../tier1/longevity-schema-topology-changes-12h-test,../tier1/longevity-twcs-48h-test,../tier1/longevity-150gb-asymmetric-cluster-12h-test</projects>
+          <condition>SUCCESS</condition>
+          <triggerWithNoParameters>false</triggerWithNoParameters>
+          <triggerFromChildProjects>false</triggerFromChildProjects>
+        </hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
+        <hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
+          <configs>
+            <hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
+              <properties>scylla_version=%(sct_branch)s:latest
+availability_zone=a,b,c
+provision_type=on_demand
+post_behavior_db_nodes=destroy
+post_behavior_monitor_nodes=destroy
+stress_duration=1440
+requested_by_user=pehala
+region=us-east-1</properties>
+              <textParamValueOnNewLine>false</textParamValueOnNewLine>
+            </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
+          </configs>
+          <projects>../tier1/longevity-50gb-3days-test</projects>
           <condition>SUCCESS</condition>
           <triggerWithNoParameters>false</triggerWithNoParameters>
           <triggerFromChildProjects>false</triggerFromChildProjects>


### PR DESCRIPTION
After #14651, this test has simulated_racks=0, so it needs 3 AZs to have 3 racks. Backport of fb54d3518 from branch-2026.1 to branch-2025.1.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
