### PR TITLE
fix(xcloud): wait for managed vector.dev with fallback installation

### DIFF
--- a/sdcm/cluster_cloud.py
+++ b/sdcm/cluster_cloud.py
@@ -152,6 +152,10 @@ def extract_short_test_id_from_name(name: str) -> str | None:
 
 VECTOR_BASE_URL = "https://packages.timber.io/vector/latest"
 
+# timeouts for detecting the Ansible/devops-managed vector.dev logging service before falling back to self-installing it
+ANSIBLE_VECTOR_PRESENCE_TIMEOUT = 60
+ANSIBLE_VECTOR_ACTIVE_TIMEOUT = 300
+
 
 def download_vector_locally(arch="amd64", dest_dir="downloads"):
     """
@@ -353,25 +357,88 @@ class CloudNode(cluster.BaseNode):
             return super().db_up()
 
     def configure_remote_logging(self):
-        if self.xcloud_connect_supported and self.parent_cluster.params.get("logs_transport") == "vector":
-            ret = self.remoter.run("dpkg --print-architecture", retry=0)
-            arch = ret.stdout.strip() if ret.return_code == 0 else "amd64"
+        """Configure vector logging on Scylla Cloud nodes."""
+        if not (self.xcloud_connect_supported and self.parent_cluster.params.get("logs_transport") == "vector"):
+            self.log.debug("Skip configuring remote logging on scylla-cloud node, for anything but vector transport")
+            return
 
-            package_path = download_vector_locally(arch=arch)
-
-            remote_path = f"/tmp/{os.path.basename(package_path)}"
-
-            LOGGER.debug(f"➡ Copying {package_path}")
-            self.remoter.send_files(str(package_path), remote_path)
-
-            LOGGER.debug("➡ Installing Vector")
-            ssh_cmd = configure_backoff_timeout() + install_vector_from_local_pkg(remote_path)
-            self.remoter.sudo(shell_script_cmd(ssh_cmd, quote="'"), retry=0, verbose=True)
-            host, port = TestConfig().get_logging_service_host_port()
-            ssh_cmd = configure_vector_target_script(host=host, port=port)
-            self.remoter.sudo(shell_script_cmd(ssh_cmd, quote="'"), retry=0, verbose=True)
+        if self._managed_vector_ready():
+            self.log.info("vector.dev is managed by Ansible on node %s — applying SCT target config only", self.name)
         else:
-            self.log.debug("Skip configuring remote logging on scylla-cloud, for anything but vector transport")
+            self.log.info("Ansible-managed vector.dev not ready on node %s — self-installing as fallback", self.name)
+            self._self_install_vector()
+
+        self._apply_vector_target_config()
+
+        if not self._vector_is_active():
+            raise ScyllaCloudError(f"vector.service is not active on node {self.name} after configuring remote logging")
+
+    def _vector_is_active(self) -> bool:
+        result = self.remoter.run("systemctl is-active vector.service", ignore_status=True, verbose=False)
+        return result.stdout.strip() == "active"
+
+    def _vector_unit_present(self) -> bool:
+        result = self.remoter.run("systemctl list-unit-files vector.service", ignore_status=True, verbose=False)
+        return result.return_code == 0 and "vector.service" in result.stdout
+
+    def _managed_vector_ready(self) -> bool:
+        """Two-phase probe for the Ansible/devops-managed vector.dev service.
+
+        Returns True only if the vector.service unit appears (presence phase) and becomes active
+        (readiness phase) within the configured timeouts.
+        """
+        unit_present = wait.wait_for(
+            func=self._vector_unit_present,
+            step=5,
+            text=f"Checking whether vector.dev is managed by Ansible on {self.name}",
+            timeout=ANSIBLE_VECTOR_PRESENCE_TIMEOUT,
+            throw_exc=False,
+        )
+        if not unit_present:
+            self.log.info(
+                "vector.service not present on node %s within %ss — Ansible is not managing it",
+                self.name,
+                ANSIBLE_VECTOR_PRESENCE_TIMEOUT,
+            )
+            return False
+
+        unit_active = wait.wait_for(
+            func=self._vector_is_active,
+            step=10,
+            text=f"Waiting for Ansible-managed vector.service to become active on {self.name}",
+            timeout=ANSIBLE_VECTOR_ACTIVE_TIMEOUT,
+            throw_exc=False,
+        )
+        if not unit_active:
+            self.log.info(
+                "vector.service present but not active on node %s within %ss",
+                self.name,
+                ANSIBLE_VECTOR_ACTIVE_TIMEOUT,
+            )
+            return False
+
+        return True
+
+    def _self_install_vector(self):
+        """Self-install vector.dev from a locally-downloaded .deb."""
+        arch_result = self.remoter.run("dpkg --print-architecture", retry=0)
+        arch = arch_result.stdout.strip() if arch_result.return_code == 0 else "amd64"
+
+        local_package = download_vector_locally(arch=arch)
+        remote_path = f"/tmp/{os.path.basename(local_package)}"
+        LOGGER.debug("Copying %s", local_package)
+        self.remoter.send_files(str(local_package), remote_path)
+
+        LOGGER.debug("Installing vector.dev package")
+        ssh_cmd = configure_backoff_timeout() + install_vector_from_local_pkg(remote_path)
+        self.remoter.sudo(shell_script_cmd(ssh_cmd, quote="'"), retry=0, verbose=True)
+
+    def _apply_vector_target_config(self):
+        """Write the SCT vector target config and (re)start vector against it."""
+        self.remoter.sudo("systemctl reset-failed vector.service", ignore_status=True)
+        host, port = TestConfig().get_logging_service_host_port()
+        ssh_cmd = configure_vector_target_script(host=host, port=port)
+        self.remoter.sudo(shell_script_cmd(ssh_cmd, quote="'"), retry=0, verbose=True)
 
     @xcloud_super_if_supported
     def start_coredump_thread(self):
@@ -439,31 +506,6 @@ class CloudVSNode(VectorStoreNodeMixin, CloudNode):
     @property
     def node_type(self) -> str:
         return "vector-store"
-
-    def configure_remote_logging(self):
-        """Wait for Ansible managed vector.dev service to be ready"""
-        if not (self.xcloud_connect_supported and self.parent_cluster.params.get("logs_transport") == "vector"):
-            self.log.debug("Skip configuring remote logging on VS node, for anything but vector transport")
-            return
-
-        self.log.debug("Waiting for Ansible to install vector.dev on VS node")
-
-        def is_vector_active():
-            result = self.remoter.run("systemctl is-active vector.service", ignore_status=True, verbose=False)
-            return result.stdout.strip() == "active"
-
-        wait.wait_for(
-            func=is_vector_active,
-            step=10,
-            text=f"Waiting for vector.service on {self.name}",
-            timeout=600,
-            throw_exc=True,
-        )
-        self.log.debug("vector.dev is active on VS node")
-
-        host, port = TestConfig().get_logging_service_host_port()
-        ssh_cmd = configure_vector_target_script(host=host, port=port)
-        self.remoter.sudo(shell_script_cmd(ssh_cmd, quote="'"), retry=0, verbose=True)
 
 
 class CloudManagerNode(CloudNode):

--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -934,6 +934,18 @@ class ScyllaLogCollector(LogCollector):
         CommandLog(name="io-properties.yaml", command="cat /etc/scylla.d/io_properties.yaml"),
         CommandLog(name="dmesg.log", command="sudo dmesg -P"),
         CommandLog(name="systemctl.status", command="sudo systemctl status --all --full --no-pager"),
+        # system.log here filters to scylla units only, so capture vector.dev's status/journal/config separately
+        CommandLog(
+            name="vector.log",
+            command=(
+                "( echo '=== systemctl status vector.service ==='; "
+                "sudo systemctl status vector.service --full --no-pager; "
+                "echo '=== journalctl -u vector.service ==='; "
+                "sudo journalctl --no-tail --no-pager -u vector.service -o short-precise; "
+                "echo '=== vector validate /etc/vector/vector.yaml ==='; "
+                "sudo vector validate /etc/vector/vector.yaml )"
+            ),
+        ),
         CommandLog(name="cassandra-rackdc.properties", command=f"cat {SCYLLA_PROPERTIES_PATH}"),
         CommandLog(name="scylla-manager-agent.yaml", command=f"cat {SCYLLA_MANAGER_AGENT_YAML_PATH}"),
         CommandLog(name="setup_scripts_errors.log", command="for i in /var/tmp/scylla/*.log;do echo [$i]; cat $i;done"),

--- a/sdcm/provision/common/utils.py
+++ b/sdcm/provision/common/utils.py
@@ -125,6 +125,9 @@ sinks:
         healthcheck: false
 EOF
 
+        chmod 0755 /etc/vector
+        chmod 0644 /etc/vector/vector.yaml
+
         systemctl restart vector || echo "WARNING: vector.service restart failed, will be reconfigured later by configure_remote_logging"
     """).format(host=host, port=port)
 
