### PR TITLE
fix(renovate): scylla-doctor custom datasource parsing

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -33,7 +33,10 @@
   "customDatasources": {
     "scylla-doctor": {
       "defaultRegistryUrlTemplate": "https://s3.amazonaws.com/downloads.scylladb.com?prefix=downloads/scylla-doctor/tar/&delimiter=/",
-      "format": "plain"
+      "format": "plain",
+      "transformTemplates": [
+        "{ \"releases\": releases[$contains(version, \"scylla-doctor-\") and $contains(version, \".tar.gz\")].{ \"version\": $match(version, /scylla-doctor-([0-9.]+)\\.tar\\.gz/).groups[0] } }"
+      ]
     }
   },
   "customManagers": [
@@ -48,7 +51,6 @@
       ],
       "depNameTemplate": "scylla-doctor",
       "datasourceTemplate": "custom.scylla-doctor",
-      "extractVersionTemplate": "scylla-doctor-(?<version>[\\d.]+)\\.tar\\.gz",
       "versioningTemplate": "semver-coerced"
     }
   ],


### PR DESCRIPTION
The S3 bucket at downloads.scylladb.com returns XML, which Renovate does not natively support. Using the `plain` format alone is insufficient without a transformation step to strip the XML tags.

This commit adds a JSONata `transformTemplates` to the `scylla-doctor` custom datasource. It filters the plain-text tokenized XML for the correct release keys and uses a regex to extract the raw version numbers.

Additionally, `extractVersionTemplate` is removed from the custom manager. Because the datasource now yields clean version strings (e.g., "1.11.1") directly, the manager no longer needs to parse the ".tar.gz" suffix.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
