### PR TITLE
perf-weekly-status-report skill: fix max throughput logic and add conclusion review

### DIFF
--- a/skills/perf-weekly-status-report/SKILL.md
+++ b/skills/perf-weekly-status-report/SKILL.md
@@ -74,13 +74,13 @@ Example: `predefined-throughput-steps-i8g-tablets (2026.3.0.dev.20260612.91ada55
 
 **Mixed workload throughput**: For the `mixed` workload, throughput is the SUM of `Throughput read` + `Throughput write` (since mixed runs report separate read and write throughput values). For single-operation workloads (read, write, read_disk_only), use the single `Throughput <op>` value directly.
 
-**Show failed results AND max throughput for ALL runs performed in the period.** The detailed table should include data from every run in the time window, not just the latest one.
+**Show failed results AND max throughput for ALL runs performed in the period.** The detailed table should include data from every run in the time window, not just the latest one. However, the Max Throughput table is only shown when unthrottled steps have FAIL/ERROR status -- if throughput is as expected (unthrottled steps pass), the table is omitted.
 
-The detailed results table columns: Workload | Max Throughput (run) | P90 (ms) | P99 (ms) | Status | Link
+The detailed results table columns: Workload | Max Throughput (run) | P99 (ms) | Status | Link
 
 ### Detailed Results: Only Failed Steps
 
-**In the detailed results, show a "Failed Results" table ONLY when there are actual failures (table status `FAIL` or `ERROR`).** This table lists individual failed/error steps across ALL runs in the period with their workload, step name, P90, P99, throughput, version, and Argus link. If there are no failures or errors, this table is omitted entirely.
+**In the detailed results, show a "Failed Results" table ONLY when there are actual failures (table status `FAIL` or `ERROR`).** This table lists individual failed/error steps across ALL runs in the period with their workload, step name, P99, throughput, version, and Argus link. If there are no failures or errors, this table is omitted entirely.
 
 Note: A run may have status `"failed"` but its individual tables may show `ERROR` status (not `FAIL`). Both `FAIL` and `ERROR` table statuses must be included in the failed results.
 
@@ -89,13 +89,14 @@ Note: A run may have status `"failed"` but its individual tables may show `ERROR
 **The entire "Detailed Results" section is ONLY shown when there are actual failures (run status `failed` or `test_error`).** When all tests pass, the Detailed Results section is completely omitted from the report.
 
 When failures exist, the section includes:
-- **Failed Results table**: Lists individual failed/error steps with workload, step name, P90, P99, throughput, version, and Argus link
-- **Max Throughput table** (only for `predefined-throughput-steps` tests with failures): Shows per-workload max throughput from the latest run
+- **Failed Results table**: Lists individual failed/error steps with workload, step name, P99, throughput, version, and Argus link
+- **Max Throughput table** (only for `predefined-throughput-steps` tests where the **unthrottled step itself** has status `FAIL` or `ERROR`): Shows per-workload max throughput from the latest run. If the unthrottled steps all pass (status `PASS`), the Max Throughput table is **omitted** even if other throttled steps failed -- the throughput is as expected.
 
 This means:
 - ✅ All tests passed → No Detailed Results section at all
 - ✅ Some tests failed → Detailed Results section appears with failed steps
-- ✅ Throughput test failed → Show both Failed Results table AND Max Throughput table
+- ✅ Throughput test failed AND unthrottled step failed → Show both Failed Results table AND Max Throughput table
+- ✅ Throughput test failed but unthrottled step passed → Show only Failed Results table (throughput is as expected)
 - ✅ Nemesis/upgrade test failed → Show only Failed Results table (no throughput table)
 
 ### Table Width
@@ -197,16 +198,33 @@ Returns JSON array of result tables. Each table has:
   - `"P99 <op>"` -- 99th percentile latency in ms
   - `"Throughput <op>"` -- Actual throughput in op/s
 
+### Fetch issues for a run
+
+```bash
+argus issue list \
+  --run-id <RUN_UUID> \
+  --url https://argus.scylladb.com
+```
+
+Returns JSON array of issue objects. Key fields:
+- `key` -- Jira issue key (e.g., "SCYLLADB-2794")
+- `title` -- Issue title/summary
+- `state` -- Jira state ("new", "todo", "done", "duplicate")
+- `url` -- Direct Jira link
+
+Note: Does NOT expose Jira creation dates. Agent must ask user to classify new vs reproduced.
+
 ## Report Structure
 
 The output HTML file must contain:
 
 1. **Header** -- Report title, date range, "Master (~dev) builds only" indicator
 2. **Summary** -- Title format: "Summary for Scylla version {full_version}" where full_version includes build date and revision hash (e.g., "2026.3.0.dev.20260612.91ada5517d59"). Body: Total tests run, passed count, failed count, error count. **Counts are per run, not per test group.** Each workload is a separate run, so a test with 4 workloads (mixed, read, write, read_disk_only) counts as 4 runs. Microbenchmark tests count as 1 run each. This ensures that Total = Passed + Failed/Error always holds.
