### PR TITLE
fix(nemesis): handle ALTER KEYSPACE timeout in AddRemoveDC

### DIFF
--- a/sdcm/nemesis/monkey/add_remove_dc.py
+++ b/sdcm/nemesis/monkey/add_remove_dc.py
@@ -87,11 +87,17 @@ class AddRemoveDcNemesis(NemesisBaseClass):
             for keyspace in self.system_keyspaces + [self.new_ks_name]:
                 strategy = ReplicationStrategy.get(self.runner.target_node, keyspace)
                 strategy.replication_factors_per_dc.update({self.new_dc_name: self.num_nodes_in_new_dc})
-                new_dc_setter(**{keyspace: strategy})
+                try:
+                    new_dc_setter(**{keyspace: strategy})
+                finally:
+                    # If the ALTER command times out, the RF is still updated, just didn't finish streaming
+                    # When context exits, set RF=0 for the new DC.
+                    # Create a separate strategy object so the applied (RF>0) record is not mutated.
+                    rollback_strategy = NetworkTopologyReplicationStrategy(
+                        **{**strategy.replication_factors_per_dc, self.new_dc_name: 0}
+                    )
+                    new_dc_setter.preserved[keyspace] = rollback_strategy
 
-            # when context exits, set RF=0 for the new DC
-            for _, preserved_strategy in new_dc_setter.preserved.items():
-                preserved_strategy.replication_factors_per_dc[self.new_dc_name] = 0
             yield
 
     @property

--- a/sdcm/utils/replication_strategy_utils.py
+++ b/sdcm/utils/replication_strategy_utils.py
@@ -43,7 +43,7 @@ class ReplicationStrategy:
     def apply(self, node: "BaseNode", keyspace: str):
         cql = f"ALTER KEYSPACE {cql_quote_if_needed(keyspace)} WITH replication = {self}"
         with node.parent_cluster.cql_connection_patient(node, connect_timeout=300) as session:
-            session.execute(cql, timeout=300)
+            session.execute(cql, timeout=1800)
 
         node.parent_cluster.wait_for_schema_agreement()
 


### PR DESCRIPTION
When altering a keyspace with a new DC, the operation may need a longer time to complete, due to RBNO.
Increase the timeout to 30m to mitigate this.
But if the timeout does happen, the schema update did succeed, so RF needs to be reset to 0 at the end.

Fixes: SCT-491

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://argus.scylladb.com/tests/scylla-cluster-tests/c504af2c-8212-4088-9f7f-427b22efe1e9/nemesis
- [x] https://argus.scylladb.com/tests/scylla-cluster-tests/1f5e53b4-4de3-4e02-aedb-4d329193e80b/nemesis

