### PR TITLE
SCYLLADB-1336: Drop 2023.1 from supported base versions

### DIFF
--- a/unit_tests/test_base_version.py
+++ b/unit_tests/test_base_version.py
@@ -53,7 +53,10 @@ class TestBaseVersion(unittest.TestCase):
         linux_distro = "ubuntu-jammy"
         cloud_provider = "azure"
         version_list = general_test(scylla_repo, linux_distro, cloud_provider)
-        assert set(version_list) == {"5.2", "2023.1"}
+        # 2023.1 is intentionally excluded from returned upgrade base versions;
+        # see: https://scylladb.atlassian.net/browse/SCT-249
+        assert set(version_list) == {"5.2"}
+        assert "2023.1" not in version_list
 
     def test_2021_1(self):
         scylla_repo = self.url_base + "-enterprise/branch-2021.1/rpm/centos/2021-08-29T00:58:58Z/scylla.repo"
@@ -91,7 +94,10 @@ class TestBaseVersion(unittest.TestCase):
         scylla_repo = self.url_base + "-enterprise/enterprise-2024.1/rpm/centos/latest/scylla.repo"
         linux_distro = "centos"
         version_list = general_test(scylla_repo, linux_distro)
-        assert set(version_list) == {"5.4", "2022.2", "2023.1", "2024.1"}
+        # 2023.1 is intentionally excluded from returned upgrade base versions;
+        # see: https://scylladb.atlassian.net/browse/SCT-249
+        assert set(version_list) == {"5.4", "2022.2", "2024.1"}
+        assert "2023.1" not in version_list
 
     def test_2024_2(self):
         scylla_repo = self.url_base + "-enterprise/enterprise-2024.2/rpm/centos/latest/scylla.repo"

--- a/utils/get_supported_scylla_base_versions.py
+++ b/utils/get_supported_scylla_base_versions.py
@@ -42,6 +42,13 @@ unsupported_versions = [
     "2024.2",
 ]
 
+# Versions that must not be returned as upgrade base versions, but are intentionally kept in the
+# supported list so they don't shift the version indexing used while selecting the base versions.
+# These are filtered out only at the very last stage, right before returning the result.
+excluded_base_versions = [
+    "2023.1",
+]
+
 
 class UpgradeBaseVersion:
     oss_start_support_version = None
@@ -155,7 +162,13 @@ class UpgradeBaseVersion:
         oss_base_version = self.filter_rc_only_version(oss_base_version)
         ent_base_version = self.filter_rc_only_version(ent_base_version)
         LOGGER.info("Supported scylla base versions for: oss=%s enterprise=%s", oss_base_version, ent_base_version)
-        return list(set(oss_base_version + ent_base_version))
+        # Drop versions that should not be used as upgrade base versions, while keeping the
+        # selection logic above operating on the full supported list (preserves version indexing).
+        base_versions = [v for v in set(oss_base_version + ent_base_version) if v not in excluded_base_versions]
+        LOGGER.info(
+            "Final supported scylla base versions after excluding %s: %s", excluded_base_versions, base_versions
+        )
+        return base_versions
 
     def filter_rc_only_version(self, base_version_list: list) -> list:
         LOGGER.info("Filtering rc versions from base version list...")


### PR DESCRIPTION
Exclude 2023.1 from the list of Scylla base versions used by rolling upgrade tests, without changing the version indexing used while the base versions are selected.

A new `excluded_base_versions` list holds versions that must not be returned as upgrade base versions. Unlike `unsupported_versions`, excluded versions are kept in the supported list during selection so they do not shift the positional indexing in `ent_release_list` (which previously caused an unrelated STS version, e.g. 2022.2, to slip into the result). The excluded versions are filtered out only at the final stage, right before returning, via a list comprehension.

This preserves the original "two latest" base version selection behavior and removes only 2023.1 from the final result.

Fixes: SCYLLADB-1336

According comments no need to run upgrade from 2023.1: 
 - https://scylladb.atlassian.net/browse/SCYLLADB-1336?focusedCommentId=68294
 - https://scylladb.atlassian.net/browse/SCYLLADB-1336?focusedCommentId=65178

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
