### PR TITLE
feature(provision/aws): region fallback on capacity exhaustion

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -231,6 +231,8 @@ pre_filter_unavailable_availability_zones: true
 
 pre_flight_capacity_probe: false
 
+fallback_to_next_region: false
+
 enable_argus: true
 argus_use_ssh_tunnel: true
 

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -4227,6 +4227,15 @@ Before provisioning, probe capacity by launching and terminating one on-demand i
 **type:** bool
 
 
+## **fallback_to_next_region** / SCT_FALLBACK_TO_NEXT_REGION
+
+On capacity errors, after all AZs in the configured region are exhausted, relocate the entire cluster to the next eligible region (should be VPC-peered with the runner region with infra-prepared and AMI available). Only applies during initial setup, to single region tests. AWS-only.
+
+**default:** False
+
+**type:** bool
+
+
 ## **num_nodes_to_rollback** / SCT_NUM_NODES_TO_ROLLBACK
 
 Number of nodes to upgrade and rollback in test_generic_cluster_upgrade

--- a/sct.py
+++ b/sct.py
@@ -348,7 +348,7 @@ def provision_resources(backend, test_name: str, config: str):
         click.echo("Generate SCT agent API key")
         test_config.generate_and_save_agent_api_key()
 
-    original_region = params.region_names[0] if params.region_names else None
+    original_region = " ".join(params.region_names) if params.region_names else None
     handoff_test_id = params.get("reuse_cluster") or test_id
 
     click.echo(f"Provision {backend} cloud resources")
@@ -358,8 +358,9 @@ def provision_resources(backend, test_name: str, config: str):
             test_config.persist_resolved_placement_if_changed(
                 handoff_test_id,
                 original_region=original_region,
-                region_name=params.region_names[0] if params.region_names else None,
+                region_name=" ".join(params.region_names) if params.region_names else None,
                 availability_zone=params.get("availability_zone"),
+                amis={key: params.get(key) for key in params.ami_id_params if params.get(key)},
             )
         elif backend in ("azure", "gce", "oci"):
             if backend == "gce":
@@ -380,8 +381,9 @@ def provision_resources(backend, test_name: str, config: str):
                     test_config.persist_resolved_placement_if_changed(
                         handoff_test_id,
                         original_region=original_region,
-                        region_name=params.region_names[0] if params.region_names else None,
+                        region_name=" ".join(params.region_names) if params.region_names else None,
                         availability_zone=params.get("availability_zone"),
+                        amis={key: params.get(key) for key in params.ami_id_params if params.get(key)},
                     )
                 finally:
                     params.update({"cluster_backend": original_backend})

--- a/sct.py
+++ b/sct.py
@@ -348,11 +348,19 @@ def provision_resources(backend, test_name: str, config: str):
         click.echo("Generate SCT agent API key")
         test_config.generate_and_save_agent_api_key()
 
+    original_region = params.region_names[0] if params.region_names else None
+    handoff_test_id = params.get("reuse_cluster") or test_id
+
     click.echo(f"Provision {backend} cloud resources")
     try:
         if backend == "aws":
-            layout = SCTProvisionLayout(params=params)
-            layout.provision()
+            SCTProvisionLayout(params=params).provision()
+            test_config.persist_resolved_placement_if_changed(
+                handoff_test_id,
+                original_region=original_region,
+                region_name=params.region_names[0] if params.region_names else None,
+                availability_zone=params.get("availability_zone"),
+            )
         elif backend in ("azure", "gce", "oci"):
             if backend == "gce":
                 from sdcm.provision.gce.zone_resolver import GceAZResolver  # noqa: PLC0415
@@ -369,6 +377,12 @@ def provision_resources(backend, test_name: str, config: str):
                 params.update({"cluster_backend": "aws"})
                 try:
                     SCTProvisionLayout(params=params).provision()
+                    test_config.persist_resolved_placement_if_changed(
+                        handoff_test_id,
+                        original_region=original_region,
+                        region_name=params.region_names[0] if params.region_names else None,
+                        availability_zone=params.get("availability_zone"),
+                    )
                 finally:
                     params.update({"cluster_backend": original_backend})
         else:

--- a/sdcm/provision/aws/az_resolver.py
+++ b/sdcm/provision/aws/az_resolver.py
@@ -260,6 +260,45 @@ class AZResolver:
             candidates.append((region, letters[:cardinality]))
         return candidates
 
+    def get_dc_fallback_candidates(self, dc_index: int) -> list[tuple[str, list[str]]]:
+        """Collect ordered ``(region, az_letters)`` candidates to relocate the DC at ``dc_index``."""
+        region_names = self._region_names()
+        if dc_index >= len(region_names):
+            return []
+
+        in_use_regions = set(region_names)
+        staying_regions = [region for index, region in enumerate(region_names) if index != dc_index]
+        configured_letters = self._configured_az_letters()
+        required_az_count = len(configured_letters) or 1
+        instance_types = [instance_type for instance_type in [self._params.get("instance_type_db")] if instance_type]
+
+        candidates = []
+        for region in AWS_SUPPORTED_REGIONS:
+            if region in in_use_regions:
+                continue
+            if not all(self._is_region_peered(staying, region) for staying in staying_regions):
+                LOGGER.info(
+                    "Region fallback (DC %d): skipping %s (no active VPC peering with all staying DCs %s)",
+                    dc_index,
+                    region,
+                    staying_regions,
+                )
+                continue
+
+            supported_letters = self._common_supported_letters([region], configured_letters, instance_types)
+            if len(supported_letters) < required_az_count:
+                LOGGER.info(
+                    "Region fallback (DC %d): skipping %s (only %d AZ letter(s) support %s, need %d)",
+                    dc_index,
+                    region,
+                    len(supported_letters),
+                    instance_types,
+                    required_az_count,
+                )
+                continue
+            candidates.append((region, supported_letters[:required_az_count]))
+        return candidates
+
     @staticmethod
     def _is_region_peered(current_region: str, candidate_region: str) -> bool:
         """Return True only when an ACTIVE VPC peering exists between the two regions."""

--- a/sdcm/provision/aws/az_resolver.py
+++ b/sdcm/provision/aws/az_resolver.py
@@ -18,7 +18,9 @@ import boto3
 from botocore.exceptions import ClientError
 
 from sdcm.provision.aws.capacity_errors import ProvisioningCapacityExhausted, is_capacity_error
+from sdcm.sct_config import AWS_SUPPORTED_REGIONS
 from sdcm.test_config import TestConfig
+from sdcm.utils.aws_peering import AwsVpcPeering
 from sdcm.utils.aws_region import AwsRegion
 
 LOGGER = logging.getLogger(__name__)
@@ -100,6 +102,11 @@ def is_az_fallback_enabled(params) -> bool:
     if (value := params.get("fallback_to_next_availability_zone")) is not None:
         return bool(value)
     return bool(params.get("aws_fallback_to_next_availability_zone"))
+
+
+def is_region_fallback_enabled(params) -> bool:
+    """Return True when whole-cluster region fallback on capacity errors is enabled."""
+    return bool(params.get("fallback_to_next_region")) and params.get("cluster_backend") == "aws"
 
 
 class AZResolver:
@@ -216,6 +223,54 @@ class AZResolver:
                     seen.add(tuple(candidate))
 
         return candidates
+
+    def get_region_fallback_candidates(self) -> list[tuple[str, list[str]]]:
+        """Collects ordered ``(region, az_letters)`` candidates for cluster region fallback.
+
+        A region is eligible only if it is:
+            - VPC-peered with the runner region
+            - able to supply the configured number of AZs that support the required instance types.
+        The current region is excluded (as the starting point).
+        """
+        region_names = self._region_names()
+        if not region_names:
+            return []
+        current_region = region_names[0]
+        configured_letters = self._configured_az_letters()
+        cardinality = len(configured_letters) or 1
+        instance_types = self.required_instance_types()
+
+        candidates = []
+        for region in AWS_SUPPORTED_REGIONS:
+            if region == current_region:
+                continue
+            if not self._is_region_peered(current_region, region):
+                LOGGER.info("Region fallback: skipping %s (no active VPC peering with %s)", region, current_region)
+                continue
+            letters = self._common_supported_letters([region], configured_letters, instance_types)
+            if len(letters) < cardinality:
+                LOGGER.info(
+                    "Region fallback: skipping %s (only %d AZ letter(s) support %s, need %d)",
+                    region,
+                    len(letters),
+                    instance_types,
+                    cardinality,
+                )
+                continue
+            candidates.append((region, letters[:cardinality]))
+        return candidates
+
+    @staticmethod
+    def _is_region_peered(current_region: str, candidate_region: str) -> bool:
+        """Return True only when an ACTIVE VPC peering exists between the two regions."""
+        try:
+            peering, _ = AwsVpcPeering._find_existing_peering(
+                AwsRegion(region_name=current_region), AwsRegion(region_name=candidate_region)
+            )
+        except Exception as exc:  # noqa: BLE001
+            LOGGER.warning("Region fallback: peering check %s<->%s failed: %s", current_region, candidate_region, exc)
+            return False
+        return peering is not None and peering.get("Status", {}).get("Code") == "active"
 
     def _supported_az_letters(self) -> list[str]:
         """Return AZ letters supported in EVERY configured region for the required types.

--- a/sdcm/provision/aws/capacity_errors.py
+++ b/sdcm/provision/aws/capacity_errors.py
@@ -33,6 +33,17 @@ def is_capacity_error(exception: BaseException) -> bool:
     return bool(codes & set(CAPACITY_ERROR_CODES))
 
 
+def attach_failed_region(exception: BaseException, region: str | None, az: str | None = None) -> None:
+    """Tag an exception with failed region/AZ info for fallback handling."""
+    exception.failed_region = region
+    exception.failed_az = az
+
+
+def get_failed_region(exception: BaseException) -> str | None:
+    """Return the region a capacity error was tagged with, or None when untagged."""
+    return getattr(exception, "failed_region", None)
+
+
 class ProvisioningCapacityExhausted(Exception):
     """Raised when a provision plan exits with no instances, signalling capacity exhaustion.
 

--- a/sdcm/provision/aws/capacity_errors.py
+++ b/sdcm/provision/aws/capacity_errors.py
@@ -41,3 +41,8 @@ class ProvisioningCapacityExhausted(Exception):
     raises this exception in that case so the AZ-fallback layer can treat it the same
     as an on-demand capacity ``ClientError``.
     """
+
+
+class RegionAMINotFoundError(Exception):
+    """Raised when no equivalent AMI exists in a target region, making that region ineligible
+    for AWS region fallback."""

--- a/sdcm/provision/aws/region_fallback.py
+++ b/sdcm/provision/aws/region_fallback.py
@@ -21,8 +21,10 @@ region when region capacity is exhausted. This module shares their common placem
 import os
 from collections.abc import Callable
 
+from sdcm.provision.aws.capacity_errors import RegionAMINotFoundError
 from sdcm.provision.aws.capacity_reservation import SCTCapacityReservation
 from sdcm.provision.aws.utils import cleanup_abandoned_region
+from sdcm.utils.common import convert_name_to_ami_if_needed, find_equivalent_ami
 
 
 def enforce_single_region_gate(params) -> None:
@@ -31,6 +33,15 @@ def enforce_single_region_gate(params) -> None:
         raise ValueError(
             f"fallback_to_next_region requires a single configured region (got {params.region_names}); "
             "region fallback does not support multi-DC."
+        )
+
+
+def enforce_multi_dc_fallback_supported(params) -> None:
+    """Reject multi-DC fallback when region-scoped reservations are enabled."""
+    if params.get("use_capacity_reservation") or params.get("use_dedicated_host"):
+        raise ValueError(
+            "fallback_to_next_region with multiple regions does not support use_capacity_reservation "
+            "or use_dedicated_host (both are region-scoped); disable them or use a single region."
         )
 
 
@@ -51,6 +62,85 @@ def switch_region(
 
     invalidate_caches()
     SCTCapacityReservation.reservations = {}
+
+
+def remap_dc_ami(params, dc_index: int, source_region: str, target_region: str) -> None:
+    """Remap the relocated DC's AMI in each AMI parameter from source to target region."""
+    region_count = len(params.region_names)
+    intent = getattr(params, "_ami_params_snapshot", None) or {}
+    pending: dict[str, str] = {}
+    for key in params.ami_id_params:
+        value = params.get(key)
+        if not value:
+            continue
+
+        amis = value.split()
+        if len(amis) not in (1, region_count):
+            raise ValueError(
+                f"{key} has {len(amis)} AMI(s) but the config has {region_count} region(s); "
+                "cannot positionally remap it for region fallback"
+            )
+
+        if dc_index >= len(amis):
+            continue
+
+        amis[dc_index] = _resolve_relocated_ami(
+            key=key,
+            original_intent=intent.get(key),
+            current_ami=amis[dc_index],
+            dc_index=dc_index,
+            region_count=region_count,
+            source_region=source_region,
+            target_region=target_region,
+        )
+        pending[key] = " ".join(amis)
+
+    for key, new_value in pending.items():
+        params[key] = new_value
+
+
+def _resolve_relocated_ami(
+    *, key, original_intent, current_ami, dc_index, region_count, source_region, target_region
+) -> str:
+    """Resolve one AMI param for the relocated DC in ``target_region``."""
+    error_suffix = f"(from {source_region}) in {target_region}; region ineligible for fallback"
+
+    def _raise_not_found(value: str) -> None:
+        raise RegionAMINotFoundError(f"No equivalent AMI for {key}={value} {error_suffix}")
+
+    tokens = (original_intent or "").split()
+    use_name = bool(tokens and not tokens[0].startswith("ami-"))
+
+    if use_name:
+        name = tokens[dc_index] if len(tokens) == region_count else tokens[0]
+        try:
+            resolved = convert_name_to_ami_if_needed(name, (target_region,)).split()
+        except ValueError as exc:
+            raise RegionAMINotFoundError(f"No equivalent AMI for {key}={name} {error_suffix}") from exc
+
+        if not resolved or not resolved[0].startswith("ami-"):
+            _raise_not_found(name)
+        return resolved[0]
+
+    matches = find_equivalent_ami(current_ami, source_region, target_regions=[target_region])
+    if not matches:
+        _raise_not_found(current_ami)
+    return matches[0]["ami_id"]
+
+
+def switch_dc_region(
+    params, dc_index: int, region: str, source_region: str, invalidate_caches: Callable[[], None]
+) -> None:
+    """Relocate one DC to the target region and refresh region-derived state."""
+    remap_dc_ami(params, dc_index, source_region=source_region, target_region=region)
+
+    region_names = list(params.region_names)
+    region_names[dc_index] = region
+    joined = " ".join(region_names)
+    os.environ["SCT_REGION_NAME"] = joined
+    params["region_name"] = joined
+
+    invalidate_caches()
 
 
 def restore_region(params, region: str | None, availability_zone: str, env_region: str | None) -> None:

