### PR TITLE
improvement(argus): enable Argus SSH Tunneling by default

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -232,7 +232,7 @@ pre_filter_unavailable_availability_zones: true
 pre_flight_capacity_probe: false
 
 enable_argus: true
-argus_use_ssh_tunnel: false
+argus_use_ssh_tunnel: true
 
 enable_kernel_panic_checker: true
 

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -4466,7 +4466,7 @@ Control reporting to argus
 
 Enable SSH tunnel support in the Argus client connection
 
-**default:** False
+**default:** True
 
 **type:** bool
 


### PR DESCRIPTION
Enable The Argus SSH Tunneling by default, after we tested weekly runs for 2 weeks.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- 🟢 https://argus.scylladb.com/tests/scylla-cluster-tests/d323536c-5773-4b41-a88b-13ce799becbd (GCE Run)
- 🟢 https://argus.scylladb.com/tests/scylla-cluster-tests/3e2f216d-0cd9-4e02-8cf2-4dc6b1e8337f (Azure Run)
- 🟢 https://argus.scylladb.com/tests/scylla-cluster-tests/a0958eb2-5ef8-4aca-a879-24feacac123d (AWS Run)
- 🟢 https://argus.scylladb.com/tests/scylla-cluster-tests/abb530f1-5dcd-4ee8-addb-8e23a179c49e (OCI Run)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
