### PR TITLE
fix(provision): unpin availability_zone for large-partition GCE test

### DIFF
--- a/jenkins-pipelines/master-triggers/sct_triggers/tier1-custom-time-trigger.xml
+++ b/jenkins-pipelines/master-triggers/sct_triggers/tier1-custom-time-trigger.xml
@@ -31,7 +31,28 @@ requested_by_user=timtimb0t</properties>
             </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
           </configs>
           <projects>
-            ../tier1/gemini-1tb-10h-test,../tier1/longevity-1tb-5days-azure-test,../tier1/longevity-large-partition-200k-pks-4days-gce-test,../tier1/longevity-mv-si-4days-streaming-test,../tier1/longevity-schema-topology-changes-12h-test,../tier1/longevity-twcs-48h-test,../tier1/longevity-multidc-schema-topology-changes-12h-test,../tier1/longevity-150gb-asymmetric-cluster-12h-test,../longevity/longevity-twcs-2h-rackaware-test</projects>
+            ../tier1/gemini-1tb-10h-test,../tier1/longevity-1tb-5days-azure-test,../tier1/longevity-mv-si-4days-streaming-test,../tier1/longevity-schema-topology-changes-12h-test,../tier1/longevity-twcs-48h-test,../tier1/longevity-multidc-schema-topology-changes-12h-test,../tier1/longevity-150gb-asymmetric-cluster-12h-test,../longevity/longevity-twcs-2h-rackaware-test</projects>
+          <condition>SUCCESS</condition>
+          <triggerWithNoParameters>false</triggerWithNoParameters>
+          <triggerFromChildProjects>false</triggerFromChildProjects>
+        </hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
+        <!-- Separate config for longevity-large-partition-200k-pks-4days-gce-test:
+             No availability_zone pinned so GceAZResolver auto-selects a valid zone,
+             avoiding ZONE_RESOURCE_POOL_EXHAUSTED failures in a single hardcoded zone.
+             See: https://scylladb.atlassian.net/browse/SCT-140 -->
+        <hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
+          <configs>
+            <hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
+              <properties>scylla_version=%(sct_branch)s:latest
+provision_type=on_demand
+post_behavior_db_nodes=destroy
+post_behavior_monitor_nodes=destroy
+stress_duration=1440
+requested_by_user=timtimb0t</properties>
+              <textParamValueOnNewLine>false</textParamValueOnNewLine>
+            </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
+          </configs>
+          <projects>../tier1/longevity-large-partition-200k-pks-4days-gce-test</projects>
           <condition>SUCCESS</condition>
           <triggerWithNoParameters>false</triggerWithNoParameters>
           <triggerFromChildProjects>false</triggerFromChildProjects>


### PR DESCRIPTION
Split longevity-large-partition-200k-pks-4days-gce-test into its own BuildTriggerConfig entry without a hardcoded availability_zone.  This lets GceAZResolver auto-select a valid zone at runtime, avoiding ZONE_RESOURCE_POOL_EXHAUSTED failures when us-east1-c is out of capacity for the z3-highmem-8-highlssd instance type.

Fixes: https://scylladb.atlassian.net/browse/SCT-140

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [longevity-large-partition-200k-pks-4days-gce-test](https://jenkins.scylladb.com/job/scylla-2025.4/job/reproducers/job/longevity-large-partition-200k-pks-4days-gce-test/2/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