-3. **Conclusion** -- Auto-generated bullet-point lines summarizing weekly results.
-4. **Reproduced Issues** -- Always shown after Conclusion. Lists issues linked to runs (from `argus issue list --run-id`). If no issues, displays "No reproduced issues in this period."
-5. **Overview Table** -- Grouped by category, then test, then workload. Columns: Category | Test | Workload | Status | Link. Microbenchmarks use "-" as workload.
-6. **Detailed Results** -- **ONLY shown when there are actual failures.** When all tests pass, this section is completely omitted. When failures exist, shows per-category breakdown of failed steps with P90/P99/throughput, and optionally a Max Throughput table for failed predefined-throughput-steps tests.
+3. **Conclusion** -- Hierarchical bullet-point lines summarizing weekly results. Structure: top-level items are test names in bold (prefixed with `- `), sub-items are specific observations (prefixed with `&#8226;`). The agent MUST print the generated conclusion text to the user and ask for confirmation or edits BEFORE saving it into the final HTML report file. This ensures the user can review and adjust the conclusion wording.
+4. **New Issues - Regression** -- Shown after Conclusion when new issues exist. Lists Jira issues whose tickets were created during the report period (i.e., newly filed regressions). Since Argus CLI doesn't expose Jira creation dates, the agent MUST present the collected issues to the user and ask them to identify which are new vs reproduced BEFORE saving the report. If no new issues, this section is omitted.
+5. **Reproduced Issues** -- Always shown after New Issues (or after Conclusion if no new issues). Lists issues linked to runs whose Jira tickets were created before the report period. If no reproduced issues, displays "No reproduced issues in this period."
+6. **Overview Table** -- Grouped by category, then test, then workload. Columns: Category | Test | Workload | Status | Link. Microbenchmarks use "-" as workload.
+7. **Detailed Results** -- **ONLY shown when there are actual failures.** When all tests pass, this section is completely omitted. When failures exist, shows per-category breakdown of failed steps with P99/throughput, and optionally a Max Throughput table for failed predefined-throughput-steps tests where the unthrottled step itself has FAIL/ERROR status.
    - **Microbenchmarks**: Shown only when they have failures.
 
 ## Reference Index
@@ -234,10 +252,15 @@ A valid weekly status report:
 - [ ] Detailed results: ONLY shown when there are actual failures (completely omitted when all pass)
 - [ ] Detailed results: test sub-heading has full version, NO status badge
 - [ ] Detailed results: Failed Results table lists all failed steps with metrics
-- [ ] Detailed results: Max Throughput table ONLY for predefined-throughput-steps tests with failures
+- [ ] Detailed results: Max Throughput table ONLY for predefined-throughput-steps tests where unthrottled step has FAIL/ERROR status
+- [ ] Detailed results: Max Throughput table omitted when unthrottled steps pass (throughput as expected)
 - [ ] Argus link format uses `/test/` (singular), not `/tests/` (plural)
 - [ ] Detailed results Argus link points to the specific run for each workload
 - [ ] Groups tests by platform category in detailed results
 - [ ] States the reporting period in the header
 - [ ] Table width is 700px
 - [ ] Output file is NOT saved into the SCT repository (use /tmp/opencode/ or home dir)
+- [ ] Conclusion text is printed to the user for review/editing BEFORE being saved into the HTML report
+- [ ] Conclusion uses hierarchical format: bold test names as top-level items, specific observations as sub-bullets
+- [ ] Issues are split into "New Issues - Regression" (created during period) and "Reproduced Issues" (pre-existing)
+- [ ] Agent asks user to classify issues as new vs reproduced BEFORE saving the report

--- a/skills/perf-weekly-status-report/references/argus-data-format.md
+++ b/skills/perf-weekly-status-report/references/argus-data-format.md
@@ -100,7 +100,7 @@ Returns array of result tables:
 
 | Cell Name | Type | Unit | Description |
 |-----------|------|------|-------------|
-| `P90 <op>` | float | ms | 90th percentile latency |
+| `P90 <op>` | float | ms | 90th percentile latency (available but NOT included in report) |
 | `P99 <op>` | float | ms | 99th percentile latency |
 | `Throughput <op>` | int | op/s | Actual sustained throughput |
 | `Overview` | URL | - | Grafana screenshot link |
@@ -109,6 +109,8 @@ Returns array of result tables:
 | `start time` | string | HH:MM:SS | When step started |
 
 Where `<op>` is one of: `read`, `write`, `read_disk_only`, `mixed`
