### PR TITLE
fix(argus): report InvalidInstanceType validation failures as TEST_ERROR

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -259,6 +259,49 @@ def cli(ctx):
         docker_hub_login(remoter=LOCALRUNNER)
 
 
+def _report_provision_error_to_argus(backend: str, exc: Exception):
+    """Report a provision-stage failure to Argus with TEST_ERROR status."""
+    test_config = get_test_config()
+    try:
+        params = SCTConfiguration()
+        test_id = params.get("test_id")
+        if test_id and test_id != "None":
+            test_config.set_test_id_only(test_id)
+        test_config.init_argus_client(params)
+    except Exception:  # noqa: BLE001
+        LOGGER.warning("Failed to initialize Argus client for error reporting", exc_info=True)
+        return
+
+    error_message = (
+        f"(TestFrameworkEvent Severity.CRITICAL) Failed to provision {backend} resources: {type(exc).__name__}: {exc}"
+    )
+    event_payload: RawEventPayload = {
+        "run_id": str(test_config.test_id()),
+        "severity": "CRITICAL",
+        "ts": time.time(),
+        "message": error_message,
+        "event_type": "TestFrameworkEvent",
+        "received_timestamp": None,
+        "nemesis_name": None,
+        "duration": None,
+        "node": None,
+        "target_node": None,
+        "known_issue": None,
+        "nemesis_status": None,
+    }
+
+    try:
+        test_config.argus_client().submit_event(event_payload)
+        LOGGER.info("Error event submitted to Argus successfully")
+    except Exception as argus_exc:  # noqa: BLE001
+        LOGGER.warning("Failed to submit error event to Argus: %s", argus_exc)
+
+    try:
+        test_config.argus_client().set_sct_run_status(TestStatus.TEST_ERROR)
+    except Exception:  # noqa: BLE001
+        LOGGER.warning("Failed to set TEST_ERROR status in Argus", exc_info=True)
+
+
 @cli.command("provision-resources", help="Provision resources for the test")
 @click.option("-b", "--backend", type=click.Choice(available_backends), help="Backend to use")
 @click.option("-t", "--test-name", type=str, help="Test name")
@@ -276,7 +319,12 @@ def provision_resources(backend, test_name: str, config: str):
         os.environ["SCT_CLUSTER_BACKEND"] = backend
 
     add_file_logger()
-    params = init_and_verify_sct_config()
+    try:
+        params = init_and_verify_sct_config()
+    except Exception as exc:
+        LOGGER.error("Configuration validation failed - aborting the test...", exc_info=True)
+        _report_provision_error_to_argus(backend or os.environ.get("SCT_CLUSTER_BACKEND", "unknown"), exc)
+        sys.exit(1)
     test_config = get_test_config()
     test_config.set_test_name(test_name)
     test_id = params.get("test_id")
@@ -326,35 +374,7 @@ def provision_resources(backend, test_name: str, config: str):
             raise ValueError(f"backend {backend} is not supported")
     except Exception as exc:
         LOGGER.error("Unable to provision resources - aborting the test...", exc_info=True)
-        test_config.init_argus_client(params)
-
-        # Create and submit error event to Argus
-        error_message = (
-            f"(TestFrameworkEvent Severity.CRITICAL) "
-            f"Failed to provision {backend} resources: {type(exc).__name__}: {exc}"
-        )
-        event_payload: RawEventPayload = {
-            "run_id": str(test_config.test_id()),
-            "severity": "CRITICAL",
-            "ts": time.time(),
-            "message": error_message,
-            "event_type": "TestFrameworkEvent",
-            "received_timestamp": None,
-            "nemesis_name": None,
-            "duration": None,
-            "node": None,
-            "target_node": None,
-            "known_issue": None,
-            "nemesis_status": None,
-        }
-
-        try:
-            test_config.argus_client().submit_event(event_payload)
-            LOGGER.info("Error event submitted to Argus successfully")
-        except Exception as argus_exc:  # noqa: BLE001
-            LOGGER.warning("Failed to submit error event to Argus: %s", argus_exc)
-
-        test_config.argus_client().set_sct_run_status(TestStatus.TEST_ERROR)
+        _report_provision_error_to_argus(backend, exc)
         sys.exit(1)
 
 

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -262,6 +262,18 @@ def teardown_on_exception(method):
                 source=args[0].__class__.__name__, source_method="SetUp", exception=exc
             ).publish_or_dump()
             TEST_LOG.exception("Exception in %s. Will call tearDown", method.__name__)
