### PR TITLE
feature(nemesis): Add precheck() hook to NemesisBaseClass 

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,10 +145,20 @@ export SCT_REUSE_CLUSTER=$(cat ~/sct-results/latest/test_id)
 Nemesis are chaos operations that test database resilience. For a comprehensive guide, see [docs/nemesis.md](docs/nemesis.md).
 
 **Architecture:**
-- `NemesisBaseClass` — Abstract base for individual disruptions (a.k.a. "Monkeys"). Each subclass sets boolean flags and implements `disrupt()`.
+- `NemesisBaseClass` — Abstract base for individual disruptions (a.k.a. "Monkeys"). Each subclass sets boolean flags, implements `disrupt()`, and optionally `precheck()`.
 - `NemesisRunner` — Orchestrator that contains all `disrupt_*` methods (the actual disruption logic), handles node selection, metrics, and error reporting.
 - `NemesisRegistry` — Discovery mechanism that filters nemesis using boolean flag expressions (e.g. `"not disruptive"`, `"topology_changes and not limited"`).
 - `NemesisNodeAllocator` — Thread-safe singleton preventing conflicting nemesis on the same node.
+
+**Static skip checks (`precheck()`):**
+
+`NemesisBaseClass.precheck(node) -> str | None` is evaluated **once** before the nemesis execution loop starts. Return `None` to keep the nemesis in the rotation; return a string (the skip reason) to permanently exclude it. The `node` argument is a representative live node for static version, feature-flag, and cluster-uniform attribute checks. Use this for static conditions that do not change during the test:
+- Test config / backend / product edition (`cluster.params.get(...)`, `_is_it_on_kubernetes()`, `node.is_enterprise`)
+- Scylla version / feature flags / cluster-uniform node attributes (`ComparableScyllaVersion`, `is_tablets_feature_enabled()`, `node.distro`)
+
+**Do not** use `precheck(node)` for dynamic state (data presence, live node counts, target-node state) — those belong in `disrupt()`.
+
+A pruned nemesis emits exactly one `SKIPPED` Argus row at precheck time. If every selected nemesis is pruned, one `CRITICAL` event is published and the test fails.
 
 **Common nemesis categories:**
 - Node operations (stop/start, reboot, terminate, decommission)

--- a/docs/nemesis.md
+++ b/docs/nemesis.md
@@ -221,7 +221,82 @@ class MyNewMonkey(NemesisBaseClass):
 ```
 
 
-### Step 2: Implement the disruption logic
+### Step 2: Add a `precheck()` for static skip conditions (optional)
+
+If your nemesis has conditions that make it permanently infeasible on certain
+backends, configs, or Scylla versions, implement `precheck()` instead of
+raising `UnsupportedNemesis` inside `disrupt()`.
+
+`precheck(node)` is called **once** before the execution loop starts, so a
+nemesis excluded here costs zero health-check, node-selection, or Argus overhead
+on every subsequent cycle. The `node` argument is a representative live node for
+static version, feature-flag, and cluster-uniform attribute checks.
+
+```python
+class MyTabletNemesis(NemesisBaseClass):
+    def precheck(self, node) -> str | None:
+        # Static config / backend condition — known before the test starts
+        if self.runner.cluster.params.get("cluster_backend") == "docker":
+            return "MyTabletNemesis requires a cloud backend"
+
+        # Version / feature flag — uniform across the cluster, checked via a representative node
+        if not node.is_tablets_feature_enabled():
+            return "tablets feature not enabled on this cluster"
+
+        return None  # runnable — keep in the rotation
+
+    def disrupt(self):
+        ...
+```
+
+#### What belongs in `precheck()` vs `disrupt()`
+
+| Condition type | Where to check |
+|---|---|
+| Test config / backend / product edition | `precheck()` |
+| Scylla version / feature flags / cluster-uniform node attribute (e.g. OS distro) | `precheck()` |
+| Dynamic cluster state (data presence, live node counts, target-node busy state) | **`disrupt()` only** |
+
+> **Representative node rule:** `precheck(node)` receives a representative node
+> for any cluster-wide probe (version, feature flags, OS distro). It is not the
+> selected `target_node`. Do **not** check per-node dynamic state in `precheck()`.
+
+#### What happens when `precheck()` returns a reason
+
+1. The nemesis is permanently removed from `disruptions_list` — it never enters
+   the execution cycle.
+2. Exactly one `DisruptionEvent` marked `SKIPPED` is published at precheck time
+   (one `NemesisStatus.SKIPPED` row in Argus per excluded nemesis, not per cycle).
+3. A warning is logged: `"Nemesis <Name> excluded by precheck: <reason>"`.
+4. If **every** selected nemesis is excluded, one `Severity.CRITICAL` `InfoEvent`
+   is published naming each exclusion reason, and the nemesis thread stops
+   cleanly. A misconfigured selector that produces an empty rotation fails the
+   test loudly.
+
+#### Before / after example
+
+**Before** — static guard inside `disrupt()`, evaluated every cycle:
+
+```python
+def disrupt(self):
+    if not self.runner.cluster.params.get("use_ldap_auth"):
+        raise UnsupportedNemesis("LDAP not configured")
+    # ... actual disruption
+```
+
+**After** — evaluated once before the execution loop via `precheck(node)`:
+
+```python
+def precheck(self, node) -> str | None:
+    if not self.runner.cluster.params.get("use_ldap_auth"):
+        return "LDAP not configured"
+    return None
+
+def disrupt(self):
+    # ... actual disruption (no static guard needed here)
+```
+
+### Step 3: Implement the disruption logic
 
 If your nemesis reuses existing logic, just call the appropriate runner method.
 You can reuse method from NemesisRunner, but it is discouraged and you should make the nemesis self-contained
@@ -309,7 +384,8 @@ from sdcm.nemesis import NemesisRunner
 class MyCustomRunner(NemesisRunner):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        # Select all non-disruptive nemesis
+        # Select all non-disruptive nemesis. precheck(node) is called by run()
+        # before the execution loop — excluded nemesis are reported and logged once.
         self.disruptions_list = self.build_disruptions_by_selector("not disruptive")
         self.disruptions_list = self.shuffle_list_of_disruptions(self.disruptions_list)
 ```

--- a/docs/nemesis.md
+++ b/docs/nemesis.md
@@ -268,10 +268,10 @@ class MyTabletNemesis(NemesisBaseClass):
 2. Exactly one `DisruptionEvent` marked `SKIPPED` is published at precheck time
    (one `NemesisStatus.SKIPPED` row in Argus per excluded nemesis, not per cycle).
 3. A warning is logged: `"Nemesis <Name> excluded by precheck: <reason>"`.
-4. If **every** selected nemesis is excluded, one `Severity.CRITICAL` `InfoEvent`
-   is published naming each exclusion reason, and the nemesis thread stops
-   cleanly. A misconfigured selector that produces an empty rotation fails the
-   test loudly.
+4. If **every** selected nemesis is excluded, one `Severity.CRITICAL`
+   `TestFrameworkEvent` is published naming each exclusion reason, and the
+   nemesis thread stops cleanly. A misconfigured selector that produces an
+   empty rotation fails the test loudly.
 
 #### Before / after example
 

--- a/docs/plans/MASTER.md
+++ b/docs/plans/MASTER.md
@@ -39,7 +39,7 @@ For plan writing guidelines, see [INSTRUCTIONS.md](INSTRUCTIONS.md).
 |------|--------|-----------|
 | Nemesis Rework (Nemesis 2.0) | `in_progress` | [nemesis-rework.md](nemesis/nemesis-rework.md) |
 | Nemesis Extraction Phase 3 | `in_progress` | [nemesis-extraction.md](nemesis/nemesis-extraction.md) |
-| Nemesis Pre-Execution Skip Check (`precheck`) | `draft` | [nemesis-precheck.md](nemesis/nemesis-precheck.md) |
+| Nemesis Pre-Execution Skip Check (`precheck`) | `in_progress` | [nemesis-precheck.md](nemesis/nemesis-precheck.md) |
 
 ### Stress Tools — Load generators
 

--- a/docs/plans/assets/progress-roadmap.svg
+++ b/docs/plans/assets/progress-roadmap.svg
@@ -4,9 +4,9 @@
 <text x="420" y="84" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="13" fill="#8899AA">31 plans across 9 domains</text>
 <rect x="30" y="120" width="780" height="50" rx="6" fill="#1B2A4A" stroke="#2A3F5F" stroke-width="1"/>
 <circle cx="50" cy="148" r="5" fill="#607D8B"/>
-<text x="60" y="152" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#E0E6ED">Draft: 11</text>
+<text x="60" y="152" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#E0E6ED">Draft: 10</text>
 <circle cx="180" cy="148" r="5" fill="#FFC107"/>
-<text x="190" y="152" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#E0E6ED">In Progress: 2</text>
+<text x="190" y="152" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#E0E6ED">In Progress: 3</text>
 <circle cx="310" cy="148" r="5" fill="#2196F3"/>
 <text x="320" y="152" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#E0E6ED">Approved: 0</text>
 <circle cx="440" cy="148" r="5" fill="#F44336"/>
@@ -18,10 +18,10 @@
 <rect x="40" y="175" width="760" height="20" rx="10" fill="#1B2A4A" stroke="#2A3F5F" stroke-width="1"/>
 <rect x="40" y="175" width="122.58064516129032" height="20" rx="10" fill="#4CAF50"/>
 <text x="101.29032258064515" y="189" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="bold" fill="#0D1B2A">5</text>
-<rect x="162.5806451612903" y="175" width="49.03225806451613" height="20" rx="0" fill="#FFC107"/>
-<text x="187.09677419354836" y="189" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="bold" fill="#0D1B2A">2</text>
-<rect x="211.61290322580643" y="175" width="269.6774193548387" height="20" rx="0" fill="#607D8B"/>
-<text x="346.4516129032258" y="189" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="bold" fill="#0D1B2A">11</text>
+<rect x="162.5806451612903" y="175" width="73.54838709677419" height="20" rx="0" fill="#FFC107"/>
+<text x="199.3548387096774" y="189" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="bold" fill="#0D1B2A">3</text>
+<rect x="236.1290322580645" y="175" width="245.16129032258064" height="20" rx="0" fill="#607D8B"/>
+<text x="358.7096774193548" y="189" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="bold" fill="#0D1B2A">10</text>
 <rect x="481.2903225806451" y="175" width="318.7096774193549" height="20" rx="0" fill="#9E9E9E"/>
 <text x="640.6451612903226" y="189" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="bold" fill="#0D1B2A">13</text>
 <rect x="30" y="220" width="380" height="32" rx="4" fill="#1B2A4A" stroke="#00BCD4" stroke-width="1"/>
@@ -90,9 +90,9 @@
 <circle cx="444" cy="294" r="4" fill="#FFC107"/>
 <text x="456" y="298" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">Nemesis Extraction Phase 3</text>
 <text x="798" y="298" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#FFC107">In Progress</text>
-<circle cx="444" cy="322" r="4" fill="#607D8B"/>
+<circle cx="444" cy="322" r="4" fill="#FFC107"/>
 <text x="456" y="326" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">Nemesis Pre-Execution Skip Check (pre...</text>
-<text x="798" y="326" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#607D8B">Draft</text>
+<text x="798" y="326" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#FFC107">In Progress</text>
 <circle cx="444" cy="350" r="4" fill="#9E9E9E"/>
 <text x="456" y="354" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">Nemesis Extraction Phase 3</text>
 <text x="798" y="354" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#9E9E9E">Pending PR</text>

--- a/docs/plans/nemesis/nemesis-precheck.md
+++ b/docs/plans/nemesis/nemesis-precheck.md
@@ -1,8 +1,8 @@
 ---
-status: draft
+status: in_progress
 domain: nemesis
 created: 2026-06-11
-last_updated: 2026-06-15
+last_updated: 2026-06-25
 owner: pehala
 ---
 
