### PR TITLE
feature(azure): add ARM (aarch64) artifact and longevity test cases

### DIFF
--- a/configurations/azure/azure-arm.yaml
+++ b/configurations/azure/azure-arm.yaml
@@ -1,0 +1,4 @@
+azure_instance_type_db: 'Standard_D8pds_v6'
+azure_region_name: "eastus"
+
+user_prefix: 'longevity-100gb-4h-azure-arm'

--- a/jenkins-pipelines/oss/artifacts/artifacts-azure-image-arm.jenkinsfile
+++ b/jenkins-pipelines/oss/artifacts/artifacts-azure-image-arm.jenkinsfile
@@ -1,0 +1,17 @@
+#! groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+artifactsPipeline(
+    params: params,
+
+    test_config: 'test-cases/artifacts/azure-image-arm.yaml',
+    backend: 'azure',
+    provision_type: 'spot',
+
+    timeout: [time: 145, unit: 'MINUTES'],
+    post_behavior_db_nodes: 'destroy',
+    ip_ssh_connections: 'public',
+    builds_to_keep: '30'
+)

--- a/jenkins-pipelines/oss/longevity/longevity-100gb-4h-azure-arm.jenkinsfile
+++ b/jenkins-pipelines/oss/longevity/longevity-100gb-4h-azure-arm.jenkinsfile
@@ -1,0 +1,10 @@
+#!groovy
+
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'azure',
+    azure_region_name: 'eastus',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: '''["test-cases/longevity/longevity-100gb-4h.yaml", "configurations/azure/azure-arm.yaml"]''',
+)

--- a/test-cases/artifacts/azure-image-arm.yaml
+++ b/test-cases/artifacts/azure-image-arm.yaml
@@ -1,0 +1,16 @@
+cluster_backend: 'azure'
+azure_region_name: "eastus"
+use_preinstalled_scylla: true
+backtrace_decoding: false
+azure_instance_type_db: 'Standard_D4pds_v6'
+instance_provision: "spot"
+instance_provision_fallback_on_demand: true
+n_db_nodes: 1
+n_loaders: 0
+n_monitor_nodes: 0
+nemesis_class_name: 'NoOpMonkey'
+test_duration: 60
+user_prefix: 'artifacts-azure-image-arm'
+
+# since running from runner in AWS, we need the address to be publicly available
+intra_node_comm_public: true


### PR DESCRIPTION
## Summary

Add Azure ARM (aarch64) test configurations and Jenkins pipelines for artifact validation and basic longevity testing.

**Jira:** [SCT-463](https://scylladb.atlassian.net/browse/SCT-463)

## Changes

- `test-cases/artifacts/azure-image-arm.yaml` — Artifact test using `Standard_D4ps_v6` (Cobbolt 100)
- `test-cases/longevity/longevity-10gb-3h-azure-arm.yaml` — Basic longevity test using `Standard_D8ps_v6`
- `jenkins-pipelines/oss/artifacts/artifacts-azure-image-arm.jenkinsfile` — Pipeline for ARM artifact test
- `jenkins-pipelines/oss/longevity/longevity-10gb-3h-azure-arm.jenkinsfile` — Pipeline for ARM longevity test

## Instance Types

| Role | Instance Type | vCPUs | RAM | Architecture |
|------|--------------|-------|-----|--------------|
| DB (artifact) | Standard_D4pds_v6 | 4 | 16 GB | ARM64 (Cobbolt 100) |
| DB (longevity) | Standard_D8pds_v6 | 8 | 32 GB | ARM64 (Cobbolt 100) |

## Staging Trigger Results

Jobs generated and triggered via `staging_trigger.py`:

## Context

Part of the Azure ARM validation work ([scylla-pkg#6344](https://github.com/scylladb/scylla-pkg/pull/6344), [scylla-machine-image#861](https://github.com/scylladb/scylla-machine-image/pull/861)). These jobs validate that SCT can provision and test Scylla on Azure ARM instances before adding triggers to the upstream packaging pipelines.

## Next Steps

- Once jobs pass: update scylla-pkg PR triggers with accurate job references
- Separately: revive Azure ARM image listing PR (SDK migration to support ARM image discovery)


[SCT-463]: https://scylladb.atlassian.net/browse/SCT-463?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

### Testing

- [x] 🟢 [oss/artifacts/artifacts-azure-image-arm-test #8](https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/oss/job/artifacts/job/artifacts-azure-image-arm-test/8/)
- [x] 🟢 [oss/longevity/longevity-100gb-4h-azure-arm-test #7](https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/oss/job/longevity/job/longevity-100gb-4h-azure-arm-test/7/)
- [x] 🟢 [oss/longevity/longevity-100gb-4h-azure-arm-test #10](https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/oss/job/longevity/job/longevity-100gb-4h-azure-arm-test/10/)
- [x] 🟢 [oss/artifacts/artifacts-azure-image-arm-test #14](https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/oss/job/artifacts/job/artifacts-azure-image-arm-test/14/)
