### PR TITLE
fix(renovate): schema validation error in scylla-doctor datasource

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -35,7 +35,7 @@
       "defaultRegistryUrlTemplate": "https://s3.amazonaws.com/downloads.scylladb.com?prefix=downloads/scylla-doctor/tar/&delimiter=/",
       "format": "plain",
       "transformTemplates": [
-        "{ \"releases\": releases[$contains(version, \"scylla-doctor-\") and $contains(version, \".tar.gz\")].{ \"version\": $match(version, /scylla-doctor-([0-9.]+)\\.tar\\.gz/).groups[0] } }"
+        "{ \"releases\": [ releases[$contains(version, /scylla-doctor-[0-9.]+\\.tar\\.gz/)].{ \"version\": $match(version, /scylla-doctor-([0-9.]+)\\.tar\\.gz/).groups[0] } ] }"
       ]
     }
   },


### PR DESCRIPTION
When the JSONata expression in the custom datasource matched exactly one release, it implicitly unwrapped the result and returned a single object instead of an array. This caused Renovate to fail with a Zod schema validation error: "Invalid input: expected array, received object".

This commit fixes the issue by wrapping the JSONata logic in square brackets `[ ... ]` to guarantee that an array is always returned, satisfying Renovate's strict schema requirements. It also tightens the `$contains` filter to use a regular expression, ensuring only valid scylla-doctor release archives are processed.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