+
+**Note on P90**: The P90 metric is available in the Argus data but is **NOT reported** in the weekly status report tables. Only P99 is shown in the Failed Results and Max Throughput tables.
 
 **Mixed workload throughput**: The `mixed` workload reports BOTH `Throughput read` and `Throughput write` in the same row. To get total throughput for mixed, sum both values:
 ```
@@ -159,3 +161,65 @@ Microbenchmark tests have a different cell structure:
 | `logallocs_per_op` | float | Log allocations per operation |
 | `tps` | float | Transactions per second |
 | `mad tps` | float | Median absolute deviation of TPS |
+
+## `argus issue list` Output
+
+Returns array of issue objects linked to a run, test, or other entity:
+
+```bash
+argus issue list \
+  --run-id <RUN_UUID> \
+  --url https://argus.scylladb.com
+```
+
+```json
+[
+  {
+    "key": "<PROJECT>-<NUMBER>",
+    "subtype": "jira",
+    "title": "<issue summary text>",
+    "state": "<state>",
+    "url": "https://scylladb.atlassian.net/browse/<PROJECT>-<NUMBER>"
+  }
+]
+```
+
+The array may contain zero, one, or many issues. Any Jira project prefix is possible (e.g., `SCYLLADB-*`, `SCT-*`, or others). The number and content of issues varies between runs and report periods.
+
+### Issue Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `key` | string | Jira issue key (e.g., `PROJECT-123`) |
+| `subtype` | string | Issue tracker type (always `"jira"` currently) |
+| `title` | string | Issue title/summary |
+| `state` | string | Jira issue state (see values below) |
+| `url` | string | Direct link to the Jira issue |
+
+### Issue State Values
+
+| State | Description |
+|-------|-------------|
+| `new` | Issue is newly created (Jira "Open" or similar) |
+| `todo` | Issue is in backlog/to-do state |
+| `done` | Issue has been resolved/closed |
+| `duplicate` | Issue is a duplicate of another |
+
+### Filter Flags
+
+Exactly one filter flag must be provided:
+
+| Flag | Description |
+|------|-------------|
+| `--run-id` | Issues linked to a specific run |
+| `--test-id` | All issues linked to any run of a test |
+| `--release-id` | Issues linked to a release |
+| `--group-id` | Issues linked to a group |
+
+### Important Notes
+
+- The `state` field reflects the Jira workflow state but does NOT indicate when the issue was created
+- The CLI does NOT expose Jira issue creation dates
+- To determine if an issue is "new" (created during the report period) vs "reproduced" (pre-existing), the agent must ask the user to classify issues
+- De-duplicate issues by `key` when querying multiple runs (same issue often linked to multiple failed runs)
+- Empty array `[]` is returned when no issues are linked to the entity

--- a/skills/perf-weekly-status-report/references/html-template.md
+++ b/skills/perf-weekly-status-report/references/html-template.md
@@ -90,6 +90,38 @@ Counts are **per run** (each workload = 1 run), not per test group. A test with 
 </tr>
 ```
 
+## Conclusion Box (hierarchical bullet points)
+
+The Conclusion section uses a white-background box with a heading table and a content table.
+Structure: heading in one table, hierarchical bullets in a separate table (both inside the same `<td>`).
+
+The number of top-level items and sub-bullets varies per report -- include one row per test/category that had runs, and one sub-bullet per notable observation.
+
+```html
+<tr><td height="15" style="font-size:1px;line-height:1px;">&nbsp;</td></tr>
+<tr>
+<td bgcolor="#ffffff" style="background-color:#ffffff;border:1px solid #dee2e6;padding:15px;">
+<table width="100%" cellpadding="0" cellspacing="0" border="0" style="font-family:Arial,Helvetica,sans-serif;font-size:13px;color:#333333;">
+<tr><td style="font-size:16px;font-weight:bold;padding-bottom:10px;">Conclusion</td></tr>
+</table>
+<table width="100%" cellpadding="0" cellspacing="0" border="0" style="font-family:Arial,Helvetica,sans-serif;font-size:12px;color:#555555;">
+<!-- Repeat this block for each test/category with runs -->
+<tr><td style="padding:2px 0 2px 15px;">- <b>{test_or_category_name}:</b></td></tr>
+<!-- Repeat this row for each observation under that test/category -->
+<tr><td style="padding:2px 0 2px 30px;">&#8226; {observation}.</td></tr>
+<!-- ... more observation rows as needed ... -->
+<!-- ... more test/category blocks as needed ... -->
+</table>
+</td>
+</tr>
+```
+
+Key details:
+- Top-level: `padding:2px 0 2px 15px;` with `- <b>test/category name:</b>` format
+- Sub-level: `padding:2px 0 2px 30px;` with `&#8226; observation.` format
+- The heading table and content table are siblings inside the same `<td>` container
+- The outer `<td>` has `bgcolor="#ffffff"` and `border:1px solid #dee2e6;padding:15px;`
+
 ## Section Headings (as table cells, not h-tags)
 
 ```html
@@ -100,12 +132,12 @@ Counts are **per run** (each workload = 1 run), not per test group. A test with 
 
 <!-- Category heading with underline -->
 <table width="100%" cellpadding="0" cellspacing="0" border="0">
-<tr><td style="font-family:Arial,Helvetica,sans-serif;font-size:15px;font-weight:bold;color:#333333;padding:15px 0 5px 0;border-bottom:2px solid #007bff;">i8g Tablets (New Platform)</td></tr>
+<tr><td style="font-family:Arial,Helvetica,sans-serif;font-size:15px;font-weight:bold;color:#333333;padding:15px 0 5px 0;border-bottom:2px solid #007bff;">{category_name}</td></tr>
 </table>
 
 <!-- Sub-heading (test name with full version, NO status badge) -->
 <table width="100%" cellpadding="0" cellspacing="0" border="0">
-<tr><td style="font-family:Arial,Helvetica,sans-serif;font-size:13px;font-weight:bold;color:#333333;padding:10px 0 5px 0;">predefined-throughput-steps-i8g-tablets (2026.3.0.dev.20260612.91ada5517d59)</td></tr>
+<tr><td style="font-family:Arial,Helvetica,sans-serif;font-size:13px;font-weight:bold;color:#333333;padding:10px 0 5px 0;">{test_name} ({full_version})</td></tr>
 </table>
 ```
 
@@ -127,7 +159,9 @@ Counts are **per run** (each workload = 1 run), not per test group. A test with 
 
 ## Data Tables
 
