### PR TITLE
fix(logcollector): pass params to monitoring entities in MonitorSetBase

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -7670,6 +7670,7 @@ class BaseMonitorSet:
         screenshot_collector = GrafanaScreenShot(
             name="grafana-screenshot", test_start_time=test_start_time, extra_entities=grafana_extra_dashboards
         )
+        screenshot_collector.set_params(self.params)
         screenshot_files = screenshot_collector.collect(node, self.logdir)
         for screenshot in screenshot_files:
             s3_path = f"{self.test_config.test_id()}/{date_time}"
@@ -7700,7 +7701,9 @@ class BaseMonitorSet:
         if not self.nodes:
             return ""
         try:
-            if snapshot_archive := PrometheusSnapshots(name="prometheus_snapshot").collect(self.nodes[0], self.logdir):
+            prometheus = PrometheusSnapshots(name="prometheus_snapshot")
+            prometheus.set_params(self.params)
+            if snapshot_archive := prometheus.collect(self.nodes[0], self.logdir):
                 self.log.debug("Snapshot local path: %s", snapshot_archive)
                 return upload_archive_to_s3(snapshot_archive, self.monitor_id)
         except Exception as details:  # noqa: BLE001


### PR DESCRIPTION
GrafanaScreenShot and PrometheusSnapshots instances created directly in BaseMonitorSet.get_grafana_screenshots() and download_monitor_data() never had set_params() called, leaving _params as an empty dict.

After commit 2bca67a5b added guards that skip collection when `n_monitor_nodes ` is 0, these direct usages always hit the early return because `{}.get('n_monitor_nodes') ` returns None.

Call `set_params(self.params)`  before `collect()` so the guard sees the actual test configuration.

Fixes: https://scylladb.atlassian.net/browse/SCT-492

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
