### PR TITLE
fix: replace scalar comparisons broken by IntOrList normalization

### DIFF
--- a/sdcm/cluster_k8s/eks.py
+++ b/sdcm/cluster_k8s/eks.py
@@ -139,7 +139,7 @@ def deploy_k8s_eks_cluster(k8s_cluster) -> None:
     k8s_cluster.deploy_node_pool(scylla_pool, wait_till_ready=False)
 
     # TODO: add support for different loaders amount in different K8S clusters
-    if params.get("n_loaders"):
+    if sum(params.get("n_loaders")) > 0:
         k8s_cluster.deploy_node_pool(
             wait_till_ready=False,
             pool=EksNodePool(

--- a/sdcm/cluster_k8s/gke.py
+++ b/sdcm/cluster_k8s/gke.py
@@ -102,7 +102,7 @@ def deploy_k8s_gke_cluster(k8s_cluster) -> None:
             k8s_cluster.deploy_scylla_manager(pool_name=k8s_cluster.AUXILIARY_POOL_NAME)
 
     # TODO: add support for different loaders amount in different K8S clusters
-    if params.get("n_loaders"):
+    if sum(params.get("n_loaders")) > 0:
         loader_pool = GkeNodePool(
             name=k8s_cluster.LOADER_POOL_NAME,
             instance_type=params.get("gce_instance_type_loader"),

--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -444,7 +444,7 @@ class PrometheusSnapshots(BaseMonitoringEntity):
 
     def collect(self, node, local_dst, remote_dst=None, local_search_path=None) -> Optional[str]:
         # Skip if no monitor nodes configured - no point collecting monitoring data
-        if not self._params.get("n_monitor_nodes"):
+        if not sum(self._params.get("n_monitor_nodes")):
             LOGGER.info("Skipping Prometheus snapshot collection - no monitor nodes configured (n_monitor_nodes=0)")
             return None
         self.setup_monitor_data_dir(node)
@@ -533,7 +533,7 @@ class MonitoringStack(BaseMonitoringEntity):
 
     def collect(self, node, local_dst, remote_dst=None, local_search_path=None):
         # Skip if no monitor nodes configured - no point collecting monitoring data
-        if not self._params.get("n_monitor_nodes"):
+        if not sum(self._params.get("n_monitor_nodes")):
             LOGGER.info("Skipping monitoring stack collection - no monitor nodes configured (n_monitor_nodes=0)")
             return None
         local_archive = self.get_monitoring_data_stack(node, local_dst)
@@ -649,7 +649,7 @@ class GrafanaScreenShot(GrafanaEntity):
 
     def collect(self, node, local_dst, remote_dst=None, local_search_path=None):
         # Skip if no monitor nodes configured - no point collecting monitoring data
-        if not self._params.get("n_monitor_nodes"):
+        if not sum(self._params.get("n_monitor_nodes")):
             LOGGER.info("Skipping Grafana screenshot collection - no monitor nodes configured (n_monitor_nodes=0)")
             return []
         node.logdir = local_dst

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -4721,7 +4721,7 @@ class SCTConfiguration(BaseModel):
         n_nodes = _n_db_nodes if isinstance(_n_db_nodes, list) else [_n_db_nodes]
         if rf is None:
             self["xcloud_replication_factor"] = min(*n_nodes, 3)
-        elif rf > n_nodes:
+        elif rf > min(n_nodes):
             raise ValueError(f"xcloud_replication_factor ({rf}) cannot be greater than n_db_nodes ({n_nodes})")
 
         # validate Vector Search parameters for cloud backend

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -3140,8 +3140,8 @@ class SCTConfiguration(BaseModel):
                     raise ValueError(f" Got error: {exp!r}, on item '{param}'") from exp
 
         # 15 Force endpoint_snitch to GossipingPropertyFileSnitch if using simulated_regions or simulated_racks
-        n_db_nodes = self.get("n_db_nodes") or 0
-        num_of_db_nodes = sum(n_db_nodes if isinstance(n_db_nodes, list) else [n_db_nodes])
+        n_db_nodes = self.get("n_db_nodes")
+        num_of_db_nodes = sum(n_db_nodes or [])
         if (
             (self.get("simulated_regions") or 0) > 1
             or (self.get("simulated_racks") or 0) > 1
@@ -3212,20 +3212,6 @@ class SCTConfiguration(BaseModel):
             data_nodes_num = self.get("n_db_nodes")
             # if number of zero nodes is set for cluster setup, check correctness of settings
             if zero_nodes_num:
-                zero_nodes_num = (
-                    zero_nodes_num
-                    if isinstance(zero_nodes_num, list)
-                    else [zero_nodes_num]
-                    if isinstance(zero_nodes_num, int)
-                    else [int(i) for i in str(zero_nodes_num).split()]
-                )
-                data_nodes_num = (
-                    data_nodes_num
-                    if isinstance(data_nodes_num, list)
-                    else [data_nodes_num]
-                    if isinstance(data_nodes_num, int)
-                    else [int(i) for i in str(data_nodes_num).split()]
-                )
                 assert len(zero_nodes_num) == len(data_nodes_num), (
                     "Config of zero token nodes is not equal config of data nodes for multi dc"
                 )
@@ -4717,8 +4703,7 @@ class SCTConfiguration(BaseModel):
                 )
 
         rf = self.get("xcloud_replication_factor")
-        _n_db_nodes: list[int] | int = self.get("n_db_nodes")
-        n_nodes = _n_db_nodes if isinstance(_n_db_nodes, list) else [_n_db_nodes]
+        n_nodes: list[int] = self.get("n_db_nodes")
         if rf is None:
             self["xcloud_replication_factor"] = min(*n_nodes, 3)
         elif rf > min(n_nodes):

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1696,7 +1696,7 @@ class ClusterTester(unittest.TestCase):
         )
         if monitor_info["n_nodes"] is None:
             monitor_info["n_nodes"] = self.params.get("n_monitor_nodes")
-        if monitor_info["n_nodes"] > 0:
+        if sum(monitor_info["n_nodes"]) > 0:
             gce_image_monitor = self.params.get("gce_image_monitor")
             if not gce_image_monitor:
                 gce_image_monitor = self.params.get("gce_image")
@@ -1766,7 +1766,7 @@ class ClusterTester(unittest.TestCase):
         )
         if monitor_info["n_nodes"] is None:
             monitor_info["n_nodes"] = self.params.get("n_monitor_nodes")
-        if monitor_info["n_nodes"] > 0:
+        if sum(monitor_info["n_nodes"]) > 0:
             azure_image_monitor = self.params.get("azure_image_monitor")
             if not azure_image_monitor:
                 azure_image_monitor = self.params.get("azure_image")
@@ -1834,7 +1834,7 @@ class ClusterTester(unittest.TestCase):
 
         if monitor_info["n_nodes"] is None:
             monitor_info["n_nodes"] = self.params.get("n_monitor_nodes")
-        if monitor_info["n_nodes"] > 0:
+        if sum(monitor_info["n_nodes"]) > 0:
             self.monitors = MonitorSetOci(
                 image_id=self.params.get("oci_image_monitor"),
                 root_disk_size=monitor_info["disk_size"],
@@ -2063,7 +2063,7 @@ class ClusterTester(unittest.TestCase):
             **common_params,
         )
 
-        if monitor_info["n_nodes"] > 0:
+        if sum(monitor_info["n_nodes"]) > 0:
             self.monitors = MonitorSetAWS(
                 ec2_ami_id=self.params.get("ami_id_monitor").split(),
                 ec2_ami_username=self.params.get("ami_monitor_user"),
@@ -2184,7 +2184,7 @@ class ClusterTester(unittest.TestCase):
             k8s_cluster.set_nodeselector_for_deployments(pool_name=k8s_cluster.AUXILIARY_POOL_NAME, namespace=namespace)
 
         loader_pool = None
-        if self.params.get("n_loaders"):
+        if sum(self.params.get("n_loaders")) > 0:
             loader_pool = mini_k8s.MinimalK8SNodePool(
                 k8s_cluster=k8s_cluster,
                 name=k8s_cluster.LOADER_POOL_NAME,
@@ -2236,7 +2236,7 @@ class ClusterTester(unittest.TestCase):
             add_nodes=False,
         )
 
-        if self.params.get("n_loaders"):
+        if sum(self.params.get("n_loaders")) > 0:
             self.loaders = cluster_k8s.LoaderPodCluster(
                 k8s_clusters=[k8s_cluster],
                 loader_cluster_name=self.params.get("k8s_loader_cluster_name"),
@@ -2358,7 +2358,7 @@ class ClusterTester(unittest.TestCase):
             add_nodes=False,
         )
 
-        if self.params.get("n_loaders"):
+        if sum(self.params.get("n_loaders")) > 0:
             self.loaders = cluster_k8s.LoaderPodCluster(
                 k8s_clusters=self.k8s_clusters,
                 loader_cluster_name=self.params.get("k8s_loader_cluster_name"),
@@ -2466,7 +2466,7 @@ class ClusterTester(unittest.TestCase):
                     namespace=self.db_cluster.namespace,
                 )
 
-        if self.params.get("n_loaders"):
+        if sum(self.params.get("n_loaders")) > 0:
             self.loaders = cluster_k8s.LoaderPodCluster(
                 k8s_clusters=self.k8s_clusters,
                 loader_cluster_name=self.params.get("k8s_loader_cluster_name"),
@@ -2498,7 +2498,7 @@ class ClusterTester(unittest.TestCase):
             "device_mappings": None,
         }
         init_monitoring_info_from_params(monitor_info, params=self.params, regions=region_names)
-        if monitor_info["n_nodes"]:
+        if sum(monitor_info["n_nodes"]) > 0:
             common_params = get_common_params(
                 params=self.params,
                 regions=region_names,
@@ -2594,7 +2594,7 @@ class ClusterTester(unittest.TestCase):
                 **common_params,
             )
 
-            if monitor_info["n_nodes"] > 0:
+            if sum(monitor_info["n_nodes"]) > 0:
                 self.monitors = MonitorSetAWS(
                     ec2_ami_id=self.params.get("ami_id_monitor").split(),
                     ec2_ami_username=self.params.get("ami_monitor_user"),
@@ -2663,7 +2663,7 @@ class ClusterTester(unittest.TestCase):
                 **common_params,
             )
 
-            if monitor_info["n_nodes"] > 0:
+            if sum(monitor_info["n_nodes"]) > 0:
                 monitor_additional_disks = {"pd-ssd": self.params.get("gce_pd_ssd_disk_size_monitor")}
                 self.monitors = MonitorSetGCE(
                     gce_image=self.params.get("gce_image_monitor").strip(),
@@ -2699,7 +2699,7 @@ class ClusterTester(unittest.TestCase):
             allowed_ips=loader_ips,
         )
 
-        if monitor_info["n_nodes"] > 0:
+        if sum(monitor_info["n_nodes"]) > 0:
             self.monitors.targets["db_cluster"] = self.db_cluster
             self.monitors.promproxy_config = self.db_cluster.get_promproxy_config()
 

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -2214,8 +2214,8 @@ class ClusterTester(unittest.TestCase):
         if self.params.get("use_mgmt"):
             k8s_cluster.deploy_scylla_manager(pool_name=k8s_cluster.AUXILIARY_POOL_NAME)
 
-        n_monitor_nodes = self.params.get("k8s_n_monitor_nodes") or self.params.get("n_monitor_nodes")
-        if n_monitor_nodes:
+        n_monitor_nodes = self.params.get("k8s_n_monitor_nodes") or sum(self.params.get("n_monitor_nodes"))
+        if n_monitor_nodes > 0:
             monitor_pool = mini_k8s.MinimalK8SNodePool(
                 k8s_cluster=k8s_cluster,
                 name=k8s_cluster.MONITORING_POOL_NAME,

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -2214,7 +2214,7 @@ class ClusterTester(unittest.TestCase):
         if self.params.get("use_mgmt"):
             k8s_cluster.deploy_scylla_manager(pool_name=k8s_cluster.AUXILIARY_POOL_NAME)
 
-        n_monitor_nodes = self.params.get("k8s_n_monitor_nodes") or sum(self.params.get("n_monitor_nodes"))
+        n_monitor_nodes = self.params.get("k8s_n_monitor_nodes") or sum(self.params.get("n_monitor_nodes") or [])
         if n_monitor_nodes > 0:
             monitor_pool = mini_k8s.MinimalK8SNodePool(
                 k8s_cluster=k8s_cluster,

--- a/unit_tests/integration/test_config.py
+++ b/unit_tests/integration/test_config.py
@@ -12,6 +12,7 @@
 # Copyright (c) 2020 ScyllaDB
 
 import logging
+from unittest.mock import patch, MagicMock
 
 import pytest
 
@@ -372,3 +373,71 @@ def test_20_user_data_format_version_azure(monkeypatch):
     # since azure image listing is still buggy, can be sure which version we'll get
     # I would expect master:latest to be version 3 now, but azure.utils.get_scylla_images
     # returns something from 5 months ago.
+
+
+def _make_xcloud_api_mock():
+    """Return a MagicMock that satisfies _validate_cloud_backend_parameters checks."""
+    mock_api = MagicMock()
+    mock_api.get_scylla_versions.return_value = {"scyllaVersions": [{"version": "2025.1.0"}]}
+    mock_api.get_regions.return_value = {"regions": [{"externalId": "eu-west-1"}, {"externalId": "us-east1"}]}
+    mock_api.get_region_id_by_name.return_value = "region-id-1"
+    mock_api.get_instance_types.return_value = {"instances": [{"externalId": "i4i.large"}]}
+    # cloud_provider_ids is subscripted with a CloudProviderType enum key — MagicMock
+    # handles __getitem__ automatically, returning a MagicMock as the provider id.
+    return mock_api
+
+
+@pytest.mark.integration
+def test_xcloud_replication_factor_valid(monkeypatch):
+    """xcloud_replication_factor <= min(n_db_nodes) must not raise.
+
+    Regression: before the fix, rf > n_nodes raised TypeError ('>' not supported
+    between int and list) because n_nodes was list[int] after IntOrList normalization.
+    """
+    monkeypatch.setenv("SCT_CLUSTER_BACKEND", "xcloud")
+    monkeypatch.setenv("SCT_XCLOUD_PROVIDER", "aws")
+    monkeypatch.setenv("SCT_REGION_NAME", "eu-west-1")
+    monkeypatch.setenv("SCT_N_DB_NODES", "3 3")
+    monkeypatch.setenv("SCT_SCYLLA_VERSION", "2025.1.0")
+    monkeypatch.setenv("SCT_XCLOUD_REPLICATION_FACTOR", "2")
+    monkeypatch.setenv("SCT_INSTANCE_TYPE_DB", "i4i.large")
+    monkeypatch.setenv("SCT_CONFIG_FILES", "unit_tests/test_configs/minimal_test_case.yaml")
+    monkeypatch.setenv("SCT_XCLOUD_ENV", "fake-env")
+
+    with (
+        patch("sdcm.sct_config.ScyllaCloudAPIClient", return_value=_make_xcloud_api_mock()),
+        patch("sdcm.sct_config.KeyStore"),
+        patch("sdcm.sct_config.convert_name_to_ami_if_needed", side_effect=lambda v, _: v),
+        patch("sdcm.sct_config.find_scylla_repo", return_value="https://fake-repo/scylla.repo"),
+    ):
+        conf = sct_config.SCTConfiguration()
+        # Must not raise TypeError or ValueError
+        conf.verify_configuration()
+
+
+@pytest.mark.integration
+def test_xcloud_replication_factor_exceeds_min_dc(monkeypatch):
+    """xcloud_replication_factor > min(n_db_nodes) must raise ValueError, not TypeError.
+
+    Regression: before the fix, this raised TypeError: '>' not supported between
+    instances of 'int' and 'list'. After the fix it correctly raises ValueError.
+    """
+    monkeypatch.setenv("SCT_CLUSTER_BACKEND", "xcloud")
+    monkeypatch.setenv("SCT_XCLOUD_PROVIDER", "aws")
+    monkeypatch.setenv("SCT_REGION_NAME", "eu-west-1")
+    monkeypatch.setenv("SCT_N_DB_NODES", "3 3")
+    monkeypatch.setenv("SCT_SCYLLA_VERSION", "2025.1.0")
+    monkeypatch.setenv("SCT_XCLOUD_REPLICATION_FACTOR", "4")
+    monkeypatch.setenv("SCT_INSTANCE_TYPE_DB", "i4i.large")
+    monkeypatch.setenv("SCT_CONFIG_FILES", "unit_tests/test_configs/minimal_test_case.yaml")
+    monkeypatch.setenv("SCT_XCLOUD_ENV", "fake-env")
+
+    with (
+        patch("sdcm.sct_config.ScyllaCloudAPIClient", return_value=_make_xcloud_api_mock()),
+        patch("sdcm.sct_config.KeyStore"),
+        patch("sdcm.sct_config.convert_name_to_ami_if_needed", side_effect=lambda v, _: v),
+        patch("sdcm.sct_config.find_scylla_repo", return_value="https://fake-repo/scylla.repo"),
+    ):
+        conf = sct_config.SCTConfiguration()
+        with pytest.raises(ValueError, match="xcloud_replication_factor .* cannot be greater than n_db_nodes"):
+            conf.verify_configuration()

--- a/unit_tests/integration/test_provisioning.py
+++ b/unit_tests/integration/test_provisioning.py
@@ -1,0 +1,295 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2026 ScyllaDB
+
+"""Regression tests for init_resources() provisioning paths across all backends.
+
+These tests call ClusterTester.init_resources() with all cloud SDK calls mocked
+at the provisioner/cluster-constructor boundary. They exist to catch breakage
+where SCTConfiguration parameter types change (e.g. IntOrList now always returns
+list[int]) and downstream code still treats the value as a scalar.
+
+Every test exercises the full control-flow path inside get_cluster_<backend>()
+so that bugs like
+
+    monitor_info["n_nodes"] = self.params.get("n_monitor_nodes")  # list[int]
+    if monitor_info["n_nodes"] > 0:                               # TypeError!
+
+are caught immediately.
+
+External services required: none — all cloud SDK calls are mocked.
+"""
+
+import logging
+from contextlib import ExitStack
+from unittest.mock import patch
+
+import pytest
+
+from sdcm.sct_config import SCTConfiguration
+from sdcm.test_config import TestConfig
+from sdcm.tester import ClusterTester
+
+
+# ---------------------------------------------------------------------------
+# MinimalProvisioningTester
+# ---------------------------------------------------------------------------
+
+
+class MinimalProvisioningTester(ClusterTester):
+    """Direct ClusterTester subclass with no event system, argus, or fixture machinery.
+
+    Only initialises the instance state that init_resources() reads, nothing more.
+    """
+
+    __test__ = False
+
+    def runTest(self):
+        pass
+
+    def prepare(self, params: SCTConfiguration) -> None:
+        """Replicate only the setUp() lines that init_resources() depends on."""
+        self.params = params
+        self.log = logging.getLogger(self.__class__.__name__)
+        self.credentials = []
+        self.db_cluster = None
+        self.cs_db_cluster = None
+        self.loaders = None
+        self.monitors = None
+        self.emr_cluster = None
+        self.kafka_cluster = None
+        self.k8s_clusters = []
+        self.test_config = TestConfig()
+
+
+# ---------------------------------------------------------------------------
+# Helpers and fixtures
+# ---------------------------------------------------------------------------
+
+
+def blank_info() -> dict:
+    """Return a fresh empty info dict that ClusterTester.init_resources() builds.
+
+    Must be a plain function (not a fixture) because init_resources() mutates all
+    three info dicts independently and each call must return a distinct instance.
+    """
+    return {
+        "n_nodes": None,
+        "type": None,
+        "disk_size": None,
+        "disk_type": None,
+        "n_local_ssd": None,
+        "device_mappings": None,
+    }
+
+
+@pytest.fixture
+def mock_gce_backend():
+    with ExitStack() as stack:
+        stack.enter_context(patch("sdcm.tester.ScyllaGCECluster"))
+        stack.enter_context(patch("sdcm.tester.LoaderSetGCE"))
+        stack.enter_context(patch("sdcm.tester.MonitorSetGCE"))
+        stack.enter_context(patch("sdcm.tester.get_gce_compute_instances_client"))
+        stack.enter_context(patch("sdcm.tester.provisioner_factory"))
+        stack.enter_context(patch("sdcm.tester.GceAZResolver"))
+        stack.enter_context(patch("sdcm.tester.UserRemoteCredentials"))
+        stack.enter_context(patch("sdcm.tester.TestConfig"))
+        stack.enter_context(patch("sdcm.tester.start_posting_grafana_annotations"))
+        yield
+
+
+@pytest.fixture
+def mock_azure_backend():
+    with ExitStack() as stack:
+        stack.enter_context(patch("sdcm.tester.ScyllaAzureCluster"))
+        stack.enter_context(patch("sdcm.tester.LoaderSetAzure"))
+        stack.enter_context(patch("sdcm.tester.MonitorSetAzure"))
+        stack.enter_context(patch("sdcm.tester.provisioner_factory"))
+        stack.enter_context(patch("sdcm.tester.UserRemoteCredentials"))
+        stack.enter_context(patch("sdcm.tester.TestConfig"))
+        stack.enter_context(patch("sdcm.tester.start_posting_grafana_annotations"))
+        yield
+
+
+@pytest.fixture
+def mock_oci_backend():
+    with ExitStack() as stack:
+        stack.enter_context(patch("sdcm.tester.ScyllaOciCluster"))
+        stack.enter_context(patch("sdcm.tester.LoaderSetOci"))
+        stack.enter_context(patch("sdcm.tester.MonitorSetOci"))
+        stack.enter_context(patch("sdcm.tester.provisioner_factory"))
+        stack.enter_context(patch("sdcm.tester.UserRemoteCredentials"))
+        stack.enter_context(patch("sdcm.tester.TestConfig"))
+        stack.enter_context(patch("sdcm.tester.start_posting_grafana_annotations"))
+        yield
+
+
+@pytest.fixture
+def mock_aws_backend():
+    with ExitStack() as stack:
+        stack.enter_context(patch("sdcm.tester.ScyllaAWSCluster"))
+        stack.enter_context(patch("sdcm.tester.LoaderSetAWS"))
+        stack.enter_context(patch("sdcm.tester.MonitorSetAWS"))
+        stack.enter_context(patch("sdcm.tester.get_ec2_services"))
+        stack.enter_context(patch("sdcm.tester.get_common_params"))
+        stack.enter_context(patch("sdcm.tester.AZResolver"))
+        stack.enter_context(patch("sdcm.tester.is_az_fallback_enabled"))
+        stack.enter_context(patch("sdcm.tester.SCTCapacityReservation"))
+        stack.enter_context(patch("sdcm.tester.run_pre_flight_capacity_probe"))
+        stack.enter_context(patch("sdcm.tester.wait_ami_available"))
+        stack.enter_context(patch("sdcm.tester.UserRemoteCredentials"))
+        stack.enter_context(patch("sdcm.tester.TestConfig"))
+        stack.enter_context(patch("sdcm.tester.start_posting_grafana_annotations"))
+        # ec2_ami_get_root_device_name is imported into tester.py namespace AND called
+        # inside aws_utils itself — patch both sites.
+        stack.enter_context(patch("sdcm.tester.ec2_ami_get_root_device_name"))
+        stack.enter_context(patch("sdcm.utils.aws_utils.ec2_ami_get_root_device_name"))
+        # KeyStore is imported into aws_utils; patch there to stop S3 calls.
+        stack.enter_context(patch("sdcm.utils.aws_utils.KeyStore"))
+        yield
+
+
+@pytest.fixture
+def mock_xcloud_backend(mock_aws_backend, mock_gce_backend):
+    """Composes AWS + GCE fixtures (covers both xcloud providers) and adds
+    xcloud-specific mocks. KeyStore for aws_utils is already covered by mock_aws_backend."""
+    with ExitStack() as stack:
+        stack.enter_context(patch("sdcm.tester.ScyllaCloudCluster"))
+        stack.enter_context(patch("sdcm.tester.ScyllaCloudAPIClient"))
+        # cloud_env_credentials is a cached_property on SCTConfiguration that calls
+        # KeyStore() directly from sct_config — patch at the usage site.
+        stack.enter_context(patch("sdcm.sct_config.KeyStore"))
+        yield
+
+
+# ---------------------------------------------------------------------------
+# Parametrized test
+# ---------------------------------------------------------------------------
+
+COMMON = {
+    "SCT_N_DB_NODES": "3",
+    "SCT_N_LOADERS": "1",
+    "SCT_N_MONITOR_NODES": "1",
+    "SCT_USE_MGMT": "false",
+    "SCT_CONFIG_FILES": "unit_tests/test_configs/minimal_test_case.yaml",
+}
+
+GCE_BASE = COMMON | {
+    "SCT_CLUSTER_BACKEND": "gce",
+    "SCT_GCE_DATACENTER": "us-east1",
+    "SCT_GCE_INSTANCE_TYPE_DB": "n2-highmem-2",
+}
+
+AZURE_BASE = COMMON | {
+    "SCT_CLUSTER_BACKEND": "azure",
+    "SCT_AZURE_REGION_NAME": "eastus",
+    "SCT_AZURE_INSTANCE_TYPE_DB": "Standard_L8s_v3",
+    "SCT_AZURE_IMAGE_DB": "fake-azure-image",
+}
+
+OCI_BASE = COMMON | {
+    "SCT_CLUSTER_BACKEND": "oci",
+    "SCT_OCI_REGION_NAME": "us-ashburn-1",
+    "SCT_OCI_INSTANCE_TYPE_DB": "VM.Standard3.Flex",
+    "SCT_OCI_IMAGE_DB": "ocid1.image.oc1.fake",
+}
+
+AWS_BASE = COMMON | {
+    "SCT_CLUSTER_BACKEND": "aws",
+    "SCT_REGION_NAME": "eu-west-1",
+    "SCT_INSTANCE_TYPE_DB": "i4i.large",
+    "SCT_AMI_ID_DB_SCYLLA": "ami-fake00001",
+    "SCT_AMI_ID_LOADER": "ami-fake00002",
+    "SCT_AMI_ID_MONITOR": "ami-fake00003",
+}
+
+XCLOUD_AWS_BASE = COMMON | {
+    "SCT_CLUSTER_BACKEND": "xcloud",
+    "SCT_XCLOUD_PROVIDER": "aws",
+    "SCT_REGION_NAME": "eu-west-1",
+    "SCT_INSTANCE_TYPE_DB": "i4i.large",
+    "SCT_AMI_ID_LOADER": "ami-fake00002",
+    "SCT_AMI_ID_MONITOR": "ami-fake00003",
+    "SCT_XCLOUD_ENV": "fake-env",
+}
+
+XCLOUD_GCE_BASE = COMMON | {
+    "SCT_CLUSTER_BACKEND": "xcloud",
+    "SCT_XCLOUD_PROVIDER": "gce",
+    "SCT_GCE_DATACENTER": "us-east1",
+    "SCT_GCE_INSTANCE_TYPE_DB": "n2-highmem-2",
+    "SCT_XCLOUD_ENV": "fake-env",
+}
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    "env,backend_mock",
+    [
+        pytest.param(GCE_BASE, "mock_gce_backend", id="gce-single-dc"),
+        pytest.param(
+            GCE_BASE
+            | {
+                "SCT_GCE_DATACENTER": "us-east1 us-west1",
+                "SCT_N_DB_NODES": "3 3",
+                "SCT_N_LOADERS": "1 1",
+                "SCT_N_MONITOR_NODES": "1 0",
+            },
+            "mock_gce_backend",
+            id="gce-multi-dc",
+        ),
+        pytest.param(AZURE_BASE, "mock_azure_backend", id="azure-single-dc"),
+        pytest.param(
+            AZURE_BASE
+            | {
+                "SCT_AZURE_REGION_NAME": "eastus westus",
+                "SCT_N_DB_NODES": "3 3",
+                "SCT_N_LOADERS": "1 1",
+                "SCT_N_MONITOR_NODES": "1 0",
+            },
+            "mock_azure_backend",
+            id="azure-multi-dc",
+        ),
+        pytest.param(OCI_BASE, "mock_oci_backend", id="oci"),
+        pytest.param(AWS_BASE, "mock_aws_backend", id="aws-single-region"),
+        pytest.param(
+            AWS_BASE
+            | {
+                "SCT_REGION_NAME": '["eu-west-1", "us-east-1"]',
+                "SCT_N_DB_NODES": "3 3",
+                "SCT_N_LOADERS": "1 1",
+                "SCT_N_MONITOR_NODES": "1 0",
+                "SCT_AMI_ID_DB_SCYLLA": "ami-fake00001 ami-fake00011",
+                "SCT_AMI_ID_LOADER": "ami-fake00002 ami-fake00012",
+            },
+            "mock_aws_backend",
+            id="aws-multi-region",
+        ),
+        pytest.param(XCLOUD_AWS_BASE, "mock_xcloud_backend", id="xcloud-aws"),
+        pytest.param(XCLOUD_GCE_BASE, "mock_xcloud_backend", id="xcloud-gce"),
+    ],
+)
+def test_init_resources(request, monkeypatch, env, backend_mock):
+    """init_resources() must complete without TypeError or AttributeError for every backend.
+
+    Regression for: IntOrList/StringOrList normalization returning list[int]/list[str]
+    where tester.py provisioning paths expected scalars (tester.py:1699, 1769, 1837,
+    2066, 2597, 2666, 2702).
+    """
+    request.getfixturevalue(backend_mock)
+
+    for key, val in env.items():
+        monkeypatch.setenv(key, val)
+
+    tester = MinimalProvisioningTester()
+    tester.prepare(SCTConfiguration())
+    ClusterTester.init_resources(tester, loader_info=blank_info(), db_info=blank_info(), monitor_info=blank_info())

--- a/unit_tests/integration/test_provisioning.py
+++ b/unit_tests/integration/test_provisioning.py
@@ -276,6 +276,15 @@ XCLOUD_GCE_BASE = COMMON | {
         ),
         pytest.param(XCLOUD_AWS_BASE, "mock_xcloud_backend", id="xcloud-aws"),
         pytest.param(XCLOUD_GCE_BASE, "mock_xcloud_backend", id="xcloud-gce"),
+        # Zero-monitor variants: exercise the NoMonitorSet else-branch and confirm
+        # sum(monitor_info["n_nodes"]) > 0 correctly returns False for [0].
+        pytest.param(GCE_BASE | {"SCT_N_MONITOR_NODES": "0"}, "mock_gce_backend", id="gce-no-monitors"),
+        pytest.param(
+            XCLOUD_AWS_BASE | {"SCT_N_MONITOR_NODES": "0"}, "mock_xcloud_backend", id="xcloud-aws-no-monitors"
+        ),
+        pytest.param(
+            XCLOUD_GCE_BASE | {"SCT_N_MONITOR_NODES": "0"}, "mock_xcloud_backend", id="xcloud-gce-no-monitors"
+        ),
     ],
 )
 def test_init_resources(request, monkeypatch, env, backend_mock):

--- a/unit_tests/unit/k8s/test_k8s_deploy.py
+++ b/unit_tests/unit/k8s/test_k8s_deploy.py
@@ -1,0 +1,160 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2026 ScyllaDB
+
+"""Unit tests for deploy_k8s_eks_cluster and deploy_k8s_gke_cluster.
+
+Regression: IntOrList normalization means params.get("n_loaders") now always
+returns list[int]. Both deploy functions used:
+
+    if params.get("n_loaders"):
+
+which is truthy for [0] — creating an empty loader node pool even when no
+loaders are configured. Fix: if sum(params.get("n_loaders")) > 0:
+
+All k8s_cluster calls are absorbed by MagicMock; EksNodePool / GkeNodePool
+are patched so no real AWS/GCE API calls are made.
+"""
+
+from unittest.mock import MagicMock, patch
+
+
+from sdcm.cluster_k8s.eks import deploy_k8s_eks_cluster
+from sdcm.cluster_k8s.gke import deploy_k8s_gke_cluster
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+EKS_PARAMS = {
+    "n_db_nodes": [3],
+    "n_loaders": None,  # overridden per test
+    "n_monitor_nodes": [1],
+    "k8s_n_auxiliary_nodes": 3,
+    "k8s_instance_type_auxiliary": "m5.xlarge",
+    "instance_type_db": "i4i.large",
+    "instance_type_loader": "i4i.large",
+    "instance_type_monitor": "m5.xlarge",
+    "eks_nodegroup_role_arn": "arn:aws:iam::123456789:role/fake-role",
+    "root_disk_size_db": 100,
+    "root_disk_size_monitor": 100,
+    "k8s_deploy_monitoring": False,
+    "k8s_enable_sni": False,
+    "k8s_use_chaos_mesh": False,
+    "use_mgmt": False,
+    "k8s_n_monitor_nodes": None,
+    "k8s_instance_type_monitor": None,
+}
+
+GKE_PARAMS = {
+    "n_db_nodes": [3],
+    "n_loaders": None,  # overridden per test
+    "n_monitor_nodes": [1],
+    "gce_instance_type_db": "n2-highmem-4",
+    "gce_instance_type_loader": "e2-standard-2",
+    "gce_instance_type_monitor": "e2-standard-4",
+    "gce_root_disk_type_db": "pd-ssd",
+    "gce_n_local_ssd_disk_db": 0,
+    "root_disk_size_db": 100,
+    "root_disk_size_monitor": 100,
+    "gce_root_disk_type_monitor": "pd-ssd",
+    "gce_n_local_ssd_disk_monitor": 0,
+    "k8s_deploy_monitoring": False,
+    "k8s_enable_sni": False,
+    "k8s_use_chaos_mesh": False,
+    "use_mgmt": False,
+    "k8s_n_monitor_nodes": None,
+    "k8s_instance_type_monitor": None,
+}
+
+
+def make_k8s_cluster(params: dict) -> MagicMock:
+    """Build a MagicMock k8s_cluster with real string pool-name constants."""
+    k8s_cluster = MagicMock()
+    k8s_cluster.AUXILIARY_POOL_NAME = "auxiliary-pool"
+    k8s_cluster.SCYLLA_POOL_NAME = "scylla-pool"
+    k8s_cluster.LOADER_POOL_NAME = "loader-pool"
+    k8s_cluster.MONITORING_POOL_NAME = "monitoring-pool"
+    k8s_cluster.params = params
+    return k8s_cluster
+
+
+# ---------------------------------------------------------------------------
+# EKS — deploy_k8s_eks_cluster
+# ---------------------------------------------------------------------------
+
+
+@patch("sdcm.cluster_k8s.eks.EksNodePool")
+def test_deploy_eks_does_not_create_loader_pool_when_n_loaders_zero(mock_eks_pool):
+    """n_loaders=[0] must not create a loader node pool.
+
+    Regression: 'if params.get("n_loaders"):' was truthy for [0].
+    """
+    k8s_cluster = make_k8s_cluster(EKS_PARAMS | {"n_loaders": [0]})
+
+    deploy_k8s_eks_cluster(k8s_cluster)
+
+    instantiated_names = [c.kwargs["name"] for c in mock_eks_pool.call_args_list]
+    assert "loader-pool" not in instantiated_names
+
+
+@patch("sdcm.cluster_k8s.eks.EksNodePool")
+def test_deploy_eks_creates_loader_pool_when_n_loaders_nonzero(mock_eks_pool):
+    """n_loaders=[2] must create a loader node pool with num_nodes=2."""
+    k8s_cluster = make_k8s_cluster(EKS_PARAMS | {"n_loaders": [2]})
+
+    deploy_k8s_eks_cluster(k8s_cluster)
+
+    mock_eks_pool.assert_any_call(
+        name="loader-pool",
+        num_nodes=2,
+        instance_type="i4i.large",
+        role_arn="arn:aws:iam::123456789:role/fake-role",
+        disk_size=100,
+        labels={"scylla.scylladb.com/node-type": "scylla"},
+        k8s_cluster=k8s_cluster,
+    )
+
+
+# ---------------------------------------------------------------------------
+# GKE — deploy_k8s_gke_cluster
+# ---------------------------------------------------------------------------
+
+
+@patch("sdcm.cluster_k8s.gke.GkeNodePool")
+def test_deploy_gke_does_not_create_loader_pool_when_n_loaders_zero(mock_gke_pool):
+    """n_loaders=[0] must not create a loader node pool.
+
+    Regression: 'if params.get("n_loaders"):' was truthy for [0].
+    """
+    k8s_cluster = make_k8s_cluster(GKE_PARAMS | {"n_loaders": [0]})
+
+    deploy_k8s_gke_cluster(k8s_cluster)
+
+    instantiated_names = [c.kwargs["name"] for c in mock_gke_pool.call_args_list]
+    assert "loader-pool" not in instantiated_names
+
+
+@patch("sdcm.cluster_k8s.gke.GkeNodePool")
+def test_deploy_gke_creates_loader_pool_when_n_loaders_nonzero(mock_gke_pool):
+    """n_loaders=[2] must create a loader node pool with num_nodes=2."""
+    k8s_cluster = make_k8s_cluster(GKE_PARAMS | {"n_loaders": [2]})
+
+    deploy_k8s_gke_cluster(k8s_cluster)
+
+    mock_gke_pool.assert_any_call(
+        name="loader-pool",
+        instance_type="e2-standard-2",
+        num_nodes=2,
+        k8s_cluster=k8s_cluster,
+    )

--- a/unit_tests/unit/test_log_collector.py
+++ b/unit_tests/unit/test_log_collector.py
@@ -292,9 +292,16 @@ def test_get_running_cluster_sets_baremetal(test_id, tmp_path_factory, baremetal
 
 
 def test_monitoring_entities_skip_when_no_monitor_nodes(tmp_path):
-    """Test that monitoring entities skip collection when n_monitor_nodes=0."""
+    """Test that monitoring entities skip collection when n_monitor_nodes=0.
+
+    Regression: IntOrList normalization means SCTConfiguration.get("n_monitor_nodes")
+    now returns [0] (always a list). The collectors must use sum() not truthiness, because
+    [0] is truthy even though it represents zero monitors.
+    """
     for backend in ["aws", "gce", "azure", "docker"]:
-        params = {"cluster_backend": backend, "n_monitor_nodes": 0}
+        # Use [0] — what SCTConfiguration.get("n_monitor_nodes") returns after normalization.
+        # Previously the raw scalar 0 was falsy; [0] is truthy, exposing the bug.
+        params = {"cluster_backend": backend, "n_monitor_nodes": [0]}
         mock_node = Mock()
         test_dir = str(tmp_path / backend)
 


### PR DESCRIPTION
https://github.com/scylladb/scylla-cluster-tests/pull/14805 broke a provisioning path for most of the clusters, this fixes all of the cases I am aware of and adds tests so it doesnt get through again. I cannot guarantee these are all of the issues but it should be majority of them

Added tests for provisioning path through integration tests by mocking all of the cloud infrastructure. It would caught these errors and this part of provisioning is IMO the most vulnerable.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] Longevity 4h (https://jenkins.scylladb.com/job/scylla-staging/job/phala/job/longevity-100gb-4h-test/25/)
   - Failed almost immediately on SPOT termination, but it failed only after it passed the provisioning stagfe where it failed before
   - https://jenkins.scylladb.com/job/scylla-staging/job/phala/job/longevity-100gb-4h-test/24/
- [ ] unit tests
- [ ] integration test
- [ ] GCE provisioning test   

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