-### Overview Table (dark header, grouped by category/test/workload, no version column)
+### Overview Table (dark header, grouped by category/test/workload, with Link column)
+
+Number of rows varies: one row per workload per test that had runs. Categories and tests with no runs are omitted.
 
 ```html
 <table width="100%" cellpadding="0" cellspacing="0" border="1" style="border-collapse:collapse;font-family:Arial,Helvetica,sans-serif;font-size:12px;border-color:#dee2e6;">
@@ -135,50 +169,55 @@ Counts are **per run** (each workload = 1 run), not per test group. A test with 
   <th style="border:1px solid #dee2e6;padding:6px 10px;text-align:left;color:#ffffff;font-weight:bold;">Category</th>
   <th style="border:1px solid #dee2e6;padding:6px 10px;text-align:left;color:#ffffff;font-weight:bold;">Test</th>
   <th style="border:1px solid #dee2e6;padding:6px 10px;text-align:center;color:#ffffff;font-weight:bold;">Workload</th>
-  <th style="border:1px solid #dee2e6;padding:6px 10px;text-align:center;color:#ffffff;font-weight:bold;">Runs</th>
   <th style="border:1px solid #dee2e6;padding:6px 10px;text-align:center;color:#ffffff;font-weight:bold;">Status</th>
+  <th style="border:1px solid #dee2e6;padding:6px 10px;text-align:center;color:#ffffff;font-weight:bold;">Link</th>
 </tr>
-<!-- Category shown only on first row of group; Test shown only on first workload row -->
+<!-- First row of a category group: category name shown, test name shown -->
 <tr bgcolor="#ffffff" style="background-color:#ffffff;">
-  <td style="border:1px solid #dee2e6;padding:4px 8px;font-weight:bold;font-family:Arial,Helvetica,sans-serif;font-size:12px;">i8g Tablets</td>
-  <td style="border:1px solid #dee2e6;padding:4px 8px;font-family:Arial,Helvetica,sans-serif;font-size:12px;">predefined-throughput-steps-i8g-tablets</td>
-  <td style="border:1px solid #dee2e6;padding:4px 8px;text-align:center;font-family:Arial,Helvetica,sans-serif;font-size:12px;">mixed</td>
-  <td style="border:1px solid #dee2e6;padding:4px 8px;text-align:center;font-family:Arial,Helvetica,sans-serif;font-size:12px;">4</td>
-  <td style="border:1px solid #dee2e6;padding:4px 8px;text-align:center;font-family:Arial,Helvetica,sans-serif;font-size:12px;"><span style="color:#28a745;">passed 3</span> / <span style="color:#dc3545;">failed 1</span></td>
+  <td style="border:1px solid #dee2e6;padding:4px 8px;font-weight:bold;font-family:Arial,Helvetica,sans-serif;font-size:12px;">{category_name}</td>
+  <td style="border:1px solid #dee2e6;padding:4px 8px;font-family:Arial,Helvetica,sans-serif;font-size:12px;">{test_name}</td>
+  <td style="border:1px solid #dee2e6;padding:4px 8px;text-align:center;font-family:Arial,Helvetica,sans-serif;font-size:12px;">{workload}</td>
+  <td style="border:1px solid #dee2e6;padding:4px 8px;text-align:center;font-family:Arial,Helvetica,sans-serif;font-size:12px;"><!-- status badge --></td>
+  <td style="border:1px solid #dee2e6;padding:4px 8px;text-align:center;font-family:Arial,Helvetica,sans-serif;font-size:12px;"><a href="https://argus.scylladb.com/test/{test_id}/runs?additionalRuns[]={run_id}" style="color:#007bff;text-decoration:none;">Argus</a></td>
 </tr>
-<!-- Subsequent workload row: category and test cells are empty -->
+<!-- Subsequent workload row within same test: category and test cells are empty -->
 <tr bgcolor="#f8f9fa" style="background-color:#f8f9fa;">
   <td style="border:1px solid #dee2e6;padding:4px 8px;font-family:Arial,Helvetica,sans-serif;font-size:12px;"></td>
   <td style="border:1px solid #dee2e6;padding:4px 8px;font-family:Arial,Helvetica,sans-serif;font-size:12px;"></td>
-  <td style="border:1px solid #dee2e6;padding:4px 8px;text-align:center;font-family:Arial,Helvetica,sans-serif;font-size:12px;">read</td>
-  <td style="border:1px solid #dee2e6;padding:4px 8px;text-align:center;font-family:Arial,Helvetica,sans-serif;font-size:12px;">3</td>
-  <td style="border:1px solid #dee2e6;padding:4px 8px;text-align:center;font-family:Arial,Helvetica,sans-serif;font-size:12px;"><span style="color:#28a745;">passed 3</span></td>
+  <td style="border:1px solid #dee2e6;padding:4px 8px;text-align:center;font-family:Arial,Helvetica,sans-serif;font-size:12px;">{workload}</td>
+  <td style="border:1px solid #dee2e6;padding:4px 8px;text-align:center;font-family:Arial,Helvetica,sans-serif;font-size:12px;"><!-- status badge --></td>
+  <td style="border:1px solid #dee2e6;padding:4px 8px;text-align:center;font-family:Arial,Helvetica,sans-serif;font-size:12px;"><a href="https://argus.scylladb.com/test/{test_id}/runs?additionalRuns[]={run_id}" style="color:#007bff;text-decoration:none;">Argus</a></td>
 </tr>
+<!-- ... repeat rows for each workload, test, and category ... -->
 </table>
 ```
 