--- a/sdcm/provision/aws/region_fallback.py
+++ b/sdcm/provision/aws/region_fallback.py
@@ -1,0 +1,72 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2026 ScyllaDB
+
+"""Shared helpers for AWS region fallback.
+
+Both the modern provisioning path (`sct_provision.aws.layout.SCTProvisionAWSLayout`) and the
+legacy tester path (`tester.ClusterTester.get_cluster_aws`) relocate the full cluster to another
+region when region capacity is exhausted. This module shares their common placement and cleanup logic.
+"""
+
+import os
+from collections.abc import Callable
+
+from sdcm.provision.aws.capacity_reservation import SCTCapacityReservation
+from sdcm.provision.aws.utils import cleanup_abandoned_region
+
+
+def enforce_single_region_gate(params) -> None:
+    """Require exactly one configured region for region fallback."""
+    if len(params.region_names) != 1:
+        raise ValueError(
+            f"fallback_to_next_region requires a single configured region (got {params.region_names}); "
+            "region fallback does not support multi-DC."
+        )
+
+
+def switch_region(
+    params, region: str, az_letters: list[str], source_region: str | None, invalidate_caches: Callable[[], None]
+) -> None:
+    """Switch to a target region and refresh region-bound state.
+
+    AMIs are re-resolved before any region state changes - if resolution fails,
+    the caller stays pinned to the source region with no partial state applied.
+    """
+    params.resolve_amis([region], source_region=source_region)
+
+    # region_names is env-first, so env. var is to be updated as well
+    os.environ["SCT_REGION_NAME"] = region
+    params["region_name"] = region
+    params["availability_zone"] = ",".join(az_letters)
+
+    invalidate_caches()
+    SCTCapacityReservation.reservations = {}
+
+
+def restore_region(params, region: str | None, availability_zone: str, env_region: str | None) -> None:
+    """Restore original region and AZ values after a failed relocation."""
+    if env_region is None:
+        os.environ.pop("SCT_REGION_NAME", None)
+    else:
+        os.environ["SCT_REGION_NAME"] = env_region
+
+    if region is not None:
+        params["region_name"] = region
+    params["availability_zone"] = availability_zone
+
+
+def cleanup_region(test_id: str, region: str | None, partial_cleanup: Callable[[], None]) -> None:
+    """Clean up abandoned resources in the old region."""
+    partial_cleanup()
+    if region:
+        cleanup_abandoned_region(test_id, region)

--- a/sdcm/provision/aws/utils.py
+++ b/sdcm/provision/aws/utils.py
@@ -38,6 +38,7 @@ from mypy_boto3_ec2.type_defs import (
     TagSpecificationTypeDef,
 )
 
+from sdcm.provision.aws.capacity_reservation import SCTCapacityReservation
 from sdcm.provision.aws.constants import (
     SPOT_REQUEST_TIMEOUT,
     SPOT_REQUEST_WAITING_TIME,
@@ -48,6 +49,7 @@ from sdcm.provision.aws.constants import (
     SPOT_CAPACITY_NOT_AVAILABLE_ERROR,
 )
 from sdcm.provision.common.provisioner import TagsType
+from sdcm.utils.common import aws_tags_to_dict, list_instances_aws
 
 
 LOGGER = logging.getLogger(__name__)
@@ -414,3 +416,40 @@ def create_cluster_placement_groups_aws(name: str, tags: dict, region=None, dry_
         ],
     )
     return result
+
+
+def cleanup_abandoned_region(test_id: str, region: str) -> None:
+    """Cleanup for a region abandoned by region fallback.
+
+    Cancels capacity reservations for `test_id` across all regions and
+    terminates stale instances tagged with `test_id` in `region`.
+    """
+    if not test_id:
+        return
+
+    try:
+        SCTCapacityReservation.cancel_all_regions(test_id)
+    except Exception as exc:  # noqa: BLE001
+        LOGGER.warning("Abandoned-region belt: failed to cancel capacity reservations for %s: %s", test_id, exc)
+
+    try:
+        instances = list_instances_aws(tags_dict={"TestId": test_id}, region_name=region, group_as_region=True).get(
+            region, []
+        )
+        instance_ids = [
+            inst["InstanceId"]
+            for inst in instances
+            if aws_tags_to_dict(inst.get("Tags")).get("NodeType") != "sct-runner"
+        ]
+
+        if not instance_ids:
+            return
+        LOGGER.info(
+            "Abandoned-region belt: terminating %d stray instance(s) in %s: %s",
+            len(instance_ids),
+            region,
+            instance_ids,
+        )
+        ec2_clients[region].terminate_instances(InstanceIds=instance_ids)
+    except Exception as exc:  # noqa: BLE001
+        LOGGER.warning("Abandoned-region belt: failed to terminate stray instances in %s: %s", region, exc)

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -3283,23 +3283,29 @@ class SCTConfiguration(BaseModel):
         if not placement:
             return
 
-        original_region = self.region_names[0] if self.region_names else None
+        original_region_list = " ".join(self.region_names) if self.region_names else None
+        original_first_region = self.region_names[0] if self.region_names else None
         region_name = placement.get("region_name")
         availability_zone = placement.get("availability_zone")
+        amis = placement.get("amis")
         if region_name:
             os.environ["SCT_REGION_NAME"] = region_name
             self["region_name"] = region_name
-            if original_region and region_name != original_region:
-                self._resolved_placement_source_region = original_region
+            if amis:
+                for key, value in amis.items():
+                    self[key] = value
+            elif original_region_list and region_name != original_region_list:
+                self._resolved_placement_source_region = original_first_region
         if availability_zone:
             os.environ["SCT_AVAILABILITY_ZONE"] = availability_zone
             self["availability_zone"] = availability_zone
 
         self.log.info(
-            "Applied resolved placement for test_id=%s: region_name=%s availability_zone=%s",
+            "Applied resolved placement for test_id=%s: region_name=%s availability_zone=%s amis=%s",
             test_id,
             region_name,
             availability_zone,
+            bool(amis),
         )
 
     def resolve_amis(self, region_names: List[str], source_region: str | None = None) -> None:

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -47,6 +47,7 @@ from sdcm.cloud_api_client import ScyllaCloudAPIClient, CloudProviderType
 from sdcm.keystore import KeyStore
 from sdcm.utils.cloud_api_utils import get_cloud_rest_credentials_from_file
 from sdcm.provision.aws.capacity_reservation import SCTCapacityReservation
+from sdcm.provision.aws.capacity_errors import RegionAMINotFoundError
 from sdcm.provision.aws.dedicated_host import SCTDedicatedHosts
 from sdcm.utils import alternator
 from sdcm.utils.aws_utils import get_arch_from_instance_type, aws_check_instance_type_supported
@@ -58,6 +59,7 @@ from sdcm.utils.common import (
     get_scylla_ami_versions,
     get_scylla_gce_images_versions,
     convert_name_to_ami_if_needed,
+    find_equivalent_ami,
     get_sct_root_path,
     get_vector_store_ami_versions,
 )
@@ -2143,6 +2145,11 @@ class SCTConfiguration(BaseModel):
         "(`instance_type_db_target`, `nemesis_grow_shrink_instance_type`) in the chosen AZ. On capacity errors, raise to "
         "trigger AZ/region fallback. Costs ~1 min per type. AWS-only.",
     )
+    fallback_to_next_region: Boolean = SctField(
+        description="On capacity errors, after all AZs in the configured region are exhausted, relocate the entire cluster "
+        "to the next eligible region (should be VPC-peered with the runner region with infra-prepared and AMI available). "
+        "Only applies during initial setup, to single region tests. AWS-only.",
+    )
     num_nodes_to_rollback: int = SctField(
         description="Number of nodes to upgrade and rollback in test_generic_cluster_upgrade",
     )
@@ -2768,6 +2775,12 @@ class SCTConfiguration(BaseModel):
         add_severity_limit_rules(self.get("max_events_severities"))
         print_critical_events()
 
+        self._apply_resolved_placement()
+
+        # snapshot the original AMI params before resolution, so AWS region fallback can
+        # re-resolve them for a relocated region
+        self._ami_params_snapshot = {key: self.get(key) for key in self.ami_id_params}
+
         # 5) overwrite AMIs
         for key in self.ami_id_params:
             if param := self.get(key):
@@ -3051,6 +3064,10 @@ class SCTConfiguration(BaseModel):
                     ami_list.append(ami)
                 self["ami_id_vector_store"] = " ".join(ami.image_id for ami in ami_list)
 
+        # 6.3) if a region-fallback relocated the cluster, re-resolve region-bound AWS AMIs for the new region
+        if self._resolved_placement_source_region:
+            self.resolve_amis(self.region_names, source_region=self._resolved_placement_source_region)
+
         # 7) support lookup of repos for upgrade test
         new_scylla_version = self.get("new_version")
         if new_scylla_version and not "k8s" in cluster_backend:
@@ -3242,6 +3259,83 @@ class SCTConfiguration(BaseModel):
 
         self.log.debug("Total nodes: %s", total_nodes)
         return total_nodes
+
+    def _apply_resolved_placement(self) -> None:
+        """Apply region/AZ selected in a previous provisioning step.
+
+        Provisioning and test execution can run in separate `hydra` invocations, so a region selected
+        by the 'region fallback' procedure at provisioning can be lost when config is reloaded during
+        test execution.
+        The provisioner writes the selected region to a test_id-keyed file, and this method applies
+        it in the loaded config.
+
+        The behavior can be disabled with `SCT_IGNORE_RESOLVED_PLACEMENT`.
+        """
+        self._resolved_placement_source_region = None
+        if os.environ.get("SCT_IGNORE_RESOLVED_PLACEMENT"):
+            return
+
+        test_id = self.get("reuse_cluster") or self.get("test_id")
+        if not test_id or test_id == "None":
+            return
+
+        placement = TestConfig.read_resolved_placement(test_id)
+        if not placement:
+            return
+
+        original_region = self.region_names[0] if self.region_names else None
+        region_name = placement.get("region_name")
+        availability_zone = placement.get("availability_zone")
+        if region_name:
+            os.environ["SCT_REGION_NAME"] = region_name
+            self["region_name"] = region_name
+            if original_region and region_name != original_region:
+                self._resolved_placement_source_region = original_region
+        if availability_zone:
+            os.environ["SCT_AVAILABILITY_ZONE"] = availability_zone
+            self["availability_zone"] = availability_zone
+
+        self.log.info(
+            "Applied resolved placement for test_id=%s: region_name=%s availability_zone=%s",
+            test_id,
+            region_name,
+            availability_zone,
+        )
+
+    def resolve_amis(self, region_names: List[str], source_region: str | None = None) -> None:
+        """Re-resolve region-bound AWS AMI IDs for the given regions `region_names`."""
+        if self.get("cluster_backend") != "aws":
+            return
+
+        target_regions = list(region_names)
+        intent = getattr(self, "_ami_params_snapshot", None) or {}
+        for key in self.ami_id_params:
+            original = intent.get(key)
+            current = self.get(key)
+            if original and not original.split()[0].startswith("ami-"):
+                self[key] = convert_name_to_ami_if_needed(original, tuple(target_regions))
+            elif current and source_region:
+                self[key] = self._remap_amis_to_regions(current, source_region, target_regions, key)
+
+        if getattr(self, "target_db_image_ids", None) and source_region:
+            self.target_db_image_ids = [
+                self._remap_amis_to_regions(ami, source_region, target_regions, "instance_type_db_target")
+                for ami in self.target_db_image_ids
+            ]
+
+    @staticmethod
+    def _remap_amis_to_regions(value: str, source_region: str, region_names: List[str], key: str) -> str:
+        """Remap AMI IDs from `source_region` into each target region."""
+        remapped = []
+        for region in region_names:
+            for ami_id in value.split():
+                matches = find_equivalent_ami(ami_id, source_region, target_regions=[region])
+                if not matches:
+                    raise RegionAMINotFoundError(
+                        f"No equivalent AMI for {key}={ami_id} (from {source_region}) in {region}; region ineligible for fallback"
+                    )
+                remapped.append(matches[0]["ami_id"])
+        return " ".join(remapped)
 
     @property
     def region_names(self) -> List[str]:

--- a/sdcm/sct_provision/aws/cluster.py
+++ b/sdcm/sct_provision/aws/cluster.py
@@ -15,9 +15,10 @@ import abc
 from functools import cached_property
 from typing import List, Tuple
 
