### PR TITLE
fix(s3-uploader): parse du output by tab delimiter instead of G suffix

### DIFF
--- a/sdcm/utils/s3_remote_uploader.py
+++ b/sdcm/utils/s3_remote_uploader.py
@@ -69,7 +69,8 @@ def upload_remote_files_directly_to_s3(
         if not out:
             raise FileNotFoundError(f"Could not get the size of {files}. Possibly it does not exist.")
         total = out.split(b"\n")[-2]
-        return int(total.split(b"G")[0].decode())
+        size_str = total.split(b"\t")[0].decode().rstrip("G")
+        return int(size_str)
 
     LOGGER.info("Uploading %s directly to S3 bucket %s with key %s", files, s3_bucket, s3_key)
     extra_args = {}


### PR DESCRIPTION
Some du implementations (e.g. BusyBox) output size without the G suffix when using -BG flag, producing '1\ttotal' instead of '1G\ttotal'. Split by tab character which is the universal du output delimiter, then strip any trailing G suffix if present.

Fixes: SCT-445

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