-NOTE: No Argus links or version column in the overview table. Version is in the Summary section. Runs column = just the count. Status column = textual breakdown with colored spans.
+NOTE: Each workload row has its own Argus link in the Link column. Version is in the Summary section.
+Argus URL format: `https://argus.scylladb.com/test/{test_id}/runs?additionalRuns[]={run_id}` (singular `/test/`, NOT `/tests/`)
+Status column: just the badge (PASSED/FAILED/ERROR) -- no counts.
 
 ### Results Table (light header) -- Per-Workload with Argus Links
+
+Number of rows varies: one per workload that has results.
 
 ```html
 <table width="100%" cellpadding="0" cellspacing="0" border="1" style="border-collapse:collapse;font-family:Arial,Helvetica,sans-serif;font-size:12px;border-color:#dee2e6;margin-bottom:5px;">
 <tr bgcolor="#f8f9fa" style="background-color:#f8f9fa;">
   <th style="border:1px solid #dee2e6;padding:4px 8px;text-align:left;font-weight:bold;">Workload</th>
   <th style="border:1px solid #dee2e6;padding:4px 8px;font-weight:bold;">Max Throughput (run)</th>
-  <th style="border:1px solid #dee2e6;padding:4px 8px;font-weight:bold;">P90 (ms)</th>
   <th style="border:1px solid #dee2e6;padding:4px 8px;font-weight:bold;">P99 (ms)</th>
   <th style="border:1px solid #dee2e6;padding:4px 8px;font-weight:bold;">Status</th>
   <th style="border:1px solid #dee2e6;padding:4px 8px;font-weight:bold;">Link</th>
 </tr>
+<!-- Repeat for each workload -->
 <tr>
-  <td style="border:1px solid #dee2e6;padding:4px 8px;font-family:Arial,Helvetica,sans-serif;font-size:12px;">mixed</td>
-  <td style="border:1px solid #dee2e6;padding:4px 8px;text-align:right;font-family:Arial,Helvetica,sans-serif;font-size:12px;">968,649</td>
-  <td style="border:1px solid #dee2e6;padding:4px 8px;text-align:right;font-family:Arial,Helvetica,sans-serif;font-size:12px;">35.16</td>
-  <td style="border:1px solid #dee2e6;padding:4px 8px;text-align:right;font-family:Arial,Helvetica,sans-serif;font-size:12px;">150.99</td>
-  <td style="border:1px solid #dee2e6;padding:4px 8px;text-align:center;font-family:Arial,Helvetica,sans-serif;font-size:12px;"><!-- PASS badge --></td>
-  <td style="border:1px solid #dee2e6;padding:4px 8px;text-align:center;font-family:Arial,Helvetica,sans-serif;font-size:12px;"><a href="https://argus.scylladb.com/test/TEST_ID/runs?additionalRuns[]=RUN_ID" style="color:#007bff;text-decoration:none;">Argus</a></td>
+  <td style="border:1px solid #dee2e6;padding:4px 8px;font-family:Arial,Helvetica,sans-serif;font-size:12px;">{workload}</td>
+  <td style="border:1px solid #dee2e6;padding:4px 8px;text-align:right;font-family:Arial,Helvetica,sans-serif;font-size:12px;">{max_throughput}</td>
+  <td style="border:1px solid #dee2e6;padding:4px 8px;text-align:right;font-family:Arial,Helvetica,sans-serif;font-size:12px;">{p99_value}</td>
+  <td style="border:1px solid #dee2e6;padding:4px 8px;text-align:center;font-family:Arial,Helvetica,sans-serif;font-size:12px;"><!-- status badge --></td>
+  <td style="border:1px solid #dee2e6;padding:4px 8px;text-align:center;font-family:Arial,Helvetica,sans-serif;font-size:12px;"><a href="https://argus.scylladb.com/test/{test_id}/runs?additionalRuns[]={run_id}" style="color:#007bff;text-decoration:none;">Argus</a></td>
 </tr>
+<!-- ... more rows as needed ... -->
 </table>
 ```
 
@@ -187,6 +226,8 @@ Argus URL format: `https://argus.scylladb.com/test/{test_id}/runs?additionalRuns
 
 ## Bullet Lists (as table rows, not ul/li)
 
+### Simple bullet list (single level)
+
 ```html
 <table width="100%" cellpadding="0" cellspacing="0" border="0" style="font-family:Arial,Helvetica,sans-serif;font-size:12px;color:#555555;">
 <tr><td style="padding:2px 0 2px 15px;">&#8226; First bullet point</td></tr>
@@ -194,11 +235,99 @@ Argus URL format: `https://argus.scylladb.com/test/{test_id}/runs?additionalRuns
 </table>
 ```
 