actions.log ✔
```
{"datetime": "2026-06-17T11:41:10.830170+00:00Z", "status": "info", "source": "Nemesisfe294b97", "action": "Started - Disruption AddRemoveDcNemesis on longevity-5gb-1h-AddRemoveDcNemesis-db-node-c504af2c-2"}
{"datetime": "2026-06-17T11:45:23.189295+00:00Z", "status": "info", "source": "Nemesisfe294b97", "action": "Started - Flush data in keyspace_new_dc on longevity-5gb-1h-AddRemoveDcNemesis-db-node-c504af2c-1 node"}
{"datetime": "2026-06-17T11:45:23.831788+00:00Z", "status": "info", "source": "Nemesisfe294b97", "action": "Finished - Flush data in keyspace_new_dc on longevity-5gb-1h-AddRemoveDcNemesis-db-node-c504af2c-1 node"}
{"datetime": "2026-06-17T11:45:23.832029+00:00Z", "status": "info", "source": "Nemesisfe294b97", "action": "Started - Flush data in keyspace_new_dc on longevity-5gb-1h-AddRemoveDcNemesis-db-node-c504af2c-2 node"}
{"datetime": "2026-06-17T11:45:24.977133+00:00Z", "status": "info", "source": "Nemesisfe294b97", "action": "Finished - Flush data in keyspace_new_dc on longevity-5gb-1h-AddRemoveDcNemesis-db-node-c504af2c-2 node"}
{"datetime": "2026-06-17T11:45:24.977272+00:00Z", "status": "info", "source": "Nemesisfe294b97", "action": "Started - Flush data in keyspace_new_dc on longevity-5gb-1h-AddRemoveDcNemesis-db-node-c504af2c-3 node"}
{"datetime": "2026-06-17T11:45:25.620097+00:00Z", "status": "info", "source": "Nemesisfe294b97", "action": "Finished - Flush data in keyspace_new_dc on longevity-5gb-1h-AddRemoveDcNemesis-db-node-c504af2c-3 node"}
{"datetime": "2026-06-17T11:45:25.620224+00:00Z", "status": "info", "source": "Nemesisfe294b97", "action": "Started - Flush data in keyspace_new_dc on longevity-5gb-1h-AddRemoveDcNemesis-db-node-c504af2c-4 node"}
{"datetime": "2026-06-17T11:45:26.761308+00:00Z", "status": "info", "source": "Nemesisfe294b97", "action": "Finished - Flush data in keyspace_new_dc on longevity-5gb-1h-AddRemoveDcNemesis-db-node-c504af2c-4 node"}
{"datetime": "2026-06-17T11:45:26.761459+00:00Z", "status": "info", "source": "Nemesisfe294b97", "action": "Started - Flush data in keyspace_new_dc on longevity-5gb-1h-AddRemoveDcNemesis-db-node-c504af2c-5 node"}
{"datetime": "2026-06-17T11:45:27.903150+00:00Z", "status": "info", "source": "Nemesisfe294b97", "action": "Finished - Flush data in keyspace_new_dc on longevity-5gb-1h-AddRemoveDcNemesis-db-node-c504af2c-5 node"}
{"datetime": "2026-06-17T11:45:27.903499+00:00Z", "status": "info", "source": "Nemesisfe294b97", "action": "Started - Flush data in keyspace_new_dc on longevity-5gb-1h-AddRemoveDcNemesis-db-node-c504af2c-6 node"}
{"datetime": "2026-06-17T11:45:29.049321+00:00Z", "status": "info", "source": "Nemesisfe294b97", "action": "Finished - Flush data in keyspace_new_dc on longevity-5gb-1h-AddRemoveDcNemesis-db-node-c504af2c-6 node"}
{"datetime": "2026-06-17T11:45:29.224095+00:00Z", "status": "info", "source": "Nemesisfe294b97", "action": "Started - Add nodes in new DC"}
{"datetime": "2026-06-17T11:46:21.017832+00:00Z", "status": "info", "source": "Nemesisfe294b97", "action": "Finished - Add nodes in new DC"}
{"datetime": "2026-06-17T11:48:03.697937+00:00Z", "status": "info", "source": "Nemesisfe294b97", "action": "Started - Temporarily switch system keyspaces to NetworkTopologyStrategy"}
{"datetime": "2026-06-17T11:50:59.168046+00:00Z", "status": "info", "source": "Nemesisfe294b97", "action": "Started - Temporarily update replication factors for new datacenter"}
{"datetime": "2026-06-17T11:57:21.140739+00:00Z", "status": "info", "source": "Nemesisfe294b97", "action": "Started - Scylla Manager repair task"}
{"datetime": "2026-06-17T12:00:31.892039+00:00Z", "status": "info", "source": "Nemesisfe294b97", "action": "Scylla Manager repair task finished with status: DONE, task id: repair/7de1904d-7afe-43a4-9325-98a12f032d41"}
{"datetime": "2026-06-17T12:00:31.892162+00:00Z", "status": "info", "source": "Nemesisfe294b97", "action": "Finished - Scylla Manager repair task"}
{"datetime": "2026-06-17T12:00:32.712234+00:00Z", "status": "info", "source": "Nemesisfe294b97", "action": "Started - Run write data to multiDC keyspace"}
{"datetime": "2026-06-17T12:05:02.201918+00:00Z", "status": "info", "source": "Nemesisfe294b97", "action": "Finished - Run write data to multiDC keyspace"}
{"datetime": "2026-06-17T12:05:12.260608+00:00Z", "status": "info", "source": "Nemesisfe294b97", "action": "Started - Verify keyspace data"}
{"datetime": "2026-06-17T12:08:53.531672+00:00Z", "status": "info", "source": "Nemesisfe294b97", "action": "Finished - Verify keyspace data"}
{"datetime": "2026-06-17T12:08:53.531842+00:00Z", "status": "info", "source": "Nemesisfe294b97", "action": "Finished - Temporarily update replication factors for new datacenter"}
{"datetime": "2026-06-17T12:14:03.965555+00:00Z", "status": "info", "source": "Nemesisfe294b97", "action": "Started - Decommission nodes in the new datacenter add_remove_nemesis_dc"}
{"datetime": "2026-06-17T12:14:04.320211+00:00Z", "status": "info", "source": "Nemesisfe294b97", "action": "Started - Decommission longevity-5gb-1h-AddRemoveDcNemesis-db-node-c504af2c-7 node"}
{"datetime": "2026-06-17T12:14:04.320677+00:00Z", "status": "info", "source": "Nemesisfe294b97", "action": "Started - Decommission longevity-5gb-1h-AddRemoveDcNemesis-db-node-c504af2c-8 node"}
{"datetime": "2026-06-17T12:15:07.938433+00:00Z", "status": "info", "source": "Nemesisfe294b97", "action": "Finished - Decommission longevity-5gb-1h-AddRemoveDcNemesis-db-node-c504af2c-8 node"}
{"datetime": "2026-06-17T12:15:08.114090+00:00Z", "status": "info", "source": "Nemesisfe294b97", "action": "Finished - Decommission longevity-5gb-1h-AddRemoveDcNemesis-db-node-c504af2c-7 node"}
{"datetime": "2026-06-17T12:15:31.834986+00:00Z", "status": "info", "source": "Nemesisfe294b97", "action": "Finished - Decommission nodes in the new datacenter add_remove_nemesis_dc"}
{"datetime": "2026-06-17T12:15:32.477237+00:00Z", "status": "info", "source": "Nemesisfe294b97", "action": "Started - Verify keyspace data"}
{"datetime": "2026-06-17T12:19:24.025613+00:00Z", "status": "info", "source": "Nemesisfe294b97", "action": "Finished - Verify keyspace data"}
{"datetime": "2026-06-17T12:19:24.025782+00:00Z", "status": "info", "source": "Nemesisfe294b97", "action": "Finished - Temporarily switch system keyspaces to NetworkTopologyStrategy"}
{"datetime": "2026-06-17T12:21:21.712790+00:00Z", "status": "info", "source": "Nemesisfe294b97", "action": "Finished - Disruption AddRemoveDcNemesis on longevity-5gb-1h-AddRemoveDcNemesis-db-node-c504af2c-2"}
{"datetime": "2026-06-17T12:24:54.543875+00:00Z", "status": "info", "source": "Nemesisfe294b97", "action": "Started - Disruption AddRemoveDcNemesis on longevity-5gb-1h-AddRemoveDcNemesis-db-node-c504af2c-1"}
{"datetime": "2026-06-17T12:28:38.302482+00:00Z", "status": "info", "source": "Nemesisfe294b97", "action": "Started - Flush data in keyspace_new_dc on longevity-5gb-1h-AddRemoveDcNemesis-db-node-c504af2c-1 node"}
{"datetime": "2026-06-17T12:28:39.446444+00:00Z", "status": "info", "source": "Nemesisfe294b97", "action": "Finished - Flush data in keyspace_new_dc on longevity-5gb-1h-AddRemoveDcNemesis-db-node-c504af2c-1 node"}
{"datetime": "2026-06-17T12:28:39.446605+00:00Z", "status": "info", "source": "Nemesisfe294b97", "action": "Started - Flush data in keyspace_new_dc on longevity-5gb-1h-AddRemoveDcNemesis-db-node-c504af2c-2 node"}
{"datetime": "2026-06-17T12:28:40.594606+00:00Z", "status": "info", "source": "Nemesisfe294b97", "action": "Finished - Flush data in keyspace_new_dc on longevity-5gb-1h-AddRemoveDcNemesis-db-node-c504af2c-2 node"}
{"datetime": "2026-06-17T12:28:40.594766+00:00Z", "status": "info", "source": "Nemesisfe294b97", "action": "Started - Flush data in keyspace_new_dc on longevity-5gb-1h-AddRemoveDcNemesis-db-node-c504af2c-3 node"}
{"datetime": "2026-06-17T12:28:41.235939+00:00Z", "status": "info", "source": "Nemesisfe294b97", "action": "Finished - Flush data in keyspace_new_dc on longevity-5gb-1h-AddRemoveDcNemesis-db-node-c504af2c-3 node"}
{"datetime": "2026-06-17T12:28:41.236173+00:00Z", "status": "info", "source": "Nemesisfe294b97", "action": "Started - Flush data in keyspace_new_dc on longevity-5gb-1h-AddRemoveDcNemesis-db-node-c504af2c-4 node"}
{"datetime": "2026-06-17T12:28:41.879951+00:00Z", "status": "info", "source": "Nemesisfe294b97", "action": "Finished - Flush data in keyspace_new_dc on longevity-5gb-1h-AddRemoveDcNemesis-db-node-c504af2c-4 node"}
{"datetime": "2026-06-17T12:28:41.880082+00:00Z", "status": "info", "source": "Nemesisfe294b97", "action": "Started - Flush data in keyspace_new_dc on longevity-5gb-1h-AddRemoveDcNemesis-db-node-c504af2c-5 node"}
{"datetime": "2026-06-17T12:28:43.023803+00:00Z", "status": "info", "source": "Nemesisfe294b97", "action": "Finished - Flush data in keyspace_new_dc on longevity-5gb-1h-AddRemoveDcNemesis-db-node-c504af2c-5 node"}
{"datetime": "2026-06-17T12:28:43.023990+00:00Z", "status": "info", "source": "Nemesisfe294b97", "action": "Started - Flush data in keyspace_new_dc on longevity-5gb-1h-AddRemoveDcNemesis-db-node-c504af2c-6 node"}
{"datetime": "2026-06-17T12:28:44.167437+00:00Z", "status": "info", "source": "Nemesisfe294b97", "action": "Finished - Flush data in keyspace_new_dc on longevity-5gb-1h-AddRemoveDcNemesis-db-node-c504af2c-6 node"}
{"datetime": "2026-06-17T12:28:44.344313+00:00Z", "status": "info", "source": "Nemesisfe294b97", "action": "Started - Add nodes in new DC"}
{"datetime": "2026-06-17T12:29:36.680471+00:00Z", "status": "info", "source": "Nemesisfe294b97", "action": "Finished - Add nodes in new DC"}
{"datetime": "2026-06-17T12:31:38.985158+00:00Z", "status": "info", "source": "Nemesisfe294b97", "action": "Started - Temporarily switch system keyspaces to NetworkTopologyStrategy"}
{"datetime": "2026-06-17T12:34:56.919865+00:00Z", "status": "info", "source": "Nemesisfe294b97", "action": "Started - Temporarily update replication factors for new datacenter"}
{"datetime": "2026-06-17T12:42:07.286935+00:00Z", "status": "info", "source": "Nemesisfe294b97", "action": "Started - Scylla Manager repair task"}
{"datetime": "2026-06-17T12:45:18.037847+00:00Z", "status": "info", "source": "Nemesisfe294b97", "action": "Scylla Manager repair task finished with status: DONE, task id: repair/392274c7-45a3-464a-a172-056315185507"}
{"datetime": "2026-06-17T12:45:18.037978+00:00Z", "status": "info", "source": "Nemesisfe294b97", "action": "Finished - Scylla Manager repair task"}
{"datetime": "2026-06-17T12:45:18.857989+00:00Z", "status": "info", "source": "Nemesisfe294b97", "action": "Started - Run write data to multiDC keyspace"}
{"datetime": "2026-06-17T12:49:19.612278+00:00Z", "status": "info", "source": "Nemesisfe294b97", "action": "Finished - Run write data to multiDC keyspace"}
{"datetime": "2026-06-17T12:49:29.192544+00:00Z", "status": "info", "source": "Nemesisfe294b97", "action": "Started - Verify keyspace data"}
{"datetime": "2026-06-17T12:53:12.197580+00:00Z", "status": "info", "source": "Nemesisfe294b97", "action": "Finished - Verify keyspace data"}
{"datetime": "2026-06-17T12:53:12.197753+00:00Z", "status": "info", "source": "Nemesisfe294b97", "action": "Finished - Temporarily update replication factors for new datacenter"}
{"datetime": "2026-06-17T12:57:56.700752+00:00Z", "status": "info", "source": "Nemesisfe294b97", "action": "Started - Decommission nodes in the new datacenter add_remove_nemesis_dc"}
{"datetime": "2026-06-17T12:57:56.999391+00:00Z", "status": "info", "source": "Nemesisfe294b97", "action": "Started - Decommission longevity-5gb-1h-AddRemoveDcNemesis-db-node-c504af2c-9 node"}
{"datetime": "2026-06-17T12:57:57.003660+00:00Z", "status": "info", "source": "Nemesisfe294b97", "action": "Started - Decommission longevity-5gb-1h-AddRemoveDcNemesis-db-node-c504af2c-10 node"}
{"datetime": "2026-06-17T12:59:01.856701+00:00Z", "status": "info", "source": "Nemesisfe294b97", "action": "Finished - Decommission longevity-5gb-1h-AddRemoveDcNemesis-db-node-c504af2c-10 node"}
{"datetime": "2026-06-17T12:59:17.279041+00:00Z", "status": "info", "source": "Nemesisfe294b97", "action": "Finished - Decommission longevity-5gb-1h-AddRemoveDcNemesis-db-node-c504af2c-9 node"}
{"datetime": "2026-06-17T12:59:40.987946+00:00Z", "status": "info", "source": "Nemesisfe294b97", "action": "Finished - Decommission nodes in the new datacenter add_remove_nemesis_dc"}
{"datetime": "2026-06-17T12:59:41.632150+00:00Z", "status": "info", "source": "Nemesisfe294b97", "action": "Started - Verify keyspace data"}
{"datetime": "2026-06-17T13:03:14.635283+00:00Z", "status": "info", "source": "Nemesisfe294b97", "action": "Finished - Verify keyspace data"}
{"datetime": "2026-06-17T13:03:14.635474+00:00Z", "status": "info", "source": "Nemesisfe294b97", "action": "Finished - Temporarily switch system keyspaces to NetworkTopologyStrategy"}
{"datetime": "2026-06-17T13:05:33.732779+00:00Z", "status": "info", "source": "Nemesisfe294b97", "action": "Finished - Disruption AddRemoveDcNemesis on longevity-5gb-1h-AddRemoveDcNemesis-db-node-c504af2c-1"}
```

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
