### PR TITLE
fix(build-image): skip Docker build steps when image is already built

### DIFF
--- a/.github/workflows/build-docker-image.yaml
+++ b/.github/workflows/build-docker-image.yaml
@@ -43,56 +43,66 @@ jobs:
           persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal access token.
 
       - name: Check if docker image is already built
+        id: check_image
         run: |
           git fetch origin master
           commits_headlines=$(git log origin/master..HEAD --pretty=format:"%s")
 
           if [[ "$commits_headlines" == *"chore(hydra): create image"* ]]; then
               echo "Docker image already built"
-              exit 0
+              echo "already_built=true" >> "$GITHUB_OUTPUT"
           else
               echo "Docker image not built yet"
+              echo "already_built=false" >> "$GITHUB_OUTPUT"
           fi
         env:
           GH_TOKEN: ${{ secrets. GITHUB_TOKEN }}
 
       - name: Set up Python
+        if: steps.check_image.outputs.already_built != 'true'
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.14'
 
       - name: Install dependencies
+        if: steps.check_image.outputs.already_built != 'true'
         run: |
           python -m pip install --upgrade pip
           pip install uv
 
       - name: Generate a random name based on PR
+        if: steps.check_image.outputs.already_built != 'true'
         run: |
           docker_version=$(cut -d'-' -f1 ./docker/env/version | awk -F. '{print $1"."$2+1}')
           sha=$(echo "${{ github.sha }}" | cut -c1-7)
           echo "${docker_version}-PR${{ github.event.number }}-${sha}" > ./docker/env/version
 
       - name: Log in to Docker Hub
+        if: steps.check_image.outputs.already_built != 'true'
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build Docker image
+        if: steps.check_image.outputs.already_built != 'true'
         run: |
           ./docker/env/build_n_push.sh
 
       - name: Configure Git
+        if: steps.check_image.outputs.already_built != 'true'
         run: |
           git config --global user.name 'scylla-sct[bot]'
           git config --global user.email 'scylla-sct[bot]@users.noreply.github.com'
 
       - name: Commit changes
+        if: steps.check_image.outputs.already_built != 'true'
         run: |
           git add -u
           git commit -m "chore(hydra): create image $( cat ./docker/env/version )"
 
       - name: Push changes
+        if: steps.check_image.outputs.already_built != 'true'
         uses: ad-m/github-push-action@881a6320fdb16eb5318c5054f31c218aec2b324c # v1.3.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem

The `build-docker-image.yaml` workflow has a step "Check if docker image is already built" that detects when the hydra image has already been built (by checking for a `chore(hydra): create image` commit). However, it only printed a message and `exit 0`, which does **not** prevent subsequent steps from running.

This caused unnecessary work: Set up Python, Install dependencies, Docker login, and even a full Docker build attempt would all run despite the image already existing.

Observed in: https://github.com/scylladb/scylla-cluster-tests/actions/runs/27681450176/job/81869689408?pr=15083

## Fix

- Added `id: check_image` to the check step
- Replaced `exit 0` with a `GITHUB_OUTPUT` variable (`already_built=true/false`)
- Added `if: steps.check_image.outputs.already_built != 'true'` to all subsequent steps

When the image is already built, all build/push steps are now cleanly skipped.