+### Hierarchical bullet list (Conclusion format)
+
+Uses two levels: bold test name at 15px indent, sub-bullets at 30px indent.
+Number of top-level items and sub-bullets varies per report.
+
+```html
+<table width="100%" cellpadding="0" cellspacing="0" border="0" style="font-family:Arial,Helvetica,sans-serif;font-size:12px;color:#555555;">
+<!-- Repeat for each test/category -->
+<tr><td style="padding:2px 0 2px 15px;">- <b>{test_or_category_name}:</b></td></tr>
+<!-- Repeat for each observation under that test/category -->
+<tr><td style="padding:2px 0 2px 30px;">&#8226; {observation}.</td></tr>
+<!-- ... more rows as needed ... -->
+</table>
+```
+
+Key styling details:
+- Top-level items: `padding:2px 0 2px 15px;` with `- <b>test name:</b>` format
+- Sub-items: `padding:2px 0 2px 30px;` with `&#8226; observation text.` format
+- Both levels are within the same `<table>` (no nested tables)
+- Wrapped in a white-background box with border (same container as the "Conclusion" heading)
+
 ## Links
 
 ```html
-<a href="https://argus.scylladb.com/tests/UUID" style="color:#007bff;text-decoration:none;">Argus</a>
+<a href="https://argus.scylladb.com/test/{test_id}/runs?additionalRuns[]={run_id}" style="color:#007bff;text-decoration:none;">Argus</a>
 ```
+
+## New Issues and Reproduced Issues Sections
+
+Issues are split into two sections based on Jira creation date (user-classified):
+- **New Issues - Regression**: tickets created during the report period
+- **Reproduced Issues**: tickets that existed before the report period
+
+Both sections use the same HTML structure but different headings.
+
+### New Issues - Regression (shown only when new issues exist)
+
+```html
+<tr><td height="15" style="font-size:1px;line-height:1px;">&nbsp;</td></tr>
+<tr>
+<td bgcolor="#ffffff" style="background-color:#ffffff;border:1px solid #dee2e6;padding:15px;">
+<table width="100%" cellpadding="0" cellspacing="0" border="0" style="font-family:Arial,Helvetica,sans-serif;font-size:13px;color:#333333;">
+<tr><td style="font-size:16px;font-weight:bold;padding-bottom:10px;">New Issues - Regression</td></tr>
+</table>
+<table width="100%" cellpadding="0" cellspacing="0" border="0" style="font-family:Arial,Helvetica,sans-serif;font-size:12px;color:#555555;">
+<!-- Repeat for each new issue -->
+<tr><td style="padding:2px 0 2px 15px;">&#8226; <a href="{issue_url}" style="color:#007bff;text-decoration:none;">{ISSUE_KEY}</a>: {issue title}</td></tr>
+<!-- ... more rows as needed ... -->
+</table>
+</td>
+</tr>
+```
+
+### Reproduced Issues (always shown)
+
+```html
+<tr><td height="15" style="font-size:1px;line-height:1px;">&nbsp;</td></tr>
+<tr>
+<td bgcolor="#ffffff" style="background-color:#ffffff;border:1px solid #dee2e6;padding:15px;">
+<table width="100%" cellpadding="0" cellspacing="0" border="0" style="font-family:Arial,Helvetica,sans-serif;font-size:13px;color:#333333;">
+<tr><td style="font-size:16px;font-weight:bold;padding-bottom:10px;">Reproduced Issues</td></tr>
+</table>
+<table width="100%" cellpadding="0" cellspacing="0" border="0" style="font-family:Arial,Helvetica,sans-serif;font-size:12px;color:#555555;">
+<!-- Repeat for each reproduced issue -->
+<tr><td style="padding:2px 0 2px 15px;">&#8226; <a href="{issue_url}" style="color:#007bff;text-decoration:none;">{ISSUE_KEY}</a>: {issue title}</td></tr>
+<!-- ... more rows as needed ... -->
+</table>
+</td>
+</tr>
+```
+
+### When no reproduced issues exist
+
+```html
+<tr><td height="15" style="font-size:1px;line-height:1px;">&nbsp;</td></tr>
+<tr>
+<td bgcolor="#ffffff" style="background-color:#ffffff;border:1px solid #dee2e6;padding:15px;">
+<table width="100%" cellpadding="0" cellspacing="0" border="0" style="font-family:Arial,Helvetica,sans-serif;font-size:13px;color:#333333;">
+<tr><td style="font-size:16px;font-weight:bold;padding-bottom:10px;">Reproduced Issues</td></tr>
+</table>
+<table width="100%" cellpadding="0" cellspacing="0" border="0" style="font-family:Arial,Helvetica,sans-serif;font-size:12px;color:#555555;">
+<tr><td style="padding:2px 0 2px 15px;">No reproduced issues in this period.</td></tr>
+</table>
+</td>
+</tr>
+```
+
+Key details:
+- Each section is in its own white-background box with border
+- Issue links use `color:#007bff;text-decoration:none;` style
+- Format: `&#8226; <a href="URL">KEY</a>: title text`
+- "New Issues - Regression" section is OMITTED entirely if there are no new issues
+- "Reproduced Issues" section is ALWAYS shown (with "No reproduced issues..." fallback text)
 
 ## Key Gmail Rules Summary
 

