### PR TITLE
fix(renovate): use S3 API for scylla-doctor version lookup

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -31,8 +31,8 @@
   ],
   "customDatasources": {
     "scylla-doctor": {
-      "defaultRegistryUrlTemplate": "https://downloads.scylladb.com/downloads/scylla-doctor/tar/",
-      "format": "html"
+      "defaultRegistryUrlTemplate": "https://s3.amazonaws.com/downloads.scylladb.com?prefix=downloads/scylla-doctor/tar/&delimiter=/",
+      "format": "plain"
     }
   },
   "customManagers": [
@@ -47,7 +47,7 @@
       ],
       "depNameTemplate": "scylla-doctor",
       "datasourceTemplate": "custom.scylla-doctor",
-      "extractVersionTemplate": "^scylla-doctor-(?<version>[\\d.]+)\\.tar\\.gz$",
+      "extractVersionTemplate": "scylla-doctor-(?<version>[\\d.]+)\\.tar\\.gz",
       "versioningTemplate": "semver-coerced"
     }
   ],


### PR DESCRIPTION
## Problem

Renovate reports:
> Failed to look up custom.scylla-doctor package scylla-doctor: no-result

The configured URL `https://downloads.scylladb.com/downloads/scylla-doctor/tar/` returns HTTP 404 because the site uses JavaScript-rendered S3 bucket listings. Renovate does a plain HTTP GET and cannot execute JavaScript, so it finds zero `<a>` tags to parse versions from.

## Fix

Switch the custom datasource to use the S3 XML listing API directly:
```
https://s3.amazonaws.com/downloads.scylladb.com?prefix=downloads/scylla-doctor/tar/&delimiter=/
```

This endpoint is publicly accessible and returns XML containing all tarball keys. Combined with:
- `format: "plain"` — treats each XML line as a version candidate
- Relaxed `extractVersionTemplate` (removed `^`/`$` anchors) — matches `scylla-doctor-X.Y.tar.gz` within XML `<Key>` elements

## Verification

The S3 API returns all versions (1.0 through 1.11.1):
```bash
curl -s 'https://s3.amazonaws.com/downloads.scylladb.com?prefix=downloads/scylla-doctor/tar/&delimiter=/' | grep -oP 'scylla-doctor-[\d.]+\.tar\.gz'
```
