### PR TITLE
feature(perf-logstor): add experimental logstor performance testing

### DIFF
--- a/configurations/performance/enable_logstor.yaml
+++ b/configurations/performance/enable_logstor.yaml
@@ -1,0 +1,19 @@
+experimental_features:
+  - logstor
+
+append_scylla_yaml:
+  logstor_disk_size_in_mb: 80000
+  logstor_separator_max_memory_in_mb: 256
+  logstor_format_on_startup: true
+
+# Append --task-quota-ms 0.2 to existing append_scylla_args (++ prefix appends instead of replacing)
+append_scylla_args: '++ --task-quota-ms 0.2'
+
+n_db_nodes: 4
+n_loaders: 1
+# Nodes used to replicate the Aerospike test to be able to compare the results
+instance_type_db: 'i4i.4xlarge'
+instance_type_loader: 'c6i.16xlarge'
+
+simulated_racks: 2
+rack_aware_loader: true

--- a/configurations/performance/logstor_hotspot_queries.yaml
+++ b/configurations/performance/logstor_hotspot_queries.yaml
@@ -1,0 +1,64 @@
+# Logstor hotspot distribution workload configuration
+# Uses latte_cs_alike_hotspot.rn with hotspot_write/hotspot_read functions
+# 55% of ops target 5M hot keys (1% of dataset), 45% spread across remaining 495M keys
+# Schema: 10 columns x 200 bytes each (matching kv_hotspot.rn reference)
+# Only mixed (hotspot_write:30,hotspot_read:70) workload at 750k ops/s for 60m
+# This test is a part of the benchmark done by Aerospike
+# https://aerospike.com/files/benchmarks/aerospike-vs-scylladb-performance-and-cost-at-multi-terabyte-scale.pdf
+
+perf_gradual_throttle_steps:
+  mixed:
+    - {threads: 16, concurrency: 128, rate: '750000'}
+
+perf_gradual_step_duration: {"mixed": '60m'}
+
+# Cache warmup: read 5M hot keys with CL=ALL before mixed workload
+stress_cmd_cache_warmup:
+  - >-
+    latte run --function read --consistency ALL --duration 5m
+    --threads 12 --concurrency 64
+    --start-cycle 1 --end-cycle 5000000
+    -P row_count=500000000 -P offset=0
+    -P column_count=10 -P column_size=200 -P key_size=48
+    data_dir/latte/latte_cs_alike_hotspot.rn
+
+prepare_stress_cmd: >-
+  latte schema -P column_count=10 -P column_size=200 -P key_size=48
+  -P speculative_retry="\"NONE\"" -P replication_factor=2
+  data_dir/latte/latte_cs_alike_hotspot.rn
+
+# Populate 500M rows with hotspot distribution (hot keys written densely, cold keys sparsely)
+prepare_write_cmd:
+  - >-
+    latte run --function hotspot_write --consistency ALL --duration 500000000
+    --threads 32 --concurrency 32 --rate 93750
+    --start-cycle 1 --end-cycle 500000000
+    -P row_count=500000000 -P offset=0
+    -P column_count=10 -P column_size=200 -P key_size=48
+    -P hotset_items=5000000 -P hotset_chance=55
+    data_dir/latte/latte_cs_alike_hotspot.rn
+
+# Mixed workload: hotspot write:30,read:70 for $duration
+stress_cmd_m:
+  - >-
+    latte run --function hotspot_write:30,hotspot_read:70 --consistency QUORUM --duration $duration
+    --threads $threads --concurrency $concurrency $throttle
+    --start-cycle 1 --end-cycle 500000000
+    -P row_count=500000000 -P offset=0
+    -P column_count=10 -P column_size=200 -P key_size=48
+    -P hotset_items=5000000 -P hotset_chance=55
+    data_dir/latte/latte_cs_alike_hotspot.rn
+
+latte_schema_parameters:
+  keyspace: 'keyspace1'
+  table: 'standard1'
+  replication_factor: 2
+  column_count: 10
+  column_size: 200
+  key_size: 48
+  speculative_retry: 'NONE'
+  storage_engine: 'logstor'
+  min_per_shard_tablet_count: 32
+
+perf_stress_keyspace: keyspace1
+perf_stress_table: standard1

