### PR TITLE
fix(nemesis): increase CREATE_MV and CREATE_INDEX soft timeouts to 5 hours

### DIFF
--- a/sdcm/nemesis/__init__.py
+++ b/sdcm/nemesis/__init__.py
@@ -4706,7 +4706,7 @@ class NemesisRunner:
                 raise UnsupportedNemesis("Tried to create already existing index. See log for details")
             try:
                 with adaptive_timeout(
-                    operation=Operations.CREATE_INDEX, node=self.target_node, timeout=14400
+                    operation=Operations.CREATE_INDEX, node=self.target_node, timeout=18000
                 ) as timeout:
                     with self.action_log_scope("Wait for index to be built"):
                         wait_for_index_to_be_built(self.target_node, ks, index_name, timeout=timeout * 2)
@@ -4769,7 +4769,7 @@ class NemesisRunner:
                         self.target_node.run_nodetool(sub_cmd="repair -pr")
                     with (
                         adaptive_timeout(
-                            operation=Operations.CREATE_MV, node=self.target_node, timeout=14400
+                            operation=Operations.CREATE_MV, node=self.target_node, timeout=18000
                         ) as timeout,
                         self.action_log_scope(
                             f"Wait for {ks_name}.{view_name} materialized view to be built on "
@@ -5294,7 +5294,7 @@ class NemesisRunner:
                         )
                         break
 
-                with adaptive_timeout(operation=Operations.CREATE_MV, node=working_node, timeout=14400) as timeout:
+                with adaptive_timeout(operation=Operations.CREATE_MV, node=working_node, timeout=18000) as timeout:
                     wait_for_view_to_be_built(working_node, ks_name, view_name, timeout=timeout * 2)
 
                 with self.cluster.cql_connection_patient(node=working_node, connect_timeout=600) as session:


### PR DESCRIPTION

Observed CREATE_MV taking ~15453s and CREATE_INDEX (wait for index build) taking ~15857s, both exceeding the previous 14400s (4h) soft timeout and triggering SoftTimeoutEvent followed by FailedResultEvent from Argus validation.

Increase the soft timeout from 14400s to 18000s (5h) for all three adaptive_timeout calls in disrupt_create_index, disrupt_add_remove_mv, and disrupt_add_drop_mv_with_node_restarts.

Fixes: https://scylladb.atlassian.net/browse/SCT-353

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
