### PR TITLE
fix(ci): add missing auth configs to the `custom-d2-w1` test scenarios

### DIFF
--- a/jenkins-pipelines/oss/longevity/longevity-aws-custom-d2-workload1-3dcs.jenkinsfile
+++ b/jenkins-pipelines/oss/longevity/longevity-aws-custom-d2-workload1-3dcs.jenkinsfile
@@ -8,5 +8,5 @@ longevityPipeline(
     backend: 'aws',
     region: '''["eu-north-1", "eu-west-1", "us-east-1"]''',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: 'test-cases/longevity/longevity-aws-custom-d2-workload1-3dcs.yaml',
+    test_config: '''["test-cases/longevity/longevity-aws-custom-d2-workload1-3dcs.yaml", "configurations/auth_cassandra.yaml"]''',
 )

--- a/jenkins-pipelines/oss/longevity/longevity-aws-custom-d2-workload1-5dcs.jenkinsfile
+++ b/jenkins-pipelines/oss/longevity/longevity-aws-custom-d2-workload1-5dcs.jenkinsfile
@@ -8,5 +8,5 @@ longevityPipeline(
     backend: 'aws',
     region: '''["eu-central-1", "eu-north-1", "eu-west-1", "eu-west-2", "us-east-1"]''',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: 'test-cases/longevity/longevity-aws-custom-d2-workload1-5dcs.yaml',
+    test_config: '''["test-cases/longevity/longevity-aws-custom-d2-workload1-5dcs.yaml", "configurations/auth_cassandra.yaml"]''',
 )


### PR DESCRIPTION
THe https://github.com/scylladb/scylla-cluster-tests/pull/13907 PR moved auth params to a dedicated file and the custom-d2 files were not updated respectively.

So, update it to avoid auth errors.

Closes: SCT-496

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [scylla-2026.2/longevity/longevity-aws-custom-d2-workload1-3dcs-test#5](https://argus.scylladb.com/tests/scylla-cluster-tests/92a1b7cf-3424-4017-b0b0-6fe6e58fbcba)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