+from botocore.exceptions import ClientError
 from pydantic import BaseModel, ConfigDict, PrivateAttr, computed_field
 from sdcm import cluster
-from sdcm.provision.aws.capacity_errors import ProvisioningCapacityExhausted
+from sdcm.provision.aws.capacity_errors import ProvisioningCapacityExhausted, attach_failed_region
 from sdcm.provision.aws.instance_parameters import AWSInstanceParams
 from sdcm.provision.aws.provisioner import AWSInstanceProvisioner
 from sdcm.provision.common.provision_plan import ProvisionPlan
@@ -83,7 +84,7 @@ class ClusterBase(BaseModel):
     def nodes(self) -> list[ClusterNode]:
         nodes = []
         node_num = 0
-        for region_id in range(len(self._regions_with_nodes)):
+        for region_id in self._active_region_ids:
             for idx in range(self._node_nums[region_id]):
                 node_num += 1
                 nodes.append(
@@ -166,14 +167,14 @@ class ClusterBase(BaseModel):
         return self.params.region_names
 
     @cached_property
-    def _regions_with_nodes(self) -> List[str]:
-        output = []
-        for region_id, region_name in enumerate(self.params.region_names):
-            if len(self._node_nums) <= region_id:
-                continue
-            if self._node_nums[region_id] > 0:
-                output.append(region_name)
-        return output
+    def _active_region_ids(self) -> List[int]:
+        """Positional indices of regions that host at least one node (zero-node DCs are skipped)."""
+        node_nums = self._node_nums
+        return [
+            region_id
+            for region_id in range(len(self.params.region_names))
+            if region_id < len(node_nums) and node_nums[region_id] > 0
+        ]
 
     def _region(self, region_id: int) -> str:
         return self.params.region_names[region_id]
@@ -223,10 +224,26 @@ class ClusterBase(BaseModel):
             **params_builder.model_dump(exclude_none=True, exclude_unset=True, exclude_defaults=True)
         )
 
+    def _provision_az_instances(self, region_id, az_id, instance_parameters, node_tags, node_names, node_count):
+        """Provision one (region, az) batch and tag capacity errors with region/AZ for fallback."""
+        try:
+            instances = self.provision_plan(region_id, self._azs[az_id]).provision_instances(
+                instance_parameters=instance_parameters,
+                node_tags=node_tags,
+                node_names=node_names,
+                node_count=node_count,
+            )
+            if not instances:
+                raise ProvisioningCapacityExhausted("End of provision plan reached, but no instances provisioned")
+        except (ClientError, ProvisioningCapacityExhausted) as exc:
+            attach_failed_region(exc, self._region(region_id), self._azs[az_id])
+            raise
+        return instances
+
     def provision(self):
         if self._node_nums == [0]:
             return []
-        for region_id in range(len(self._regions_with_nodes)):
+        for region_id in self._active_region_ids:
             az_nodes = self._az_nodes(region_id=region_id)
             for az_id, _ in enumerate(self._azs):
                 node_count = az_nodes[az_id]
@@ -235,14 +252,9 @@ class ClusterBase(BaseModel):
                 instance_parameters = self._instance_parameters(region_id=region_id, availability_zone=az_id)
                 node_tags = self._node_tags(region_id=region_id, az_id=az_id)
                 node_names = self._node_names(region_id=region_id, az_id=az_id)