+            # Try to initialize Argus if it hasn't been done yet, so the failure
+            # is reported with proper TEST_ERROR status.
+            tester = args[0]
+            if hasattr(tester, "params") and tester.params and not hasattr(tester, "argus_heartbeat_stop_signal"):
+                try:
+                    if not tester.test_config.test_id():
+                        reuse_id = tester.params.get("reuse_cluster")
+                        tester.test_config.set_test_id(reuse_id or tester.params.get("test_id") or uuid4())
+                    tester.init_argus_run()
+                    tester.argus_heartbeat_stop_signal = tester.start_argus_heartbeat_thread()
+                except Exception:  # noqa: BLE001
+                    TEST_LOG.warning("Failed to initialize Argus for error reporting", exc_info=True)
             args[0].tearDown()
             raise
 
@@ -674,6 +686,10 @@ class ClusterTester(unittest.TestCase):
                     r"source=[\w]+.SetUp\(\).+exception=403 FORBIDDEN QUOTA_EXCEEDED", re.IGNORECASE | re.DOTALL
                 ),
                 re.compile(r"source=[\w]+.SetUp\(\).+InsufficientInstanceCapacity", re.IGNORECASE | re.DOTALL),
+                re.compile(r"source=[\w]+.SetUp\(\).+InvalidInstanceType", re.IGNORECASE | re.DOTALL),
+                re.compile(
+                    r"source=[\w]+.SetUp\(\).+is not (supported|available) in region", re.IGNORECASE | re.DOTALL
+                ),
             ]
             for error in errors:
                 if error.search(event):
@@ -4219,7 +4235,8 @@ class ClusterTester(unittest.TestCase):
         """
         yield
         self.argus_finalize_test_run()
-        self.argus_heartbeat_stop_signal.set()
+        if hasattr(self, "argus_heartbeat_stop_signal"):
+            self.argus_heartbeat_stop_signal.set()
 
     @silence()
     def destroy_localhost(self):

--- a/sdcm/utils/aws_utils.py
+++ b/sdcm/utils/aws_utils.py
@@ -512,10 +512,14 @@ def get_arch_from_instance_type(instance_type: str, region_name: str) -> AwsArch
             instance_type_info = client.describe_instance_types(InstanceTypes=[instance_type])
         except ClientError as exc:
             if exc.response["Error"]["Code"] == "InvalidInstanceType":
-                raise ValueError(
-                    f"Instance type '{instance_type}' is not available in region '{region_name}'. "
-                    f"Please verify the instance type exists in this region or use a different one."
-                ) from exc
+                LOGGER.warning(
+                    "Instance type '%s' is not available in region '%s'. "
+                    "Defaulting to arch '%s'. Validation will report this error later.",
+                    instance_type,
+                    region_name,
+                    arch,
+                )
+                return arch
             raise
 
         try:

--- a/unit_tests/unit/test_provision_error_event.py
+++ b/unit_tests/unit/test_provision_error_event.py
@@ -62,7 +62,7 @@ def test_provision_resources_sends_error_event_to_argus():
         assert result.exit_code == 1
 
         # Verify argus_client was initialized
-        test_config_instance.init_argus_client.assert_called_once_with(mock_params)
+        test_config_instance.init_argus_client.assert_called_once()
 
         # Verify submit_event was called
         assert mock_argus_client.submit_event.called


### PR DESCRIPTION
Config validation errors (e.g. invalid instance types) were not reported to Argus because they occurred before Argus was initialized.

Two entry points are fixed:

1. sct.py provision_resources: init_and_verify_sct_config() can fail before the provisioning try/except block. Wrap it in a try/except that reports to Argus via the new _report_provision_error_to_argus helper. Refactor existing provisioning error handler to use the same helper.

2. sdcm/tester.py setUp: teardown_on_exception now attempts to initialize Argus when setUp fails before init_argus_run was called, so the failure event reaches Argus.

Also add regex patterns to _is_test_error() for:
- InvalidInstanceType (boto ClientError)
- 'is not supported/available in region' (validation assert/ValueError)

Add hasattr guard on argus_heartbeat_stop_signal in fixture_argus_finalize.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] provision AWS
- [x] provision GCE
- [x]  [scylla-enterprise-perf-regression-predefined-throughput-steps-i8g-tablets failed with correct error and correct ru status](https://argus.scylladb.com/tests/scylla-cluster-tests/0476a274-2bb1-4a35-8689-b15fb9d0f584)
- [x]  [scylla-enterprise-perf-regression-predefined-throughput-steps-i8g-tablets- instances created](https://argus.scylladb.com/tests/scylla-cluster-tests/cbecf0ef-ca3c-401e-846e-a07abfcd82ae)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