--- a/skills/perf-weekly-status-report/workflows/generate-report.md
+++ b/skills/perf-weekly-status-report/workflows/generate-report.md
@@ -128,6 +128,53 @@ master_runs = [
 
 **Exit criteria:** Data organized by category > test > workload > step, throughput tracker populated.
 
+## Phase 4a: Collect Issues
+
+**Entry criteria:** Filtered master runs identified (from Phase 2).
+
+1. For each run with status `failed` or `test_error`, fetch linked issues:
+   ```bash
+   argus issue list \
+     --run-id <RUN_ID> \
+     --url https://argus.scylladb.com
+   ```
+
+2. Each issue object contains:
+   ```json
+   {
+     "key": "<PROJECT>-<NUMBER>",
+     "subtype": "jira",
+     "title": "<issue summary text>",
+     "state": "<state>",
+     "url": "https://scylladb.atlassian.net/browse/<PROJECT>-<NUMBER>"
+   }
+   ```
+   The array may contain zero, one, or many issues of any Jira project.
+
+3. De-duplicate issues by `key` (same issue may appear on multiple runs).
+
+4. **Classification: New vs Reproduced**
+
+   Since the Argus CLI does not expose Jira issue creation dates, the agent MUST present the full de-duplicated issue list to the user and ask them to classify each issue:
+   - **New Issues - Regression**: Jira ticket was created during the report period (newly filed regression)
+   - **Reproduced Issues**: Jira ticket existed before the report period but was reproduced this week
+
+   Example interaction:
+   ```
+   I found the following issues linked to failed runs this week:
+
+   1. PROJECT-123: <issue title>
+   2. PROJECT-456: <issue title>
+   3. PROJECT-789: <issue title>
+
+   Which of these are NEW issues (Jira ticket created this week)?
+   Please provide the issue keys that are new (e.g., "PROJECT-789"), or "none" if all are reproduced.
+   ```
+
+5. Store the classification for use in the HTML report generation.
+
+**Exit criteria:** Issues collected and classified as new vs reproduced based on user input.
+
 ## Phase 5: Generate HTML Report
 
 **Entry criteria:** Data grouped and aggregated.
@@ -135,21 +182,33 @@ master_runs = [
 1. Generate the HTML file with these sections:
    - Header (solid navy background `#1a237e`, title, date range)
    - Summary box (total/passed/failed counts per run + Scylla version). **Count individual runs, not test groups.** Each workload is a separate run (e.g., a test with mixed/read/write/read_disk_only = 4 runs). Microbenchmarks = 1 run each. Total must equal Passed + Failed/Error.
-   - Conclusion (auto-generated text summary)
-   - Overview table (grouped by workload, no Argus links, no version column)
+   - Conclusion (auto-generated hierarchical text summary)
+   - New Issues - Regression (issues created during the period, if any)
+   - Reproduced Issues (pre-existing issues seen again this week)
+   - Overview table (grouped by workload, with Argus links in Link column)
    - Detailed results (per-category tables with metrics + Argus links)
 
    **Conclusion section** (between Summary and Overview):
    - Heading "Conclusion" must use same style as "Summary" heading: `font-size:16px;font-weight:bold;padding-bottom:10px;`
-   - Auto-generate bullet-point lines summarizing the week's performance results
-   - Each line starts with "- " and is rendered on its own line (use table rows)
-   - Include: overall pass/fail status, any ERROR/FAIL steps
+   - Auto-generate **hierarchical** bullet-point lines summarizing the week's performance results
+   - Structure uses two levels:
+     - **Top-level items**: Test name in bold, prefixed with `- ` (indented 15px from left)
+     - **Sub-items**: Specific observations, prefixed with `&#8226;` bullet (indented 30px from left)
+   - Each top-level item and sub-item is rendered as its own table row
+   - Include: which workloads failed/passed for each test, specific failure details (metric, value)
    - Do NOT mention registered tests with no runs
-   - Example output:
+   - Example output structure:
      ```
-     - All 5 tests with dev runs passed this week.
+     - predefined-throughput-steps-i8g-tablets:
+       * write workload failed with P99 latency regression at 600K op/s step (225.44ms).
+       * Read workload failed with P99 spike at 1.5M op/s step (8933.87ms).
+       * Mixed and read_disk_only workloads passed.
+     - Microbenchmark:
+       * write tests (arm64 and x86_64) both failed with ERROR on instructions_per_op (~8% regression).
+       * Read tests passed on both architectures.
      ```
    - Render in a white-background box with border
+   - **CRITICAL: Before saving the report, print the generated conclusion text to the user and ask them to confirm or provide edits.** Wait for user response. If the user provides changes, incorporate them. Only then write the final HTML file.
 
 2. **Overview table structure:**
    - Columns: Category | Test | Workload | Status | Link (NO version column, NO Runs column)
@@ -171,12 +230,13 @@ master_runs = [
      - Category heading with blue underline (`#007bff`)
      - For each test with failures: sub-heading with test name and full version, NO status badge
        Example: `predefined-throughput-steps-i8g-tablets (2026.3.0.dev.20260612.91ada5517d59)`
-     - **Failed Results table**:
-       - Columns: Workload | Step | P90 (ms) | P99 (ms) | Throughput (op/s) | Version | Link
-       - Shows all failed steps across ALL runs in the period
-       - P90/P99 values highlighted in red bold
-      - **Max Throughput table** (ONLY for `predefined-throughput-steps` tests that have failures):
-        - Columns: Workload | Max Throughput (run) | P90 (ms) | P99 (ms) | Status | Link
+      - **Failed Results table**:
+        - Columns: Workload | Step | P99 (ms) | Throughput (op/s) | Version | Link
+        - Shows all failed steps across ALL runs in the period
+        - P99 values highlighted in red bold
+      - **Max Throughput table** (ONLY for `predefined-throughput-steps` tests where the **unthrottled step itself** has status `FAIL` or `ERROR`):
+        - If all unthrottled steps pass (status `PASS`), **omit this table entirely** -- the throughput is as expected and does not need to be highlighted
+        - Columns: Workload | Max Throughput (run) | P99 (ms) | Status | Link
         - One row per workload, using latest run's data
         - Each workload has its own Argus link to its specific run
         - Argus link format: `https://argus.scylladb.com/test/{test_id}/runs?additionalRuns[]={run_id}` (singular `/test/`)
@@ -202,7 +262,59 @@ master_runs = [
    - Error: `#fd7e14` (orange)
    - No runs: `#6c757d` (gray)
 
-**Exit criteria:** File `perf-weekly-status-report.html` written to /tmp/opencode/ (NOT in the SCT repo) and renderable in a browser.
+**Exit criteria:** Conclusion text printed to user and confirmed/edited. Issues classified by user. File `perf-weekly-status-report.html` written to /tmp/opencode/ (NOT in the SCT repo) and renderable in a browser.
+
+## Phase 5a: Conclusion and Issues Review (Interactive)
+
+**Entry criteria:** HTML report content is ready to be generated (all data collected and processed, issues collected from Phase 4a).
+
+Before writing the final HTML file, the agent MUST perform TWO interactive steps:
+
+### Step 1: Conclusion Review
+
+1. Print the auto-generated Conclusion bullet points to the user in plain text format (hierarchical structure)
+2. Ask the user to confirm the conclusion or provide edits
+3. Wait for user response
+4. If the user approves: proceed to Step 2
+5. If the user provides changes: incorporate the edits
+
+Example interaction:
+```
+Here is the generated Conclusion for the report:
+
+- predefined-throughput-steps-i8g-tablets:
+  * write workload failed with P99 latency regression at 600K op/s step (225.44ms).
+  * Read workload failed with P99 spike at 1.5M op/s step (8933.87ms).
+  * Mixed and read_disk_only workloads passed.
+- Microbenchmark:
+  * write tests (arm64 and x86_64) both failed with ERROR on instructions_per_op (~8% regression).
+  * Read tests passed on both architectures.
+
+Would you like to use this conclusion as-is, or would you like to edit it?
+```
+
+### Step 2: Issue Classification
+
+1. Present the de-duplicated list of all issues found on failed/errored runs
+2. Ask the user to identify which issues are **new** (Jira ticket created during the report period)
+3. Wait for user response
+4. Classify accordingly:
+   - Issues identified as new → "New Issues - Regression" section
+   - Remaining issues → "Reproduced Issues" section
+
+Example interaction:
+```
+I found the following issues linked to failed runs:
+
+1. PROJECT-123: <issue title>
+2. PROJECT-456: <issue title>
+3. PROJECT-789: <issue title>
+
+Which of these are NEW issues (Jira ticket created this week)?
+Please provide the keys (e.g., "PROJECT-789"), or "none" if all are reproduced.
+```
+
+This ensures the user has final control over both the conclusion wording and issue classification before they appear in the report.
 
 ## Phase 6: Verify Output
 
@@ -222,7 +334,12 @@ master_runs = [
 12. Verify detailed section has per-workload Argus links (format: `/test/` singular)
 13. Verify full version with revision hash appears in Summary title (e.g., `2026.3.0.dev.20260612.91ada5517d59`)
 14. Verify Detailed Results section is completely omitted when all tests pass
-15. Verify report is NOT placed inside the SCT repository
+15. Verify Max Throughput table is omitted when all unthrottled steps pass (throughput as expected)
+16. Verify Conclusion text was shown to user before final save
+17. Verify Conclusion uses hierarchical format (bold test names + indented sub-bullets)
+18. Verify issues are split into "New Issues - Regression" and "Reproduced Issues" sections
+19. Verify user was asked to classify issues before final save
+20. Verify report is NOT placed inside the SCT repository
 
 **Exit criteria:** Report is ready for email distribution.
 
@@ -249,6 +366,13 @@ argus run results \
   --run-id <RUN_ID> \
   --url https://argus.scylladb.com > /tmp/opencode/results.json
 
-# 5. Generate HTML report (output to /tmp/opencode/, NOT to repo)
-# python3 script generates /tmp/opencode/perf-weekly-status-report.html
+# 5. Fetch issues for failed/errored runs
+argus issue list \
+  --run-id <RUN_ID> \
+  --url https://argus.scylladb.com
+
+# 6. Generate HTML report (output to /tmp/opencode/, NOT to repo)
+# - Ask user to confirm conclusion text
+# - Ask user to classify issues as new vs reproduced
+# - Write /tmp/opencode/perf-weekly-status-report.html
 ```


### PR DESCRIPTION
Two fixes to the `perf-weekly-status-report` skill:

1. Max Throughput table in Detailed Results is now only shown when the unthrottled step itself has FAIL/ERROR status. Previously it was shown whenever a predefined-throughput-steps test had any failure, even if the throughput was as expected (unthrottled steps passing). This avoids misleading inclusion of passing throughput data in the failure details section.

2. The Conclusion section must now be printed to the user for review and confirmation before being saved into the final HTML report. This adds a new Phase 5a (interactive) to the workflow, ensuring the user can adjust the conclusion wording before it goes into the email.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->

[perf-weekly-status-report.html](https://github.com/user-attachments/files/29249216/perf-weekly-status-report.html)


### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