-                instances = self.provision_plan(region_id, self._azs[az_id]).provision_instances(
-                    instance_parameters=instance_parameters,
-                    node_tags=node_tags,
-                    node_names=node_names,
-                    node_count=node_count,
+                instances = self._provision_az_instances(
+                    region_id, az_id, instance_parameters, node_tags, node_names, node_count
                 )
-                if not instances:
-                    raise ProvisioningCapacityExhausted("End of provision plan reached, but no instances provisioned")
                 self._provisioned_instances.extend(instances)
         return list(self._provisioned_instances)
 
@@ -337,10 +349,13 @@ class DBCluster(ClusterBase):
             total_nodes = [n1 + n2 for n1, n2 in zip(total_nodes, zero_token_nodes)]
         return total_nodes
 
-    def provision(self):
+    def provision(self, skip_region_ids: set[int] | None = None):
         if self._node_nums == [0]:
             return []
-        for region_id in range(len(self._regions_with_nodes)):
+        skip_region_ids = skip_region_ids or set()
+        for region_id in self._active_region_ids:
+            if region_id in skip_region_ids:
+                continue
             az_nodes, az_zero_nodes = self._az_nodes(region_id=region_id)
             for az_id, _ in enumerate(self._azs):
                 node_count = az_nodes[az_id]
@@ -349,16 +364,9 @@ class DBCluster(ClusterBase):
                     instance_parameters = self._instance_parameters(region_id=region_id, availability_zone=az_id)
                     node_tags = self._node_tags(region_id=region_id, az_id=az_id)[:node_count]
                     node_names = self._node_names(region_id=region_id, az_id=az_id)[:node_count]
-                    instances = self.provision_plan(region_id, self._azs[az_id]).provision_instances(
-                        instance_parameters=instance_parameters,
-                        node_tags=node_tags,
-                        node_names=node_names,
-                        node_count=node_count,
+                    instances = self._provision_az_instances(
+                        region_id, az_id, instance_parameters, node_tags, node_names, node_count
                     )
-                    if not instances:
-                        raise ProvisioningCapacityExhausted(
-                            "End of provision plan reached, but no instances provisioned"
-                        )
                     self._provisioned_instances.extend(instances)
 
                 if zero_node_count:
@@ -369,16 +377,9 @@ class DBCluster(ClusterBase):
                     for node_tag in node_tags:
                         node_tag.update({"ZeroTokenNode": "True"})
                     node_names = self._node_names(region_id=region_id, az_id=az_id)[node_count:]
-                    instances = self.provision_plan(region_id, self._azs[az_id]).provision_instances(
-                        instance_parameters=instance_parameters,
-                        node_tags=node_tags,
-                        node_names=node_names,
-                        node_count=zero_node_count,
+                    instances = self._provision_az_instances(
+                        region_id, az_id, instance_parameters, node_tags, node_names, zero_node_count
                     )
-                    if not instances:
-                        raise ProvisioningCapacityExhausted(
-                            "End of provision plan reached, but no instances provisioned"
-                        )
                     self._provisioned_instances.extend(instances)
         return list(self._provisioned_instances)
 

--- a/sdcm/sct_provision/aws/layout.py
+++ b/sdcm/sct_provision/aws/layout.py
@@ -12,14 +12,27 @@
 # Copyright (c) 2021 ScyllaDB
 
 import logging
+import os
 from functools import cached_property
 
 from botocore.exceptions import ClientError
 
-from sdcm.provision.aws.az_resolver import AZResolver, is_az_fallback_enabled, run_pre_flight_capacity_probe
-from sdcm.provision.aws.capacity_errors import ProvisioningCapacityExhausted, is_capacity_error
+from sdcm.exceptions import CapacityReservationError
+from sdcm.provision.aws.az_resolver import (
+    AZResolver,
+    is_az_fallback_enabled,
+    is_region_fallback_enabled,
+    run_pre_flight_capacity_probe,
+)
+from sdcm.provision.aws.capacity_errors import ProvisioningCapacityExhausted, RegionAMINotFoundError, is_capacity_error
 from sdcm.provision.aws.capacity_reservation import SCTCapacityReservation
 from sdcm.provision.aws.dedicated_host import SCTDedicatedHosts
+from sdcm.provision.aws.region_fallback import (
+    cleanup_region,
+    enforce_single_region_gate,
+    restore_region,
+    switch_region,
+)
 from sdcm.provision.aws.utils import ec2_clients
 from sdcm.sct_provision.aws.cluster import OracleDBCluster, DBCluster, LoaderCluster, MonitoringCluster, PlacementGroup
 from sdcm.sct_provision.common.layout import SCTProvisionLayout
@@ -43,6 +56,13 @@ class SCTProvisionAWSLayout(SCTProvisionLayout, cluster_backend="aws"):
         return TestConfig()
 
     def provision(self):
+        if is_region_fallback_enabled(self._params):
+            self._provision_with_region_fallback()
+            return
+        self._provision_once()
+
+    def _provision_once(self) -> None:
+        """Provision the whole cluster in the configured region, with AZ fallback. (No region fallback.)"""
         AZResolver(self._params).resolve()
 
         # capacity reservation handles its own AZ fallback internally
@@ -59,6 +79,13 @@ class SCTProvisionAWSLayout(SCTProvisionLayout, cluster_backend="aws"):
             self._do_provision()
             return
 
+        region_exhausted, last_error = self._provision_az_loop(candidates)
+        if region_exhausted:
+            tried = ", ".join("+".join(c) for c in candidates)
+            raise RuntimeError(f"Provisioning failed in all {len(candidates)} AZ candidate(s): {tried}") from last_error
+
+    def _provision_az_loop(self, candidates: list[list[str]]) -> tuple[bool, Exception | None]:
+        """Try each AZ candidate in the current region."""
         original_az = self._params.get("availability_zone")
         last_error: Exception | None = None
         for attempt_idx, candidate in enumerate(candidates):
@@ -75,7 +102,7 @@ class SCTProvisionAWSLayout(SCTProvisionLayout, cluster_backend="aws"):
 
             try:
                 self._do_provision()
-                return
+                return False, last_error
             except (ClientError, ProvisioningCapacityExhausted) as exc:
                 # ClientError is the on-demand path (raised by ec2.create_instances);
                 # ProvisioningCapacityExhausted is the spot path.
@@ -88,8 +115,105 @@ class SCTProvisionAWSLayout(SCTProvisionLayout, cluster_backend="aws"):
                 self._cleanup_partial_provision()
 
         self._params["availability_zone"] = original_az
-        tried = ", ".join("+".join(c) for c in candidates)
-        raise RuntimeError(f"Provisioning failed in all {len(candidates)} AZ candidate(s): {tried}") from last_error
+        return True, last_error
+
+    def _attempt_region(self) -> tuple[bool, Exception | None]:
+        """Provision the whole cluster in the currently-configured region."""
+        AZResolver(self._params).resolve()
+
+        if SCTCapacityReservation.is_capacity_reservation_enabled(self._params):
+            try:
+                self._do_provision()
+                return False, None
+            except (CapacityReservationError, ProvisioningCapacityExhausted) as exc:
+                return True, exc
+            except ClientError as exc:
+                if is_capacity_error(exc):
+                    return True, exc
+                raise
+
+        if not is_az_fallback_enabled(self._params):
+            return self._provision_capacity_aware()
+
+        candidates = AZResolver(self._params).get_fallback_candidates()
+        if not candidates:
+            return self._provision_capacity_aware()
+
+        return self._provision_az_loop(candidates)
+
+    def _provision_capacity_aware(self) -> tuple[bool, Exception | None]:
+        """Provision once; report capacity errors as region exhaustion and re-raise any other error."""
+        try:
+            self._do_provision()
+        except (ClientError, ProvisioningCapacityExhausted) as exc:
+            if isinstance(exc, ClientError) and not is_capacity_error(exc):
+                raise
+            return True, exc
+        return False, None
+
+    def _provision_with_region_fallback(self) -> None:
+        """Provision in the current region, then relocate to fallback regions on capacity exhaustion.
+
+        On success, keeps `os.environ["SCT_REGION_NAME"]` set to the resolved region.
+        On failure, restores the original region/AZ in both env and params before raising.
+        """
+        self._enforce_single_region_gate()
+
+        original_region = self._params.region_names[0] if self._params.region_names else None
+        original_az = self._params.get("availability_zone")
+        original_env_region = os.environ.get("SCT_REGION_NAME")
+
+        source_region = original_region
+        region_candidates = AZResolver(self._params).get_region_fallback_candidates()
+        last_error: Exception | None = None
+
+        for attempt_idx, candidate in enumerate([None, *region_candidates]):
+            if attempt_idx > 0:
+                target_region, az_letters = candidate
+                LOGGER.warning(
+                    "Region '%s' exhausted; relocating whole cluster to '%s' (region attempt %d/%d)",
+                    source_region,
+                    target_region,
+                    attempt_idx + 1,
+                    len(region_candidates) + 1,
+                )
+                try:
+                    self._switch_region(target_region, az_letters, source_region)
+                except RegionAMINotFoundError as exc:
+                    last_error = exc
+                    LOGGER.warning("Region '%s' ineligible (no equivalent AMI): %s", target_region, exc)
+                    continue
+                source_region = target_region
+
+            try:
+                region_exhausted, attempt_error = self._attempt_region()
+            except Exception:
+                self._restore_region(original_region, original_az, original_env_region)
+                raise
+
+            if not region_exhausted:
+                return
+
+            last_error = attempt_error or last_error
+            self._cleanup_region(source_region)
+
+        self._restore_region(original_region, original_az, original_env_region)
+        tried = ", ".join(region for region, _ in region_candidates) or "(no eligible candidates)"
+        raise RuntimeError(
+            f"Provisioning failed in region '{original_region}' and all fallback candidates [{tried}]"
+        ) from last_error
+
+    def _enforce_single_region_gate(self) -> None:
+        enforce_single_region_gate(self._params)
+
+    def _switch_region(self, region: str, az_letters: list[str], source_region: str | None) -> None:
+        switch_region(self._params, region, az_letters, source_region, invalidate_caches=self._clear_cluster_caches)
+
+    def _restore_region(self, region: str | None, availability_zone: str, env_region: str | None) -> None:
+        restore_region(self._params, region, availability_zone, env_region)
+
+    def _cleanup_region(self, region: str | None) -> None:
+        cleanup_region(self._test_config.test_id(), region, partial_cleanup=self._cleanup_partial_provision)
 
     def _do_provision(self):
         use_scylla_cloud = self._params.get("cluster_backend") == "xcloud" or self._params.get("xcloud_provider")

--- a/sdcm/sct_provision/aws/layout.py
+++ b/sdcm/sct_provision/aws/layout.py
@@ -24,16 +24,23 @@ from sdcm.provision.aws.az_resolver import (
     is_region_fallback_enabled,
     run_pre_flight_capacity_probe,
 )
-from sdcm.provision.aws.capacity_errors import ProvisioningCapacityExhausted, RegionAMINotFoundError, is_capacity_error
+from sdcm.provision.aws.capacity_errors import (
+    ProvisioningCapacityExhausted,
+    RegionAMINotFoundError,
+    get_failed_region,
+    is_capacity_error,
+)
 from sdcm.provision.aws.capacity_reservation import SCTCapacityReservation
 from sdcm.provision.aws.dedicated_host import SCTDedicatedHosts
 from sdcm.provision.aws.region_fallback import (
     cleanup_region,
+    enforce_multi_dc_fallback_supported,
     enforce_single_region_gate,
     restore_region,
+    switch_dc_region,
     switch_region,
 )
-from sdcm.provision.aws.utils import ec2_clients
+from sdcm.provision.aws.utils import cleanup_abandoned_region, ec2_clients
 from sdcm.sct_provision.aws.cluster import OracleDBCluster, DBCluster, LoaderCluster, MonitoringCluster, PlacementGroup
 from sdcm.sct_provision.common.layout import SCTProvisionLayout
 from sdcm.test_config import TestConfig
@@ -57,7 +64,10 @@ class SCTProvisionAWSLayout(SCTProvisionLayout, cluster_backend="aws"):
 
     def provision(self):
         if is_region_fallback_enabled(self._params):
-            self._provision_with_region_fallback()
+            if len(self._params.region_names) > 1:
+                self._provision_with_multi_dc_fallback()
+            else:
+                self._provision_with_region_fallback()
             return
         self._provision_once()
 
@@ -214,6 +224,144 @@ class SCTProvisionAWSLayout(SCTProvisionLayout, cluster_backend="aws"):
 
     def _cleanup_region(self, region: str | None) -> None:
         cleanup_region(self._test_config.test_id(), region, partial_cleanup=self._cleanup_partial_provision)
+
+    def _provision_with_multi_dc_fallback(self) -> None:
+        """Provision a multi-region cluster, relocating DB DCs on capacity exhaustion."""
+        enforce_multi_dc_fallback_supported(self._params)
+
+        if is_az_fallback_enabled(self._params):
+            LOGGER.info(
+                "Multi-DC fallback: availability_zone is global, so a DC that exhausts capacity is relocated "
+                "to another region rather than retried in a different AZ within the same region."
+            )
+
+        original_region_names = list(self._params.region_names)
+        original_az = self._params.get("availability_zone")
+        original_env_region = os.environ.get("SCT_REGION_NAME")
+
+        try:
+            AZResolver(self._params).resolve()
+            run_pre_flight_capacity_probe(self._params)
+
+            if self.placement_group:
+                self.placement_group.provision()
+
+            self._provision_db_with_dc_fallback()
+
+            for cluster in (self.monitoring_cluster, self.loader_cluster, self.cs_db_cluster):
+                if cluster:
+                    cluster.provision()
+        except Exception:
+            self._restore_region_names(original_region_names, original_az, original_env_region)
+            raise
+
+    def _provision_db_with_dc_fallback(self) -> None:
+        """Provision the DB cluster across DCs, relocating any DC that exhausts capacity."""
+        if not self.db_cluster:
+            return
+
+        tried_by_dc = {}
+        while True:
+            try:
+                self.db_cluster.provision(skip_region_ids=self._completed_db_region_ids())
+                return
+            except (ClientError, ProvisioningCapacityExhausted) as exc:
+                if isinstance(exc, ClientError) and not is_capacity_error(exc):
+                    raise
+                self._relocate_failed_db_dc(exc, tried_by_dc)
+
+    def _relocate_failed_db_dc(self, exc: Exception, tried_by_dc: dict[int, set[str]]) -> None:
+        """Relocate the DC whose DB provisioning exhausted to its next eligible region, or give up."""
+        region_names = list(self._params.region_names)
+        failed_region = get_failed_region(exc)
+        if failed_region is None or failed_region not in region_names:
+            raise exc
+
+        dc_index = region_names.index(failed_region)
+        self._cleanup_dc_region(failed_region)
+        tried = tried_by_dc.setdefault(dc_index, set())
+        tried.add(failed_region)
+
+        candidates = [
+            region for region, _ in AZResolver(self._params).get_dc_fallback_candidates(dc_index) if region not in tried
+        ]
+        for target in candidates:
+            tried.add(target)
+            try:
+                self._switch_dc_region(dc_index, target, source_region=failed_region)
+                LOGGER.warning("DB DC '%s' (index %d) exhausted; relocated to '%s'", failed_region, dc_index, target)
+                return
+            except RegionAMINotFoundError as ami_exc:
+                LOGGER.warning("Region '%s' ineligible for DC %d (no equivalent AMI): %s", target, dc_index, ami_exc)
+
+        raise RuntimeError(
+            f"DB DC '{failed_region}' (index {dc_index}) exhausted; no eligible fallback region "
+            f"(tried: {sorted(tried)})"
+        ) from exc
+
+    def _completed_db_region_ids(self) -> set[int]:
+        """Region indices whose DB instances are already provisioned, so a retry skips them."""
+        region_names = list(self._params.region_names)
+        done: set[int] = set()
+        for instance in getattr(self.db_cluster, "_provisioned_instances", None) or []:
+            region = self._instance_region(instance)
+            if region in region_names:
+                done.add(region_names.index(region))
+
+        return done
+
+    def _cleanup_dc_region(self, region: str) -> None:
+        """Terminate one region's partial instances across cached clusters, drop them from tracking, then sweep."""
+        for prop in _CLUSTER_CACHED_PROPS:
+            cluster_obj = self.__dict__.get(prop)
+            provisioned = getattr(cluster_obj, "_provisioned_instances", None) if cluster_obj is not None else None
+            if not provisioned:
+                continue
+
+            instance_ids = []
+            for inst in provisioned:
+                if self._instance_region(inst) != region:
+                    continue
+                instance_id = getattr(inst, "instance_id", None) or getattr(inst, "id", None)
+                if instance_id:
+                    instance_ids.append(instance_id)
+
+            if instance_ids:
+                LOGGER.info(
+                    "Terminating %d partial instance(s) in abandoned DC %s: %s", len(instance_ids), region, instance_ids
+                )
+                try:
+                    ec2_clients[region].terminate_instances(InstanceIds=instance_ids)
+                except Exception as exc:  # noqa: BLE001
+                    LOGGER.warning("Failed to terminate instances in %s: %s", region, exc)
+
+            provisioned[:] = [inst for inst in provisioned if self._instance_region(inst) != region]
+
+        cleanup_abandoned_region(self._test_config.test_id(), region)
+
+    def _switch_dc_region(self, dc_index: int, region: str, source_region: str) -> None:
+        switch_dc_region(
+            self._params, dc_index, region, source_region, invalidate_caches=self._invalidate_region_derived_caches
+        )
+
+    def _invalidate_region_derived_caches(self) -> None:
+        """Drop region-name-derived caches on the retained cluster objects, preserving _provisioned_instances."""
+        for prop in _CLUSTER_CACHED_PROPS:
+            cluster_obj = self.__dict__.get(prop)
+            if cluster_obj is None:
+                continue
+            for cached in ("_active_region_ids", "_azs", "_node_nums"):
+                cluster_obj.__dict__.pop(cached, None)
+
+    def _restore_region_names(self, region_names: list[str], availability_zone, env_region: str | None) -> None:
+        """Restore the original multi-region placement after a failed relocation."""
+        if env_region is None:
+            os.environ.pop("SCT_REGION_NAME", None)
+        else:
+            os.environ["SCT_REGION_NAME"] = env_region
+
+        self._params["region_name"] = " ".join(region_names)
+        self._params["availability_zone"] = availability_zone
 
     def _do_provision(self):
         use_scylla_cloud = self._params.get("cluster_backend") == "xcloud" or self._params.get("xcloud_provider")

--- a/sdcm/test_config.py
+++ b/sdcm/test_config.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Optional, Dict, TYPE_CHECKING
 from unittest.mock import MagicMock
 
+import yaml
 from argus.client.sct.client import ArgusSCTClient
 
 
@@ -59,6 +60,7 @@ class TestConfig(metaclass=Singleton):
     LDAP_ADDRESS = None
     LDAP_USERS_ON_SCYLLA: bool = False
     DECODING_QUEUE = None
+    RESOLVED_PLACEMENT_FILENAME = "resolved_placement.yaml"
 
     _test_id = None
     _test_name = None
@@ -153,6 +155,71 @@ class TestConfig(metaclass=Singleton):
             cls._logdir = cls.make_new_logdir(update_latest_symlink=True)
             os.environ["_SCT_TEST_LOGDIR"] = cls._logdir
         return cls._logdir
+
+    @classmethod
+    def resolved_placement_file_path(cls, test_id: str) -> str:
+        """Return the file path for resolved placement of the given test id."""
+        return os.path.join(cls.base_logdir(), f"{test_id}", cls.RESOLVED_PLACEMENT_FILENAME)
+
+    @classmethod
+    def write_resolved_placement(cls, test_id: str, region_name: str, availability_zone: str) -> str:
+        """Save the resolved region/AZ placement."""
+        file_path = cls.resolved_placement_file_path(test_id)
+        os.makedirs(os.path.dirname(file_path), exist_ok=True)
+
+        payload = {
+            "test_id": f"{test_id}",
+            "region_name": region_name,
+            "availability_zone": availability_zone,
+        }
+        with open(file_path, "w", encoding="utf-8") as handle:
+            yaml.safe_dump(payload, handle)
+        LOGGER.info("Wrote resolved placement handoff to %s: %s", file_path, payload)
+
+        return file_path
+
+    @classmethod
+    def read_resolved_placement(cls, test_id: str) -> Optional[Dict[str, str]]:
+        """Read resolved placement for a test id."""
+        file_path = cls.resolved_placement_file_path(test_id)
+        if not os.path.exists(file_path):
+            return None
+
+        try:
+            with open(file_path, encoding="utf-8") as handle:
+                data = yaml.safe_load(handle)
+        except (OSError, yaml.YAMLError) as exc:
+            LOGGER.warning("Failed to read resolved placement handoff %s: %s", file_path, exc)
+            return None
+
+        test_id_value = data.get("test_id") if isinstance(data, dict) else data
+        if not isinstance(data, dict) or str(test_id_value) != str(test_id):
+            LOGGER.warning(
+                "Ignoring resolved placement handoff %s: test_id guard failed (got %s, expected %s)",
+                file_path,
+                test_id_value,
+                test_id,
+            )
+            return None
+        return data
+
+    @classmethod
+    def persist_resolved_placement_if_changed(
+        cls, test_id: str, original_region: Optional[str], region_name: Optional[str], availability_zone: Optional[str]
+    ) -> None:
+        """Save the resolved placement only when the cluster was relocated to a different region."""
+        if region_name and original_region and region_name != original_region:
+            cls.write_resolved_placement(test_id, region_name=region_name, availability_zone=availability_zone)
+
+    @classmethod
+    def delete_resolved_placement(cls, test_id: str) -> None:
+        """Remove the resolved placement file after test completion."""
+        try:
+            file_path = cls.resolved_placement_file_path(test_id)
+            os.remove(file_path)
+        except FileNotFoundError:
+            return
+        LOGGER.info("Deleted resolved placement handoff %s", file_path)
 
     @classmethod
     def latency_results_file(cls):

--- a/sdcm/test_config.py
+++ b/sdcm/test_config.py
@@ -162,8 +162,10 @@ class TestConfig(metaclass=Singleton):
         return os.path.join(cls.base_logdir(), f"{test_id}", cls.RESOLVED_PLACEMENT_FILENAME)
 
     @classmethod
-    def write_resolved_placement(cls, test_id: str, region_name: str, availability_zone: str) -> str:
-        """Save the resolved region/AZ placement."""
+    def write_resolved_placement(
+        cls, test_id: str, region_name: str, availability_zone: str, amis: Optional[Dict[str, str]] = None
+    ) -> str:
+        """Save the resolved region/AZ placement (and resolved AMIs, when provided)."""
         file_path = cls.resolved_placement_file_path(test_id)
         os.makedirs(os.path.dirname(file_path), exist_ok=True)
 
@@ -172,6 +174,8 @@ class TestConfig(metaclass=Singleton):
             "region_name": region_name,
             "availability_zone": availability_zone,
         }
+        if amis:
+            payload["amis"] = amis
         with open(file_path, "w", encoding="utf-8") as handle:
             yaml.safe_dump(payload, handle)
         LOGGER.info("Wrote resolved placement handoff to %s: %s", file_path, payload)
@@ -205,11 +209,22 @@ class TestConfig(metaclass=Singleton):
 
     @classmethod
     def persist_resolved_placement_if_changed(
-        cls, test_id: str, original_region: Optional[str], region_name: Optional[str], availability_zone: Optional[str]
+        cls,
+        test_id: str,
+        original_region: Optional[str],
+        region_name: Optional[str],
+        availability_zone: Optional[str],
+        amis: Optional[Dict[str, str]] = None,
     ) -> None:
-        """Save the resolved placement only when the cluster was relocated to a different region."""
+        """Save the resolved placement only when the cluster was relocated to a different region.
+
+        ``original_region`` / ``region_name`` are the full (space-joined) region lists, so a relocation
+        of any DC - not only the first - is detected.
+        """
         if region_name and original_region and region_name != original_region:
-            cls.write_resolved_placement(test_id, region_name=region_name, availability_zone=availability_zone)
+            cls.write_resolved_placement(
+                test_id, region_name=region_name, availability_zone=availability_zone, amis=amis
+            )
 
     @classmethod
     def delete_resolved_placement(cls, test_id: str) -> None:

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -80,9 +80,20 @@ from sdcm.cluster_k8s.eks import MonitorSetEKS
 from sdcm.cluster_cloud import ScyllaCloudCluster
 from sdcm.cql_stress_cassandra_stress_thread import CqlStressCassandraStressThread
 from sdcm.mgmt import get_scylla_manager_tool
-from sdcm.provision.aws.az_resolver import AZResolver, is_az_fallback_enabled, run_pre_flight_capacity_probe
-from sdcm.provision.aws.capacity_errors import ProvisioningCapacityExhausted, is_capacity_error
+from sdcm.provision.aws.az_resolver import (
+    AZResolver,
+    is_az_fallback_enabled,
+    is_region_fallback_enabled,
+    run_pre_flight_capacity_probe,
+)
+from sdcm.provision.aws.capacity_errors import ProvisioningCapacityExhausted, RegionAMINotFoundError, is_capacity_error
 from sdcm.provision.aws.capacity_reservation import SCTCapacityReservation
+from sdcm.provision.aws.region_fallback import (
+    cleanup_region,
+    enforce_single_region_gate,
+    restore_region,
+    switch_region,
+)
 from sdcm.kafka.kafka_cluster import LocalKafkaCluster
 from sdcm.provision.aws.emr_provisioner import EmrClusterProvisioner, ensure_emr_roles
 from sdcm.spark_migrator import build_spark4_bootstrap_actions
@@ -218,7 +229,7 @@ from sdcm.utils.raft.common import validate_raft_on_nodes
 from sdcm.commit_log_check_thread import CommitLogCheckThread
 from sdcm.kafka.kafka_consumer import KafkaCDCReaderThread
 from test_lib.compaction import CompactionStrategy
-from sdcm.exceptions import TestFailedByEvents
+from sdcm.exceptions import TestFailedByEvents, CapacityReservationError
 from sdcm.utils.subtest_utils import SUBTESTS_FAILURES
 
 CLUSTER_CLOUD_IMPORT_ERROR = ""
@@ -1849,6 +1860,23 @@ class ClusterTester(unittest.TestCase):
             self.monitors = NoMonitorSet()
 
     def get_cluster_aws(self, loader_info, db_info, monitor_info):
+        """Provision AWS cluster with optional region fallback."""
+        if is_region_fallback_enabled(self.params):
+            self._get_cluster_aws_with_region_fallback(loader_info, db_info, monitor_info)
+            return
+        self._get_cluster_aws_once(loader_info, db_info, monitor_info)
+
+    def _get_cluster_aws_once(self, loader_info, db_info, monitor_info):
+        """Provision AWS clusters in the configured region with AZ fallback only."""
+        region_exhausted, last_error, candidates = self._attempt_region_legacy(loader_info, db_info, monitor_info)
+        if region_exhausted:
+            attempted_azs = ", ".join("+".join(candidate) for candidate in candidates)
+            raise CriticalTestFailure(
+                f"Failed creating AWS clusters in all {len(candidates)} AZ candidate(s) [{attempted_azs}]: {last_error}"
+            ) from last_error
+
+    def _attempt_region_legacy(self, loader_info, db_info, monitor_info):
+        """Provision the entire cluster in the currently configured region."""
         AZResolver(self.params).resolve()
 
         # capacity reservation handles its own AZ fallback internally
@@ -1866,14 +1894,87 @@ class ClusterTester(unittest.TestCase):
         region_exhausted, last_error = self._provision_legacy_with_az_fallback(
             loader_info, db_info, monitor_info, candidates, last_error=None
         )
-        if not region_exhausted:
-            return
 
-        self.params["availability_zone"] = original_az
-        tried = ", ".join("+".join(c) for c in candidates)
+        if region_exhausted:
+            self.params["availability_zone"] = original_az
+        return region_exhausted, last_error, candidates
+
+    def _get_cluster_aws_with_region_fallback(self, loader_info, db_info, monitor_info):
+        """Provision in the configured AWS region, then relocate to fallback regions on capacity exhaustion."""
+        self._enforce_single_region_gate()
+
+        original_region = self.params.region_names[0] if self.params.region_names else None
+        original_az = self.params.get("availability_zone")
+        original_env_region = os.environ.get("SCT_REGION_NAME")
+
+        source_region = original_region
+        region_candidates = AZResolver(self.params).get_region_fallback_candidates()
+        last_error = None
+
+        for attempt_idx, candidate in enumerate([None, *region_candidates]):
+            if attempt_idx > 0:
+                target_region, az_letters = candidate
+                self.log.warning(
+                    "Region '%s' exhausted; relocating whole cluster to '%s' (region attempt %d/%d)",
+                    source_region,
+                    target_region,
+                    attempt_idx + 1,
+                    len(region_candidates) + 1,
+                )
+                try:
+                    self._switch_region_legacy(
+                        target_region, az_letters, source_region, loader_info, db_info, monitor_info
+                    )
+                except RegionAMINotFoundError as exc:
+                    last_error = exc
+                    self.log.warning("Region '%s' ineligible (no equivalent AMI): %s", target_region, exc)
+                    continue
+                source_region = target_region
+
+            try:
+                region_exhausted, attempt_error, _ = self._attempt_region_legacy(loader_info, db_info, monitor_info)
+            except CapacityReservationError as exc:
+                region_exhausted, attempt_error = True, exc
+            except Exception:
+                self._restore_region_legacy(original_region, original_az, original_env_region)
+                raise
+
+            if not region_exhausted:
+                current_region = self.params.region_names[0] if self.params.region_names else None
+                self.test_config.persist_resolved_placement_if_changed(
+                    self.test_config.test_id(),
+                    original_region=original_region,
+                    region_name=current_region,
+                    availability_zone=self.params.get("availability_zone"),
+                )
+                return
+
+            last_error = attempt_error or last_error
+            self._cleanup_region_legacy(source_region)
+
+        self._restore_region_legacy(original_region, original_az, original_env_region)
+        tried_regions = ", ".join(region for region, _ in region_candidates) or "(no eligible candidates)"
         raise CriticalTestFailure(
-            f"Failed creating AWS clusters in all {len(candidates)} AZ candidate(s) [{tried}]: {last_error}"
+            f"Failed creating AWS clusters in region '{original_region}' and all fallback candidates [{tried_regions}]: "
+            f"{last_error}"
         ) from last_error
+
+    def _enforce_single_region_gate(self) -> None:
+        enforce_single_region_gate(self.params)
+
+    def _switch_region_legacy(self, region, az_letters, source_region, loader_info, db_info, monitor_info):
+        def reset_info_device_mappings():
+            # recompute AMI-root-based mappings after region switch
+            for info in (loader_info, db_info, monitor_info):
+                info["device_mappings"] = None
+
+        switch_region(self.params, region, az_letters, source_region, invalidate_caches=reset_info_device_mappings)
+
+    def _restore_region_legacy(self, region, availability_zone, env_region):
+        restore_region(self.params, region, availability_zone, env_region)
+
+    def _cleanup_region_legacy(self, region):
+        cleanup_region(self.test_config.test_id(), region, partial_cleanup=self._cleanup_legacy_partial_aws_clusters)
 
     def _populate_aws_info_dicts(self, loader_info: dict, db_info: dict, monitor_info: dict) -> None:
         """Fill missing AWS info values for the current region."""

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1861,7 +1861,7 @@ class ClusterTester(unittest.TestCase):
 
     def get_cluster_aws(self, loader_info, db_info, monitor_info):
         """Provision AWS cluster with optional region fallback."""
-        if is_region_fallback_enabled(self.params):
+        if is_region_fallback_enabled(self.params) and len(self.params.region_names) == 1:
             self._get_cluster_aws_with_region_fallback(loader_info, db_info, monitor_info)
             return
         self._get_cluster_aws_once(loader_info, db_info, monitor_info)
@@ -1946,6 +1946,7 @@ class ClusterTester(unittest.TestCase):
                     original_region=original_region,
                     region_name=current_region,
                     availability_zone=self.params.get("availability_zone"),
+                    amis={key: self.params.get(key) for key in self.params.ami_id_params if self.params.get(key)},
                 )
                 return
 

--- a/sdcm/utils/resources_cleanup.py
+++ b/sdcm/utils/resources_cleanup.py
@@ -36,6 +36,7 @@ from sdcm.utils.argus import ArgusError, get_argus_client, get_argus_use_tunnel_
 from sdcm.utils.aws_kms import AwsKms
 from sdcm.utils.aws_region import AwsRegion
 from sdcm.utils.gce_region import GceRegion
+from sdcm.sct_config import AWS_SUPPORTED_REGIONS
 from sdcm.utils.common import (
     all_aws_regions,
     aws_tags_to_dict,
@@ -99,6 +100,13 @@ def clean_cloud_resources(tags_dict, config=None, dry_run=False):
 
     cluster_backend = config.get("cluster_backend") or ""
     aws_regions = config.region_names
+    if config.get("fallback_to_next_region"):
+        # region fallback may have relocated the cluster, so scan the fallback-eligible regions, not
+        # every AWS region (which would hit unreachable opt-in regions e.g. me-south-1 and time out).
+        aws_regions = sorted(set(AWS_SUPPORTED_REGIONS) | set(config.region_names or []))
+        LOGGER.info(
+            "fallback_to_next_region enabled: scanning fallback-eligible AWS regions for cleanup: %s", aws_regions
+        )
     gce_projects = [config.get("gce_project") or "gcp-sct-project-1"]
 
     if cluster_backend.startswith("k8s-local"):
@@ -124,12 +132,19 @@ def clean_cloud_resources(tags_dict, config=None, dry_run=False):
             SCTCapacityReservation.cancel(config)
         else:
             SCTCapacityReservation.cancel_all_regions(config.get("test_id"))
+        # cleanup capacity reservations across all regions as region fallback can leave an idle CR in an abandoned region
+        if not dry_run and (test_id := config.get("test_id")):
+            SCTCapacityReservation.cancel_all_regions(test_id)
         SCTDedicatedHosts.release_by_tags(tags_dict, regions=aws_regions, dry_run=dry_run)
         clean_elastic_ips_aws(tags_dict, regions=aws_regions, dry_run=dry_run)
         clean_test_security_groups(tags_dict, regions=aws_regions, dry_run=dry_run)
         clean_placement_groups_aws(tags_dict, regions=aws_regions, dry_run=dry_run)
         if cluster_backend == "aws" and not dry_run:
             clean_aws_kms_alias(tags_dict, aws_regions or all_aws_regions())
+        if not dry_run and (test_id := tags_dict.get("TestId")):
+            from sdcm.test_config import TestConfig  # noqa: PLC0415  # avoid import cycle at module load
+
+            TestConfig.delete_resolved_placement(test_id)
     if cluster_backend in ("gce", "k8s-gke", ""):
         for project in gce_projects:
             with environment(SCT_GCE_PROJECT=project):

--- a/unit_tests/unit/provisioner/test_az_fallback.py
+++ b/unit_tests/unit/provisioner/test_az_fallback.py
@@ -11,6 +11,7 @@
 #
 # Copyright (c) 2026 ScyllaDB
 
+import os
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -19,7 +20,11 @@ from botocore.exceptions import ClientError
 
 from sdcm.cluster import NoMonitorSet
 from sdcm.cluster_aws import AWSCluster
-from sdcm.provision.aws.capacity_errors import ProvisioningCapacityExhausted
+from sdcm.exceptions import CapacityReservationError
+from sdcm.provision.aws import utils as aws_utils
+from sdcm.provision.aws.az_resolver import AZResolver
+from sdcm.provision.aws.capacity_errors import ProvisioningCapacityExhausted, RegionAMINotFoundError
+from sdcm.provision.aws.region_fallback import switch_region
 from sdcm.sct_provision.aws.layout import SCTProvisionAWSLayout
 from sdcm.tester import ClusterTester
 
@@ -336,3 +341,250 @@ def test_provision_legacy_with_az_fallback_non_capacity_error_propagates():
             stub, loader_info={}, db_info={}, monitor_info={}, candidates=[["a"], ["b"]], last_error=None
         )
     assert stub._provision_legacy_aws_clusters.call_count == 1
+
+
+class _RegionParams(_DotDict):
+    """Params stub that derives `region_names` from `region_name` like `SCTConfiguration`."""
+
+    @property
+    def region_names(self):
+        return (self.get("region_name") or "").split()
+
+    def resolve_amis(self, region_names, source_region=None):
+        calls = self.setdefault("resolve_amis_calls", [])
+        calls.append((list(region_names), source_region))
+
+
+def _make_region_params(**overrides):
+    return _RegionParams(
+        {
+            "cluster_backend": "aws",
+            "region_name": "us-east-1",
+            "availability_zone": "a",
+            "instance_type_db": "i4i.large",
+            "instance_type_loader": "t3.small",
+            "instance_type_monitor": "t3.small",
+            "fallback_to_next_region": True,
+            "fallback_to_next_availability_zone": False,
+            "use_capacity_reservation": False,
+            "instance_provision": "on_demand",
+            "test_id": "test-id-123",
+            "n_db_nodes": 1,
+            **overrides,
+        }
+    )
+
+
+@pytest.fixture(name="restore_region_env")
+def restore_region_env_fixture():
+    saved = {k: os.environ.get(k) for k in ("SCT_REGION_NAME", "SCT_AVAILABILITY_ZONE")}
+
+    yield
+
+    for key, value in saved.items():
+        if value is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = value
+
+
+def test_region_fallback_relocates_on_capacity_exhaustion(patched_capacity_reservation, restore_region_env):  # noqa: ARG001
+    params = _make_region_params()
+    layout = SCTProvisionAWSLayout(params)
+    seen_regions = []
+
+    def fake_do_provision():
+        seen_regions.append(params["region_name"])
+        if len(seen_regions) == 1:
+            raise _capacity_error()
+
+    with (
+        patch.object(AZResolver, "resolve"),
+        patch.object(AZResolver, "get_region_fallback_candidates", return_value=[("eu-west-1", ["a"])]),
+        patch.object(layout, "_do_provision", side_effect=fake_do_provision),
+        patch.object(layout, "_cleanup_region") as mock_cleanup,
+    ):
+        layout.provision()
+
+    assert seen_regions == ["us-east-1", "eu-west-1"]
+    assert params["region_name"] == "eu-west-1"
+    assert os.environ["SCT_REGION_NAME"] == "eu-west-1"
+    assert params.get("resolve_amis_calls") == [(["eu-west-1"], "us-east-1")]
+    mock_cleanup.assert_called_once()
+
+
+def test_region_fallback_non_capacity_error_propagates_and_restores(patched_capacity_reservation, restore_region_env):  # noqa: ARG001
+    params = _make_region_params()
+    layout = SCTProvisionAWSLayout(params)
+    auth_error = ClientError({"Error": {"Code": "AuthFailure", "Message": "denied"}}, "RunInstances")
+
+    with (
+        patch.object(AZResolver, "resolve"),
+        patch.object(AZResolver, "get_region_fallback_candidates", return_value=[("eu-west-1", ["a"])]),
+        patch.object(layout, "_do_provision", side_effect=auth_error),
+        patch.object(layout, "_cleanup_region") as mock_cleanup,
+    ):
+        with pytest.raises(ClientError):
+            layout.provision()
+
+    mock_cleanup.assert_not_called()
+    assert params["region_name"] == "us-east-1"  # original region restored
+
+
+def test_region_fallback_gate_rejects_multi_region(restore_region_env):  # noqa: ARG001
+    layout = SCTProvisionAWSLayout(_make_region_params(region_name="us-east-1 eu-west-1"))
+    with pytest.raises(ValueError, match="single configured region"):
+        layout.provision()
+
+
+def test_region_fallback_all_regions_exhausted_raises_and_restores(patched_capacity_reservation, restore_region_env):  # noqa: ARG001
+    params = _make_region_params()
+    layout = SCTProvisionAWSLayout(params)
+
+    with (
+        patch.object(AZResolver, "resolve"),
+        patch.object(AZResolver, "get_region_fallback_candidates", return_value=[("eu-west-1", ["a"])]),
+        patch.object(layout, "_do_provision", side_effect=_capacity_error()),
+        patch.object(layout, "_cleanup_region"),
+    ):
+        with pytest.raises(RuntimeError, match="all fallback candidates"):
+            layout.provision()
+
+    assert params["region_name"] == "us-east-1"
+    assert os.environ.get("SCT_REGION_NAME") is None
+
+
+def test_region_fallback_capacity_reservation_exhaustion_relocates(patched_capacity_reservation, restore_region_env):  # noqa: ARG001
+    patched_capacity_reservation.is_capacity_reservation_enabled.return_value = True
+    params = _make_region_params(use_capacity_reservation=True)
+    layout = SCTProvisionAWSLayout(params)
+    seen_regions = []
+
+    def fake_do_provision():
+        seen_regions.append(params["region_name"])
+        if len(seen_regions) == 1:
+            raise CapacityReservationError("no CR capacity in any AZ")
+
+    with (
+        patch.object(AZResolver, "resolve"),
+        patch.object(AZResolver, "get_region_fallback_candidates", return_value=[("eu-west-1", ["a"])]),
+        patch.object(layout, "_do_provision", side_effect=fake_do_provision),
+        patch.object(layout, "_cleanup_region"),
+    ):
+        layout.provision()
+
+    assert seen_regions == ["us-east-1", "eu-west-1"]
+    assert params["region_name"] == "eu-west-1"
+
+
+def test_region_fallback_skips_region_without_equivalent_ami(patched_capacity_reservation, restore_region_env):  # noqa: ARG001
+    params = _make_region_params()
+    layout = SCTProvisionAWSLayout(params)
+
+    def raise_no_ami(region_names, source_region=None):  # noqa: ARG001
+        raise RegionAMINotFoundError("no equivalent AMI in eu-west-1")
+
+    params.resolve_amis = raise_no_ami
+    with (
+        patch.object(AZResolver, "resolve"),
+        patch.object(AZResolver, "get_region_fallback_candidates", return_value=[("eu-west-1", ["a"])]),
+        patch.object(layout, "_do_provision", side_effect=_capacity_error()),
+        patch.object(layout, "_cleanup_region"),
+    ):
+        with pytest.raises(RuntimeError, match="all fallback candidates"):
+            layout.provision()
+    assert params["region_name"] == "us-east-1"
+
+
+def _make_region_tester_stub(**param_overrides):
+    params = _RegionParams(
+        {
+            "region_name": "us-east-1",
+            "availability_zone": "a",
+            "fallback_to_next_region": True,
+            "cluster_backend": "aws",
+            "test_id": "t-1",
+            **param_overrides,
+        }
+    )
+    stub = SimpleNamespace(params=params, log=MagicMock(), test_config=MagicMock())
+
+    def bind(method):
+        return lambda *args, **kwargs: method(stub, *args, **kwargs)
+
+    stub._enforce_single_region_gate = bind(ClusterTester._enforce_single_region_gate)
+    stub._switch_region_legacy = bind(ClusterTester._switch_region_legacy)
+    stub._restore_region_legacy = bind(ClusterTester._restore_region_legacy)
+    stub._cleanup_region_legacy = MagicMock()
+    return stub
+
+
+def test_legacy_region_fallback_relocates_on_exhaustion(restore_region_env):  # noqa: ARG001
+    stub = _make_region_tester_stub()
+    seen_regions = []
+
+    def fake_attempt(loader_info, db_info, monitor_info):  # noqa: ARG001
+        seen_regions.append(stub.params["region_name"])
+        if len(seen_regions) == 1:
+            return True, _capacity_error(), [["a"]]
+        return False, None, [["a"]]
+
+    stub._attempt_region_legacy = fake_attempt
+    with patch.object(AZResolver, "get_region_fallback_candidates", return_value=[("eu-west-1", ["a"])]):
+        ClusterTester._get_cluster_aws_with_region_fallback(stub, {}, {}, {})
+
+    assert seen_regions == ["us-east-1", "eu-west-1"]
+    assert stub.params["region_name"] == "eu-west-1"
+    assert stub.params.get("resolve_amis_calls") == [(["eu-west-1"], "us-east-1")]
+    stub._cleanup_region_legacy.assert_called_once()
+    stub.test_config.persist_resolved_placement_if_changed.assert_called_once()
+
+
+def test_switch_region_sets_placement_resolves_amis_and_invalidates(restore_region_env):  # noqa: ARG001
+    params = _DotDict({"region_name": "us-east-1", "availability_zone": "a"})
+    params.region_names = ["us-east-1"]
+    params.resolve_amis = MagicMock()
+    invalidate = MagicMock()
+
+    with patch("sdcm.provision.aws.region_fallback.SCTCapacityReservation") as mock_cr:
+        mock_cr.reservations = {"stale": 1}
+        switch_region(params, "eu-west-1", ["b", "c"], source_region="us-east-1", invalidate_caches=invalidate)
+        assert mock_cr.reservations == {}
+
+    assert os.environ["SCT_REGION_NAME"] == "eu-west-1"
+    assert params["region_name"] == "eu-west-1"
+    assert params["availability_zone"] == "b,c"
+    params.resolve_amis.assert_called_once_with(["eu-west-1"], source_region="us-east-1")
+    invalidate.assert_called_once_with()
+
+
+def test_cleanup_abandoned_region_cancels_crs_and_terminates_non_runner_instances():
+    region = "us-east-1"
+    instances = [
+        {"InstanceId": "i-runner", "Tags": [{"Key": "NodeType", "Value": "sct-runner"}]},
+        {"InstanceId": "i-db", "Tags": [{"Key": "NodeType", "Value": "scylla-db"}]},
+    ]
+    client = MagicMock()
+
+    with (
+        patch(
+            "sdcm.provision.aws.capacity_reservation.SCTCapacityReservation.cancel_all_regions"
+        ) as cancel_all_regions,
+        patch("sdcm.provision.aws.utils.list_instances_aws", return_value={region: instances}),
+        patch.dict(aws_utils.ec2_clients, {region: client}, clear=False),
+    ):
+        aws_utils.cleanup_abandoned_region("t-1", region)
+
+    cancel_all_regions.assert_called_once_with("t-1")
+    client.terminate_instances.assert_called_once_with(InstanceIds=["i-db"])
+
+
+def test_cleanup_abandoned_region_never_raises_on_failure():
+    with (
+        patch(
+            "sdcm.provision.aws.capacity_reservation.SCTCapacityReservation.cancel_all_regions",
+            side_effect=RuntimeError("boom"),
+        ),
+        patch("sdcm.provision.aws.utils.list_instances_aws", side_effect=RuntimeError("boom")),
+    ):
+        aws_utils.cleanup_abandoned_region("t-1", "us-east-1")  # must not raise

--- a/unit_tests/unit/provisioner/test_az_fallback.py
+++ b/unit_tests/unit/provisioner/test_az_fallback.py
@@ -346,6 +346,8 @@ def test_provision_legacy_with_az_fallback_non_capacity_error_propagates():
 class _RegionParams(_DotDict):
     """Params stub that derives `region_names` from `region_name` like `SCTConfiguration`."""
 
+    ami_id_params = ["ami_id_db_scylla", "ami_id_loader"]
+
     @property
     def region_names(self):
         return (self.get("region_name") or "").split()
@@ -431,10 +433,30 @@ def test_region_fallback_non_capacity_error_propagates_and_restores(patched_capa
     assert params["region_name"] == "us-east-1"  # original region restored
 
 
-def test_region_fallback_gate_rejects_multi_region(restore_region_env):  # noqa: ARG001
-    layout = SCTProvisionAWSLayout(_make_region_params(region_name="us-east-1 eu-west-1"))
+def test_legacy_region_fallback_gate_rejects_multi_region(restore_region_env):  # noqa: ARG001
+    """The modern path now supports multi-DC fallback; the legacy path still refuses it via the gate."""
+    stub = _make_region_tester_stub(region_name="us-east-1 eu-west-1")
     with pytest.raises(ValueError, match="single configured region"):
-        layout.provision()
+        ClusterTester._get_cluster_aws_with_region_fallback(stub, {}, {}, {})
+
+
+@pytest.mark.parametrize(
+    ("region_name", "expect_once", "expect_fallback"),
+    [
+        pytest.param("eu-west-1 us-west-2", True, False, id="multi_region_uses_once_path"),
+        pytest.param("us-east-1", False, True, id="single_region_uses_region_fallback"),
+    ],
+)
+def test_get_cluster_aws_routing_by_region_count(region_name, expect_once, expect_fallback, restore_region_env):  # noqa: ARG001
+    """`get_cluster_aws` routes multi-region to once-path, and single-region to legacy region-fallback path."""
+    stub = _make_region_tester_stub(region_name=region_name)
+    stub._get_cluster_aws_once = MagicMock()
+    stub._get_cluster_aws_with_region_fallback = MagicMock()
+
+    ClusterTester.get_cluster_aws(stub, {}, {}, {})
+
+    assert stub._get_cluster_aws_once.called is expect_once
+    assert stub._get_cluster_aws_with_region_fallback.called is expect_fallback
 
 
 def test_region_fallback_all_regions_exhausted_raises_and_restores(patched_capacity_reservation, restore_region_env):  # noqa: ARG001

--- a/unit_tests/unit/provisioner/test_az_resolver.py
+++ b/unit_tests/unit/provisioner/test_az_resolver.py
@@ -450,6 +450,31 @@ def test_get_region_fallback_candidates_excludes_current_and_non_peered():
     assert set(regions) == peered
 
 
+def test_get_dc_fallback_candidates_requires_peering_with_every_staying_dc():
+    """A candidate must be peered with ALL staying DCs, not just one."""
+    params = _make_params(region_name="us-east-1 eu-west-1 us-west-2", availability_zone="a")
+    resolver = AZResolver(params)
+
+    peering = {
+        ("us-east-1", "eu-west-2"): True,
+        ("us-west-2", "eu-west-2"): True,
+        ("us-east-1", "eu-west-3"): True,
+        ("us-west-2", "eu-west-3"): False,
+    }
+
+    def is_region_peered(staying: str, candidate: str) -> bool:
+        return peering.get((staying, candidate), False)
+
+    with (
+        patch.object(AZResolver, "_is_region_peered", side_effect=is_region_peered),
+        patch.object(AZResolver, "_common_supported_letters", return_value=["a"]),
+    ):
+        regions = [region for region, _ in resolver.get_dc_fallback_candidates(dc_index=1)]
+
+    assert "eu-west-2" in regions
+    assert "eu-west-3" not in regions
+
+
 def test_is_region_peered_true_only_for_active_connection():
     """_is_region_peered must accept only active peering, not pending-acceptance or missing."""
     region_pair = ("us-east-1", "eu-west-1")

--- a/unit_tests/unit/provisioner/test_az_resolver.py
+++ b/unit_tests/unit/provisioner/test_az_resolver.py
@@ -430,3 +430,40 @@ def test_run_pre_flight_capacity_probe_raises_on_capacity_failure(mock_probe_aws
                 test_id="t-1",
             )
         )
+
+
+def test_get_region_fallback_candidates_excludes_current_and_non_peered():
+    """Only actively-peered regions (other than the current one) become candidates."""
+    params = _make_params(region_name="us-east-1", availability_zone="a")
+    resolver = AZResolver(params)
+    peered = {"eu-west-1", "us-west-2"}
+
+    with (
+        patch.object(AZResolver, "_is_region_peered", side_effect=lambda cur, cand: cand in peered),
+        patch.object(AZResolver, "_common_supported_letters", return_value=["a", "b", "c"]),
+    ):
+        candidates = resolver.get_region_fallback_candidates()
+
+    regions = [region for region, _ in candidates]
+    assert "us-east-1" not in regions
+    assert "us-east-2" not in regions
+    assert set(regions) == peered
+
+
+def test_is_region_peered_true_only_for_active_connection():
+    """_is_region_peered must accept only active peering, not pending-acceptance or missing."""
+    region_pair = ("us-east-1", "eu-west-1")
+    peer_name = "peer-name"
+
+    with (
+        patch("sdcm.provision.aws.az_resolver.AwsRegion"),
+        patch("sdcm.utils.aws_peering.AwsVpcPeering._find_existing_peering") as mock_find,
+    ):
+        mock_find.return_value = ({"Status": {"Code": "active"}}, peer_name)
+        assert AZResolver._is_region_peered(*region_pair) is True
+
+        mock_find.return_value = ({"Status": {"Code": "pending-acceptance"}}, peer_name)
+        assert AZResolver._is_region_peered(*region_pair) is False
+
+        mock_find.return_value = (None, peer_name)
+        assert AZResolver._is_region_peered(*region_pair) is False

--- a/unit_tests/unit/provisioner/test_multi_dc_region_fallback.py
+++ b/unit_tests/unit/provisioner/test_multi_dc_region_fallback.py
@@ -1,0 +1,337 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2026 ScyllaDB
+
+import os
+from contextlib import ExitStack
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from botocore.exceptions import ClientError
+
+from sdcm.provision.aws.az_resolver import AZResolver
+from sdcm.provision.aws.capacity_errors import (
+    ProvisioningCapacityExhausted,
+    attach_failed_region,
+    get_failed_region,
+)
+from sdcm.provision.aws.region_fallback import (
+    enforce_multi_dc_fallback_supported,
+    remap_dc_ami,
+    switch_dc_region,
+)
+from sdcm.sct_provision.aws.cluster import DBCluster
+from sdcm.sct_provision.aws.layout import SCTProvisionAWSLayout
+
+
+class _BaseParams(dict):
+    @property
+    def region_names(self):
+        return (self.get("region_name") or "").split()
+
+
+class _LayoutParams(_BaseParams):
+    """SCTConfiguration stand-in accepted by SCTProvisionAWSLayout for the multi-DC fallback path."""
+
+    ami_id_params = ["ami_id_db_scylla"]
+
+
+class _AmiParams(_BaseParams):
+    """Stand-in for SCTConfiguration covering the bits remap/switch touch."""
+
+    ami_id_params = ["ami_id_db_scylla", "ami_id_loader", "ami_id_monitor"]
+
+
+class _StubParams(_BaseParams):
+    """Minimal SCTConfiguration stand-in for DBCluster tests."""
+
+
+def _make_multi_dc_layout_params(**overrides):
+    return _LayoutParams(
+        {
+            "cluster_backend": "aws",
+            "region_name": "us-east-1 eu-west-1",
+            "availability_zone": "a",
+            "instance_type_db": "i4i.large",
+            "fallback_to_next_region": True,
+            "use_capacity_reservation": False,
+            "use_dedicated_host": False,
+            "n_db_nodes": "3 3",
+            **overrides,
+        }
+    )
+
+
+def _instance_in(region: str) -> SimpleNamespace:
+    """boto3 Instance-shaped stub whose region is resolvable by the layout's _instance_region."""
+    return SimpleNamespace(
+        instance_id=f"i-{region}",
+        meta=SimpleNamespace(client=SimpleNamespace(meta=SimpleNamespace(region_name=region))),
+    )
+
+
+def _tagged_capacity_error(region: str) -> ProvisioningCapacityExhausted:
+    exc = ProvisioningCapacityExhausted("no capacity")
+    attach_failed_region(exc, region)
+    return exc
+
+
+def _fake_find_equivalent_ami(ami_id, source_region, target_regions):  # noqa: ARG001
+    return [{"ami_id": f"{ami_id}@{target_regions[0]}"}]
+
+
+def _fake_convert_name_to_ami_if_needed(name, regions):
+    # the real helper is @lru_cache-decorated, so the regions arg must be hashable (a tuple, not a list)
+    assert isinstance(regions, tuple), f"regions must be a hashable tuple for lru_cache, got {type(regions).__name__}"
+    return f"ami-{name}@{regions[0]}"
+
+
+@pytest.fixture(name="restore_region_env")
+def restore_region_env_fixture():
+    saved = os.environ.get("SCT_REGION_NAME")
+    yield
+    if saved is None:
+        os.environ.pop("SCT_REGION_NAME", None)
+    else:
+        os.environ["SCT_REGION_NAME"] = saved
+
+
+def _db_cluster(**param_overrides) -> DBCluster:
+    """Build a DBCluster without pydantic validation so a stub params is enough for region/node mapping."""
+    params = _StubParams(
+        {
+            "region_name": "us-east-1 eu-west-1 us-west-2",
+            "n_db_nodes": "3 0 3",
+            "availability_zone": "a",
+            "user_prefix": "test",
+            "use_zero_nodes": False,
+            "n_db_zero_token_nodes": None,
+            "db_type": "scylla",
+            **param_overrides,
+        }
+    )
+    return DBCluster.model_construct(params=params, test_id="testid123", common_tags={})
+
+
+def _patch_cluster_internals():
+    return (
+        patch.object(DBCluster, "_instance_parameters", return_value=MagicMock()),
+        patch.object(DBCluster, "_node_tags", return_value=[]),
+        patch.object(DBCluster, "_node_names", return_value=[]),
+    )
+
+
+def test_nodes_map_to_absolute_region_ids_when_a_middle_dc_has_zero_nodes():
+    """A zero-node middle DC must not shift later DCs: n_db_nodes='3 0 3' -> regions 0 and 2, not 0 and 1."""
+    cluster = _db_cluster(n_db_nodes="3 0 3")
+    assert [node.region_id for node in cluster.nodes] == [0, 0, 0, 2, 2, 2]
+
+
+def test_db_cluster_provision_skips_given_region_ids():
+    """skip_region_ids lets the multi-DC loop re-provision only a relocated DC, not the healthy ones."""
+    cluster = _db_cluster(n_db_nodes="3 3 3")
+    plan = MagicMock()
+    plan.provision_instances.return_value = [object()]
+
+    with ExitStack() as stack:
+        mock_plan = stack.enter_context(patch.object(DBCluster, "provision_plan", return_value=plan))
+        for ctx in _patch_cluster_internals():
+            stack.enter_context(ctx)
+        cluster.provision(skip_region_ids={0, 1})
+
+    assert sorted({call.args[0] for call in mock_plan.call_args_list}) == [2]
+
+
+def _capacity_client_error() -> ClientError:
+    return ClientError({"Error": {"Code": "InsufficientInstanceCapacity", "Message": "x"}}, "RunInstances")
+
+
+def _plan_factory(fail_region_id: int, *, raise_client_error: bool):
+    """provision_plan side_effect: succeed everywhere except `fail_region_id`, which signals exhaustion."""
+
+    def factory(region_id, _az):
+        plan = MagicMock()
+        if region_id != fail_region_id:
+            plan.provision_instances.return_value = [object()]
+        elif raise_client_error:
+            plan.provision_instances.side_effect = _capacity_client_error()  # on-demand path
+        else:
+            plan.provision_instances.return_value = []  # spot/empty path -> ProvisioningCapacityExhausted
+        return plan
+
+    return factory
+
+
+@pytest.mark.parametrize(
+    ("raise_client_error", "expected_exc"),
+    [
+        pytest.param(True, ClientError, id="on_demand_client_error"),
+        pytest.param(False, ProvisioningCapacityExhausted, id="spot_empty_result"),
+    ],
+)
+def test_provision_tags_capacity_error_with_failing_region(raise_client_error, expected_exc):
+    """The exhausted DC's region must be recoverable from the propagated capacity error, for both shapes."""
+    cluster = _db_cluster(n_db_nodes="3 0 3")
+
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch.object(
+                DBCluster,
+                "provision_plan",
+                side_effect=_plan_factory(2, raise_client_error=raise_client_error),
+            )
+        )
+        for ctx in _patch_cluster_internals():
+            stack.enter_context(ctx)
+
+        with pytest.raises(expected_exc) as exc_info:
+            cluster.provision()
+
+    assert get_failed_region(exc_info.value) == "us-west-2"
+
+
+def test_remap_dc_ami_remaps_only_the_relocated_index():
+    """Relocating DC 0 remaps element[0] of every per-region AMI list, leaving other DCs untouched."""
+    params = _AmiParams(
+        {
+            "region_name": "us-east-1 eu-west-1",
+            "ami_id_db_scylla": "ami-EAST ami-WEST",
+            "ami_id_loader": "ami-LE ami-LW",
+            "ami_id_monitor": "ami-MON",
+        }
+    )
+    with patch("sdcm.provision.aws.region_fallback.find_equivalent_ami", side_effect=_fake_find_equivalent_ami):
+        remap_dc_ami(params, dc_index=0, source_region="us-east-1", target_region="us-west-2")
+
+    assert params["ami_id_db_scylla"] == "ami-EAST@us-west-2 ami-WEST"
+    assert params["ami_id_loader"] == "ami-LE@us-west-2 ami-LW"
+    assert params["ami_id_monitor"] == "ami-MON@us-west-2"  # length 1, dc_index 0 -> remapped
+
+
+def test_remap_dc_ami_reresolves_named_param_by_name_not_tags():
+    """Named AMI intents must be re-resolved by name in the target region, not via find_equivalent_ami."""
+    params = _AmiParams(
+        {
+            "region_name": "us-east-1 eu-west-1",
+            "ami_id_db_scylla": "ami-DBE ami-DBW",
+            "ami_id_loader": "ami-LE ami-LW",
+        }
+    )
+    params._ami_params_snapshot = {
+        "ami_id_db_scylla": "scylla-2026.1.5",
+        "ami_id_loader": "ubuntu-jammy-22.04",
+    }
+
+    expected_db = "ami-scylla-2026.1.5@us-west-2 ami-DBW"
+    expected_loader = "ami-ubuntu-jammy-22.04@us-west-2 ami-LW"
+
+    with (
+        patch(
+            "sdcm.provision.aws.region_fallback.convert_name_to_ami_if_needed",
+            side_effect=_fake_convert_name_to_ami_if_needed,
+        ),
+        patch(
+            "sdcm.provision.aws.region_fallback.find_equivalent_ami",
+            side_effect=AssertionError("named AMI params must be resolved by name, not find_equivalent_ami"),
+        ),
+    ):
+        remap_dc_ami(params, dc_index=0, source_region="us-east-1", target_region="us-west-2")
+
+    assert params["ami_id_db_scylla"] == expected_db
+    assert params["ami_id_loader"] == expected_loader
+
+
+def test_switch_dc_region_splices_index_keeps_global_az_and_invalidates(restore_region_env):  # noqa: ARG001
+    """Switching DC 0 rewrites only region_names[0] + its AMI, leaves availability_zone global/unchanged."""
+    params = _AmiParams(
+        {
+            "region_name": "us-east-1 eu-west-1",
+            "availability_zone": "a,b",
+            "ami_id_db_scylla": "ami-EAST ami-WEST",
+        }
+    )
+    invalidate = MagicMock()
+    with patch("sdcm.provision.aws.region_fallback.find_equivalent_ami", side_effect=_fake_find_equivalent_ami):
+        switch_dc_region(
+            params, dc_index=0, region="us-west-2", source_region="us-east-1", invalidate_caches=invalidate
+        )
+
+    assert params["region_name"] == "us-west-2 eu-west-1"
+    assert os.environ["SCT_REGION_NAME"] == "us-west-2 eu-west-1"
+    assert params["availability_zone"] == "a,b"  # global AZ unchanged
+    assert params["ami_id_db_scylla"] == "ami-EAST@us-west-2 ami-WEST"
+    invalidate.assert_called_once_with()
+
+
+@pytest.mark.parametrize(
+    "feature",
+    [
+        pytest.param("use_capacity_reservation", id="capacity_reservation"),
+        pytest.param("use_dedicated_host", id="dedicated_host"),
+    ],
+)
+def test_enforce_multi_dc_fallback_supported_rejects_region_scoped_reservations(feature):
+    """Multi-DC fallback + region-scoped CR/DH is refused (fail fast) in v1."""
+    params = _AmiParams({"region_name": "us-east-1 eu-west-1", feature: True})
+    with pytest.raises(ValueError, match="region-scoped"):
+        enforce_multi_dc_fallback_supported(params)
+
+
+def test_multi_dc_fallback_relocates_failed_db_dc_then_provisions_support_clusters(restore_region_env):  # noqa: ARG001
+    """One DB DC exhausts -> relocate only it (skip the healthy DC on retry), then provision monitor/loader once."""
+    params = _make_multi_dc_layout_params()
+    layout = SCTProvisionAWSLayout(params)
+
+    class _FakeDB:
+        def __init__(self):
+            self._provisioned_instances = []
+            self.skips = []
+
+        def provision(self, skip_region_ids=None):
+            self.skips.append(set(skip_region_ids or set()))
+            if len(self.skips) == 1:
+                self._provisioned_instances.append(_instance_in("us-east-1"))  # DC0 ok
+                raise _tagged_capacity_error("eu-west-1")  # DC1 exhausts
+            self._provisioned_instances.append(_instance_in("us-west-2"))  # relocated DC1 ok
+
+    db = _FakeDB()
+    monitor, loader = MagicMock(), MagicMock()
+    layout.__dict__.update(
+        {
+            "db_cluster": db,
+            "monitoring_cluster": monitor,
+            "loader_cluster": loader,
+            "cs_db_cluster": None,
+            "placement_group": None,
+        }
+    )
+
+    def fake_switch(dc_index, region, source_region):  # noqa: ARG001
+        names = params["region_name"].split()
+        names[dc_index] = region
+        params["region_name"] = " ".join(names)
+
+    with (
+        patch.object(AZResolver, "resolve"),
+        patch("sdcm.sct_provision.aws.layout.run_pre_flight_capacity_probe"),
+        patch.object(AZResolver, "get_dc_fallback_candidates", return_value=[("us-west-2", ["a"])]),
+        patch.object(SCTProvisionAWSLayout, "_cleanup_dc_region") as cleanup,
+        patch.object(SCTProvisionAWSLayout, "_switch_dc_region", side_effect=fake_switch),
+    ):
+        layout.provision()
+
+    assert db.skips == [set(), {0}]  # first attempt all DCs; retry skips the healthy DC0
+    cleanup.assert_called_once_with("eu-west-1")
+    monitor.provision.assert_called_once()
+    loader.provision.assert_called_once()
+    assert params["region_name"] == "us-east-1 us-west-2"