@@ -37,7 +37,7 @@ A code analysis of all **130** explicit `raise UnsupportedNemesis(...)` sites (p
 
 So **~65 % (85/130)** of skip decisions never change after the cluster is up, yet they are re-evaluated every cycle behind the expensive setup described above. The remaining **~35 % (45/130)** legitimately depend on live, mutable state and must stay inside `disrupt()`.
 
-The node OS/distro check in `disrupt_memory_stress` (`sdcm/nemesis/__init__.py:4768-4774`) is Category 2, not Category 3: although it reads `self.target_node.distro`, the distro is fixed at provisioning by a single `scylla_linux_distro` config param (`sdcm/sct_config.py:671`) and is uniform across the data-node pool, so `cluster.nodes[0].distro` yields the same answer for any target.
+The node OS/distro check in `disrupt_memory_stress` (`sdcm/nemesis/__init__.py:4768-4774`) is Category 2, not Category 3: although it reads `self.target_node.distro`, the distro is fixed at provisioning by a single `scylla_linux_distro` config param (`sdcm/sct_config.py:671`) and is uniform across the data-node pool, so the representative `node.distro` passed to `precheck(node)` yields the same answer for any target.
 
 There is no mechanism today to evaluate a static skip **once** and exclude the nemesis from the rotation.
 
@@ -49,11 +49,16 @@ There is no mechanism today to evaluate a static skip **once** and exclude the n
 - `sdcm/nemesis/__init__.py:261` — `NemesisBaseClass(NemesisFlags, ABC)`: abstract base for individual disruptions. Holds `self.runner`, declares the abstract `disrupt()` (`sdcm/nemesis/__init__.py:269`). **No feasibility hook exists.**
 - `sdcm/nemesis/__init__.py:276` — `NemesisRunner`: orchestrator. Builds and owns `self.disruptions_list` and the execution flow.
 
-### Where the disruption list is built (the proposed gate point)
+### Where the disruption list is built
 
 - `sdcm/nemesis/__init__.py:2005` — `build_disruptions_by_selector()` instantiates each subclass returned by `NemesisRegistry.filter_subclasses(...)` and appends it to `disruptions`. It already swallows construction errors with a broad `except Exception` (`sdcm/nemesis/__init__.py:2023-2024`).
 - `sdcm/nemesis/__init__.py:2027` — `build_disruptions_by_name()` routes through `build_disruptions_by_selector()`, so both selection styles share one gate.
 - `sdcm/nemesis/monkey/runners.py:16` — `SisyphusMonkey.__init__` calls `build_disruptions_by_selector(self.nemesis_selector)` then `shuffle_list_of_disruptions(...)`. Other runners (`ScyllaCloudLimitedChaosMonkey`, `K8sSetMonkey`, etc.) call `build_disruptions_by_name([...])`.
+
+### Where the precheck gate runs
+
+- `sdcm/nemesis/__init__.py:443` — `NemesisRunner.run()` calls `precheck_nemesis()` once before the execution loop starts.
+- `sdcm/nemesis/__init__.py:2054` — `precheck_nemesis()` passes a representative live node to `nemesis.precheck(node=...)`, removes excluded nemesis from `disruptions_list`, and reports each exclusion once.
 
 ### Execution path that the precheck will short-circuit
 
@@ -64,7 +69,7 @@ There is no mechanism today to evaluate a static skip **once** and exclude the n
 
 - `sdcm/cluster.py:5780` — `add_nemesis()` instantiates each runner (which immediately builds its disruption list).
 - `longevity_test.py:136` calls `add_nemesis(...)` **after** the cluster is initialized (`db_cluster.wait_for_init(...)` in `sdcm/tester.py:965-974`) but **before** data prepare/load and **before** `db_cluster.start_nemesis()` (`longevity_test.py:240`).
-- Consequence at build time: the cluster is **up** (Category 2 version/feature probes work against `self.runner.cluster.nodes[0]`), config/backend is **known** (Category 1), but **no data is loaded** and **no target node is selected** (Category 3 is not yet meaningful). This is exactly the right place for a one-time static check.
+- Consequence at precheck time: the cluster is **up** (Category 2 version/feature probes work against the representative node passed to `precheck(node)`), config/backend is **known** (Category 1), and **no target node is selected** (Category 3 target-node state is not meaningful). This is exactly the right place for a one-time static check.
 
 ### Skip reporting today
 
@@ -81,35 +86,35 @@ There is no mechanism today to evaluate a static skip **once** and exclude the n
 ### What's Missing
 
 - An overridable, return-based feasibility hook on `NemesisBaseClass`. → **Phase 1**
-- A one-time evaluation/pruning step in `build_disruptions_by_selector()`. → **Phase 1**
+- A one-time evaluation/pruning step in `precheck_nemesis()` before the run loop. → **Phase 1**
 - Graceful handling (a single CRITICAL event that fails the test) when every selected nemesis is pruned. → **Phase 2**
 - A taxonomy-driven migration of the 85 static skips out of the per-cycle `disrupt()` path. → **Phases 3–4**
   - 57 Category 1 (config / backend / edition) guards → **Phase 3**
   - 28 Category 2 (version / feature flag / cluster-uniform node attribute) guards → **Phase 4**
-- Documentation of the `precheck()` contract, the category rule, and the pruning/reporting behavior for future nemesis authors. → **Phase 5**
+- Documentation of the `precheck(node)` contract, the category rule, and the pruning/reporting behavior for future nemesis authors. → **Phase 5**
 
 ## Goals
 
-1. **Add a return-based `precheck()` hook** to `NemesisBaseClass` that returns `str | None` (no exception-based control flow): `None` = runnable, a string = skip reason. Default implementation returns `None`.
-2. **Evaluate `precheck()` exactly once** per nemesis, at disruption-list build time, and permanently exclude any nemesis that returns a reason — so pruned nemesis incur **zero** per-cycle health-check, node-selection, or event cost.
-3. **Migrate all 85 static skips** (Category 1 + Category 2) from runner `disrupt_*` methods into the owning nemesis class `precheck()`, removing the now-redundant static guards in the **same PR** as each migration. Category 3 (45) checks remain in `disrupt()`.
+1. **Add a return-based `precheck(node)` hook** to `NemesisBaseClass` that returns `str | None` (no exception-based control flow): `None` = runnable, a string = skip reason. Default implementation returns `None`.
+2. **Evaluate `precheck(node)` exactly once** per nemesis before the execution loop starts, and permanently exclude any nemesis that returns a reason — so pruned nemesis incur **zero** per-cycle health-check, node-selection, or event cost.
+3. **Migrate all 85 static skips** (Category 1 + Category 2) from runner `disrupt_*` methods into the owning nemesis class `precheck(node)`, removing the now-redundant static guards in the **same PR** as each migration. Category 3 (45) checks remain in `disrupt()`.
 4. **Fail the test loudly when misconfigured**: if every selected nemesis is pruned, emit exactly one `Severity.CRITICAL` event and stop the nemesis thread (configured nemesis not running must fail the test).
 5. **Report each pruned nemesis as a `SKIPPED` Argus row exactly once** (not per cycle, not zero times), preserving skip visibility while eliminating the repeated work.
-6. **No behavioral regression** for nemesis with no static skip (default `precheck()` returns `None`; they run exactly as before).
+6. **No behavioral regression** for nemesis with no static skip (default `precheck(node)` returns `None`; they run exactly as before).
 
 ## Implementation Phases
 
 Phases are ordered by dependency: the framework hook and reporting/empty-list handling land first (foundational, must leave the tree working), then the bulk migration is split into reviewable, domain-grouped PRs of ≤200 LOC each. Migration PRs depend only on Phase 1/2 and are independent of one another.
 
-### Phase 1: Add the `precheck()` hook and one-time pruning
+### Phase 1: Add the `precheck(node)` hook and one-time pruning — Done
 
 **Importance**: Critical
-**Description**: Introduce the return-based hook and wire it into the single build gate. No nemesis overrides it yet, so behavior is unchanged (every `precheck()` returns `None`).
+**Description**: Introduce the return-based hook and wire it into the one-time pre-execution gate. No nemesis overrides it yet, so behavior is unchanged (every `precheck(node)` returns `None`).
 
 **Deliverables**:
 - New method on `NemesisBaseClass` (`sdcm/nemesis/__init__.py:261`):
   ```python
-  def precheck(self) -> str | None:
+  def precheck(self, node: BaseNode) -> str | None:
       """
       Static feasibility check, evaluated ONCE before the nemesis is scheduled.
 
@@ -121,24 +126,24 @@ Phases are ordered by dependency: the framework hook and reporting/empty-list ha
         - Scylla version / feature flags / cluster-uniform
           node attributes such as OS distro                (Category 2)
 
-      No target node is selected yet — use self.runner.cluster.nodes[0] as a
-      representative live node. Do NOT check dynamic state (data presence,
+      No target node is selected yet — use the provided representative live node.
+      Do NOT check dynamic state (data presence,
       live node counts, whether a specific target node is busy or alone in
       its rack) — those stay inside disrupt().
       """
       return None
   ```
-- `build_disruptions_by_selector()` (`sdcm/nemesis/__init__.py:2005`) calls `precheck()` after instantiation and keeps the nemesis only when it returns `None`. Real errors raised inside `precheck()` continue to be caught by the existing broad `except Exception` (treated as today: log and skip the nemesis). Excluded nemesis are collected with their reasons and logged once.
+- `NemesisRunner.precheck_nemesis()` (`sdcm/nemesis/__init__.py`) calls `precheck(node)` before the execution loop and keeps the nemesis only when it returns `None`. Real errors raised inside `precheck(node)` are caught and reported as failed prechecks. Excluded nemesis are collected with their reasons and logged once.
 
 **Adaptation Notes**: A bare `str | None` contract is used (per design decision) rather than a structured result; the reason string is what flows to logs and the Argus row in Phase 2.
 
 **Definition of Done**:
-- [ ] `NemesisBaseClass.precheck()` exists with the documented contract and `None` default.
-- [ ] `build_disruptions_by_selector()` invokes `precheck()` exactly once per nemesis and excludes those returning a reason.
-- [ ] Exceptions inside `precheck()` are handled by the existing `except Exception` path (no new crash modes).
-- [ ] With no overrides, `_disruption_list_names` is identical to pre-change for a representative selector (regression-covered by unit test).
-- [ ] Unit tests in `unit_tests/unit/nemesis/` cover: default keeps nemesis; reason prunes nemesis; exception in `precheck()` prunes and logs.
-- [ ] `uv run sct.py pre-commit` passes.
+- [x] `NemesisBaseClass.precheck(node)` exists with the documented contract and `None` default.
+- [x] `precheck_nemesis()` invokes `precheck(node)` before the execution loop and excludes those returning a reason.
+- [x] Exceptions inside `precheck(node)` are handled and reported as failed prechecks (no new crash modes).
+- [x] With no overrides, `_disruption_list_names` is identical to pre-change for a representative selector (regression-covered by unit test).
+- [x] Unit tests in `unit_tests/unit/nemesis/` cover: default keeps nemesis; reason prunes nemesis; exception in `precheck(node)` prunes and logs; the passed node is the representative cluster node, not `target_node`.
+- [x] `uv run sct.py pre-commit` passes for the changed files. Full commit-range pre-commit is blocked by unstaged working-tree edits during checkout.
 
 ---
 
@@ -150,7 +155,7 @@ Phases are ordered by dependency: the framework hook and reporting/empty-list ha
 **Dependencies**: Phase 1
 
 **Deliverables**:
-- For each pruned nemesis, publish a single `DisruptionEvent` marked skipped (via `DisruptionEvent.skip(reason)`, `sdcm/sct_events/continuous_event.py:134`) so it appears exactly once as `NemesisStatus.SKIPPED` in Argus (`sdcm/sct_events/argus.py:66`). Emitted at build time, not per cycle.
+- For each pruned nemesis, publish a single `DisruptionEvent` marked skipped (via `DisruptionEvent.skip(reason)`, `sdcm/sct_events/continuous_event.py:134`) so it appears exactly once as `NemesisStatus.SKIPPED` in Argus (`sdcm/sct_events/argus.py:66`). Emitted at precheck time, not per cycle.
 - Empty-rotation guard: if `disruptions_list` is empty after pruning, publish one `InfoEvent(..., severity=Severity.CRITICAL)` naming the excluded nemesis and their reasons, and stop the nemesis thread cleanly instead of letting `call_next_nemesis()` raise the bare `AssertionError` at `sdcm/nemesis/__init__.py:2085`. This supersedes the "skipped 3× in a row" static path (`sdcm/nemesis/__init__.py:440`) for prune-based cases.
 
 **Adaptation Notes**: "Configured nemesis not running must fail the test" — the CRITICAL event is the failure signal. Decide whether to raise after publishing or rely on the event severity to fail the test summary; align with how existing CRITICAL nemesis events fail runs (`get_event_summary().get("CRITICAL")`, used at `sdcm/nemesis/__init__.py:1953`).
@@ -167,20 +172,20 @@ Phases are ordered by dependency: the framework hook and reporting/empty-list ha
 ### Phase 3: Migrate Category 1 (config / backend / edition) skips
 
 **Importance**: Important
-**Description**: Move the 57 config/backend/edition guards from runner `disrupt_*` methods into the owning class `precheck()`, switching `self.target_node` references to `self.runner.cluster.nodes[0]`. Remove the migrated static guards from the runner methods in the same PR. Split into ≤200 LOC PRs grouped by nemesis family (e.g. SLA group, LDAP/auth group, network-interface group, K8s-only group, manager group).
+**Description**: Move the 57 config/backend/edition guards from runner `disrupt_*` methods into the owning class `precheck(node)`, switching `self.target_node` references to the provided representative `node`. Remove the migrated static guards from the runner methods in the same PR. Split into ≤200 LOC PRs grouped by nemesis family (e.g. SLA group, LDAP/auth group, network-interface group, K8s-only group, manager group).
 
 **Dependencies**: Phase 1, Phase 2
 
 **Deliverables**:
-- `precheck()` overrides on the relevant classes in `sdcm/nemesis/monkey/` (and extracted modules), e.g. LDAP nemesis (`sdcm/nemesis/__init__.py:1117-1123`), SLA nemesis (`sdcm/nemesis/__init__.py:5084-5232`), KMS-encryption backend gate (`sdcm/nemesis/__init__.py:4474`), network-interface nemesis (`3557/3648/4016`).
+- `precheck(node)` overrides on the relevant classes in `sdcm/nemesis/monkey/` (and extracted modules), e.g. LDAP nemesis (`sdcm/nemesis/__init__.py:1117-1123`), SLA nemesis (`sdcm/nemesis/__init__.py:5084-5232`), KMS-encryption backend gate (`sdcm/nemesis/__init__.py:4474`), network-interface nemesis (`3557/3648/4016`).
 - Removal of the corresponding `raise UnsupportedNemesis(...)` static guards from the runner methods.
 - Per-family unit tests asserting the nemesis is pruned under the negative config and kept under the positive config.
 
-**Adaptation Notes**: Some SLA methods mix a Category 1 gate (`sla`/`enterprise`/`authenticator`) with a Category 3 data-presence gate (`get_cassandra_stress_write_cmds()`). Only the Category 1 portion moves to `precheck()`; the data-presence check stays in `disrupt()`.
+**Adaptation Notes**: Some SLA methods mix a Category 1 gate (`sla`/`enterprise`/`authenticator`) with a Category 3 data-presence gate (`get_cassandra_stress_write_cmds()`). Only the Category 1 portion moves to `precheck(node)`; the data-presence check stays in `disrupt()`.
 
 **Definition of Done**:
-- [ ] All 57 Category 1 guards are evaluated via `precheck()` and removed from the per-cycle path.
-- [ ] No remaining `target_node`-dependent reference inside any migrated `precheck()`.
+- [ ] All 57 Category 1 guards are evaluated via `precheck(node)` and removed from the per-cycle path.
+- [ ] No remaining `target_node`-dependent reference inside any migrated `precheck(node)`.
 - [ ] Unit tests per family (negative prunes, positive keeps).
 - [ ] `uv run sct.py pre-commit` passes for each PR.
 
@@ -189,18 +194,18 @@ Phases are ordered by dependency: the framework hook and reporting/empty-list ha
 ### Phase 4: Migrate Category 2 (version / feature flag / cluster-uniform node attribute) skips
 
 **Importance**: Important
-**Description**: Move the 28 version/feature/uniform-attribute guards into `precheck()`, using a representative node (`cluster.nodes[0]`) for cluster-wide probes. Convert the implicit `@scylla_versions` `MethodVersionNotFound` cases into explicit `precheck()` version checks where the method group is owned by a single nemesis. Split into ≤200 LOC PRs (e.g. tablets group, raft-coordinator group, version-compare group, `SkipPerIssues` group).
+**Description**: Move the 28 version/feature/uniform-attribute guards into `precheck(node)`, using the provided representative node for cluster-wide probes. Convert the implicit `@scylla_versions` `MethodVersionNotFound` cases into explicit `precheck(node)` version checks where the method group is owned by a single nemesis. Split into ≤200 LOC PRs (e.g. tablets group, raft-coordinator group, version-compare group, `SkipPerIssues` group).
 
 **Dependencies**: Phase 1, Phase 2
 
 **Deliverables**:
-- `precheck()` overrides for tablets-gated nemesis (`915-920`, `1090-1094`, `4242`, `5277`, `5334`, `5837`, `5921`), raft-coordinator nemesis (`5652`, `5723`, `5834`), version-compare nemesis (`1798`, `5409`, `5413`), the node OS/distro check in `disrupt_memory_stress` (`4768-4774`, evaluated via `cluster.nodes[0].distro`), and `SkipPerIssues`-gated nemesis.
-- Removal of the corresponding static guards from runner methods; for `@scylla_versions`-decorated single-owner groups, add an explicit version `precheck()` and document that the decorator remains the in-method safety net.
+- `precheck(node)` overrides for tablets-gated nemesis (`915-920`, `1090-1094`, `4242`, `5277`, `5334`, `5837`, `5921`), raft-coordinator nemesis (`5652`, `5723`, `5834`), version-compare nemesis (`1798`, `5409`, `5413`), the node OS/distro check in `disrupt_memory_stress` (`4768-4774`, evaluated via `node.distro`), and `SkipPerIssues`-gated nemesis.
+- Removal of the corresponding static guards from runner methods; for `@scylla_versions`-decorated single-owner groups, add an explicit version `precheck(node)` and document that the decorator remains the in-method safety net.
 
-**Adaptation Notes (Needs Investigation)**: `disrupt_create_index`, `disrupt_add_remove_mv`, `disrupt_kill_mv_building_coordinator`, and `disrupt_trigger_split_merge_tablets_with_alter` mix Category 2 feature gates with Category 3 table-existence / node-busy gates. Confirm per nemesis that only the feature/version portion is hoisted to `precheck()` and the dynamic portion remains in `disrupt()`. Verify that `is_views_with_tablets_enabled(session)` (`sdcm/nemesis/__init__.py:5841`) can be evaluated against a representative node session at build time.
+**Adaptation Notes (Needs Investigation)**: `disrupt_create_index`, `disrupt_add_remove_mv`, `disrupt_kill_mv_building_coordinator`, and `disrupt_trigger_split_merge_tablets_with_alter` mix Category 2 feature gates with Category 3 table-existence / node-busy gates. Confirm per nemesis that only the feature/version portion is hoisted to `precheck(node)` and the dynamic portion remains in `disrupt()`. Verify that `is_views_with_tablets_enabled(session)` (`sdcm/nemesis/__init__.py:5841`) can be evaluated against a representative node session before the execution loop.
 
 **Definition of Done**:
-- [ ] All 28 Category 2 guards evaluated via `precheck()`; static guards removed from the per-cycle path.
+- [ ] All 28 Category 2 guards evaluated via `precheck(node)`; static guards removed from the per-cycle path.
 - [ ] Feature probes use a representative node, not a target node.
 - [ ] Unit tests assert pruning under disabled feature/version and retention under enabled.
 - [ ] `uv run sct.py pre-commit` passes for each PR.
@@ -210,18 +215,18 @@ Phases are ordered by dependency: the framework hook and reporting/empty-list ha
 ### Phase 5: Documentation update
 
 **Importance**: Critical
-**Description**: Document the `precheck()` contract, the Category 1/2/3 rule, and the pruning/reporting behavior so future nemesis authors place static checks correctly.
+**Description**: Document the `precheck(node)` contract, the Category 1/2/3 rule, and the pruning/reporting behavior so future nemesis authors place static checks correctly.
 
 **Dependencies**: Phase 1 (content can expand as Phases 3–4 land)
 
 **Deliverables**:
-- New "Pre-execution skip checks (`precheck`)" section in `docs/nemesis.md` covering the contract, the representative-node rule, the "Category 3 stays in `disrupt()`" rule, the one-time SKIPPED Argus row, and the empty-rotation CRITICAL behavior.
-- Update the `writing-nemesis` skill (`skills/writing-nemesis/SKILL.md`) and AGENTS.md nemesis notes to mention `precheck()`.
+- New "Pre-execution skip checks (`precheck`)" section in `docs/nemesis.md` covering the `precheck(node)` contract, the representative-node rule, the "Category 3 stays in `disrupt()`" rule, the one-time SKIPPED Argus row, and the empty-rotation CRITICAL behavior.
+- Update the `writing-nemesis` skill (`skills/writing-nemesis/SKILL.md`) and AGENTS.md nemesis notes to mention `precheck(node)`.
 - Update this plan's PR History table as phases merge.
 
 **Definition of Done**:
-- [ ] `docs/nemesis.md` documents `precheck()` with a before/after example.
-- [ ] `writing-nemesis` skill references `precheck()` and the category rule.
+- [ ] `docs/nemesis.md` documents `precheck(node)` with a before/after example.
+- [ ] `writing-nemesis` skill references `precheck(node)` and the category rule.
 - [ ] `uv run sct.py pre-commit` passes.
 
 ## Testing Requirements
@@ -229,9 +234,9 @@ Phases are ordered by dependency: the framework hook and reporting/empty-list ha
 ### Unit Tests
 
 - Use the existing nemesis test harness (`unit_tests/unit/nemesis/`, `TestRunner`, `fake_cluster.py`).
-- Phase 1: default `precheck()` keeps nemesis; reason-returning `precheck()` is excluded from `build_disruptions_by_selector()`; an exception inside `precheck()` is caught and the nemesis excluded; build output is unchanged when no class overrides `precheck()`.
+- Phase 1: default `precheck(node)` keeps nemesis; reason-returning `precheck(node)` is excluded by `precheck_nemesis()`; an exception inside `precheck(node)` is caught and the nemesis excluded; build output is unchanged when no class overrides `precheck(node)`.
 - Phase 2: a pruned nemesis publishes exactly one skipped `DisruptionEvent` (assert via `fake_events`); all-pruned emits one CRITICAL event and stops the thread without `AssertionError`.
-- Phases 3–4: per migrated family, parametrized tests toggling the relevant config/flag and asserting prune-vs-keep, plus an assertion that the representative node (not `target_node`) is used.
+- Phases 3–4: per migrated family, parametrized tests toggling the relevant config/flag and asserting prune-vs-keep, plus an assertion that the passed representative node (not `target_node`) is used.
 - Run with: `uv run sct.py unit-tests -t unit_tests/unit/nemesis/`.
 
 ### Integration Tests
@@ -257,15 +262,15 @@ All Definition of Done items across phases are met. Additionally:
 
 ## Risk Mitigation
 
-### Risk: A `precheck()` mis-categorizes a dynamic condition as static
+### Risk: A `precheck(node)` mis-categorizes a dynamic condition as static
 **Likelihood**: Medium
 **Impact**: A nemesis is permanently pruned based on state that would have become valid later (e.g. data not yet loaded), reducing coverage silently.
-**Mitigation**: The contract explicitly forbids dynamic-state and `target_node` checks in `precheck()`; code review enforces the Category 1/2/3 rule; migration PRs keep Category 3 checks in `disrupt()`. The taxonomy in this plan lists the exact line references for each category.
+**Mitigation**: The contract explicitly forbids dynamic-state and `target_node` checks in `precheck(node)`; code review enforces the Category 1/2/3 rule; migration PRs keep Category 3 checks in `disrupt()`. The taxonomy in this plan lists the exact line references for each category.
 
 ### Risk: Representative-node probe differs from target-node reality
 **Likelihood**: Low
-**Impact**: A feature/version probe against `cluster.nodes[0]` yields a different answer than the eventual target node.
-**Mitigation**: All Category 2 conditions identified are cluster-wide (tablets, raft, views, version) or cluster-uniform by provisioning config (OS distro, fixed by the single `scylla_linux_distro` param at `sdcm/sct_config.py:671`). Phase 4 includes a DoD item and review gate rejecting any genuinely per-node-specific check in `precheck()`.
+**Impact**: A feature/version probe against the representative node yields a different answer than the eventual target node.
+**Mitigation**: All Category 2 conditions identified are cluster-wide (tablets, raft, views, version) or cluster-uniform by provisioning config (OS distro, fixed by the single `scylla_linux_distro` param at `sdcm/sct_config.py:671`). Phase 4 includes a DoD item and review gate rejecting any genuinely per-node-specific check in `precheck(node)`.
 
 ### Risk: Empty rotation false-positive fails a legitimately-configured run
 **Likelihood**: Low
@@ -275,7 +280,7 @@ All Definition of Done items across phases are met. Additionally:
 ### Risk: Removing the static guard from a runner method while another caller relies on it
 **Likelihood**: Medium
 **Impact**: A `disrupt_*` method still reachable from a legacy delegate could lose its guard and run where it should not.
-**Mitigation**: Migrate and remove in the same PR; before removing a guard, `grep` for all callers of the runner method; keep guards that are shared by multiple nemesis until all owners have a `precheck()`. Phase 3/4 DoD requires per-family tests.
+**Mitigation**: Migrate and remove in the same PR; before removing a guard, `grep` for all callers of the runner method; keep guards that are shared by multiple nemesis until all owners have a `precheck(node)`. Phase 3/4 DoD requires per-family tests.
 
 ### Risk: Double reporting or missing the one-time SKIPPED row
 **Likelihood**: Low
@@ -284,14 +289,93 @@ All Definition of Done items across phases are met. Additionally:
 
 ## Related Plans
 
-- [nemesis-rework.md](nemesis-rework.md) — Phase 3 of the rework extracts disrupt logic into self-contained classes; `precheck()` builds on that class-as-carrier model and is most cleanly applied to already-extracted nemesis.
-- [nemesis-extraction.md](nemesis-extraction.md) — As methods are extracted, their static guards become natural `precheck()` overrides; sequencing migrations after extraction reduces churn.
+- [nemesis-rework.md](nemesis-rework.md) — Phase 3 of the rework extracts disrupt logic into self-contained classes; `precheck(node)` builds on that class-as-carrier model and is most cleanly applied to already-extracted nemesis.
+- [nemesis-extraction.md](nemesis-extraction.md) — As methods are extracted, their static guards become natural `precheck(node)` overrides; sequencing migrations after extraction reduces churn.
+
+## Commit Plan
+
+The foundation (Phases 1–2 + 5 of this plan — the `precheck(node)` hook, one-time
+pruning/reporting, and documentation) ships as **one PR of 3 commits**. Each
+commit is self-standing: all tests in `unit_tests/unit/nemesis/` pass after every
+individual commit.
+
+Verification after every commit:
+```bash
+uv run python -m pytest unit_tests/unit/nemesis/
+uv run sct.py pre-commit
+```
+
+> **Design note.** Pruning is performed by a dedicated `NemesisRunner.precheck_nemesis()`
+> method invoked **once at the start of `run()`**, before the execution loop — *not*
+> inside `build_disruptions_by_selector()`. This keeps `build_disruptions_by_selector()`
+> a pure builder (it still returns a plain list), avoids changing every caller's
+> signature, and means runners that legitimately keep an empty `disruptions_list`
+> and override `call_next_nemesis()` (`NoOpMonkey`, `ManagerRcloneBackup`,
+> `ManagerNativeBackup`, `CategoricalMonkey`) are unaffected.
+
+### Commit 1 — `feat(nemesis): add precheck(node) hook to NemesisBaseClass`
+
+Files: `sdcm/nemesis/__init__.py`
+
+Add `precheck(self, node: BaseNode) -> str | None` to `NemesisBaseClass` with the
+full contract docstring and a `return None` default. No other changes — zero
+behavioral impact, every existing test passes.
+
+### Commit 2 — `feat(nemesis): prune infeasible nemesis via precheck_nemesis() before the run loop`
+
+Files: `sdcm/nemesis/__init__.py`, `unit_tests/unit/nemesis/__init__.py`,
+`unit_tests/unit/nemesis/execute_nemesis/__init__.py`,
+`unit_tests/unit/nemesis/execute_nemesis/test_precheck.py` (new)
+
+- Add `NemesisRunner.precheck_nemesis()`. It iterates `self.disruptions_list`,
+  evaluates each nemesis's `precheck(node)`, prunes the infeasible ones in place, and
+  returns the `(name, reason)` exclusions. Each exclusion is reported once:
+  - a returned reason → `DisruptionEvent.skip()` (SKIPPED, NORMAL) +
+    Argus `finalize_nemesis(status=SKIPPED)`.
+  - a raised exception → `DisruptionEvent.add_simple_error()` (FAILED, ERROR) +
+    Argus `finalize_nemesis(status=FAILED)` — a broken `precheck(node)` is a test
+    error, not an intentional skip.
+- Argus reporting reuses `argus_submit()`, which gains an optional `node`
+  parameter so pre-execution callers can reuse the same representative node
+  passed to `precheck(node)` (no `target_node` exists yet). Existing call-sites are
+  unchanged (default `node=None` → `self.target_node`).
+- `run()` calls `precheck_nemesis()` before the loop; if exclusions emptied the
+  rotation it publishes one `Severity.CRITICAL` `InfoEvent` naming every excluded
+  nemesis and returns.
+- Test infrastructure (shipped here to keep the suite green — `run()` now calls
+  `precheck(node)` on test nemesis): add a `precheck(node)` stub to `TestBaseClass` and
+  `TestExecuteBaseClass`, plus `PrecheckSkipNemesis` / `PrecheckErrorNemesis`.
+- `execute_nemesis/test_precheck.py` covers pruning, DisruptionEvent shapes,
+  Argus submit/finalize, the representative node argument, and the `run()` empty-
+  rotation path. Skip-vs-exception variants are parametrized; full event dicts
+  are asserted.
+
+### Commit 3 — `docs(nemesis): document precheck(node) contract and pruning behavior`
+
+Files: `docs/nemesis.md`, `skills/writing-nemesis/SKILL.md`, `AGENTS.md`,
+`docs/plans/nemesis/nemesis-precheck.md`, `docs/plans/progress.json`,
+`docs/plans/assets/progress-roadmap.svg`
+
+Add a "Pre-execution skip checks (`precheck`)" section to `docs/nemesis.md`
+(`precheck(node)` contract, what-belongs-where rule in plain language, representative-node rule,
+SKIPPED/FAILED reporting, empty-rotation CRITICAL, before/after example). Update
+the `writing-nemesis` skill and the AGENTS.md nemesis section. Advance plan
+status to `in_progress`.
+
+### Future work — migrating the 85 static skips (Phases 3–4)
+
+Migrating the 57 config/backend and 28 version/feature guards out of the
+`disrupt_*` methods into `precheck(node)` overrides (Implementation Phases 3 and 4
+above) is **not** part of this foundation PR. Each migration adds a `precheck(node)`
+override to a nemesis class and removes the matching `raise UnsupportedNemesis`
+guard, grouped by nemesis family into ≤200 LOC PRs, using the `precheck_nemesis()`
+machinery landed here.
 
 ## PR History
 
 | Phase | PR | Status |
 |-------|-----|--------|
-| Phase 1 — `precheck()` hook + pruning | — | Not started |
+| Phase 1 — `precheck(node)` hook + pruning | current PR | Done |
 | Phase 2 — Empty-list + Argus reporting | — | Not started |
 | Phase 3 — Migrate Category 1 skips | — | Not started |
 | Phase 4 — Migrate Category 2 skips | — | Not started |

--- a/docs/plans/nemesis/nemesis-precheck.md
+++ b/docs/plans/nemesis/nemesis-precheck.md
@@ -156,7 +156,7 @@ Phases are ordered by dependency: the framework hook and reporting/empty-list ha
 
 **Deliverables**:
 - For each pruned nemesis, publish a single `DisruptionEvent` marked skipped (via `DisruptionEvent.skip(reason)`, `sdcm/sct_events/continuous_event.py:134`) so it appears exactly once as `NemesisStatus.SKIPPED` in Argus (`sdcm/sct_events/argus.py:66`). Emitted at precheck time, not per cycle.
-- Empty-rotation guard: if `disruptions_list` is empty after pruning, publish one `InfoEvent(..., severity=Severity.CRITICAL)` naming the excluded nemesis and their reasons, and stop the nemesis thread cleanly instead of letting `call_next_nemesis()` raise the bare `AssertionError` at `sdcm/nemesis/__init__.py:2085`. This supersedes the "skipped 3× in a row" static path (`sdcm/nemesis/__init__.py:440`) for prune-based cases.
+- Empty-rotation guard: if `disruptions_list` is empty after pruning, publish one `TestFrameworkEvent(..., severity=Severity.CRITICAL)` naming the excluded nemesis and their reasons, and stop the nemesis thread cleanly instead of letting `call_next_nemesis()` raise the bare `AssertionError` at `sdcm/nemesis/__init__.py:2085`. This supersedes the "skipped 3× in a row" static path (`sdcm/nemesis/__init__.py:440`) for prune-based cases.
 
 **Adaptation Notes**: "Configured nemesis not running must fail the test" — the CRITICAL event is the failure signal. Decide whether to raise after publishing or rely on the event severity to fail the test summary; align with how existing CRITICAL nemesis events fail runs (`get_event_summary().get("CRITICAL")`, used at `sdcm/nemesis/__init__.py:1953`).
 
@@ -194,7 +194,7 @@ Phases are ordered by dependency: the framework hook and reporting/empty-list ha
 ### Phase 4: Migrate Category 2 (version / feature flag / cluster-uniform node attribute) skips
 
 **Importance**: Important
-**Description**: Move the 28 version/feature/uniform-attribute guards into `precheck(node)`, using the provided representative node for cluster-wide probes. Convert the implicit `@scylla_versions` `MethodVersionNotFound` cases into explicit `precheck(node)` version checks where the method group is owned by a single nemesis. Split into ≤200 LOC PRs (e.g. tablets group, raft-coordinator group, version-compare group, `SkipPerIssues` group).
+**Description**: Move the remaining 27 version/feature/uniform-attribute guards into `precheck(node)`, using the provided representative node for cluster-wide probes. Convert the implicit `@scylla_versions` `MethodVersionNotFound` cases into explicit `precheck(node)` version checks where the method group is owned by a single nemesis. Split into ≤200 LOC PRs (e.g. tablets group, raft-coordinator group, version-compare group, `SkipPerIssues` group). Excludes `AbortDecommissionMonkey`'s tablets guard, already migrated ahead of schedule in the foundation PR (see PR History).
 
 **Dependencies**: Phase 1, Phase 2
 
@@ -205,7 +205,7 @@ Phases are ordered by dependency: the framework hook and reporting/empty-list ha
 **Adaptation Notes (Needs Investigation)**: `disrupt_create_index`, `disrupt_add_remove_mv`, `disrupt_kill_mv_building_coordinator`, and `disrupt_trigger_split_merge_tablets_with_alter` mix Category 2 feature gates with Category 3 table-existence / node-busy gates. Confirm per nemesis that only the feature/version portion is hoisted to `precheck(node)` and the dynamic portion remains in `disrupt()`. Verify that `is_views_with_tablets_enabled(session)` (`sdcm/nemesis/__init__.py:5841`) can be evaluated against a representative node session before the execution loop.
 
 **Definition of Done**:
-- [ ] All 28 Category 2 guards evaluated via `precheck(node)`; static guards removed from the per-cycle path.
+- [ ] Remaining 27 Category 2 guards evaluated via `precheck(node)`; static guards removed from the per-cycle path.
 - [ ] Feature probes use a representative node, not a target node.
 - [ ] Unit tests assert pruning under disabled feature/version and retention under enabled.
 - [ ] `uv run sct.py pre-commit` passes for each PR.
@@ -340,8 +340,8 @@ Files: `sdcm/nemesis/__init__.py`, `unit_tests/unit/nemesis/__init__.py`,
   passed to `precheck(node)` (no `target_node` exists yet). Existing call-sites are
   unchanged (default `node=None` → `self.target_node`).
 - `run()` calls `precheck_nemesis()` before the loop; if exclusions emptied the
-  rotation it publishes one `Severity.CRITICAL` `InfoEvent` naming every excluded
-  nemesis and returns.
+  rotation it publishes one `Severity.CRITICAL` `TestFrameworkEvent` naming every
+  excluded nemesis and returns.
 - Test infrastructure (shipped here to keep the suite green — `run()` now calls
   `precheck(node)` on test nemesis): add a `precheck(node)` stub to `TestBaseClass` and
   `TestExecuteBaseClass`, plus `PrecheckSkipNemesis` / `PrecheckErrorNemesis`.
@@ -362,14 +362,20 @@ SKIPPED/FAILED reporting, empty-rotation CRITICAL, before/after example). Update
 the `writing-nemesis` skill and the AGENTS.md nemesis section. Advance plan
 status to `in_progress`.
 
