### PR TITLE
fix(nemesis): downgrade expected raft gate-closed errors

### DIFF
--- a/sdcm/nemesis/__init__.py
+++ b/sdcm/nemesis/__init__.py
@@ -94,6 +94,7 @@ from sdcm.sct_events.group_common_events import (
     ignore_ipv6_failure_to_assign,
     ignore_raft_topology_cmd_failing,
     suppress_expected_unavailability_errors,
+    ignore_raft_applier_gate_closed_errors,
 )
 
 from sdcm.sct_events.loaders import CassandraStressLogEvent, ScyllaBenchEvent
@@ -5398,7 +5399,7 @@ class NemesisRunner:
             bootstrap_node=new_node, verification_node=self.target_node, actions_log=self.actions_log
         )
 
-        with suppress_expected_unavailability_errors():
+        with suppress_expected_unavailability_errors(), ignore_raft_applier_gate_closed_errors():
             bootstrapabortmanager.run_bootstrap_and_abort_with_action(
                 terminate_pattern, abort_action=new_node.stop_scylla
             )

--- a/sdcm/sct_events/group_common_events.py
+++ b/sdcm/sct_events/group_common_events.py
@@ -514,6 +514,14 @@ def ignore_raft_topology_cmd_failing():
                 extra_time_to_expiration=30,
             )
         )
+        stack.enter_context(
+            EventsSeverityChangerFilter(
+                new_severity=Severity.WARNING,
+                event_class=DatabaseLogEvent,
+                regex=r".*raft_topology\s+-\s+raft_topology_cmd stream_ranges failed with:\s+seastar::gate_closed_exception \(gate closed\).*",
+                extra_time_to_expiration=30,
+            )
+        )
         yield
 
 
@@ -603,6 +611,22 @@ def ignore_hints_sending_errors():
                 extra_time_to_expiration=30,
             )
         )
+        yield
+
+
+@contextmanager
+def ignore_raft_applier_gate_closed_errors():
+    with EventsSeverityChangerFilter(
+        new_severity=Severity.WARNING,
+        event_class=DatabaseLogEvent,
+        regex=(
+            r".*raft\s+-\s+\[[0-9a-f-]+\]\s+"
+            r"applier fiber stopped because of the error:\s*"
+            r".*?raft::state_machine_error"
+            r".*?seastar::gate_closed_exception\s+\(gate closed\).*"
+        ),
+        extra_time_to_expiration=30,
+    ):
         yield
 
 


### PR DESCRIPTION
Add event filters for Raft errors that may occur while a node is shutting down and internal Seastar gates are being closed.

### Testing
local regexp testing

Fixes: SCT-452

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