--- a/unit_tests/unit/test_config.py
+++ b/unit_tests/unit/test_config.py
@@ -970,3 +970,25 @@ def test_overlay_beats_env_when_test_id_matches(monkeypatch, placement_logdir): 
     assert conf["availability_zone"] == "b"
     # AMIs must have been re-resolved for the relocated region
     assert conf["ami_id_db_scylla"] == "ami-dummy-west"
+
+
+def test_resolved_placement_with_amis_applies_directly_and_skips_re_resolution(monkeypatch, placement_logdir):  # noqa: ARG001
+    """When the handoff carries resolved AMIs, apply them verbatim and do not re-resolve."""
+    test_id = "22222222-2222-2222-2222-222222222222"
+    _set_aws_overlay_env(monkeypatch, test_id, original_region="us-east-1")
+    TestConfig.write_resolved_placement(
+        test_id,
+        region_name="eu-west-1",
+        availability_zone="b",
+        amis={"ami_id_db_scylla": "ami-persisted-west"},
+    )
+
+    with patch(
+        "sdcm.sct_config.find_equivalent_ami",
+        return_value=[{"region": "eu-west-1", "ami_id": "ami-reresolved"}],
+    ):
+        conf = sct_config.SCTConfiguration()
+
+    assert conf.region_names == ["eu-west-1"]
+    assert conf["availability_zone"] == "b"
+    assert conf["ami_id_db_scylla"] == "ami-persisted-west"