--- a/configurations/performance/logstor_uniform_queries.yaml
+++ b/configurations/performance/logstor_uniform_queries.yaml
@@ -1,0 +1,54 @@
+# Logstor uniform distribution workload configuration
+# Uses latte_cs_alike.rn with write/read functions (uniform: i % ROW_COUNT + OFFSET)
+# Schema: 10 columns x 200 bytes each (matching kv_uniform.rn reference)
+# Only mixed (write:30,read:70) workload at 600k ops/s for 60m
+# This test is a part of the benchmark done by Aerospike
+# https://aerospike.com/files/benchmarks/aerospike-vs-scylladb-performance-and-cost-at-multi-terabyte-scale.pdf
+
+perf_gradual_throttle_steps:
+  mixed:
+    - {threads: 12, concurrency: 128, rate: '600000'}
+
+perf_gradual_step_duration: {"mixed": '60m'}
+
+# No cache warmup for uniform workload (data is uniformly distributed, no hot set)
+stress_cmd_cache_warmup: []
+
+prepare_stress_cmd: >-
+  latte schema -P column_count=10 -P column_size=200 -P key_size=48
+  -P speculative_retry="\"NONE\"" -P replication_factor=2
+  data_dir/latte/latte_cs_alike.rn
+
+# Populate 500M rows with uniform distribution
+prepare_write_cmd:
+  - >-
+    latte run --function write --consistency ALL --duration 500000000
+    --threads 32 --concurrency 32 --rate 93750
+    --start-cycle 1 --end-cycle 500000000
+    -P row_count=500000000 -P offset=0
+    -P column_count=10 -P column_size=200 -P key_size=48
+    data_dir/latte/latte_cs_alike.rn
+
+# Mixed workload: uniform write:30,read:70 for $duration
+stress_cmd_m:
+  - >-
+    latte run --function write:30,read:70 --consistency QUORUM --duration $duration
+    --threads $threads --concurrency $concurrency $throttle
+    --start-cycle 1 --end-cycle 500000000
+    -P row_count=500000000 -P offset=0
+    -P column_count=10 -P column_size=200 -P key_size=48
+    data_dir/latte/latte_cs_alike.rn
+
+latte_schema_parameters:
+  keyspace: 'keyspace1'
+  table: 'standard1'
+  replication_factor: 2
+  column_count: 10
+  column_size: 200
+  key_size: 48
+  speculative_retry: 'NONE'
+  storage_engine: 'logstor'
+  min_per_shard_tablet_count: 32
+
+perf_stress_keyspace: keyspace1
+perf_stress_table: standard1

--- a/data_dir/latte/latte_cs_alike.rn
+++ b/data_dir/latte/latte_cs_alike.rn
@@ -35,19 +35,21 @@ const REPLICATION_FACTOR = latte::param!("replication_factor", 3);
 const COMPRESSION = latte::param!("compression", "");
 const COMPACTION_STRATEGY = latte::param!("compaction_strategy", "");
 const SPECULATIVE_RETRY = latte::param!("speculative_retry", "");
-const KEYSPACE = latte::param!("keyspace", "keyspace1");
-const TABLE = latte::param!("table", "standard1");
+const STORAGE_ENGINE = latte::param!("storage_engine", "");
+const MIN_PER_SHARD_TABLET_COUNT = latte::param!("min_per_shard_tablet_count", 0);
+pub const KEYSPACE = latte::param!("keyspace", "keyspace1");
+pub const TABLE = latte::param!("table", "standard1");
 const COUNTER_TABLE = latte::param!("counter_table", "");
-const KEY_SIZE = latte::param!("key_size", 10);
-const COLUMN_SIZE = latte::param!("column_size", 128);
-const COLUMN_COUNT = latte::param!("column_count", 8);
-const ROW_COUNT = latte::param!("row_count", 1_000_000);
-const OFFSET = latte::param!("offset", 0);
+pub const KEY_SIZE = latte::param!("key_size", 10);
+pub const COLUMN_SIZE = latte::param!("column_size", 128);
+pub const COLUMN_COUNT = latte::param!("column_count", 8);
+pub const ROW_COUNT = latte::param!("row_count", 1_000_000);
+pub const OFFSET = latte::param!("offset", 0);
 const GAUSS_MEAN = latte::param!("gauss_mean", 0);
 const GAUSS_STDDEV = latte::param!("gauss_stddev", 0);
 
-const P_STMT_WRITE = "latte_prep_stmt__write";
-const P_STMT_READ = "latte_prep_stmt__read";
+pub const P_STMT_WRITE = "latte_prep_stmt__write";
+pub const P_STMT_READ = "latte_prep_stmt__read";
 const P_STMT_COUNTER_WRITE = "latte_prep_stmt__counter_write";
 const P_STMT_COUNTER_READ = "latte_prep_stmt__counter_read";
 
