### PR TITLE
fix(gce): enable AZ fallback in GCE artifact test configs

### DIFF
--- a/test-cases/artifacts/centos9-selinux.yaml
+++ b/test-cases/artifacts/centos9-selinux.yaml
@@ -16,5 +16,6 @@ test_duration: 60
 user_prefix: 'artifacts-centos9-selinux'
 append_scylla_setup_args: '--no-selinux-setup'
 use_preinstalled_scylla: false
+fallback_to_next_availability_zone: true
 
 user_credentials_path: '~/.ssh/scylla_test_id_ed25519'

--- a/test-cases/artifacts/debian11.yaml
+++ b/test-cases/artifacts/debian11.yaml
@@ -15,3 +15,4 @@ scylla_linux_distro: 'debian-bullseye'
 test_duration: 60
 user_prefix: 'artifacts-debian11'
 use_preinstalled_scylla: false
+fallback_to_next_availability_zone: true

--- a/test-cases/artifacts/debian12.yaml
+++ b/test-cases/artifacts/debian12.yaml
@@ -15,3 +15,4 @@ scylla_linux_distro: 'debian-bookworm'
 test_duration: 60
 user_prefix: 'artifacts-debian12'
 use_preinstalled_scylla: false
+fallback_to_next_availability_zone: true

--- a/test-cases/artifacts/gce-image-persistent-disk.yaml
+++ b/test-cases/artifacts/gce-image-persistent-disk.yaml
@@ -14,3 +14,4 @@ nemesis_class_name: 'NoOpMonkey'
 scylla_linux_distro: 'centos'
 test_duration: 60
 user_prefix: 'artifacts-gce-image-pd'
+fallback_to_next_availability_zone: true

--- a/test-cases/artifacts/gce-image.yaml
+++ b/test-cases/artifacts/gce-image.yaml
@@ -13,3 +13,4 @@ nemesis_class_name: 'NoOpMonkey'
 scylla_linux_distro: 'centos'
 test_duration: 60
 user_prefix: 'artifacts-gce-image'
+fallback_to_next_availability_zone: true

--- a/test-cases/artifacts/rhel7.yaml
+++ b/test-cases/artifacts/rhel7.yaml
@@ -15,3 +15,4 @@ scylla_linux_distro: 'centos'
 test_duration: 60
 user_prefix: 'artifacts-rhel7'
 use_preinstalled_scylla: false
+fallback_to_next_availability_zone: true

--- a/test-cases/artifacts/rhel8.yaml
+++ b/test-cases/artifacts/rhel8.yaml
@@ -15,3 +15,4 @@ scylla_linux_distro: 'centos'
 test_duration: 60
 user_prefix: 'artifacts-rhel8'
 use_preinstalled_scylla: false
+fallback_to_next_availability_zone: true

--- a/test-cases/artifacts/rocky8.yaml
+++ b/test-cases/artifacts/rocky8.yaml
@@ -15,3 +15,4 @@ scylla_linux_distro: 'centos'
 test_duration: 60
 user_prefix: 'artifacts-rocky8'
 use_preinstalled_scylla: false
+fallback_to_next_availability_zone: true

--- a/test-cases/artifacts/rocky9-selinux.yaml
+++ b/test-cases/artifacts/rocky9-selinux.yaml
@@ -18,3 +18,4 @@ append_scylla_setup_args: '--no-selinux-setup'
 
 user_credentials_path: '~/.ssh/scylla_test_id_ed25519'
 use_preinstalled_scylla: false
+fallback_to_next_availability_zone: true

--- a/test-cases/artifacts/rocky9.yaml
+++ b/test-cases/artifacts/rocky9.yaml
@@ -17,3 +17,4 @@ user_prefix: 'artifacts-rocky9'
 
 user_credentials_path: '~/.ssh/scylla_test_id_ed25519'
 use_preinstalled_scylla: false
+fallback_to_next_availability_zone: true


### PR DESCRIPTION
Add fallback_to_next_availability_zone: true to 10 GCE artifact test configs that were missing the parameter. Without it, provisioning fails immediately on a single exhausted zone instead of falling back to other available AZs in the same region.

Affected configs: gce-image, gce-image-persistent-disk, rhel7, rhel8, debian11, debian12, rocky8, rocky9, rocky9-selinux, centos9-selinux.

The 4 remaining GCE artifact configs (ubuntu2204, ubuntu2404, ubuntu2604, centos9) already had this parameter set.

Fixes: SCT-494

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