--- a/unit_tests/unit/test_config.py
+++ b/unit_tests/unit/test_config.py
@@ -12,12 +12,16 @@
 # Copyright (c) 2020 ScyllaDB
 
 import logging
+import os
 import unittest.mock
 from collections import namedtuple
+from unittest.mock import patch
 
 import pytest
+import yaml
 
 from sdcm import sct_config
+from sdcm.provision.aws.capacity_errors import RegionAMINotFoundError
 from sdcm.test_config import TestConfig
 from sdcm.utils.common import get_latest_scylla_release
 
@@ -831,3 +835,138 @@ def test_env_var_whitespace_is_stripped(monkeypatch, raw_value, expected):
     monkeypatch.setenv("SCT_SCYLLA_VERSION", raw_value)
     conf = sct_config.SCTConfiguration()
     assert conf.get("scylla_version") == expected
+
+
+def _make_aws_conf(monkeypatch, **env):
+    monkeypatch.setenv("SCT_CLUSTER_BACKEND", "aws")
+    monkeypatch.setenv("SCT_CONFIG_FILES", "unit_tests/test_configs/minimal_test_case.yaml")
+    monkeypatch.setenv("SCT_AMI_ID_DB_SCYLLA", "ami-source-scylla")
+    monkeypatch.setenv("SCT_REGION_NAME", "us-east-1")
+    monkeypatch.setenv("SCT_USE_MGMT", "false")
+    monkeypatch.setenv("SCT_IGNORE_RESOLVED_PLACEMENT", "1")
+    monkeypatch.delenv("SCT_TEST_ID", raising=False)
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+
+    conf = sct_config.SCTConfiguration()
+    # start each test from a clean AMI slate so resolve_amis only touches what the test sets up
+    for key in conf.ami_id_params:
+        conf[key] = ""
+
+    conf._ami_params_snapshot = {}
+    conf.target_db_image_ids = []
+    return conf
+
+
+def test_resolve_amis_reresolves_name_intent_via_convert(monkeypatch):
+    conf = _make_aws_conf(monkeypatch)
+    conf._ami_params_snapshot = {"ami_id_loader": "resolve:ssm:/some/loader/path"}
+    conf["ami_id_loader"] = "ami-loader-east"
+
+    with patch("sdcm.sct_config.convert_name_to_ami_if_needed", return_value="ami-loader-west") as mock_convert:
+        conf.resolve_amis(["eu-west-1"], source_region="us-east-1")
+
+    mock_convert.assert_called_once_with("resolve:ssm:/some/loader/path", ("eu-west-1",))
+    assert conf["ami_id_loader"] == "ami-loader-west"
+
+
+def test_resolve_amis_remaps_explicit_ami_via_find_equivalent(monkeypatch):
+    conf = _make_aws_conf(monkeypatch)
+    conf._ami_params_snapshot = {"ami_id_db_scylla": "ami-source-scylla"}
+    conf["ami_id_db_scylla"] = "ami-source-scylla"
+
+    with patch(
+        "sdcm.sct_config.find_equivalent_ami",
+        return_value=[{"region": "eu-west-1", "ami_id": "ami-target-scylla"}],
+    ) as mock_equiv:
+        conf.resolve_amis(["eu-west-1"], source_region="us-east-1")
+
+    mock_equiv.assert_called_once_with("ami-source-scylla", "us-east-1", target_regions=["eu-west-1"])
+    assert conf["ami_id_db_scylla"] == "ami-target-scylla"
+
+
+def test_resolve_amis_raises_region_ineligible_when_no_equivalent(monkeypatch):
+    conf = _make_aws_conf(monkeypatch)
+    conf._ami_params_snapshot = {"ami_id_db_scylla": "ami-source-scylla"}
+    conf["ami_id_db_scylla"] = "ami-source-scylla"
+
+    with patch("sdcm.sct_config.find_equivalent_ami", return_value=[]):
+        with pytest.raises(RegionAMINotFoundError):
+            conf.resolve_amis(["eu-west-1"], source_region="us-east-1")
+
+
+@pytest.fixture(name="placement_logdir")
+def fixture_placement_logdir(monkeypatch, tmp_path):
+    """Point base_logdir at a tmp dir to not touch ~/sct-results."""
+    monkeypatch.setenv("_SCT_LOGDIR", str(tmp_path))
+    return tmp_path
+
+
+def test_write_then_read_resolved_placement_round_trips(placement_logdir):  # noqa: ARG001
+    TestConfig.write_resolved_placement("tid-1", region_name="eu-west-1", availability_zone="b")
+    data = TestConfig.read_resolved_placement("tid-1")
+    assert data["test_id"] == "tid-1"
+    assert data["region_name"] == "eu-west-1"
+    assert data["availability_zone"] == "b"
+
+
+def test_read_resolved_placement_returns_none_on_test_id_mismatch(placement_logdir):  # noqa: ARG001
+    path = TestConfig.resolved_placement_file_path("tid-2")
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as handle:
+        yaml.safe_dump({"test_id": "some-other-id", "region_name": "eu-west-1", "availability_zone": "b"}, handle)
+    assert TestConfig.read_resolved_placement("tid-2") is None
+
+
+@pytest.mark.parametrize(
+    "test_id, original_region, region_name, availability_zone, expected",
+    [
+        (
+            "tid-pa",
+            "us-east-1",
+            "eu-west-1",
+            "b",
+            {"test_id": "tid-pa", "region_name": "eu-west-1", "availability_zone": "b"},
+        ),
+        ("tid-pb", "us-east-1", "us-east-1", "a", None),
+        ("tid-pc", None, None, None, None),
+    ],
+    ids=["region_changed_writes", "unchanged_noop", "missing_noop"],
+)
+def test_persist_resolved_placement_writes_only_when_region_changed(
+    placement_logdir, test_id, original_region, region_name, availability_zone, expected
+):  # noqa: ARG001
+    TestConfig.persist_resolved_placement_if_changed(
+        test_id, original_region=original_region, region_name=region_name, availability_zone=availability_zone
+    )
+    assert TestConfig.read_resolved_placement(test_id) == expected
+
+
+def _set_aws_overlay_env(monkeypatch, test_id, original_region="us-east-1"):
+    monkeypatch.setenv("SCT_CLUSTER_BACKEND", "aws")
+    monkeypatch.setenv("SCT_CONFIG_FILES", "unit_tests/test_configs/minimal_test_case.yaml")
+    monkeypatch.setenv("SCT_AMI_ID_DB_SCYLLA", "ami-dummy")
+    monkeypatch.setenv("SCT_REGION_NAME", original_region)
+    monkeypatch.setenv("SCT_TEST_ID", test_id)
+    monkeypatch.setenv("SCT_USE_MGMT", "false")
+    monkeypatch.delenv("SCT_IGNORE_RESOLVED_PLACEMENT", raising=False)
+
+
+def test_overlay_beats_env_when_test_id_matches(monkeypatch, placement_logdir):  # noqa: ARG001
+    test_id = "11111111-1111-1111-1111-111111111111"
+    _set_aws_overlay_env(monkeypatch, test_id, original_region="us-east-1")
+    TestConfig.write_resolved_placement(test_id, region_name="eu-west-1", availability_zone="b")
+
+    # relocation re-resolves region-bound AMIs; ami-dummy is explicit so it goes through find_equivalent_ami
+    with patch(
+        "sdcm.sct_config.find_equivalent_ami",
+        return_value=[{"region": "eu-west-1", "ami_id": "ami-dummy-west"}],
+    ):
+        conf = sct_config.SCTConfiguration()
+
+    # region_names is env-first, so the overlay must have rewritten SCT_REGION_NAME
+    assert conf.region_names == ["eu-west-1"]
+    assert os.environ["SCT_REGION_NAME"] == "eu-west-1"
+    assert conf["availability_zone"] == "b"
+    # AMIs must have been re-resolved for the relocated region
+    assert conf["ami_id_db_scylla"] == "ami-dummy-west"