-### Future work — migrating the 85 static skips (Phases 3–4)
+### Future work — migrating the remaining 84 static skips (Phases 3–4)
 
-Migrating the 57 config/backend and 28 version/feature guards out of the
+Migrating the 57 config/backend and remaining 27 version/feature guards out of the
 `disrupt_*` methods into `precheck(node)` overrides (Implementation Phases 3 and 4
 above) is **not** part of this foundation PR. Each migration adds a `precheck(node)`
 override to a nemesis class and removes the matching `raise UnsupportedNemesis`
 guard, grouped by nemesis family into ≤200 LOC PRs, using the `precheck_nemesis()`
 machinery landed here.
+
+One Category 2 guard already migrated ahead of schedule as part of this branch:
+`AbortDecommissionMonkey`'s `is_tablets_feature_enabled()` check
+(`sdcm/nemesis/monkey/abort_decommission.py`) moved from `decommission_target_node()`
+into `precheck(node)` — see PR History below. It is excluded from the Phase 4 count
+and deliverables to avoid double-migrating it.
 
 ## PR History
 
@@ -378,5 +384,5 @@ machinery landed here.
 | Phase 1 — `precheck(node)` hook + pruning | current PR | Done |
 | Phase 2 — Empty-list + Argus reporting | current PR | Done |
 | Phase 3 — Migrate Category 1 skips | — | Not started |
-| Phase 4 — Migrate Category 2 skips | — | Not started |
+| Phase 4 — Migrate Category 2 skips | — | Not started (1/28 done ahead of schedule: `AbortDecommissionMonkey` tablets guard, current PR) |
 | Phase 5 — Documentation | current PR | Done |

--- a/docs/plans/nemesis/nemesis-precheck.md
+++ b/docs/plans/nemesis/nemesis-precheck.md
@@ -1,8 +1,8 @@
 ---
-status: draft
+status: in_progress
 domain: nemesis
 created: 2026-06-11
-last_updated: 2026-06-15
+last_updated: 2026-06-25
 owner: pehala
 ---
 