@@ -90,12 +92,22 @@ pub async fn schema(db) {
         // Result: WITH speculative_retry = "NONE"
         speculative_retry += " AND speculative_retry = '" + SPECULATIVE_RETRY + "' "
     }
+    let storage_engine = "";
+    if !STORAGE_ENGINE.is_empty() {
+        // Result: AND storage_engine = 'logstor'
+        storage_engine += " AND storage_engine = '" + STORAGE_ENGINE + "'"
+    }
+    let tablets = "";
+    if MIN_PER_SHARD_TABLET_COUNT > 0 {
+        // Result: AND tablets = {'min_per_shard_tablet_count': '32'}
+        tablets += ` AND tablets = {'min_per_shard_tablet_count': '${MIN_PER_SHARD_TABLET_COUNT}'}`
+    }
     let comment = " AND comment='Created by latte'";
 
     // Create blob table
     db.execute(
         `CREATE TABLE IF NOT EXISTS ${KEYSPACE}.${TABLE}` +
-        `(key blob PRIMARY KEY${columns_def}${compression}${compaction}${speculative_retry}${comment}`
+        `(key blob PRIMARY KEY${columns_def}${compression}${compaction}${speculative_retry}${storage_engine}${tablets}${comment}`
     ).await?;
 
     if !COUNTER_TABLE.is_empty() {
@@ -193,7 +205,7 @@ async fn get_partition_idx(db, i) {
 }
 
 /// Utility function to be used by the 'write' public function
-async fn get_blob_columns_data(key, idx) {
+pub async fn get_blob_columns_data(key, idx) {
     let columns = [key];
     for current_column_idx in 0..=COLUMN_COUNT-1 {
         columns.push(blob(idx + current_column_idx * ROW_COUNT, COLUMN_SIZE));

--- a/data_dir/latte/latte_cs_alike_hotspot.rn
+++ b/data_dir/latte/latte_cs_alike_hotspot.rn
@@ -1,0 +1,93 @@
+// This rune script extends latte_cs_alike.rn with hotspot distribution.
+//
+// Hotspot means HOTSET_CHANCE% of operations target HOTSET_ITEMS keys (the "hot set"),
+// while the remaining operations are spread uniformly across the rest of the keyspace.
+//
+// Run populate (write all rows using hotspot distribution):
+// $ latte run /path/to/latte_cs_alike_hotspot.rn %IP% -q \
+//     -f hotspot_write \
+//     --consistency ALL \
+//     --threads 64 --concurrency 128 --rate 200000 \
+//     --start-cycle 1 --end-cycle 500000000 \
+//     -P row_count=500_000_000 -P offset=0 \
+//     -P column_count=10 -P column_size=200 -P key_size=48 \
+//     -P hotset_items=5000000 -P hotset_chance=55
+//
+// Run mixed hotspot workload:
+// $ latte run /path/to/latte_cs_alike_hotspot.rn %IP% -q \
+//     -f hotspot_write:30,hotspot_read:70 \
+//     --consistency QUORUM --duration 60m \
+//     --threads 16 --concurrency 128 --rate 750000 \
+//     -P row_count=500_000_000 -P offset=0 \
+//     -P column_count=10 -P column_size=200 -P key_size=48 \
+//     -P hotset_items=5000000 -P hotset_chance=55
+
+mod latte_cs_alike;
+
+use latte_cs_alike::{
+    KEYSPACE, TABLE, KEY_SIZE, COLUMN_SIZE, COLUMN_COUNT, ROW_COUNT, OFFSET,
+    P_STMT_WRITE, P_STMT_READ,
+    get_blob_columns_data,
+};
+use latte::*;
+
+const HOTSET_ITEMS = latte::param!("hotset_items", 5000000);
+const HOTSET_CHANCE = latte::param!("hotset_chance", 55);
+
+pub async fn schema(db) {
+    latte_cs_alike::schema(db).await;
+}
+
+pub async fn prepare(db) {
+    if HOTSET_ITEMS < 1 {
+        return Err("'hotset_items' must be greater than 0")
+    }
+    if HOTSET_ITEMS >= ROW_COUNT {
+        return Err(format!(
+            "'hotset_items' ({hotset_items}) must be less than 'row_count' ({row_count})",
+            hotset_items=HOTSET_ITEMS, row_count=ROW_COUNT));
+    }
+    if HOTSET_CHANCE < 1 || HOTSET_CHANCE > 99 {
+        return Err(format!(
+            "'hotset_chance' ({chance}) must be between 1 and 99",
+            chance=HOTSET_CHANCE));
+    }
+    println!(
+        "debug: Hotspot distribution enabled: hotset_items={items}, hotset_chance={chance}%",
+        items=HOTSET_ITEMS, chance=HOTSET_CHANCE);
+    latte_cs_alike::prepare(db).await;
+}
+
+///////////////////////
+// UTILITY FUNCTIONS //
+///////////////////////
+
+/// Hotspot index: HOTSET_CHANCE% of ops target HOTSET_ITEMS keys, rest spread across remaining
+fn get_hotspot_idx(i) {
+    if i % 100 < HOTSET_CHANCE {
+        OFFSET + (i % HOTSET_ITEMS)
+    } else {
+        OFFSET + HOTSET_ITEMS + (i % (ROW_COUNT - HOTSET_ITEMS))
+    }
+}
+
+///////////////////////////
+// USER-FACING FUNCTIONS //
+///////////////////////////
+
+pub async fn hotspot_write(db, i) {
+    let partition_idx = get_hotspot_idx(i);
+    let key = blob(partition_idx, KEY_SIZE);
+    db.execute_prepared(P_STMT_WRITE, get_blob_columns_data(key, partition_idx).await).await?
+}
+
+pub async fn hotspot_read(db, i) {
+    let partition_idx = get_hotspot_idx(i);
+    let key = blob(partition_idx, KEY_SIZE);
+    db.execute_prepared(P_STMT_READ, [key]).await?
+}
+
+/// Delegate plain read to base module (useful for cache warmup)
+pub async fn read(db, i) {
+    latte_cs_alike::read(db, i).await
+}

--- a/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/logstor_hotspot.jenkinsfile
+++ b/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/logstor_hotspot.jenkinsfile
@@ -1,0 +1,13 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+perfRegressionParallelPipeline(
+    backend: "aws",
+    region: "us-east-1",
+    provision_type: 'on_demand',
+    test_name: "performance_regression_gradual_grow_throughput.PerformanceRegressionPredefinedStepsTest",
+    test_config: '''["test-cases/performance/perf-regression-predefined-throughput-steps.yaml", "configurations/disable_kms.yaml", "configurations/disable_speculative_retry.yaml", "configurations/performance/latency-decorator-error-thresholds-steps-ent-tablets.yaml", "configurations/performance/enable_logstor.yaml", "configurations/performance/logstor_hotspot_queries.yaml"]''',
+    sub_tests: ["test_mixed_gradual_increase_load"],
+)

--- a/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/logstor_uniform.jenkinsfile
+++ b/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/logstor_uniform.jenkinsfile
@@ -1,0 +1,13 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+perfRegressionParallelPipeline(
+    backend: "aws",
+    region: "us-east-1",
+    provision_type: 'on_demand',
+    test_name: "performance_regression_gradual_grow_throughput.PerformanceRegressionPredefinedStepsTest",
+    test_config: '''["test-cases/performance/perf-regression-predefined-throughput-steps.yaml", "configurations/disable_kms.yaml", "configurations/disable_speculative_retry.yaml", "configurations/performance/latency-decorator-error-thresholds-steps-ent-tablets.yaml", "configurations/performance/enable_logstor.yaml", "configurations/performance/logstor_uniform_queries.yaml"]''',
+    sub_tests: ["test_mixed_gradual_increase_load"],
+)


### PR DESCRIPTION
add experimental logstor performance testing pipelines using Latte

- Simplify to a mixed-only (write:30, read:70) workload configuration
- Configure a 4-node i4i.4xlarge cluster shape with RF=2
- Enable simulated_racks=2 and rack_aware_loader for optimized replica placement

These two tests is attempt to reproduce the testing done by [Aerospike](https://aerospike.com/files/benchmarks/aerospike-vs-scylladb-performance-and-cost-at-multi-terabyte-scale.pdf). 

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://jenkins.scylladb.com/job/scylla-staging/job/xtrey/job/sct/job/logstor/job/logstor-hotspot/9/
- [x] https://jenkins.scylladb.com/job/scylla-staging/job/xtrey/job/sct/job/logstor/job/logstor-uniform/23

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-2499