### PR DESCRIPTION
Add `fallback_to_next_region` logic when a region is exhausted during provisioning, after AZ fallback - relocate the whole cluster to the next eligible region instead of failing.
The feature off by default and applicable only to single-region test configs.

A region to relocate to is eligible only with an active VPC peering, when there are enough AZs for the instance types the test uses, and an equivalent AMIs are present. AMIs are re-resolved for the target region. The abandoned region is cleaned up for test_id in question (capacity reservations are cancelled, stale instances are terminated).

The target placement is resolved at provision time and is persisted to resolved_placement.yaml, and re-applied to config during test execution, since provisioning and the test run can be separate hydra steps.

Fixes: SCT-406

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :green_circle: [single region, happy path (no capacity exhaustion) ](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/pr-provision-test-new/325/)
- [x] :green_circle: [multi region, happy path (no capacity exhaustion) ](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/pr-provision-test-new/325/)
- [x] :green_circle: [single region fallback](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/pr-provision-test-new/324/)
initially selected tegion
```
23:33:03  region_name:
23:33:03  - eu-central-1
23:33:03  required_params:
```
after fallback the cluster was provisioned in `eu-west-1` region
<img width="1112" height="783" alt="Screenshot from 2026-06-30 00-31-26" src="https://github.com/user-attachments/assets/7429b860-15bb-475d-bc07-42ccebebbf94" />
- [x] :green_circle: [multi region fallback, one region failed provisioning and was relocated](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/pr-provision-test-new/321/)
initially selected regions
```
15:09:25  region_name:
15:09:25  - eu-west-1
15:09:25  - eu-central-1
```
after fallback the cluster was provisioned in `eu-west-1 us-west-2` regions
<img width="1112" height="783" alt="Screenshot from 2026-06-30 00-40-50" src="https://github.com/user-attachments/assets/67715f4d-7c4e-447c-8b2d-f96b943ec4f3" />
- [x] :green_circle: [multi region fallback, both regions failed provisioning and were relocated](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/pr-provision-test-new/322/)
initially selected regions
```
21:27:04  region_name:
21:27:04  - eu-central-1
21:27:04  - eu-west-2
```
after fallback the cluster was provisioned in `eu-west-1 us-west-2` regions
<img width="1112" height="783" alt="Screenshot from 2026-06-30 00-43-26" src="https://github.com/user-attachments/assets/40035410-2318-458d-be8d-da2576fc651b" />

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
