### PR TITLE
fix(2TB_high_disk_used_capacity.yaml): Added a supports_high_disk_utilization nemesis selector

### DIFF
--- a/configurations/2TB_high_disk_used_capacity.yaml
+++ b/configurations/2TB_high_disk_used_capacity.yaml
@@ -24,3 +24,4 @@ sizing_db:  # no OCI match (min 16 vCPUs in OCI catalog)
   memory: '>=64'
 
 user_prefix: 'longevity-2tb-high-disk-used'
+nemesis_selector: 'supports_high_disk_utilization'


### PR DESCRIPTION

In order to avoid disk capacity issues for this high-disk-used-capacity configuration, only nemesis having supports_high_disk_utilization should be used. Preious runs encountered disk-usage errors running a nemesis of add-remove-mv, for example.

See a discussion in https://argus.scylladb.com/tests/scylla-cluster-tests/4e40f329-ecc7-4109-93df-a1edf7063719/discuss

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
