### PR TITLE
fix(configuration): Slightly increase adaptive timeout multipliers

### DIFF
--- a/configurations/adaptive_timeout_multipliers.yaml
+++ b/configurations/adaptive_timeout_multipliers.yaml
@@ -1,4 +1,4 @@
 adaptive_timeout_multipliers:
-  decommission: 4
-  new_node: 4
-  remove_node: 4
+  decommission: 5
+  new_node: 5
+  remove_node: 5


### PR DESCRIPTION
Some jobs are still reaching soft and hard limit by a bit.
Example: https://scylladb.atlassian.net/browse/SCT-392?focusedCommentId=68921

Fixes https://scylladb.atlassian.net/browse/SCT-392

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