@@ -417,8 +420,9 @@ def install_vector_from_local_pkg(pkg_path: str) -> str:
             exit 1
         fi
 
+        # vector is intentionally not started — it is started by configure_vector_target_script only
+        # after the SCT target config is written
         systemctl enable vector
-        systemctl start vector
     """)
 
 

--- a/unit_tests/unit/test_cluster_cloud.py
+++ b/unit_tests/unit/test_cluster_cloud.py
@@ -3,7 +3,12 @@
 import pytest
 from unittest.mock import MagicMock, patch
 
-from sdcm.cluster_cloud import xcloud_super_if_supported, ScyllaCloudCluster, ScyllaCloudError
+from sdcm.cluster_cloud import (
+    xcloud_super_if_supported,
+    ScyllaCloudCluster,
+    ScyllaCloudError,
+    CloudNode,
+)
 from sdcm.sct_config import SCTConfiguration
 from sdcm.utils.cloud_api_utils import (
     build_cloud_cluster_name,
@@ -405,3 +410,34 @@ class TestCloudServiceInstallationOrdering:
 
         mock_cluster._wait_for_cloud_service_installations()
         mock_cluster._wait_for_cloud_request_completed.assert_not_called()
+
+
+def _make_cloud_node():
+    """Create a CloudNode-like mock for configure_remote_logging tests."""
+    node = MagicMock()
+    node.name = "db-node-test-1"
+    node.xcloud_connect_supported = True
+    node.parent_cluster.params.get.return_value = "vector"
+    node._vector_is_active.return_value = True
+    return node
+
+
+def test_configure_remote_logging_managed_path_does_not_self_install():
+    node = _make_cloud_node()
+    node._managed_vector_ready.return_value = True
+    CloudNode.configure_remote_logging(node)
+
+    node._apply_vector_target_config.assert_called_once()
+    node._self_install_vector.assert_not_called()
+
+
+def test_configure_remote_logging_falls_back_to_self_install():
+    node = _make_cloud_node()
+    node._managed_vector_ready.return_value = False
+    CloudNode.configure_remote_logging(node)
+
+    node._self_install_vector.assert_called_once()
+    node._apply_vector_target_config.assert_called_once()
+
+    ordered = [c[0] for c in node.mock_calls]
+    assert ordered.index("_self_install_vector") < ordered.index("_apply_vector_target_config")


### PR DESCRIPTION
On Scylla Cloud the vector.dev service is managed by the devops tooling, which became the case at some point in the past.
Initially DB nodes of xcloud backend in SCT were self-installing and starting the vector.dev service, but now this installation is occasionally racing with managed installation, which can send service into a crash-loop.

The change refactors remote logging configuration sequence for managed nodes in xcloud backend (DB and VS nodes). It introduces a 2-phase sequence - first probe for the managed vector.dev installation and when ready, override its config with the SCT-specific one. If managed installation is not successful (devops tooling occasionally has their own issues), then self-install service as a fallback.
Vector logging service is started only after the SCT config is applied.

Fixes: SCT-449

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :green_circle: [pr-provision-test on xcloud with 2 VS nodes](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/xcloud-test/10/)
Some lines from logs that indicate that fallback for vector.dev installation happened - test waited for managed vector logging service to be up and running and once time was out, it installed vector-dev itself and configured it for SCT.
Happened for 3 out of 3 DB nodes and 1 out of 2 VS nodes:
```
❯ grep -nE "self-installing as fallback|applying SCT target config only" sct-69145d4a.log
17356:< t:2026-06-22 23:16:14,479 f:cluster_cloud.py l:368  c:sdcm.cluster_cloud   p:INFO  > Node db-node-69145d4a-0-1 [None | 172.31.32.100] (Type: i4i.large): Ansible-managed vector.dev not ready on node db-node-69145d4a-0-1 — self-installing as fallback
19059:< t:2026-06-22 23:17:53,060 f:cluster_cloud.py l:368  c:sdcm.cluster_cloud   p:INFO  > Node db-node-69145d4a-0-2 [None | 172.31.32.171] (Type: i4i.large): Ansible-managed vector.dev not ready on node db-node-69145d4a-0-2 — self-installing as fallback
20829:< t:2026-06-22 23:19:29,606 f:cluster_cloud.py l:368  c:sdcm.cluster_cloud   p:INFO  > Node db-node-69145d4a-0-3 [None | 172.31.32.56] (Type: i4i.large): Ansible-managed vector.dev not ready on node db-node-69145d4a-0-3 — self-installing as fallback
23086:< t:2026-06-22 23:23:10,366 f:cluster_cloud.py l:368  c:sdcm.cluster_cloud   p:INFO  > Node vs-node-69145d4a-0-1 [None | None] (Type: CloudManaged): Ansible-managed vector.dev not ready on node vs-node-69145d4a-0-1 — self-installing as fallback
23644:< t:2026-06-22 23:24:07,443 f:cluster_cloud.py l:366  c:sdcm.cluster_cloud   p:INFO  > Node vs-node-69145d4a-0-2 [None | None] (Type: CloudManaged): vector.dev is managed by Ansible on node vs-node-69145d4a-0-2 — applying SCT target config only
```

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
