### PR TITLE
fix(renovate): version string validation for scylla-doctor datasource

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -35,7 +35,7 @@
       "defaultRegistryUrlTemplate": "https://s3.amazonaws.com/downloads.scylladb.com?prefix=downloads/scylla-doctor/tar/&delimiter=/",
       "format": "plain",
       "transformTemplates": [
-        "{ \"releases\": [ releases[$contains(version, /scylla-doctor-[0-9.]+\\.tar\\.gz/)].{ \"version\": $match(version, /scylla-doctor-([0-9.]+)\\.tar\\.gz/).groups[0] } ] }"
+        "{ \"releases\": [ releases[$contains(version, /scylla-doctor-[0-9.]+\\.tar\\.gz/)].{ \"version\": $string($match(version, /scylla-doctor-([0-9.]+)\\.tar\\.gz/).groups[0]) } ] }"
       ]
     }
   },


### PR DESCRIPTION
Renovate's strict Zod schema expects the extracted release version to be a plain string. However, the JSONata `$match(...).groups[0]` expression evaluated the result as a sequence/array, causing the validation to fail with the error: "Invalid input: expected string, received array".

This commit fixes the issue by wrapping the regex extraction in JSONata's `$string()` function. This safely casts the extracted regex group into a flat string, satisfying Renovate's schema requirements and allowing the custom datasource to successfully process the S3 XML payload.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