@@ -37,7 +37,7 @@ A code analysis of all **130** explicit `raise UnsupportedNemesis(...)` sites (p
 
 So **~65 % (85/130)** of skip decisions never change after the cluster is up, yet they are re-evaluated every cycle behind the expensive setup described above. The remaining **~35 % (45/130)** legitimately depend on live, mutable state and must stay inside `disrupt()`.
 
-The node OS/distro check in `disrupt_memory_stress` (`sdcm/nemesis/__init__.py:4768-4774`) is Category 2, not Category 3: although it reads `self.target_node.distro`, the distro is fixed at provisioning by a single `scylla_linux_distro` config param (`sdcm/sct_config.py:671`) and is uniform across the data-node pool, so `cluster.nodes[0].distro` yields the same answer for any target.
+The node OS/distro check in `disrupt_memory_stress` (`sdcm/nemesis/__init__.py:4768-4774`) is Category 2, not Category 3: although it reads `self.target_node.distro`, the distro is fixed at provisioning by a single `scylla_linux_distro` config param (`sdcm/sct_config.py:671`) and is uniform across the data-node pool, so the representative `node.distro` passed to `precheck(node)` yields the same answer for any target.
 
 There is no mechanism today to evaluate a static skip **once** and exclude the nemesis from the rotation.
 
@@ -49,11 +49,16 @@ There is no mechanism today to evaluate a static skip **once** and exclude the n
 - `sdcm/nemesis/__init__.py:261` — `NemesisBaseClass(NemesisFlags, ABC)`: abstract base for individual disruptions. Holds `self.runner`, declares the abstract `disrupt()` (`sdcm/nemesis/__init__.py:269`). **No feasibility hook exists.**
 - `sdcm/nemesis/__init__.py:276` — `NemesisRunner`: orchestrator. Builds and owns `self.disruptions_list` and the execution flow.
 
-### Where the disruption list is built (the proposed gate point)
+### Where the disruption list is built
 
 - `sdcm/nemesis/__init__.py:2005` — `build_disruptions_by_selector()` instantiates each subclass returned by `NemesisRegistry.filter_subclasses(...)` and appends it to `disruptions`. It already swallows construction errors with a broad `except Exception` (`sdcm/nemesis/__init__.py:2023-2024`).
 - `sdcm/nemesis/__init__.py:2027` — `build_disruptions_by_name()` routes through `build_disruptions_by_selector()`, so both selection styles share one gate.
 - `sdcm/nemesis/monkey/runners.py:16` — `SisyphusMonkey.__init__` calls `build_disruptions_by_selector(self.nemesis_selector)` then `shuffle_list_of_disruptions(...)`. Other runners (`ScyllaCloudLimitedChaosMonkey`, `K8sSetMonkey`, etc.) call `build_disruptions_by_name([...])`.
+
+### Where the precheck gate runs
+
+- `sdcm/nemesis/__init__.py:443` — `NemesisRunner.run()` calls `precheck_nemesis()` once before the execution loop starts.
+- `sdcm/nemesis/__init__.py:2054` — `precheck_nemesis()` passes a representative live node to `nemesis.precheck(node=...)`, removes excluded nemesis from `disruptions_list`, and reports each exclusion once.
 
 ### Execution path that the precheck will short-circuit
 
@@ -64,7 +69,7 @@ There is no mechanism today to evaluate a static skip **once** and exclude the n
 
 - `sdcm/cluster.py:5780` — `add_nemesis()` instantiates each runner (which immediately builds its disruption list).
 - `longevity_test.py:136` calls `add_nemesis(...)` **after** the cluster is initialized (`db_cluster.wait_for_init(...)` in `sdcm/tester.py:965-974`) but **before** data prepare/load and **before** `db_cluster.start_nemesis()` (`longevity_test.py:240`).
-- Consequence at build time: the cluster is **up** (Category 2 version/feature probes work against `self.runner.cluster.nodes[0]`), config/backend is **known** (Category 1), but **no data is loaded** and **no target node is selected** (Category 3 is not yet meaningful). This is exactly the right place for a one-time static check.
+- Consequence at precheck time: the cluster is **up** (Category 2 version/feature probes work against the representative node passed to `precheck(node)`), config/backend is **known** (Category 1), and **no target node is selected** (Category 3 target-node state is not meaningful). This is exactly the right place for a one-time static check.
 
 ### Skip reporting today
 
@@ -81,35 +86,35 @@ There is no mechanism today to evaluate a static skip **once** and exclude the n
 ### What's Missing
 
 - An overridable, return-based feasibility hook on `NemesisBaseClass`. → **Phase 1**
-- A one-time evaluation/pruning step in `build_disruptions_by_selector()`. → **Phase 1**
+- A one-time evaluation/pruning step in `precheck_nemesis()` before the run loop. → **Phase 1**
 - Graceful handling (a single CRITICAL event that fails the test) when every selected nemesis is pruned. → **Phase 2**
 - A taxonomy-driven migration of the 85 static skips out of the per-cycle `disrupt()` path. → **Phases 3–4**
   - 57 Category 1 (config / backend / edition) guards → **Phase 3**
   - 28 Category 2 (version / feature flag / cluster-uniform node attribute) guards → **Phase 4**
-- Documentation of the `precheck()` contract, the category rule, and the pruning/reporting behavior for future nemesis authors. → **Phase 5**
+- Documentation of the `precheck(node)` contract, the category rule, and the pruning/reporting behavior for future nemesis authors. → **Phase 5**
 
 ## Goals
 
-1. **Add a return-based `precheck()` hook** to `NemesisBaseClass` that returns `str | None` (no exception-based control flow): `None` = runnable, a string = skip reason. Default implementation returns `None`.
-2. **Evaluate `precheck()` exactly once** per nemesis, at disruption-list build time, and permanently exclude any nemesis that returns a reason — so pruned nemesis incur **zero** per-cycle health-check, node-selection, or event cost.
-3. **Migrate all 85 static skips** (Category 1 + Category 2) from runner `disrupt_*` methods into the owning nemesis class `precheck()`, removing the now-redundant static guards in the **same PR** as each migration. Category 3 (45) checks remain in `disrupt()`.
+1. **Add a return-based `precheck(node)` hook** to `NemesisBaseClass` that returns `str | None` (no exception-based control flow): `None` = runnable, a string = skip reason. Default implementation returns `None`.
+2. **Evaluate `precheck(node)` exactly once** per nemesis before the execution loop starts, and permanently exclude any nemesis that returns a reason — so pruned nemesis incur **zero** per-cycle health-check, node-selection, or event cost.
+3. **Migrate all 85 static skips** (Category 1 + Category 2) from runner `disrupt_*` methods into the owning nemesis class `precheck(node)`, removing the now-redundant static guards in the **same PR** as each migration. Category 3 (45) checks remain in `disrupt()`.
 4. **Fail the test loudly when misconfigured**: if every selected nemesis is pruned, emit exactly one `Severity.CRITICAL` event and stop the nemesis thread (configured nemesis not running must fail the test).
 5. **Report each pruned nemesis as a `SKIPPED` Argus row exactly once** (not per cycle, not zero times), preserving skip visibility while eliminating the repeated work.
-6. **No behavioral regression** for nemesis with no static skip (default `precheck()` returns `None`; they run exactly as before).
+6. **No behavioral regression** for nemesis with no static skip (default `precheck(node)` returns `None`; they run exactly as before).
 
 ## Implementation Phases
 
 Phases are ordered by dependency: the framework hook and reporting/empty-list handling land first (foundational, must leave the tree working), then the bulk migration is split into reviewable, domain-grouped PRs of ≤200 LOC each. Migration PRs depend only on Phase 1/2 and are independent of one another.
 
-### Phase 1: Add the `precheck()` hook and one-time pruning
+### Phase 1: Add the `precheck(node)` hook and one-time pruning — Done
 
 **Importance**: Critical
-**Description**: Introduce the return-based hook and wire it into the single build gate. No nemesis overrides it yet, so behavior is unchanged (every `precheck()` returns `None`).
+**Description**: Introduce the return-based hook and wire it into the one-time pre-execution gate. No nemesis overrides it yet, so behavior is unchanged (every `precheck(node)` returns `None`).
 
 **Deliverables**:
 - New method on `NemesisBaseClass` (`sdcm/nemesis/__init__.py:261`):
   ```python
-  def precheck(self) -> str | None:
+  def precheck(self, node: BaseNode) -> str | None:
       """
       Static feasibility check, evaluated ONCE before the nemesis is scheduled.
 
@@ -121,24 +126,24 @@ Phases are ordered by dependency: the framework hook and reporting/empty-list ha
         - Scylla version / feature flags / cluster-uniform
           node attributes such as OS distro                (Category 2)
 
-      No target node is selected yet — use self.runner.cluster.nodes[0] as a
-      representative live node. Do NOT check dynamic state (data presence,
+      No target node is selected yet — use the provided representative live node.
+      Do NOT check dynamic state (data presence,
       live node counts, whether a specific target node is busy or alone in
       its rack) — those stay inside disrupt().
       """
       return None
   ```
-- `build_disruptions_by_selector()` (`sdcm/nemesis/__init__.py:2005`) calls `precheck()` after instantiation and keeps the nemesis only when it returns `None`. Real errors raised inside `precheck()` continue to be caught by the existing broad `except Exception` (treated as today: log and skip the nemesis). Excluded nemesis are collected with their reasons and logged once.
+- `NemesisRunner.precheck_nemesis()` (`sdcm/nemesis/__init__.py`) calls `precheck(node)` before the execution loop and keeps the nemesis only when it returns `None`. Real errors raised inside `precheck(node)` are caught and reported as failed prechecks. Excluded nemesis are collected with their reasons and logged once.
 
 **Adaptation Notes**: A bare `str | None` contract is used (per design decision) rather than a structured result; the reason string is what flows to logs and the Argus row in Phase 2.
 
 **Definition of Done**:
-- [ ] `NemesisBaseClass.precheck()` exists with the documented contract and `None` default.
-- [ ] `build_disruptions_by_selector()` invokes `precheck()` exactly once per nemesis and excludes those returning a reason.
-- [ ] Exceptions inside `precheck()` are handled by the existing `except Exception` path (no new crash modes).
-- [ ] With no overrides, `_disruption_list_names` is identical to pre-change for a representative selector (regression-covered by unit test).
-- [ ] Unit tests in `unit_tests/unit/nemesis/` cover: default keeps nemesis; reason prunes nemesis; exception in `precheck()` prunes and logs.
-- [ ] `uv run sct.py pre-commit` passes.
+- [x] `NemesisBaseClass.precheck(node)` exists with the documented contract and `None` default.
+- [x] `precheck_nemesis()` invokes `precheck(node)` before the execution loop and excludes those returning a reason.
+- [x] Exceptions inside `precheck(node)` are handled and reported as failed prechecks (no new crash modes).
+- [x] With no overrides, `_disruption_list_names` is identical to pre-change for a representative selector (regression-covered by unit test).
+- [x] Unit tests in `unit_tests/unit/nemesis/` cover: default keeps nemesis; reason prunes nemesis; exception in `precheck(node)` prunes and logs; the passed node is the representative cluster node, not `target_node`.
+- [x] `uv run sct.py pre-commit` passes for the changed files. Full commit-range pre-commit is blocked by unstaged working-tree edits during checkout.
 
 ---
 
@@ -150,37 +155,37 @@ Phases are ordered by dependency: the framework hook and reporting/empty-list ha
 **Dependencies**: Phase 1
 
 **Deliverables**:
-- For each pruned nemesis, publish a single `DisruptionEvent` marked skipped (via `DisruptionEvent.skip(reason)`, `sdcm/sct_events/continuous_event.py:134`) so it appears exactly once as `NemesisStatus.SKIPPED` in Argus (`sdcm/sct_events/argus.py:66`). Emitted at build time, not per cycle.
+- For each pruned nemesis, publish a single `DisruptionEvent` marked skipped (via `DisruptionEvent.skip(reason)`, `sdcm/sct_events/continuous_event.py:134`) so it appears exactly once as `NemesisStatus.SKIPPED` in Argus (`sdcm/sct_events/argus.py:66`). Emitted at precheck time, not per cycle.
 - Empty-rotation guard: if `disruptions_list` is empty after pruning, publish one `InfoEvent(..., severity=Severity.CRITICAL)` naming the excluded nemesis and their reasons, and stop the nemesis thread cleanly instead of letting `call_next_nemesis()` raise the bare `AssertionError` at `sdcm/nemesis/__init__.py:2085`. This supersedes the "skipped 3× in a row" static path (`sdcm/nemesis/__init__.py:440`) for prune-based cases.
 
 **Adaptation Notes**: "Configured nemesis not running must fail the test" — the CRITICAL event is the failure signal. Decide whether to raise after publishing or rely on the event severity to fail the test summary; align with how existing CRITICAL nemesis events fail runs (`get_event_summary().get("CRITICAL")`, used at `sdcm/nemesis/__init__.py:1953`).
 
 **Definition of Done**:
-- [ ] Each pruned nemesis produces exactly one `SKIPPED` Argus row (verified in unit test by asserting one published skipped `DisruptionEvent` per pruned class).
-- [ ] No per-cycle skip events are produced for pruned nemesis (they are absent from `infinite_cycle`).
-- [ ] Empty rotation after pruning emits one CRITICAL event and stops the thread without an uncaught `AssertionError`.
-- [ ] Unit tests cover: single pruned nemesis → one SKIPPED row; all pruned → one CRITICAL event + graceful stop.
-- [ ] `uv run sct.py pre-commit` passes.
+- [x] Each pruned nemesis produces exactly one `SKIPPED` Argus row (verified in unit test by asserting one published skipped `DisruptionEvent` per pruned class).
+- [x] No per-cycle skip events are produced for pruned nemesis (they are absent from `infinite_cycle`).
+- [x] Empty rotation after pruning emits one CRITICAL event and stops the thread without an uncaught `AssertionError`.
+- [x] Unit tests cover: single pruned nemesis → one SKIPPED row; all pruned → one CRITICAL event + graceful stop.
+- [x] `uv run sct.py pre-commit` passes.
 
 ---
 
 ### Phase 3: Migrate Category 1 (config / backend / edition) skips
 
 **Importance**: Important
-**Description**: Move the 57 config/backend/edition guards from runner `disrupt_*` methods into the owning class `precheck()`, switching `self.target_node` references to `self.runner.cluster.nodes[0]`. Remove the migrated static guards from the runner methods in the same PR. Split into ≤200 LOC PRs grouped by nemesis family (e.g. SLA group, LDAP/auth group, network-interface group, K8s-only group, manager group).
+**Description**: Move the 57 config/backend/edition guards from runner `disrupt_*` methods into the owning class `precheck(node)`, switching `self.target_node` references to the provided representative `node`. Remove the migrated static guards from the runner methods in the same PR. Split into ≤200 LOC PRs grouped by nemesis family (e.g. SLA group, LDAP/auth group, network-interface group, K8s-only group, manager group).
 
 **Dependencies**: Phase 1, Phase 2
 
 **Deliverables**:
-- `precheck()` overrides on the relevant classes in `sdcm/nemesis/monkey/` (and extracted modules), e.g. LDAP nemesis (`sdcm/nemesis/__init__.py:1117-1123`), SLA nemesis (`sdcm/nemesis/__init__.py:5084-5232`), KMS-encryption backend gate (`sdcm/nemesis/__init__.py:4474`), network-interface nemesis (`3557/3648/4016`).
+- `precheck(node)` overrides on the relevant classes in `sdcm/nemesis/monkey/` (and extracted modules), e.g. LDAP nemesis (`sdcm/nemesis/__init__.py:1117-1123`), SLA nemesis (`sdcm/nemesis/__init__.py:5084-5232`), KMS-encryption backend gate (`sdcm/nemesis/__init__.py:4474`), network-interface nemesis (`3557/3648/4016`).
 - Removal of the corresponding `raise UnsupportedNemesis(...)` static guards from the runner methods.
 - Per-family unit tests asserting the nemesis is pruned under the negative config and kept under the positive config.
 
-**Adaptation Notes**: Some SLA methods mix a Category 1 gate (`sla`/`enterprise`/`authenticator`) with a Category 3 data-presence gate (`get_cassandra_stress_write_cmds()`). Only the Category 1 portion moves to `precheck()`; the data-presence check stays in `disrupt()`.
+**Adaptation Notes**: Some SLA methods mix a Category 1 gate (`sla`/`enterprise`/`authenticator`) with a Category 3 data-presence gate (`get_cassandra_stress_write_cmds()`). Only the Category 1 portion moves to `precheck(node)`; the data-presence check stays in `disrupt()`.
 
 **Definition of Done**:
-- [ ] All 57 Category 1 guards are evaluated via `precheck()` and removed from the per-cycle path.
-- [ ] No remaining `target_node`-dependent reference inside any migrated `precheck()`.
+- [ ] All 57 Category 1 guards are evaluated via `precheck(node)` and removed from the per-cycle path.
+- [ ] No remaining `target_node`-dependent reference inside any migrated `precheck(node)`.
 - [ ] Unit tests per family (negative prunes, positive keeps).
 - [ ] `uv run sct.py pre-commit` passes for each PR.
 
@@ -189,18 +194,18 @@ Phases are ordered by dependency: the framework hook and reporting/empty-list ha
 ### Phase 4: Migrate Category 2 (version / feature flag / cluster-uniform node attribute) skips
 
 **Importance**: Important
-**Description**: Move the 28 version/feature/uniform-attribute guards into `precheck()`, using a representative node (`cluster.nodes[0]`) for cluster-wide probes. Convert the implicit `@scylla_versions` `MethodVersionNotFound` cases into explicit `precheck()` version checks where the method group is owned by a single nemesis. Split into ≤200 LOC PRs (e.g. tablets group, raft-coordinator group, version-compare group, `SkipPerIssues` group).
+**Description**: Move the 28 version/feature/uniform-attribute guards into `precheck(node)`, using the provided representative node for cluster-wide probes. Convert the implicit `@scylla_versions` `MethodVersionNotFound` cases into explicit `precheck(node)` version checks where the method group is owned by a single nemesis. Split into ≤200 LOC PRs (e.g. tablets group, raft-coordinator group, version-compare group, `SkipPerIssues` group).
 
 **Dependencies**: Phase 1, Phase 2
 
 **Deliverables**:
-- `precheck()` overrides for tablets-gated nemesis (`915-920`, `1090-1094`, `4242`, `5277`, `5334`, `5837`, `5921`), raft-coordinator nemesis (`5652`, `5723`, `5834`), version-compare nemesis (`1798`, `5409`, `5413`), the node OS/distro check in `disrupt_memory_stress` (`4768-4774`, evaluated via `cluster.nodes[0].distro`), and `SkipPerIssues`-gated nemesis.
-- Removal of the corresponding static guards from runner methods; for `@scylla_versions`-decorated single-owner groups, add an explicit version `precheck()` and document that the decorator remains the in-method safety net.
+- `precheck(node)` overrides for tablets-gated nemesis (`915-920`, `1090-1094`, `4242`, `5277`, `5334`, `5837`, `5921`), raft-coordinator nemesis (`5652`, `5723`, `5834`), version-compare nemesis (`1798`, `5409`, `5413`), the node OS/distro check in `disrupt_memory_stress` (`4768-4774`, evaluated via `node.distro`), and `SkipPerIssues`-gated nemesis.
+- Removal of the corresponding static guards from runner methods; for `@scylla_versions`-decorated single-owner groups, add an explicit version `precheck(node)` and document that the decorator remains the in-method safety net.
 
-**Adaptation Notes (Needs Investigation)**: `disrupt_create_index`, `disrupt_add_remove_mv`, `disrupt_kill_mv_building_coordinator`, and `disrupt_trigger_split_merge_tablets_with_alter` mix Category 2 feature gates with Category 3 table-existence / node-busy gates. Confirm per nemesis that only the feature/version portion is hoisted to `precheck()` and the dynamic portion remains in `disrupt()`. Verify that `is_views_with_tablets_enabled(session)` (`sdcm/nemesis/__init__.py:5841`) can be evaluated against a representative node session at build time.
+**Adaptation Notes (Needs Investigation)**: `disrupt_create_index`, `disrupt_add_remove_mv`, `disrupt_kill_mv_building_coordinator`, and `disrupt_trigger_split_merge_tablets_with_alter` mix Category 2 feature gates with Category 3 table-existence / node-busy gates. Confirm per nemesis that only the feature/version portion is hoisted to `precheck(node)` and the dynamic portion remains in `disrupt()`. Verify that `is_views_with_tablets_enabled(session)` (`sdcm/nemesis/__init__.py:5841`) can be evaluated against a representative node session before the execution loop.
 
 **Definition of Done**:
-- [ ] All 28 Category 2 guards evaluated via `precheck()`; static guards removed from the per-cycle path.
+- [ ] All 28 Category 2 guards evaluated via `precheck(node)`; static guards removed from the per-cycle path.
 - [ ] Feature probes use a representative node, not a target node.
 - [ ] Unit tests assert pruning under disabled feature/version and retention under enabled.
 - [ ] `uv run sct.py pre-commit` passes for each PR.
@@ -210,18 +215,18 @@ Phases are ordered by dependency: the framework hook and reporting/empty-list ha
 ### Phase 5: Documentation update
 
 **Importance**: Critical
-**Description**: Document the `precheck()` contract, the Category 1/2/3 rule, and the pruning/reporting behavior so future nemesis authors place static checks correctly.
+**Description**: Document the `precheck(node)` contract, the Category 1/2/3 rule, and the pruning/reporting behavior so future nemesis authors place static checks correctly.
 
 **Dependencies**: Phase 1 (content can expand as Phases 3–4 land)
 
 **Deliverables**:
-- New "Pre-execution skip checks (`precheck`)" section in `docs/nemesis.md` covering the contract, the representative-node rule, the "Category 3 stays in `disrupt()`" rule, the one-time SKIPPED Argus row, and the empty-rotation CRITICAL behavior.
-- Update the `writing-nemesis` skill (`skills/writing-nemesis/SKILL.md`) and AGENTS.md nemesis notes to mention `precheck()`.
+- New "Pre-execution skip checks (`precheck`)" section in `docs/nemesis.md` covering the `precheck(node)` contract, the representative-node rule, the "Category 3 stays in `disrupt()`" rule, the one-time SKIPPED Argus row, and the empty-rotation CRITICAL behavior.
+- Update the `writing-nemesis` skill (`skills/writing-nemesis/SKILL.md`) and AGENTS.md nemesis notes to mention `precheck(node)`.
 - Update this plan's PR History table as phases merge.
 
 **Definition of Done**:
-- [ ] `docs/nemesis.md` documents `precheck()` with a before/after example.
-- [ ] `writing-nemesis` skill references `precheck()` and the category rule.
+- [ ] `docs/nemesis.md` documents `precheck(node)` with a before/after example.
+- [ ] `writing-nemesis` skill references `precheck(node)` and the category rule.
 - [ ] `uv run sct.py pre-commit` passes.
 
 ## Testing Requirements
@@ -229,9 +234,9 @@ Phases are ordered by dependency: the framework hook and reporting/empty-list ha
 ### Unit Tests
 
 - Use the existing nemesis test harness (`unit_tests/unit/nemesis/`, `TestRunner`, `fake_cluster.py`).
-- Phase 1: default `precheck()` keeps nemesis; reason-returning `precheck()` is excluded from `build_disruptions_by_selector()`; an exception inside `precheck()` is caught and the nemesis excluded; build output is unchanged when no class overrides `precheck()`.
+- Phase 1: default `precheck(node)` keeps nemesis; reason-returning `precheck(node)` is excluded by `precheck_nemesis()`; an exception inside `precheck(node)` is caught and the nemesis excluded; build output is unchanged when no class overrides `precheck(node)`.
 - Phase 2: a pruned nemesis publishes exactly one skipped `DisruptionEvent` (assert via `fake_events`); all-pruned emits one CRITICAL event and stops the thread without `AssertionError`.
-- Phases 3–4: per migrated family, parametrized tests toggling the relevant config/flag and asserting prune-vs-keep, plus an assertion that the representative node (not `target_node`) is used.
+- Phases 3–4: per migrated family, parametrized tests toggling the relevant config/flag and asserting prune-vs-keep, plus an assertion that the passed representative node (not `target_node`) is used.
 - Run with: `uv run sct.py unit-tests -t unit_tests/unit/nemesis/`.
 
 ### Integration Tests
@@ -257,15 +262,15 @@ All Definition of Done items across phases are met. Additionally:
 
 ## Risk Mitigation
 
-### Risk: A `precheck()` mis-categorizes a dynamic condition as static
+### Risk: A `precheck(node)` mis-categorizes a dynamic condition as static
 **Likelihood**: Medium
 **Impact**: A nemesis is permanently pruned based on state that would have become valid later (e.g. data not yet loaded), reducing coverage silently.
-**Mitigation**: The contract explicitly forbids dynamic-state and `target_node` checks in `precheck()`; code review enforces the Category 1/2/3 rule; migration PRs keep Category 3 checks in `disrupt()`. The taxonomy in this plan lists the exact line references for each category.
+**Mitigation**: The contract explicitly forbids dynamic-state and `target_node` checks in `precheck(node)`; code review enforces the Category 1/2/3 rule; migration PRs keep Category 3 checks in `disrupt()`. The taxonomy in this plan lists the exact line references for each category.
 
 ### Risk: Representative-node probe differs from target-node reality
 **Likelihood**: Low
-**Impact**: A feature/version probe against `cluster.nodes[0]` yields a different answer than the eventual target node.
-**Mitigation**: All Category 2 conditions identified are cluster-wide (tablets, raft, views, version) or cluster-uniform by provisioning config (OS distro, fixed by the single `scylla_linux_distro` param at `sdcm/sct_config.py:671`). Phase 4 includes a DoD item and review gate rejecting any genuinely per-node-specific check in `precheck()`.
+**Impact**: A feature/version probe against the representative node yields a different answer than the eventual target node.
+**Mitigation**: All Category 2 conditions identified are cluster-wide (tablets, raft, views, version) or cluster-uniform by provisioning config (OS distro, fixed by the single `scylla_linux_distro` param at `sdcm/sct_config.py:671`). Phase 4 includes a DoD item and review gate rejecting any genuinely per-node-specific check in `precheck(node)`.
 
 ### Risk: Empty rotation false-positive fails a legitimately-configured run
 **Likelihood**: Low
@@ -275,7 +280,7 @@ All Definition of Done items across phases are met. Additionally:
 ### Risk: Removing the static guard from a runner method while another caller relies on it
 **Likelihood**: Medium
 **Impact**: A `disrupt_*` method still reachable from a legacy delegate could lose its guard and run where it should not.
-**Mitigation**: Migrate and remove in the same PR; before removing a guard, `grep` for all callers of the runner method; keep guards that are shared by multiple nemesis until all owners have a `precheck()`. Phase 3/4 DoD requires per-family tests.
+**Mitigation**: Migrate and remove in the same PR; before removing a guard, `grep` for all callers of the runner method; keep guards that are shared by multiple nemesis until all owners have a `precheck(node)`. Phase 3/4 DoD requires per-family tests.
 
 ### Risk: Double reporting or missing the one-time SKIPPED row
 **Likelihood**: Low
@@ -284,15 +289,94 @@ All Definition of Done items across phases are met. Additionally:
 
 ## Related Plans
 
-- [nemesis-rework.md](nemesis-rework.md) — Phase 3 of the rework extracts disrupt logic into self-contained classes; `precheck()` builds on that class-as-carrier model and is most cleanly applied to already-extracted nemesis.
-- [nemesis-extraction.md](nemesis-extraction.md) — As methods are extracted, their static guards become natural `precheck()` overrides; sequencing migrations after extraction reduces churn.
+- [nemesis-rework.md](nemesis-rework.md) — Phase 3 of the rework extracts disrupt logic into self-contained classes; `precheck(node)` builds on that class-as-carrier model and is most cleanly applied to already-extracted nemesis.
+- [nemesis-extraction.md](nemesis-extraction.md) — As methods are extracted, their static guards become natural `precheck(node)` overrides; sequencing migrations after extraction reduces churn.
+
+## Commit Plan
+
+The foundation (Phases 1–2 + 5 of this plan — the `precheck(node)` hook, one-time
+pruning/reporting, and documentation) ships as **one PR of 3 commits**. Each
+commit is self-standing: all tests in `unit_tests/unit/nemesis/` pass after every
+individual commit.
+
+Verification after every commit:
+```bash
+uv run python -m pytest unit_tests/unit/nemesis/
+uv run sct.py pre-commit
+```
+
+> **Design note.** Pruning is performed by a dedicated `NemesisRunner.precheck_nemesis()`
+> method invoked **once at the start of `run()`**, before the execution loop — *not*
+> inside `build_disruptions_by_selector()`. This keeps `build_disruptions_by_selector()`
+> a pure builder (it still returns a plain list), avoids changing every caller's
+> signature, and means runners that legitimately keep an empty `disruptions_list`
+> and override `call_next_nemesis()` (`NoOpMonkey`, `ManagerRcloneBackup`,
+> `ManagerNativeBackup`, `CategoricalMonkey`) are unaffected.
+
+### Commit 1 — `feat(nemesis): add precheck(node) hook to NemesisBaseClass`
+
+Files: `sdcm/nemesis/__init__.py`
+
+Add `precheck(self, node: BaseNode) -> str | None` to `NemesisBaseClass` with the
+full contract docstring and a `return None` default. No other changes — zero
+behavioral impact, every existing test passes.
+
+### Commit 2 — `feat(nemesis): prune infeasible nemesis via precheck_nemesis() before the run loop`
+
+Files: `sdcm/nemesis/__init__.py`, `unit_tests/unit/nemesis/__init__.py`,
+`unit_tests/unit/nemesis/execute_nemesis/__init__.py`,
+`unit_tests/unit/nemesis/execute_nemesis/test_precheck.py` (new)
+
+- Add `NemesisRunner.precheck_nemesis()`. It iterates `self.disruptions_list`,
+  evaluates each nemesis's `precheck(node)`, prunes the infeasible ones in place, and
+  returns the `(name, reason)` exclusions. Each exclusion is reported once:
+  - a returned reason → `DisruptionEvent.skip()` (SKIPPED, NORMAL) +
+    Argus `finalize_nemesis(status=SKIPPED)`.
+  - a raised exception → `DisruptionEvent.add_simple_error()` (FAILED, ERROR) +
+    Argus `finalize_nemesis(status=FAILED)` — a broken `precheck(node)` is a test
+    error, not an intentional skip.
+- Argus reporting reuses `argus_submit()`, which gains an optional `node`
+  parameter so pre-execution callers can reuse the same representative node
+  passed to `precheck(node)` (no `target_node` exists yet). Existing call-sites are
+  unchanged (default `node=None` → `self.target_node`).
+- `run()` calls `precheck_nemesis()` before the loop; if exclusions emptied the
+  rotation it publishes one `Severity.CRITICAL` `InfoEvent` naming every excluded
+  nemesis and returns.
+- Test infrastructure (shipped here to keep the suite green — `run()` now calls
+  `precheck(node)` on test nemesis): add a `precheck(node)` stub to `TestBaseClass` and
+  `TestExecuteBaseClass`, plus `PrecheckSkipNemesis` / `PrecheckErrorNemesis`.
+- `execute_nemesis/test_precheck.py` covers pruning, DisruptionEvent shapes,
+  Argus submit/finalize, the representative node argument, and the `run()` empty-
+  rotation path. Skip-vs-exception variants are parametrized; full event dicts
+  are asserted.
+
+### Commit 3 — `docs(nemesis): document precheck(node) contract and pruning behavior`
+
+Files: `docs/nemesis.md`, `skills/writing-nemesis/SKILL.md`, `AGENTS.md`,
+`docs/plans/nemesis/nemesis-precheck.md`, `docs/plans/progress.json`,
+`docs/plans/assets/progress-roadmap.svg`
+
+Add a "Pre-execution skip checks (`precheck`)" section to `docs/nemesis.md`
+(`precheck(node)` contract, what-belongs-where rule in plain language, representative-node rule,
+SKIPPED/FAILED reporting, empty-rotation CRITICAL, before/after example). Update
+the `writing-nemesis` skill and the AGENTS.md nemesis section. Advance plan
+status to `in_progress`.
+
+### Future work — migrating the 85 static skips (Phases 3–4)
+
+Migrating the 57 config/backend and 28 version/feature guards out of the
+`disrupt_*` methods into `precheck(node)` overrides (Implementation Phases 3 and 4
+above) is **not** part of this foundation PR. Each migration adds a `precheck(node)`
+override to a nemesis class and removes the matching `raise UnsupportedNemesis`
+guard, grouped by nemesis family into ≤200 LOC PRs, using the `precheck_nemesis()`
+machinery landed here.
 
 ## PR History
 
 | Phase | PR | Status |
 |-------|-----|--------|
-| Phase 1 — `precheck()` hook + pruning | — | Not started |
-| Phase 2 — Empty-list + Argus reporting | — | Not started |
+| Phase 1 — `precheck(node)` hook + pruning | current PR | Done |
+| Phase 2 — Empty-list + Argus reporting | current PR | Done |
 | Phase 3 — Migrate Category 1 skips | — | Not started |
 | Phase 4 — Migrate Category 2 skips | — | Not started |
-| Phase 5 — Documentation | — | Not started |
+| Phase 5 — Documentation | current PR | Done |

--- a/docs/plans/progress.json
+++ b/docs/plans/progress.json
@@ -156,10 +156,10 @@
       "title": "Nemesis Pre-Execution Skip Check (precheck)",
       "file": "nemesis/nemesis-precheck.md",
       "domain": "nemesis",
-      "status": "draft",
+      "status": "in_progress",
       "created": "2026-06-11",
       "phases_total": 5,
-      "phases_done": 0
+      "phases_done": 2
     },
     {
       "id": "k8s-multitenancy-dict-config",

--- a/docs/plans/progress.json
+++ b/docs/plans/progress.json
@@ -156,10 +156,10 @@
       "title": "Nemesis Pre-Execution Skip Check (precheck)",
       "file": "nemesis/nemesis-precheck.md",
       "domain": "nemesis",
-      "status": "draft",
+      "status": "in_progress",
       "created": "2026-06-11",
       "phases_total": 5,
-      "phases_done": 0
+      "phases_done": 3
     },
     {
       "id": "k8s-multitenancy-dict-config",

--- a/sdcm/nemesis/__init__.py
+++ b/sdcm/nemesis/__init__.py
@@ -254,6 +254,29 @@ class NemesisBaseClass(NemesisFlags, ABC):
         super().__init__()
         self.runner: "NemesisRunner" = runner
 
+    def precheck(self, node: BaseNode) -> str | None:
+        """
+        Static feasibility check evaluated ONCE before the nemesis is scheduled.
+
+        Return None  -> nemesis is runnable and kept in the rotation.
+        Return a str -> human-readable skip reason; nemesis is permanently excluded
+                        from the disruption list and will not run during this test.
+
+        Use ONLY for conditions that do not change during the test run:
+          - Test config, backend, or product edition
+            (e.g. cluster.params.get(...), _is_it_on_kubernetes(), node.is_enterprise)
+          - Scylla version, feature flags, or cluster-uniform node attributes
+            (e.g. ComparableScyllaVersion checks, is_tablets_feature_enabled(), node.distro)
+
+        No target node is selected yet — use the provided representative live
+        node for any cluster-wide probes.
+
+        Do NOT check dynamic state (data presence, live node counts, whether a
+        specific target node is busy or alone in its rack) — those belong in
+        disrupt().
+        """
+        return None
+
     @abstractmethod
     def disrupt(self):
         """

--- a/sdcm/nemesis/__init__.py
+++ b/sdcm/nemesis/__init__.py
@@ -97,7 +97,7 @@ from sdcm.sct_events.group_common_events import (
 
 from sdcm.sct_events.loaders import CassandraStressLogEvent, ScyllaBenchEvent
 from sdcm.sct_events.nemesis import DisruptionEvent
-from sdcm.sct_events.system import InfoEvent
+from sdcm.sct_events.system import InfoEvent, TestFrameworkEvent
 from sdcm.sla.sla_tests import SlaTests
 from sdcm.utils.aws_kms import AwsKms
 from sdcm.utils import cdc
@@ -438,12 +438,15 @@ class NemesisRunner:
         excluded = self.precheck_nemesis()
         if excluded and not self.disruptions_list:
             reason_list = "; ".join(f"{name}: {reason}" for name, reason in excluded)
-            InfoEvent(
-                message=(
-                    f"All {len(excluded)} selected nemesis were excluded by precheck and will not run. "
-                    f"Reasons: {reason_list}"
-                ),
+            selector_message = f" Selector: {self.nemesis_selector!r}." if self.nemesis_selector else ""
+            TestFrameworkEvent(
+                source=self.__class__.__name__,
                 severity=Severity.CRITICAL,
+                message=(
+                    f"No runnable nemesis remain after precheck. "
+                    f"All {len(excluded)} selected nemesis were excluded before execution.{selector_message} "
+                    f"Exclusions: {reason_list}"
+                ),
             ).publish()
             return
         try:

--- a/sdcm/nemesis/__init__.py
+++ b/sdcm/nemesis/__init__.py
@@ -435,6 +435,17 @@ class NemesisRunner:
         if interval:
             self.interval = interval * 60
         self.log.info("Interval: %s s", self.interval)
+        excluded = self.precheck_nemesis()
+        if excluded and not self.disruptions_list:
+            reason_list = "; ".join(f"{name}: {reason}" for name, reason in excluded)
+            InfoEvent(
+                message=(
+                    f"All {len(excluded)} selected nemesis were excluded by precheck and will not run. "
+                    f"Reasons: {reason_list}"
+                ),
+                severity=Severity.CRITICAL,
+            ).publish()
+            return
         try:
             while not self.termination_event.is_set():
                 if cycles_count == 0:
@@ -2042,6 +2053,63 @@ class NemesisRunner:
             except Exception as e:  # noqa: BLE001
                 self.log.warning(f"Error while initializing nemesis {subclass.__name__}, ignoring: {e}")
         return disruptions
+
+    def precheck_nemesis(self) -> list[tuple[str, str]]:
+        """Evaluate precheck() on every nemesis in disruptions_list, prune the
+        infeasible ones, and report each exclusion.
+
+        Called once from run() before the execution loop starts. A nemesis whose
+        precheck(node) returns a reason string is excluded and reported as SKIPPED; one
+        whose precheck(node) raises is excluded and reported as FAILED (a broken
+        precheck() is a test error, not an intentional skip).
+
+        Updates self.disruptions_list in place to keep only runnable nemesis and
+        returns the list of (name, reason) exclusions. Each class is evaluated and
+        reported at most once — when nemesis_multiply_factor > 1 the disruptions_list
+        may contain multiple instances of the same class, but precheck() is invariant
+        so only the first instance triggers the report; subsequent copies are silently
+        pruned without duplicate Argus calls.
+        """
+        runnable = []
+        excluded: list[tuple[str, str]] = []
+        reported: set[str] = set()  # classes already reported to avoid duplicates
+        start_time = time.time()
+        precheck_node = self.cluster.nodes[0]
+        for nemesis in self.disruptions_list:
+            name = nemesis.__class__.__name__
+            captured_tb = ""
+            is_error = False
+            try:
+                skip_reason = nemesis.precheck(node=precheck_node)
+            except Exception as e:  # noqa: BLE001
+                skip_reason = str(e)
+                captured_tb = traceback.format_exc()
+                is_error = True
+            if skip_reason is None:
+                runnable.append(nemesis)
+                continue
+            # Prune this instance regardless of whether we already reported the class.
+            if name in reported:
+                continue
+            reported.add(name)
+            self.log.warning("Nemesis %s excluded by precheck: %s", name, skip_reason)
+            excluded.append((name, skip_reason))
+            with (
+                DisruptionEvent(nemesis_name=name, node=None, publish_event=True) as event,
+                self.argus_submit(
+                    nemesis_name=name,
+                    start_time=start_time,
+                    nemesis_event=event,
+                    description=nemesis.__class__.__doc__,
+                    node=precheck_node,
+                ),
+            ):
+                if is_error:
+                    event.add_simple_error(skip_reason, captured_tb)
+                else:
+                    event.skip(skip_reason=skip_reason)
+        self.disruptions_list = runnable
+        return excluded
 
     def build_disruptions_by_name(self, disrupt_methods: List[str]):
         """Builds list of available disruptions according to class names"""
@@ -5407,8 +5475,20 @@ class NemesisRunner:
 
     @contextlib.contextmanager
     def argus_submit(
-        self, nemesis_name: str, start_time: int | float, nemesis_event: DisruptionEvent, description: str | None = None
+        self,
+        nemesis_name: str,
+        start_time: int | float,
+        nemesis_event: DisruptionEvent,
+        description: str | None = None,
+        node: "BaseNode | None" = None,
     ):
+        """Submit and finalize a nemesis run in Argus.
+
+        The optional *node* parameter allows callers that have not yet selected a
+        target node (e.g. precheck_nemesis) to pass a representative node
+        explicitly instead of relying on self.target_node.
+        """
+        effective_node = node if node is not None else self.target_node
         argus_client = None
         submitted = False
         try:
@@ -5417,9 +5497,9 @@ class NemesisRunner:
                 name=nemesis_name,
                 class_name=self.get_class_name(),
                 start_time=int(start_time),
-                target_name=self.target_node.name,
-                target_ip=self.target_node.public_ip_address,
-                target_shards=self.target_node.scylla_shards,
+                target_name=effective_node.name,
+                target_ip=effective_node.public_ip_address,
+                target_shards=effective_node.scylla_shards,
                 description=description,
             )
             submitted = True

--- a/sdcm/nemesis/__init__.py
+++ b/sdcm/nemesis/__init__.py
@@ -431,6 +431,17 @@ class NemesisRunner:
         if interval:
             self.interval = interval * 60
         self.log.info("Interval: %s s", self.interval)
+        excluded = self.precheck_nemesis()
+        if excluded and not self.disruptions_list:
+            reason_list = "; ".join(f"{name}: {reason}" for name, reason in excluded)
+            InfoEvent(
+                message=(
+                    f"All {len(excluded)} selected nemesis were excluded by precheck and will not run. "
+                    f"Reasons: {reason_list}"
+                ),
+                severity=Severity.CRITICAL,
+            ).publish()
+            return
         try:
             while not self.termination_event.is_set():
                 if cycles_count == 0:
@@ -2004,6 +2015,65 @@ class NemesisRunner:
             except Exception as e:  # noqa: BLE001
                 self.log.warning(f"Error while initializing nemesis {subclass.__name__}, ignoring: {e}")
         return disruptions
+
+    def precheck_nemesis(self) -> list[tuple[str, str]]:
+        """Evaluate precheck() on every nemesis in disruptions_list, prune the
+        infeasible ones, and report each exclusion.
+
+        Called once from run() before the execution loop starts. A nemesis whose
+        precheck(node) returns a reason string is excluded and reported as SKIPPED; one
+        whose precheck(node) raises is excluded and reported as FAILED (a broken
+        precheck() is a test error, not an intentional skip).
+
+        Updates self.disruptions_list in place to keep only runnable nemesis and
+        returns the list of (name, reason) exclusions. Each class is evaluated and
+        reported at most once — when nemesis_multiply_factor > 1 the disruptions_list
+        may contain multiple instances of the same class, but precheck() is invariant
+        so only the first instance triggers the call and the report; subsequent copies
+        reuse the cached result without a repeat precheck() call or duplicate Argus call.
+        """
+        runnable = []
+        excluded: list[tuple[str, str]] = []
+        results: dict[str, tuple[str | None, bool, str]] = {}  # class name -> (skip_reason, is_error, tb)
+        start_time = time.time()
+        precheck_node = self.cluster.nodes[0]
+        for nemesis in self.disruptions_list:
+            name = nemesis.__class__.__name__
+            if name in results:
+                skip_reason, is_error, captured_tb = results[name]
+                if skip_reason is None:
+                    runnable.append(nemesis)
+                continue
+            try:
+                skip_reason = nemesis.precheck(node=precheck_node)
+                is_error = False
+                captured_tb = ""
+            except Exception as e:  # noqa: BLE001
+                skip_reason = str(e)
+                captured_tb = traceback.format_exc()
+                is_error = True
+            results[name] = (skip_reason, is_error, captured_tb)
+            if skip_reason is None:
+                runnable.append(nemesis)
+                continue
+            self.log.warning("Nemesis %s excluded by precheck: %s", name, skip_reason)
+            excluded.append((name, skip_reason))
+            with (
+                DisruptionEvent(nemesis_name=name, node=None, publish_event=True) as event,
+                self.argus_submit(
+                    nemesis_name=name,
+                    start_time=start_time,
+                    nemesis_event=event,
+                    description=nemesis.__class__.__doc__,
+                    node=precheck_node,
+                ),
+            ):
+                if is_error:
+                    event.add_simple_error(skip_reason, captured_tb)
+                else:
+                    event.skip(skip_reason=skip_reason)
+        self.disruptions_list = runnable
+        return excluded
 
     def build_disruptions_by_name(self, disrupt_methods: List[str]):
         """Builds list of available disruptions according to class names"""
@@ -5168,8 +5238,20 @@ class NemesisRunner:
 
     @contextlib.contextmanager
     def argus_submit(
-        self, nemesis_name: str, start_time: int | float, nemesis_event: DisruptionEvent, description: str | None = None
+        self,
+        nemesis_name: str,
+        start_time: int | float,
+        nemesis_event: DisruptionEvent,
+        description: str | None = None,
+        node: "BaseNode | None" = None,
     ):
+        """Submit and finalize a nemesis run in Argus.
+
+        The optional *node* parameter allows callers that have not yet selected a
+        target node (e.g. precheck_nemesis) to pass a representative node
+        explicitly instead of relying on self.target_node.
+        """
+        effective_node = node if node is not None else self.target_node
         argus_client = None
         submitted = False
         try:
@@ -5178,9 +5260,9 @@ class NemesisRunner:
                 name=nemesis_name,
                 class_name=self.get_class_name(),
                 start_time=int(start_time),
-                target_name=self.target_node.name,
-                target_ip=self.target_node.public_ip_address,
-                target_shards=self.target_node.scylla_shards,
+                target_name=effective_node.name,
+                target_ip=effective_node.public_ip_address,
+                target_shards=effective_node.scylla_shards,
                 description=description,
             )
             submitted = True

--- a/sdcm/nemesis/__init__.py
+++ b/sdcm/nemesis/__init__.py
@@ -250,6 +250,29 @@ class NemesisBaseClass(NemesisFlags, ABC):
         super().__init__()
         self.runner: "NemesisRunner" = runner
 
+    def precheck(self, node: BaseNode) -> str | None:
+        """
+        Static feasibility check evaluated ONCE before the nemesis is scheduled.
+
+        Return None  -> nemesis is runnable and kept in the rotation.
+        Return a str -> human-readable skip reason; nemesis is permanently excluded
+                        from the disruption list and will not run during this test.
+
+        Use ONLY for conditions that do not change during the test run:
+          - Test config, backend, or product edition
+            (e.g. cluster.params.get(...), _is_it_on_kubernetes(), node.is_enterprise)
+          - Scylla version, feature flags, or cluster-uniform node attributes
+            (e.g. ComparableScyllaVersion checks, is_tablets_feature_enabled(), node.distro)
+
+        No target node is selected yet — use the provided representative live
+        node for any cluster-wide probes.
+
+        Do NOT check dynamic state (data presence, live node counts, whether a
+        specific target node is busy or alone in its rack) — those belong in
+        disrupt().
+        """
+        return None
+
     @abstractmethod
     def disrupt(self):
         """

--- a/sdcm/nemesis/__init__.py
+++ b/sdcm/nemesis/__init__.py
@@ -96,7 +96,7 @@ from sdcm.sct_events.group_common_events import (
 
 from sdcm.sct_events.loaders import CassandraStressLogEvent, ScyllaBenchEvent
 from sdcm.sct_events.nemesis import DisruptionEvent
-from sdcm.sct_events.system import InfoEvent
+from sdcm.sct_events.system import InfoEvent, TestFrameworkEvent
 from sdcm.utils.aws_kms import AwsKms
 from sdcm.utils import cdc
 from sdcm.utils.adaptive_timeouts import adaptive_timeout, Operations
@@ -434,12 +434,15 @@ class NemesisRunner:
         excluded = self.precheck_nemesis()
         if excluded and not self.disruptions_list:
             reason_list = "; ".join(f"{name}: {reason}" for name, reason in excluded)
-            InfoEvent(
-                message=(
-                    f"All {len(excluded)} selected nemesis were excluded by precheck and will not run. "
-                    f"Reasons: {reason_list}"
-                ),
+            selector_message = f" Selector: {self.nemesis_selector!r}." if self.nemesis_selector else ""
+            TestFrameworkEvent(
+                source=self.__class__.__name__,
                 severity=Severity.CRITICAL,
+                message=(
+                    f"No runnable nemesis remain after precheck. "
+                    f"All {len(excluded)} selected nemesis were excluded before execution.{selector_message} "
+                    f"Exclusions: {reason_list}"
+                ),
             ).publish()
             return
         try:

--- a/sdcm/nemesis/monkey/abort_decommission.py
+++ b/sdcm/nemesis/monkey/abort_decommission.py
@@ -26,6 +26,12 @@ _RECOVERY_TIMEOUT_S = 300
 class AbortDecommissionMonkey(NemesisBaseClass):
     disruptive = True
 
+    def precheck(self, node) -> str | None:
+        # Aborting decommission is only supported with tablets, https://github.com/scylladb/scylladb/pull/24129
+        if not is_tablets_feature_enabled(node):
+            return "Aborting decommission is only supported with tablets."
+        return None
+
     def decommission_target_node(self):
         try:
             with EventsSeverityChangerFilter(
@@ -95,10 +101,6 @@ class AbortDecommissionMonkey(NemesisBaseClass):
             raise UnsupportedNemesis(
                 f"Target node {self.runner.target_node.name} is the only one in rack {self.runner.target_node.rack}, cannot decommission it."
             )
-
-        # Aborting decommission is only supported with tablets, https://github.com/scylladb/scylladb/pull/24129
-        if not is_tablets_feature_enabled(self.runner.target_node):
-            raise UnsupportedNemesis("Aborting decommission is only supported with tablets.")
 
         if not self.runner.cluster.get_non_system_ks_cf_with_tablets_list(db_node=self.runner.target_node):
             raise UnsupportedNemesis("No test tables with tablets found.")

--- a/sdcm/nemesis/monkey/runners.py
+++ b/sdcm/nemesis/monkey/runners.py
@@ -208,7 +208,26 @@ class CategoricalMonkey(NemesisRunner):
 
     def __init__(self, tester_obj, termination_event, dist: dict, *args, default_weight: float = 1, **kwargs):
         super().__init__(tester_obj, termination_event, *args, **kwargs)
-        self.disruption_distribution = self.get_disruption_distribution(dist, default_weight)
+        population, weights = self.get_disruption_distribution(dist, default_weight)
+        self._weight_by_nemesis = dict(zip(population, weights))
+        self.disruptions_list = population
+        self.disruption_distribution = (population, weights)
+
+    def precheck_nemesis(self) -> list[tuple[str, str]]:
+        """Prune infeasible members from disruption_distribution too, via disruptions_list.
+
+        CategoricalMonkey keeps its executable candidates in disruption_distribution rather
+        than disruptions_list, so the base precheck alone would leave infeasible weighted
+        candidates selectable by select_next_nemesis(). Mirroring the population into
+        disruptions_list lets the base pruning run once, then this resyncs the weights to
+        match the survivors.
+        """
+        excluded = super().precheck_nemesis()
+        self.disruption_distribution = (
+            list(self.disruptions_list),
+            [self._weight_by_nemesis[nemesis] for nemesis in self.disruptions_list],
+        )
+        return excluded
 
     def select_next_nemesis(self):
         population, weights = self.disruption_distribution

--- a/skills/writing-nemesis/SKILL.md
+++ b/skills/writing-nemesis/SKILL.md
@@ -92,7 +92,43 @@ class DiskCorruptionMonkey(NemesisBaseClass):
 
 If your nemesis is part of a logical group, create a new module (e.g., `monkey/disk_operations.py`). The auto-discovery will find it.
 
-### Step 2: Implement disruption logic in disrupt()
+### Step 2: Add a `precheck()` for static skip conditions (optional)
+
+If your nemesis should never run on certain backends, configs, or Scylla
+versions, implement `precheck(node)`. It is called **once** before the execution
+loop — before any health checks or target-node selection — so an excluded nemesis
+costs nothing per cycle. The `node` argument is a representative live node for
+static version, feature-flag, and cluster-uniform attribute checks.
+
+```python
+def precheck(self, node) -> str | None:
+    # Static config / backend condition — known before the test starts
+    if not self.runner.cluster.params.get("use_ldap_auth"):
+        return "LDAP not configured"
+
+    # Version / feature flag — uniform across the cluster, checked via a representative node
+    if not node.is_tablets_feature_enabled():
+        return "tablets feature not enabled"
+
+    return None  # runnable — keep in the rotation
+```
+
+**What belongs in `precheck()` vs `disrupt()`:**
+
+| Condition type | Where to check |
+|---|---|
+| Test config / backend / product edition | `precheck()` |
+| Scylla version / feature flags / cluster-uniform node attribute (e.g. OS distro) | `precheck()` |
+| Dynamic state (data presence, live node counts, target-node busy state) | **`disrupt()` only** |
+
+Use the provided `node` for cluster-wide probes — `target_node` is not selected
+yet. A non-`None` return permanently removes the nemesis from the rotation and
+emits one `SKIPPED` Argus row. If every selected nemesis is excluded, one
+`CRITICAL` event is published and the test fails loudly.
+
+See [docs/nemesis.md](../../docs/nemesis.md#step-2-add-a-precheck-for-static-skip-conditions-optional) for a full before/after example.
+
+### Step 3: Implement disruption logic in disrupt()
 
 Write self-contained logic. Access the target node via `self.runner.target_node`:
 
@@ -109,7 +145,7 @@ def disrupt(self):
 
 Do NOT write: `self.runner.disrupt_corrupt_disk()` — that adds to legacy debt.
 
-### Step 3: Configure target node pool (optional)
+### Step 4: Configure target node pool (optional)
 
 By default, nemesis target data nodes. Use decorators to change this:
 
@@ -122,7 +158,7 @@ class MyAllNodesMonkey(NemesisBaseClass):
         ...
 ```
 
-### Step 4: Add CI configuration (optional)
+### Step 5: Add CI configuration (optional)
 
 If your nemesis needs extra YAML configs or Jenkins parameters for CI jobs:
 
@@ -139,7 +175,7 @@ class DiskCorruptionMonkey(NemesisBaseClass):
 
 These are consumed by `NemesisJobGenerator` to create per-nemesis Jenkins pipelines.
 
-### Step 5: Write unit tests
+### Step 6: Write unit tests
 
 Add tests in `unit_tests/nemesis/`. The existing test infrastructure provides reusable fakes and patterns:
 
@@ -225,6 +261,8 @@ All flags are on `NemesisFlags` in `sdcm/nemesis/__init__.py`. Each defaults to 
 - [ ] Class inherits from `NemesisBaseClass`
 - [ ] File is under `sdcm/nemesis/monkey/`
 - [ ] Boolean flags accurately describe the nemesis behavior
+- [ ] Static skip conditions (config, backend, version, feature flags) placed in `precheck()`, not `raise UnsupportedNemesis` in `disrupt()`
+- [ ] Dynamic skip conditions (data presence, live node counts, target-node state) remain in `disrupt()` as `raise UnsupportedNemesis`
 - [ ] Disruption logic is self-contained in `disrupt()` — no `self.runner.disrupt_*()` delegation
 - [ ] Unit tests in `unit_tests/nemesis/` covering disruption logic
 - [ ] No inline imports (SCT convention)

--- a/unit_tests/unit/nemesis/__init__.py
+++ b/unit_tests/unit/nemesis/__init__.py
@@ -58,6 +58,10 @@ class TestBaseClass(ABC):
     def __init__(self, runner):
         self.runner = runner
 
+    def precheck(self, node) -> str | None:
+        """Stub matching NemesisBaseClass.precheck(node) contract; always runnable."""
+        return None
+
     @abstractmethod
     def disrupt(self):
         """Disrupt method"""

--- a/unit_tests/unit/nemesis/execute_nemesis/__init__.py
+++ b/unit_tests/unit/nemesis/execute_nemesis/__init__.py
@@ -17,6 +17,10 @@ class TestExecuteBaseClass(ABC):
     def __init__(self, runner):
         self.runner = runner
 
+    def precheck(self, node) -> str | None:
+        """Stub matching NemesisBaseClass.precheck(node) contract; always runnable."""
+        return None
+
     @abstractmethod
     def disrupt(self):
         """Disrupt method"""
@@ -55,6 +59,26 @@ class VersionNotFoundTestNemesis(TestExecuteBaseClass):
 
     def disrupt(self):
         raise MethodVersionNotFound("Intentional version skip")
+
+
+class PrecheckSkipNemesis(TestExecuteBaseClass):
+    """A nemesis whose precheck() returns a skip reason."""
+
+    def precheck(self, node) -> str | None:
+        return "static condition not met"
+
+    def disrupt(self):
+        print("Disrupting cluster")
+
+
+class PrecheckErrorNemesis(TestExecuteBaseClass):
+    """A nemesis whose precheck() raises an exception."""
+
+    def precheck(self, node) -> str | None:
+        raise RuntimeError("precheck blew up")
+
+    def disrupt(self):
+        print("Disrupting cluster")
 
 
 class TestNemesisRunner(NemesisRunner):

--- a/unit_tests/unit/nemesis/execute_nemesis/test_precheck.py
+++ b/unit_tests/unit/nemesis/execute_nemesis/test_precheck.py
@@ -1,0 +1,373 @@
+"""Tests for NemesisRunner.precheck_nemesis() and its integration with run().
+
+precheck_nemesis() is evaluated once before the execution loop starts. It prunes
+every nemesis whose precheck() returns a reason (or raises) from disruptions_list,
+reports each exclusion via a DisruptionEvent and the Argus nemesis tab
+(submit_nemesis + finalize_nemesis), and returns the list of (name, reason)
+exclusions.  run() emits a single CRITICAL InfoEvent and stops when every selected
+nemesis was pruned.
+
+This is part of the execute-nemesis reporting pattern, hence its home here.
+"""
+
+import re
+import threading
+from unittest.mock import ANY, MagicMock
+
+import pytest
+from argus.common.enums import NemesisStatus
+
+from unit_tests.unit.nemesis.execute_nemesis import (
+    CustomTestNemesis,
+    PrecheckErrorNemesis,
+    PrecheckSkipNemesis,
+    TestNemesisRunner,
+)
+from unit_tests.unit.nemesis.fake_cluster import FakeTester, PARAMS
+
+# Fields that vary with time or identity — excluded from full-dict event assertions.
+_TIMESTAMP_FIELDS = frozenset({"event_id", "event_timestamp", "begin_timestamp", "end_timestamp", "source_timestamp"})
+
+# Expected DisruptionEvent END-phase snapshot for a clean skip reason.
+SKIPPED_EVENT = {
+    "base": "DisruptionEvent",
+    "type": None,
+    "subtype": None,
+    "nemesis_name": "PrecheckSkipNemesis",
+    "node": "None",
+    "full_traceback": "",
+    "log_level": 20,
+    "errors": [],
+    "publish_event": True,
+    "is_skipped": True,
+    "skip_reason": "static condition not met",
+    "severity": "NORMAL",
+    "period_type": "end",
+    "subcontext": [],
+}
+
+# Expected DisruptionEvent END-phase snapshot for a precheck() exception.
+# full_traceback is the real call stack — we store a canonical form here and
+# reduce the actual value to the same form with a single re.sub in the test.
+FAILED_EVENT = {
+    "base": "DisruptionEvent",
+    "type": None,
+    "subtype": None,
+    "nemesis_name": "PrecheckErrorNemesis",
+    "node": "None",
+    "full_traceback": "Traceback...RuntimeError: precheck blew up\n",
+    "log_level": 20,
+    "errors": ["precheck blew up"],
+    "publish_event": True,
+    "is_skipped": False,
+    "skip_reason": "",
+    "severity": "ERROR",
+    "period_type": "end",
+    "subcontext": [],
+}
+
+
+def stable(event: dict) -> dict:
+    """Return the event dict with time-varying fields removed."""
+    return {k: v for k, v in event.items() if k not in _TIMESTAMP_FIELDS}
+
+
+def disruption_end_events(events_fixture) -> list[dict]:
+    """All DisruptionEvent END-phase snapshots (stable fields only)."""
+    return [
+        stable(e)
+        for e in events_fixture.published_events
+        if e.get("base") == "DisruptionEvent" and e.get("period_type") == "end"
+    ]
+
+
+@pytest.fixture()
+def runner(events_function_scope):
+    """A TestNemesisRunner with a fresh FakeEventsDevice per test."""
+    termination_event = threading.Event()
+    tester = FakeTester(params=PARAMS)
+    tester.db_cluster.check_cluster_health = MagicMock()
+    tester.db_cluster.test_config = MagicMock()
+    instance = TestNemesisRunner(tester, termination_event)
+    instance.interval = 0
+    return instance
+
+
+@pytest.fixture()
+def argus_mock(runner):
+    """Wire a MagicMock Argus client into the runner's test_config."""
+    mock = MagicMock()
+    runner.cluster.test_config.argus_client = MagicMock(return_value=mock)
+    return mock
+
+
+# ---------------------------------------------------------------------------
+# Pruning behaviour: disruptions_list is updated in place, excluded returned
+# ---------------------------------------------------------------------------
+
+
+def test_precheck_keeps_runnable_nemesis(runner):
+    """A nemesis whose precheck() returns None stays in disruptions_list."""
+    runner.disruptions_list = [CustomTestNemesis(runner)]
+
+    excluded = runner.precheck_nemesis()
+
+    assert excluded == []
+    assert [n.__class__.__name__ for n in runner.disruptions_list] == ["CustomTestNemesis"]
+
+
+def test_precheck_default_contract_keeps_disruptions_list_unchanged(runner):
+    """Nemesis without precheck overrides keep the same disruption list."""
+    runner.disruptions_list = [CustomTestNemesis(runner), CustomTestNemesis(runner)]
+    before = runner._disruption_list_names
+
+    excluded = runner.precheck_nemesis()
+
+    assert excluded == []
+    assert runner._disruption_list_names == before
+
+
+def test_precheck_receives_representative_node_not_target_node(runner):
+    """precheck() receives the representative cluster node before target selection."""
+    nemesis = CustomTestNemesis(runner)
+    nemesis.precheck = MagicMock(return_value=None)
+    runner.target_node = MagicMock()
+    runner.disruptions_list = [nemesis]
+
+    excluded = runner.precheck_nemesis()
+
+    assert excluded == []
+    nemesis.precheck.assert_called_once_with(node=runner.cluster.nodes[0])
+    assert nemesis.precheck.call_args.kwargs["node"] is not runner.target_node
+
+
+@pytest.mark.parametrize(
+    "nemesis_cls, reason",
+    [
+        pytest.param(PrecheckSkipNemesis, "static condition not met", id="skip"),
+        pytest.param(PrecheckErrorNemesis, "precheck blew up", id="error"),
+    ],
+)
+def test_precheck_excludes_nemesis(runner, nemesis_cls, reason):
+    """A nemesis whose precheck() returns a reason or raises is pruned and returned."""
+    runner.disruptions_list = [nemesis_cls(runner)]
+
+    excluded = runner.precheck_nemesis()
+
+    assert runner.disruptions_list == []
+    assert excluded == [(nemesis_cls.__name__, reason)]
+
+
+def test_precheck_partitions_mixed_list(runner):
+    """Runnable nemesis stay, excluded ones (reason or exception) are pruned."""
+    runner.disruptions_list = [
+        CustomTestNemesis(runner),
+        PrecheckSkipNemesis(runner),
+        PrecheckErrorNemesis(runner),
+    ]
+
+    excluded = runner.precheck_nemesis()
+
+    assert [n.__class__.__name__ for n in runner.disruptions_list] == ["CustomTestNemesis"]
+    assert {name for name, _ in excluded} == {"PrecheckSkipNemesis", "PrecheckErrorNemesis"}
+
+
+# ---------------------------------------------------------------------------
+# Duplicate deduplication (nemesis_multiply_factor > 1)
+# ---------------------------------------------------------------------------
+
+
+def test_duplicate_instances_all_pruned_reported_once(runner, argus_mock, events_function_scope):
+    """When disruptions_list contains N copies of the same excluded class
+    (nemesis_multiply_factor > 1), the Argus report, excluded list, and
+    DisruptionEvent are each emitted exactly once — not N times."""
+    runner.disruptions_list = [PrecheckSkipNemesis(runner)] * 3
+
+    excluded = runner.precheck_nemesis()
+
+    assert runner.disruptions_list == []
+    assert excluded == [("PrecheckSkipNemesis", "static condition not met")]
+    argus_mock.submit_nemesis.assert_called_once()
+    argus_mock.finalize_nemesis.assert_called_once()
+    assert len(disruption_end_events(events_function_scope)) == 1
+
+
+def test_duplicate_mixed_list_all_pruned_reported_once(runner, argus_mock):
+    """Multiple copies of two different excluded classes produce two reports, not more."""
+    runner.disruptions_list = [
+        PrecheckSkipNemesis(runner),
+        PrecheckSkipNemesis(runner),
+        PrecheckErrorNemesis(runner),
+        PrecheckErrorNemesis(runner),
+    ]
+
+    excluded = runner.precheck_nemesis()
+
+    assert runner.disruptions_list == []
+    assert len(excluded) == 2
+    assert {name for name, _ in excluded} == {"PrecheckSkipNemesis", "PrecheckErrorNemesis"}
+    assert argus_mock.submit_nemesis.call_count == 2
+    assert argus_mock.finalize_nemesis.call_count == 2
+
+
+def test_duplicate_instances_with_runnable_are_all_kept(runner):
+    """Multiple copies of a runnable nemesis are ALL kept in disruptions_list."""
+    runner.disruptions_list = [CustomTestNemesis(runner)] * 3
+
+    excluded = runner.precheck_nemesis()
+
+    assert excluded == []
+    assert len(runner.disruptions_list) == 3
+
+
+# ---------------------------------------------------------------------------
+# DisruptionEvent reporting: skip -> SKIPPED/NORMAL, exception -> FAILED/ERROR
+# ---------------------------------------------------------------------------
+
+
+def test_skip_reason_emits_skipped_disruption_event(runner, events_function_scope):
+    """A reason-returning precheck() emits one SKIPPED DisruptionEvent (END phase)
+    with the full expected shape."""
+    runner.disruptions_list = [PrecheckSkipNemesis(runner)]
+
+    runner.precheck_nemesis()
+
+    assert disruption_end_events(events_function_scope) == [SKIPPED_EVENT]
+
+
+def test_exception_emits_failed_disruption_event(runner, events_function_scope):
+    """A precheck() exception emits one FAILED DisruptionEvent (END phase).
+    full_traceback is collapsed to 'Traceback...RuntimeError: <msg>' before
+    comparison so the assertion is precise without encoding absolute paths."""
+    runner.disruptions_list = [PrecheckErrorNemesis(runner)]
+
+    runner.precheck_nemesis()
+
+    end_events = disruption_end_events(events_function_scope)
+    assert len(end_events) == 1
+    event = {
+        **end_events[0],
+        "full_traceback": re.sub(
+            r"Traceback.*?(RuntimeError:)", r"Traceback...\1", end_events[0]["full_traceback"], flags=re.DOTALL
+        ),
+    }
+    assert event == FAILED_EVENT
+
+
+# ---------------------------------------------------------------------------
+# Argus nemesis tab (submit_nemesis + finalize_nemesis)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "nemesis_cls, description, status, message",
+    [
+        pytest.param(
+            PrecheckSkipNemesis,
+            "A nemesis whose precheck() returns a skip reason.",
+            NemesisStatus.SKIPPED,
+            "static condition not met",
+            id="skip",
+        ),
+        pytest.param(
+            PrecheckErrorNemesis,
+            "A nemesis whose precheck() raises an exception.",
+            NemesisStatus.FAILED,
+            ANY,  # full traceback string — asserted in test_exception_emits_failed_disruption_event
+            id="error",
+        ),
+    ],
+)
+def test_exclusion_reports_to_argus(runner, argus_mock, nemesis_cls, description, status, message):
+    """Each pruned nemesis is submitted to and finalized in the Argus nemesis tab,
+    using the representative precheck node and the matching status."""
+    runner.disruptions_list = [nemesis_cls(runner)]
+
+    runner.precheck_nemesis()
+
+    argus_mock.submit_nemesis.assert_called_once_with(
+        name=nemesis_cls.__name__,
+        class_name="TestNemesisRunner",
+        start_time=ANY,
+        target_name="Node1",
+        target_ip="127.0.0.1",
+        target_shards=8,
+        description=description,
+    )
+    argus_mock.finalize_nemesis.assert_called_once_with(
+        name=nemesis_cls.__name__,
+        start_time=ANY,
+        status=status,
+        message=message,
+    )
+    assert (
+        argus_mock.submit_nemesis.call_args.kwargs["start_time"]
+        == argus_mock.finalize_nemesis.call_args.kwargs["start_time"]
+    )
+
+
+def test_two_exclusions_report_both_to_argus(runner, argus_mock):
+    """Two excluded nemesis produce two submit + finalize pairs with the right statuses."""
+    runner.disruptions_list = [PrecheckSkipNemesis(runner), PrecheckErrorNemesis(runner)]
+
+    runner.precheck_nemesis()
+
+    assert argus_mock.submit_nemesis.call_count == 2
+    finalize_by_name = {c.kwargs["name"]: c.kwargs["status"] for c in argus_mock.finalize_nemesis.call_args_list}
+    assert finalize_by_name == {
+        "PrecheckSkipNemesis": NemesisStatus.SKIPPED,
+        "PrecheckErrorNemesis": NemesisStatus.FAILED,
+    }
+
+
+def test_no_exclusion_does_not_touch_argus(runner, argus_mock):
+    """When no nemesis is excluded, Argus is not touched."""
+    runner.disruptions_list = [CustomTestNemesis(runner)]
+
+    runner.precheck_nemesis()
+
+    argus_mock.submit_nemesis.assert_not_called()
+    argus_mock.finalize_nemesis.assert_not_called()
+
+
+def test_exception_argus_message_contains_traceback(runner, argus_mock):
+    """finalize_nemesis for a broken precheck() passes the full traceback as the
+    message, not just the bare exception string — matching the normal FAILED path."""
+    runner.disruptions_list = [PrecheckErrorNemesis(runner)]
+
+    runner.precheck_nemesis()
+
+    message = argus_mock.finalize_nemesis.call_args.kwargs["message"]
+    assert "precheck blew up" in message
+    assert "Traceback" in message
+    assert "precheck" in message
+
+
+# ---------------------------------------------------------------------------
+# run() integration: empty-rotation CRITICAL and clean stop
+# ---------------------------------------------------------------------------
+
+
+def test_run_all_pruned_emits_critical_and_stops(runner, events_function_scope):
+    """When every selected nemesis is pruned, run() publishes one CRITICAL
+    InfoEvent and stops without executing any nemesis."""
+    runner.disruptions_list = [PrecheckSkipNemesis(runner)]
+
+    runner.run(cycles_count=5)
+
+    assert runner.disruptions_list == []
+    critical_events = events_function_scope.get_events_by_category()["CRITICAL"]
+    assert len(critical_events) == 1, f"Expected 1 CRITICAL InfoEvent, got {len(critical_events)}: {critical_events}"
+    assert "PrecheckSkipNemesis" in critical_events[0]
+    assert runner.duration_list == []
+
+
+def test_run_partial_prune_runs_survivors_without_critical(runner, events_function_scope):
+    """A partial prune keeps the runnable nemesis, runs it, and emits no CRITICAL event."""
+    runner.disruptions_list = [PrecheckSkipNemesis(runner), CustomTestNemesis(runner)]
+
+    runner.run(cycles_count=1)
+
+    assert [n.__class__.__name__ for n in runner.disruptions_list] == ["CustomTestNemesis"]
+    assert events_function_scope.get_events_by_category()["CRITICAL"] == []
+    assert len(runner.duration_list) == 1

--- a/unit_tests/unit/nemesis/execute_nemesis/test_precheck.py
+++ b/unit_tests/unit/nemesis/execute_nemesis/test_precheck.py
@@ -4,7 +4,7 @@ precheck_nemesis() is evaluated once before the execution loop starts. It prunes
 every nemesis whose precheck() returns a reason (or raises) from disruptions_list,
 reports each exclusion via a DisruptionEvent and the Argus nemesis tab
 (submit_nemesis + finalize_nemesis), and returns the list of (name, reason)
-exclusions.  run() emits a single CRITICAL InfoEvent and stops when every selected
+exclusions.  run() emits a single CRITICAL TestFrameworkEvent and stops when every selected
 nemesis was pruned.
 
 This is part of the execute-nemesis reporting pattern, hence its home here.
@@ -350,15 +350,23 @@ def test_exception_argus_message_contains_traceback(runner, argus_mock):
 
 def test_run_all_pruned_emits_critical_and_stops(runner, events_function_scope):
     """When every selected nemesis is pruned, run() publishes one CRITICAL
-    InfoEvent and stops without executing any nemesis."""
+    TestFrameworkEvent and stops without executing any nemesis."""
     runner.disruptions_list = [PrecheckSkipNemesis(runner)]
 
     runner.run(cycles_count=5)
 
     assert runner.disruptions_list == []
-    critical_events = events_function_scope.get_events_by_category()["CRITICAL"]
-    assert len(critical_events) == 1, f"Expected 1 CRITICAL InfoEvent, got {len(critical_events)}: {critical_events}"
-    assert "PrecheckSkipNemesis" in critical_events[0]
+    framework_events = [
+        event
+        for event in events_function_scope.published_events
+        if event.get("base") == "TestFrameworkEvent" and event.get("severity") == "CRITICAL"
+    ]
+    assert len(framework_events) == 1, (
+        f"Expected 1 CRITICAL TestFrameworkEvent, got {len(framework_events)}: {framework_events}"
+    )
+    assert framework_events[0]["source"] == "TestNemesisRunner"
+    assert "No runnable nemesis remain after precheck" in framework_events[0]["message"]
+    assert "PrecheckSkipNemesis" in framework_events[0]["message"]
     assert runner.duration_list == []
 
 

--- a/unit_tests/unit/nemesis/execute_nemesis/test_precheck.py
+++ b/unit_tests/unit/nemesis/execute_nemesis/test_precheck.py
@@ -4,7 +4,7 @@ precheck_nemesis() is evaluated once before the execution loop starts. It prunes
 every nemesis whose precheck() returns a reason (or raises) from disruptions_list,
 reports each exclusion via a DisruptionEvent and the Argus nemesis tab
 (submit_nemesis + finalize_nemesis), and returns the list of (name, reason)
-exclusions.  run() emits a single CRITICAL InfoEvent and stops when every selected
+exclusions.  run() emits a single CRITICAL TestFrameworkEvent and stops when every selected
 nemesis was pruned.
 
 This is part of the execute-nemesis reporting pattern, hence its home here.
@@ -374,15 +374,23 @@ def test_exception_argus_message_contains_traceback(runner, argus_mock):
 
 def test_run_all_pruned_emits_critical_and_stops(runner, events_function_scope):
     """When every selected nemesis is pruned, run() publishes one CRITICAL
-    InfoEvent and stops without executing any nemesis."""
+    TestFrameworkEvent and stops without executing any nemesis."""
     runner.disruptions_list = [PrecheckSkipNemesis(runner)]
 
     runner.run(cycles_count=5)
 
     assert runner.disruptions_list == []
-    critical_events = events_function_scope.get_events_by_category()["CRITICAL"]
-    assert len(critical_events) == 1, f"Expected 1 CRITICAL InfoEvent, got {len(critical_events)}: {critical_events}"
-    assert "PrecheckSkipNemesis" in critical_events[0]
+    framework_events = [
+        event
+        for event in events_function_scope.published_events
+        if event.get("base") == "TestFrameworkEvent" and event.get("severity") == "CRITICAL"
+    ]
+    assert len(framework_events) == 1, (
+        f"Expected 1 CRITICAL TestFrameworkEvent, got {len(framework_events)}: {framework_events}"
+    )
+    assert framework_events[0]["source"] == "TestNemesisRunner"
+    assert "No runnable nemesis remain after precheck" in framework_events[0]["message"]
+    assert "PrecheckSkipNemesis" in framework_events[0]["message"]
     assert runner.duration_list == []
 
 

--- a/unit_tests/unit/nemesis/execute_nemesis/test_precheck.py
+++ b/unit_tests/unit/nemesis/execute_nemesis/test_precheck.py
@@ -1,0 +1,397 @@
+"""Tests for NemesisRunner.precheck_nemesis() and its integration with run().
+
+precheck_nemesis() is evaluated once before the execution loop starts. It prunes
+every nemesis whose precheck() returns a reason (or raises) from disruptions_list,
+reports each exclusion via a DisruptionEvent and the Argus nemesis tab
+(submit_nemesis + finalize_nemesis), and returns the list of (name, reason)
+exclusions.  run() emits a single CRITICAL InfoEvent and stops when every selected
+nemesis was pruned.
+
+This is part of the execute-nemesis reporting pattern, hence its home here.
+"""
+
+import re
+import threading
+from unittest.mock import ANY, MagicMock
+
+import pytest
+from argus.common.enums import NemesisStatus
+
+from unit_tests.unit.nemesis.execute_nemesis import (
+    CustomTestNemesis,
+    PrecheckErrorNemesis,
+    PrecheckSkipNemesis,
+    TestNemesisRunner,
+)
+from unit_tests.unit.nemesis.fake_cluster import FakeTester, PARAMS
+
+# Fields that vary with time or identity — excluded from full-dict event assertions.
+_TIMESTAMP_FIELDS = frozenset({"event_id", "event_timestamp", "begin_timestamp", "end_timestamp", "source_timestamp"})
+
+# Expected DisruptionEvent END-phase snapshot for a clean skip reason.
+SKIPPED_EVENT = {
+    "base": "DisruptionEvent",
+    "type": None,
+    "subtype": None,
+    "nemesis_name": "PrecheckSkipNemesis",
+    "node": "None",
+    "full_traceback": "",
+    "log_level": 20,
+    "errors": [],
+    "publish_event": True,
+    "is_skipped": True,
+    "skip_reason": "static condition not met",
+    "severity": "NORMAL",
+    "period_type": "end",
+    "subcontext": [],
+}
+
+# Expected DisruptionEvent END-phase snapshot for a precheck() exception.
+# full_traceback is the real call stack — we store a canonical form here and
+# reduce the actual value to the same form with a single re.sub in the test.
+FAILED_EVENT = {
+    "base": "DisruptionEvent",
+    "type": None,
+    "subtype": None,
+    "nemesis_name": "PrecheckErrorNemesis",
+    "node": "None",
+    "full_traceback": "Traceback...RuntimeError: precheck blew up\n",
+    "log_level": 20,
+    "errors": ["precheck blew up"],
+    "publish_event": True,
+    "is_skipped": False,
+    "skip_reason": "",
+    "severity": "ERROR",
+    "period_type": "end",
+    "subcontext": [],
+}
+
+
+def stable(event: dict) -> dict:
+    """Return the event dict with time-varying fields removed."""
+    return {k: v for k, v in event.items() if k not in _TIMESTAMP_FIELDS}
+
+
+def disruption_end_events(events_fixture) -> list[dict]:
+    """All DisruptionEvent END-phase snapshots (stable fields only)."""
+    return [
+        stable(e)
+        for e in events_fixture.published_events
+        if e.get("base") == "DisruptionEvent" and e.get("period_type") == "end"
+    ]
+
+
+@pytest.fixture()
+def runner(events_function_scope):
+    """A TestNemesisRunner with a fresh FakeEventsDevice per test."""
+    termination_event = threading.Event()
+    tester = FakeTester(params=PARAMS)
+    tester.db_cluster.check_cluster_health = MagicMock()
+    tester.db_cluster.test_config = MagicMock()
+    instance = TestNemesisRunner(tester, termination_event)
+    instance.interval = 0
+    return instance
+
+
+@pytest.fixture()
+def argus_mock(runner):
+    """Wire a MagicMock Argus client into the runner's test_config."""
+    mock = MagicMock()
+    runner.cluster.test_config.argus_client = MagicMock(return_value=mock)
+    return mock
+
+
+# ---------------------------------------------------------------------------
+# Pruning behaviour: disruptions_list is updated in place, excluded returned
+# ---------------------------------------------------------------------------
+
+
+def test_precheck_keeps_runnable_nemesis(runner):
+    """A nemesis whose precheck() returns None stays in disruptions_list."""
+    runner.disruptions_list = [CustomTestNemesis(runner)]
+
+    excluded = runner.precheck_nemesis()
+
+    assert excluded == []
+    assert [n.__class__.__name__ for n in runner.disruptions_list] == ["CustomTestNemesis"]
+
+
+def test_precheck_default_contract_keeps_disruptions_list_unchanged(runner):
+    """Nemesis without precheck overrides keep the same disruption list."""
+    runner.disruptions_list = [CustomTestNemesis(runner), CustomTestNemesis(runner)]
+    before = runner._disruption_list_names
+
+    excluded = runner.precheck_nemesis()
+
+    assert excluded == []
+    assert runner._disruption_list_names == before
+
+
+def test_precheck_receives_representative_node_not_target_node(runner):
+    """precheck() receives the representative cluster node before target selection."""
+    nemesis = CustomTestNemesis(runner)
+    nemesis.precheck = MagicMock(return_value=None)
+    runner.target_node = MagicMock()
+    runner.disruptions_list = [nemesis]
+
+    excluded = runner.precheck_nemesis()
+
+    assert excluded == []
+    nemesis.precheck.assert_called_once_with(node=runner.cluster.nodes[0])
+    assert nemesis.precheck.call_args.kwargs["node"] is not runner.target_node
+
+
+@pytest.mark.parametrize(
+    "nemesis_cls, reason",
+    [
+        pytest.param(PrecheckSkipNemesis, "static condition not met", id="skip"),
+        pytest.param(PrecheckErrorNemesis, "precheck blew up", id="error"),
+    ],
+)
+def test_precheck_excludes_nemesis(runner, nemesis_cls, reason):
+    """A nemesis whose precheck() returns a reason or raises is pruned and returned."""
+    runner.disruptions_list = [nemesis_cls(runner)]
+
+    excluded = runner.precheck_nemesis()
+
+    assert runner.disruptions_list == []
+    assert excluded == [(nemesis_cls.__name__, reason)]
+
+
+def test_precheck_partitions_mixed_list(runner):
+    """Runnable nemesis stay, excluded ones (reason or exception) are pruned."""
+    runner.disruptions_list = [
+        CustomTestNemesis(runner),
+        PrecheckSkipNemesis(runner),
+        PrecheckErrorNemesis(runner),
+    ]
+
+    excluded = runner.precheck_nemesis()
+
+    assert [n.__class__.__name__ for n in runner.disruptions_list] == ["CustomTestNemesis"]
+    assert {name for name, _ in excluded} == {"PrecheckSkipNemesis", "PrecheckErrorNemesis"}
+
+
+# ---------------------------------------------------------------------------
+# Duplicate deduplication (nemesis_multiply_factor > 1)
+# ---------------------------------------------------------------------------
+
+
+def test_duplicate_instances_all_pruned_reported_once(runner, argus_mock, events_function_scope):
+    """When disruptions_list contains N copies of the same excluded class
+    (nemesis_multiply_factor > 1), the Argus report, excluded list, and
+    DisruptionEvent are each emitted exactly once — not N times."""
+    runner.disruptions_list = [PrecheckSkipNemesis(runner)] * 3
+
+    excluded = runner.precheck_nemesis()
+
+    assert runner.disruptions_list == []
+    assert excluded == [("PrecheckSkipNemesis", "static condition not met")]
+    argus_mock.submit_nemesis.assert_called_once()
+    argus_mock.finalize_nemesis.assert_called_once()
+    assert len(disruption_end_events(events_function_scope)) == 1
+
+
+def test_duplicate_mixed_list_all_pruned_reported_once(runner, argus_mock):
+    """Multiple copies of two different excluded classes produce two reports, not more."""
+    runner.disruptions_list = [
+        PrecheckSkipNemesis(runner),
+        PrecheckSkipNemesis(runner),
+        PrecheckErrorNemesis(runner),
+        PrecheckErrorNemesis(runner),
+    ]
+
+    excluded = runner.precheck_nemesis()
+
+    assert runner.disruptions_list == []
+    assert len(excluded) == 2
+    assert {name for name, _ in excluded} == {"PrecheckSkipNemesis", "PrecheckErrorNemesis"}
+    assert argus_mock.submit_nemesis.call_count == 2
+    assert argus_mock.finalize_nemesis.call_count == 2
+
+
+def test_duplicate_instances_with_runnable_are_all_kept(runner):
+    """Multiple copies of a runnable nemesis are ALL kept in disruptions_list."""
+    runner.disruptions_list = [CustomTestNemesis(runner)] * 3
+
+    excluded = runner.precheck_nemesis()
+
+    assert excluded == []
+    assert len(runner.disruptions_list) == 3
+
+
+def test_duplicate_excluded_instances_precheck_called_once(runner):
+    """precheck() itself is invoked once per class, not once per copy."""
+    nemesis = PrecheckSkipNemesis(runner)
+    nemesis.precheck = MagicMock(return_value="static condition not met")
+    runner.disruptions_list = [nemesis, nemesis, nemesis]
+
+    runner.precheck_nemesis()
+
+    nemesis.precheck.assert_called_once()
+
+
+def test_duplicate_runnable_instances_precheck_called_once(runner):
+    """precheck() itself is invoked once per class even when every copy is runnable."""
+    nemesis = CustomTestNemesis(runner)
+    nemesis.precheck = MagicMock(return_value=None)
+    runner.disruptions_list = [nemesis, nemesis, nemesis]
+
+    excluded = runner.precheck_nemesis()
+
+    assert excluded == []
+    assert len(runner.disruptions_list) == 3
+    nemesis.precheck.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# DisruptionEvent reporting: skip -> SKIPPED/NORMAL, exception -> FAILED/ERROR
+# ---------------------------------------------------------------------------
+
+
+def test_skip_reason_emits_skipped_disruption_event(runner, events_function_scope):
+    """A reason-returning precheck() emits one SKIPPED DisruptionEvent (END phase)
+    with the full expected shape."""
+    runner.disruptions_list = [PrecheckSkipNemesis(runner)]
+
+    runner.precheck_nemesis()
+
+    assert disruption_end_events(events_function_scope) == [SKIPPED_EVENT]
+
+
+def test_exception_emits_failed_disruption_event(runner, events_function_scope):
+    """A precheck() exception emits one FAILED DisruptionEvent (END phase).
+    full_traceback is collapsed to 'Traceback...RuntimeError: <msg>' before
+    comparison so the assertion is precise without encoding absolute paths."""
+    runner.disruptions_list = [PrecheckErrorNemesis(runner)]
+
+    runner.precheck_nemesis()
+
+    end_events = disruption_end_events(events_function_scope)
+    assert len(end_events) == 1
+    event = {
+        **end_events[0],
+        "full_traceback": re.sub(
+            r"Traceback.*?(RuntimeError:)", r"Traceback...\1", end_events[0]["full_traceback"], flags=re.DOTALL
+        ),
+    }
+    assert event == FAILED_EVENT
+
+
+# ---------------------------------------------------------------------------
+# Argus nemesis tab (submit_nemesis + finalize_nemesis)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "nemesis_cls, description, status, message",
+    [
+        pytest.param(
+            PrecheckSkipNemesis,
+            "A nemesis whose precheck() returns a skip reason.",
+            NemesisStatus.SKIPPED,
+            "static condition not met",
+            id="skip",
+        ),
+        pytest.param(
+            PrecheckErrorNemesis,
+            "A nemesis whose precheck() raises an exception.",
+            NemesisStatus.FAILED,
+            ANY,  # full traceback string — asserted in test_exception_emits_failed_disruption_event
+            id="error",
+        ),
+    ],
+)
+def test_exclusion_reports_to_argus(runner, argus_mock, nemesis_cls, description, status, message):
+    """Each pruned nemesis is submitted to and finalized in the Argus nemesis tab,
+    using the representative precheck node and the matching status."""
+    runner.disruptions_list = [nemesis_cls(runner)]
+
+    runner.precheck_nemesis()
+
+    argus_mock.submit_nemesis.assert_called_once_with(
+        name=nemesis_cls.__name__,
+        class_name="TestNemesisRunner",
+        start_time=ANY,
+        target_name="Node1",
+        target_ip="127.0.0.1",
+        target_shards=8,
+        description=description,
+    )
+    argus_mock.finalize_nemesis.assert_called_once_with(
+        name=nemesis_cls.__name__,
+        start_time=ANY,
+        status=status,
+        message=message,
+    )
+    assert (
+        argus_mock.submit_nemesis.call_args.kwargs["start_time"]
+        == argus_mock.finalize_nemesis.call_args.kwargs["start_time"]
+    )
+
+
+def test_two_exclusions_report_both_to_argus(runner, argus_mock):
+    """Two excluded nemesis produce two submit + finalize pairs with the right statuses."""
+    runner.disruptions_list = [PrecheckSkipNemesis(runner), PrecheckErrorNemesis(runner)]
+
+    runner.precheck_nemesis()
+
+    assert argus_mock.submit_nemesis.call_count == 2
+    finalize_by_name = {c.kwargs["name"]: c.kwargs["status"] for c in argus_mock.finalize_nemesis.call_args_list}
+    assert finalize_by_name == {
+        "PrecheckSkipNemesis": NemesisStatus.SKIPPED,
+        "PrecheckErrorNemesis": NemesisStatus.FAILED,
+    }
+
+
+def test_no_exclusion_does_not_touch_argus(runner, argus_mock):
+    """When no nemesis is excluded, Argus is not touched."""
+    runner.disruptions_list = [CustomTestNemesis(runner)]
+
+    runner.precheck_nemesis()
+
+    argus_mock.submit_nemesis.assert_not_called()
+    argus_mock.finalize_nemesis.assert_not_called()
+
+
+def test_exception_argus_message_contains_traceback(runner, argus_mock):
+    """finalize_nemesis for a broken precheck() passes the full traceback as the
+    message, not just the bare exception string — matching the normal FAILED path."""
+    runner.disruptions_list = [PrecheckErrorNemesis(runner)]
+
+    runner.precheck_nemesis()
+
+    message = argus_mock.finalize_nemesis.call_args.kwargs["message"]
+    assert "precheck blew up" in message
+    assert "Traceback" in message
+    assert "precheck" in message
+
+
+# ---------------------------------------------------------------------------
+# run() integration: empty-rotation CRITICAL and clean stop
+# ---------------------------------------------------------------------------
+
+
+def test_run_all_pruned_emits_critical_and_stops(runner, events_function_scope):
+    """When every selected nemesis is pruned, run() publishes one CRITICAL
+    InfoEvent and stops without executing any nemesis."""
+    runner.disruptions_list = [PrecheckSkipNemesis(runner)]
+
+    runner.run(cycles_count=5)
+
+    assert runner.disruptions_list == []
+    critical_events = events_function_scope.get_events_by_category()["CRITICAL"]
+    assert len(critical_events) == 1, f"Expected 1 CRITICAL InfoEvent, got {len(critical_events)}: {critical_events}"
+    assert "PrecheckSkipNemesis" in critical_events[0]
+    assert runner.duration_list == []
+
+
+def test_run_partial_prune_runs_survivors_without_critical(runner, events_function_scope):
+    """A partial prune keeps the runnable nemesis, runs it, and emits no CRITICAL event."""
+    runner.disruptions_list = [PrecheckSkipNemesis(runner), CustomTestNemesis(runner)]
+
+    runner.run(cycles_count=1)
+
+    assert [n.__class__.__name__ for n in runner.disruptions_list] == ["CustomTestNemesis"]
+    assert events_function_scope.get_events_by_category()["CRITICAL"] == []
+    assert len(runner.duration_list) == 1

--- a/unit_tests/unit/nemesis/monkey/test_abort_decommission.py
+++ b/unit_tests/unit/nemesis/monkey/test_abort_decommission.py
@@ -217,11 +217,20 @@ def test_disrupt_raises_unsupported_when_single_node_in_rack(runner):
         AbortDecommissionMonkey(runner).disrupt()
 
 
-def test_disrupt_raises_unsupported_when_tablets_not_enabled(runner):
-    """UnsupportedNemesis raised when tablets feature is not enabled."""
+def test_precheck_skips_when_tablets_not_enabled(runner):
+    """precheck() skips when tablets feature is not enabled."""
     with patch(f"{_MODULE}.is_tablets_feature_enabled", return_value=False):
-        with pytest.raises(UnsupportedNemesis, match="only supported with tablets"):
-            AbortDecommissionMonkey(runner).disrupt()
+        assert AbortDecommissionMonkey(runner).precheck(node=runner.cluster.data_nodes[0]) == (
+            "Aborting decommission is only supported with tablets."
+        )
+
+
+def test_precheck_keeps_when_tablets_enabled(runner):
+    """precheck() keeps the nemesis when tablets feature is enabled."""
+    with patch(f"{_MODULE}.is_tablets_feature_enabled", return_value=True) as mock_tablets_enabled:
+        assert AbortDecommissionMonkey(runner).precheck(node=runner.cluster.data_nodes[0]) is None
+
+    mock_tablets_enabled.assert_called_once_with(runner.cluster.data_nodes[0])
 
 
 def test_disrupt_raises_unsupported_when_no_tablet_tables(runner):

--- a/unit_tests/unit/nemesis/monkey/test_categorical_monkey.py
+++ b/unit_tests/unit/nemesis/monkey/test_categorical_monkey.py
@@ -1,0 +1,121 @@
+"""Tests for CategoricalMonkey: weighted disruption selection and precheck() pruning."""
+
+import threading
+from unittest.mock import MagicMock
+
+import pytest
+
+from sdcm.nemesis.monkey.runners import CategoricalMonkey
+from unit_tests.unit.nemesis import TestNemesisClass
+from unit_tests.unit.nemesis.fake_cluster import FakeTester
+
+
+class FakeCategorialMonkey(CategoricalMonkey, TestNemesisClass):
+    """Override CategoricalMonkey with a new disruption tree"""
+
+
+@pytest.fixture()
+def categorical_runner():
+    """A FakeCategorialMonkey wired like a real NemesisRunner for run() integration."""
+    tester = FakeTester()
+    tester.db_cluster.check_cluster_health = MagicMock()
+
+    def build(dist):
+        instance = FakeCategorialMonkey(tester, threading.Event(), dist, default_weight=0)
+        instance.interval = 0
+        return instance
+
+    return build
+
+
+def _member_named(nemesis, name):
+    """Find the disruption_distribution population member with the given class name."""
+    population, _ = nemesis.disruption_distribution
+    return next(member for member in population if member.__class__.__name__ == name)
+
+
+@pytest.mark.parametrize(
+    "dist, output",
+    [
+        ({"CustomNemesisA": 1}, "called test function a\n"),
+        ({"CustomNemesisC": 0.5}, "called test function c\n"),
+        ({"CustomNemesisAD": 1, "CustomNemesisA": 0}, "called test function d\n"),
+    ],
+)
+def test_categorical_monkey_simple(dist, output, capsys):
+    nemesis = FakeCategorialMonkey(FakeTester(), None, dist, default_weight=0)
+    method = nemesis.select_next_nemesis()
+
+    method.disrupt()
+    captured = capsys.readouterr()
+    assert output in captured.out
+
+
+# ---------------------------------------------------------------------------
+# precheck() pruning of disruption_distribution (via disruptions_list)
+# ---------------------------------------------------------------------------
+
+
+def test_categorical_monkey_precheck_prunes_distribution(events_function_scope):
+    """precheck() removes an infeasible member from both population and weights,
+    keeping them zipped, and leaves the runnable member's weight untouched."""
+    nemesis = FakeCategorialMonkey(FakeTester(), None, {"CustomNemesisA": 1, "CustomNemesisC": 2}, default_weight=0)
+    _member_named(nemesis, "CustomNemesisA").precheck = MagicMock(return_value="not feasible")
+
+    excluded = nemesis.precheck_nemesis()
+
+    assert excluded == [("CustomNemesisA", "not feasible")]
+    population, weights = nemesis.disruption_distribution
+    assert [m.__class__.__name__ for m in population] == ["CustomNemesisC"]
+    assert weights == [2.0]
+    assert nemesis.disruptions_list == population
+
+
+def test_categorical_monkey_precheck_all_excluded(events_function_scope):
+    """When every member is excluded, the distribution ends up empty on both sides."""
+    nemesis = FakeCategorialMonkey(FakeTester(), None, {"CustomNemesisA": 1, "CustomNemesisC": 2}, default_weight=0)
+    _member_named(nemesis, "CustomNemesisA").precheck = MagicMock(return_value="not feasible")
+    _member_named(nemesis, "CustomNemesisC").precheck = MagicMock(return_value="also not feasible")
+
+    excluded = nemesis.precheck_nemesis()
+
+    assert {name for name, _ in excluded} == {"CustomNemesisA", "CustomNemesisC"}
+    assert nemesis.disruption_distribution == ([], [])
+    assert nemesis.disruptions_list == []
+
+
+# ---------------------------------------------------------------------------
+# run() integration: empty-rotation CRITICAL applies to CategoricalMonkey too
+# ---------------------------------------------------------------------------
+
+
+def test_categorical_monkey_run_all_pruned_emits_critical_and_stops(categorical_runner, events_function_scope):
+    """run() stops cleanly with a CRITICAL TestFrameworkEvent when precheck empties
+    the whole distribution, instead of select_next_nemesis() hitting its bare assert."""
+    nemesis = categorical_runner({"CustomNemesisA": 1})
+    _member_named(nemesis, "CustomNemesisA").precheck = MagicMock(return_value="not feasible")
+
+    nemesis.run(cycles_count=5)
+
+    assert nemesis.disruption_distribution == ([], [])
+    framework_events = [
+        event
+        for event in events_function_scope.published_events
+        if event.get("base") == "TestFrameworkEvent" and event.get("severity") == "CRITICAL"
+    ]
+    assert len(framework_events) == 1
+    assert "CustomNemesisA" in framework_events[0]["message"]
+
+
+def test_categorical_monkey_run_partial_prune_runs_survivors_without_critical(
+    categorical_runner, events_function_scope, capsys
+):
+    """A partial prune keeps the runnable member selectable and runs it, no CRITICAL event."""
+    nemesis = categorical_runner({"CustomNemesisA": 1, "CustomNemesisC": 1})
+    _member_named(nemesis, "CustomNemesisA").precheck = MagicMock(return_value="not feasible")
+
+    nemesis.run(cycles_count=1)
+
+    population, _ = nemesis.disruption_distribution
+    assert [m.__class__.__name__ for m in population] == ["CustomNemesisC"]
+    assert events_function_scope.get_events_by_category()["CRITICAL"] == []

--- a/unit_tests/unit/nemesis/monkey/test_specific_nemesis.py
+++ b/unit_tests/unit/nemesis/monkey/test_specific_nemesis.py
@@ -9,15 +9,10 @@ from sdcm.cluster_gce import ScyllaGCECluster
 from sdcm.cluster_k8s.eks import EksScyllaPodCluster
 from sdcm.cluster_k8s.gke import GkeScyllaPodCluster
 from sdcm.cluster_k8s.mini_k8s import LocalMinimalScyllaPodCluster
-from sdcm.nemesis.monkey.runners import CategoricalMonkey
 from unit_tests.unit.nemesis.fake_cluster import FakeTester
 from unit_tests.unit.nemesis import TestNemesisClass
 
 LOGGER = logging.getLogger(__name__)
-
-
-class FakeCategorialMonkey(CategoricalMonkey, TestNemesisClass):
-    """Override CategoricalMonkey with a new disruption tree"""
 
 
 @pytest.mark.parametrize(
@@ -42,20 +37,3 @@ def test_is_it_on_kubernetes(parent, result):
     params = {"nemesis_interval": 10, "nemesis_filter_seeds": 1}
     nemesis = TestNemesisClass(FakeTester(db_cluster=FakeClass(), params=params), None)
     assert nemesis._is_it_on_kubernetes() == result
-
-
-@pytest.mark.parametrize(
-    "dist, output",
-    [
-        ({"CustomNemesisA": 1}, "called test function a\n"),
-        ({"CustomNemesisC": 0.5}, "called test function c\n"),
-        ({"CustomNemesisAD": 1, "CustomNemesisA": 0}, "called test function d\n"),
-    ],
-)
-def test_categorical_monkey_simple(dist, output, capsys):
-    nemesis = FakeCategorialMonkey(FakeTester(), None, dist, default_weight=0)
-    method = nemesis.select_next_nemesis()
-
-    method.disrupt()
-    captured = capsys.readouterr()
-    assert output in captured.out


### PR DESCRIPTION
Implement the skip plan docs/plans/nemesis/nemesis-precheck.md. The precheck will be evaluated before execution, nemesis will be removed from the pool and sent as skipped to Argus (maybe we can in the future add a different mark to distinguish them).

Not currently present, but I will migrate some nemesis to use precheck here for verification. Rest is going to be done separately

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] unittests
- [x] integration tests
- [x] Longevity https://argus.scylladb.com/tests/scylla-cluster-tests/24b0f3a1-b5d8-4fac-90cf-c53d75cf61eb
     - With skipped test at the start: https://argus.scylladb.com/tests/scylla-cluster-tests/b339d915-69eb-490e-a410-b42d496a787a/nemesis

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
