### PR TITLE
fix(nemesis): stop overriding rpc_address in AddRemoveDcNemesis

### DIFF
--- a/sdcm/nemesis/monkey/add_remove_dc.py
+++ b/sdcm/nemesis/monkey/add_remove_dc.py
@@ -123,7 +123,6 @@ class AddRemoveDcNemesis(NemesisBaseClass):
             node: New datacenter node to configure.
         """
         with node.remote_scylla_yaml() as scylla_yml:
-            scylla_yml.rpc_address = node.ip_address
             scylla_yml.seed_provider = [
                 SeedProvider(
                     class_name="org.apache.cassandra.locator.SimpleSeedProvider",


### PR DESCRIPTION
`config_setup()` already writes rpc_address to `scylla.yaml` via `ScyllaNetworkConfiguration`, which correctly maps it to the NIC defined in scylla_network_config. Setting `rpc_address = node.ip_address` afterwards overwrites it with the primary NIC address, causing Scylla to bind CQL on the wrong interface. On multi-NIC test configurations (e.g. `scylladb_addresses_on_different_interfaces.yaml`), cql_address points to NIC 1 while Scylla is now bound to NIC 0, so wait_for_init times out after 3600s with NodeSetupFailed.

Remove the rpc_address override and let config_setup handle it. Seed provider and DC name (rackdc.properties) are still set here as they are specific to the new-DC bootstrap.

This bug was introduced https://github.com/scylladb/scylla-cluster-tests/pull/13381

Fixes: https://scylladb.atlassian.net/browse/SCT-462
Fixes: https://scylladb.atlassian.net/browse/SCT-482

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://argus.scylladb.com/tests/scylla-cluster-tests/b3b9890f-8d65-4f9a-956a-6d4042657373
- [x] Reproduced error: https://jenkins.scylladb.com/job/scylla-staging/job/jsmolar/job/longevity/job/longevity-schema-topology-changes-12h-test/9/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
