### PR TITLE
fix(events): ignore audit unavailable errors globally

### DIFF
--- a/sdcm/nemesis/monkey/network.py
+++ b/sdcm/nemesis/monkey/network.py
@@ -22,7 +22,6 @@ from sdcm.sct_events import Severity
 from sdcm.sct_events.filters import EventsSeverityChangerFilter
 from sdcm.sct_events.group_common_events import (
     ignore_alternator_client_errors,
-    ignore_audit_errors,
     suppress_expected_unavailability_errors,
 )
 from sdcm.sct_events.system import InfoEvent, CoreDumpEvent
@@ -557,14 +556,13 @@ class StopStartInterfacesNetworkMonkey(NemesisBaseClass):
         wait_time = self.runner.random.choice(list_of_timeout_options)
         self.runner.log.debug("Taking down eth1 for %dsec", wait_time)
 
-        with ignore_audit_errors():
-            try:
-                self.runner.target_node.stop_network_interface()
-                self.runner.actions_log.info(f"Taking {self.runner.target_node.name} node network interface down")
-                time.sleep(wait_time)
-            finally:
-                self.runner.actions_log.info(f"Brigning {self.runner.target_node.name} node network interface up")
-                self.runner.target_node.start_network_interface()
-                with self.runner.action_log_scope("Wait all nodes up and normal"):
-                    self.runner.cluster.wait_all_nodes_un()
+        try:
+            self.runner.target_node.stop_network_interface()
+            self.runner.actions_log.info(f"Taking {self.runner.target_node.name} node network interface down")
+            time.sleep(wait_time)
+        finally:
+            self.runner.actions_log.info(f"Brigning {self.runner.target_node.name} node network interface up")
+            self.runner.target_node.start_network_interface()
+            with self.runner.action_log_scope("Wait all nodes up and normal"):
+                self.runner.cluster.wait_all_nodes_un()
         self.runner.actions_log.info(f"Network interface down/up finished on {self.runner.target_node.name} node")

--- a/sdcm/sct_events/group_common_events.py
+++ b/sdcm/sct_events/group_common_events.py
@@ -747,22 +747,3 @@ def decorate_with_context_if_issues_open(
         return wrapper
 
     return decorator
-
-
-@contextmanager
-def ignore_audit_errors():
-    """Suppress audit unavailable_exception errors by lowering their severity to WARNING.
-
-    After network disruptions (e.g. interface down/up, node restart), there is a brief
-    period where a node may fail to write to the audit table because it still considers
-    other nodes as down. This is expected behavior and should not fail the test.
-
-    See: https://scylladb.atlassian.net/browse/SCYLLADB-706
-    """
-    with EventsSeverityChangerFilter(
-        new_severity=Severity.WARNING,
-        event_class=DatabaseLogEvent,
-        regex=r".*audit - Unexpected exception when writing.*unavailable_exception.*",
-        extra_time_to_expiration=30,
-    ):
-        yield

--- a/sdcm/sct_events/setup.py
+++ b/sdcm/sct_events/setup.py
@@ -175,6 +175,17 @@ def enable_default_filters(sct_config: SCTConfiguration):
             r"Cannot achieve consistency level for cl ONE",
         ).publish()
 
+    # Audit writes can briefly fail with unavailable_exception during transient cluster
+    # disruptions. This is expected and should not fail the test.
+    # Decided to do a global ignore instead of ignoring on all of the nemesis
+    # https://scylladb.atlassian.net/browse/SCT-518
+    # https://scylladb.atlassian.net/browse/SCYLLADB-706
+    EventsSeverityChangerFilter(
+        new_severity=Severity.WARNING,
+        event_class=DatabaseLogEvent,
+        regex=r".*audit - Unexpected exception when writing.*unavailable_exception.*",
+    ).publish()
+
     DbEventsFilter(db_event=DatabaseLogEvent.BACKTRACE, line="Rate-limit: supressed").publish()
     DbEventsFilter(db_event=DatabaseLogEvent.BACKTRACE, line="Rate-limit: suppressed").publish()
     DbEventsFilter(db_event=DatabaseLogEvent.WARNING, line="abort_requested_exception").publish()

--- a/unit_tests/integration/test_events.py
+++ b/unit_tests/integration/test_events.py
@@ -13,6 +13,7 @@
 
 import pytest
 
+import sdcm.sct_events.setup as events_setup
 from sdcm.sct_events.loaders import CassandraStressLogEvent
 from sdcm.sct_events.database import DatabaseLogEvent
 from sdcm.sct_events.setup import enable_default_filters
@@ -24,11 +25,13 @@ from unit_tests.lib.real_events import RealEventsTest
 
 class TestSctEventsIntegration(RealEventsTest):
     @pytest.mark.integration
-    def test_default_filters(self):
+    def test_default_filters(self, monkeypatch):
+        monkeypatch.setattr(events_setup, "SkipPerIssues", lambda *args, **kwargs: True)
+
         with environment(SCT_CLUSTER_BACKEND="docker"):
             enable_default_filters(SCTConfiguration())
 
-        with self.wait_for_n_events(self.get_events_logger(), count=5):
+        with self.wait_for_n_events(self.get_events_logger(), count=6):
             DatabaseLogEvent.BACKTRACE().add_info(
                 node="A",
                 line_number=22,
@@ -62,6 +65,13 @@ class TestSctEventsIntegration(RealEventsTest):
                 "(raft topology: exec_global_command(barrier) failed with seastar::rpc::closed_error (connection is closed))",
             ).publish()
 
+            DatabaseLogEvent.DATABASE_ERROR().add_info(
+                node="A",
+                line_number=22,
+                line="ERROR 2023-12-18 12:45:25,673 [shard 0:stre] audit - Unexpected exception when writing login log: "
+                "std::runtime_error (exception exceptions::unavailable_exception (Cannot achieve consistency level for cl ONE. Requires 1, alive 0))",
+            ).publish()
+
         log_content = self.get_event_log_file("events.log")
 
         assert "other back trace" in log_content
@@ -69,9 +79,11 @@ class TestSctEventsIntegration(RealEventsTest):
 
         warnings_log_content = self.get_event_log_file("warning.log")
         assert "data_dictionary::no_such_column_family" in warnings_log_content
-        assert "Authentication error" not in warnings_log_content
+        assert "Authentication error" in warnings_log_content
+        assert "Unexpected exception when writing login log" in warnings_log_content
 
         error_log_content = self.get_event_log_file("error.log")
         assert "data_dictionary::no_such_column_family" not in error_log_content
-        assert "Authentication error" in error_log_content
+        assert "Authentication error" not in error_log_content
+        assert "Unexpected exception when writing login log" not in error_log_content
         assert "topology change coordinator fiber got error" not in error_log_content


### PR DESCRIPTION
## Summary
- add a global default event filter for audit write unavailable errors
- remove the nemesis-local audit ignore wrapper now that the filter is always on
- extend the events integration test to cover the audit login unavailable case
   - Mock SkipPerIssues to make the deterministic

Fixes https://scylladb.atlassian.net/browse/SCT-518

## Testing
- uv run pytest unit_tests/integration/test_events.py -k test_default_filters
