### PR TITLE
fix(renovate): add recreateWhen to prevent stale Edited/Blocked PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,7 @@
     "helpers:pinGitHubActionDigestsToSemver"
   ],
   "commitBodyTable": true,
+  "recreateWhen": "always",
   "ignorePresets": [
     "group:monorepos",
     "group:recommended"


### PR DESCRIPTION
## Problem

When Renovate PRs are merged after manual edits (extra commits pushed to the branch), the branch is not automatically deleted. On the next run, Renovate sees the stale branch and permanently marks the PR as "Edited/Blocked" on the Dependency Dashboard. Checking the "rebase" checkbox does not resolve it.

## Fix

Add `"recreateWhen": "always"` to `renovate.json`. This tells Renovate to force-recreate PRs even when old branches or previously closed/merged PRs block recreation.

## Context

This happened with:
- `renovate/pypi-paramiko-vulnerability` (PR #14571, merged but branch lingered)
- `renovate/major-all-pip-dependencies` (PR #14333, merged but branch lingered)

Stale branches were manually deleted, and this config change prevents recurrence.
