### PR TITLE
fix(seeds): change default seeds_selector from 'all' to 'random' 3 nodes

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -47,8 +47,8 @@ nemesis_add_node_cnt: 3
 
 nemesis_filter_seeds: false
 
-seeds_selector: "first"
-seeds_num: 1
+seeds_selector: "random"
+seeds_num: 3
 
 instance_provision: "spot"
 

--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -47,7 +47,7 @@ nemesis_add_node_cnt: 3
 
 nemesis_filter_seeds: false
 
-seeds_selector: "all"
+seeds_selector: "first"
 seeds_num: 1
 
 instance_provision: "spot"

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -5392,6 +5392,7 @@ class BaseScyllaCluster:
                 throw_exc=True,
             )
         else:
+            seeds_num = min(seeds_num, len(self.nodes))
             if seeds_selector == "random":
                 selected_nodes = random.sample(self.nodes, seeds_num)
             # seeds_selector == 'first'
@@ -5401,8 +5402,7 @@ class BaseScyllaCluster:
             seed_nodes_addresses = [node.scylla_listen_address for node in selected_nodes]
 
         for node in self.nodes:
-            if node.scylla_listen_address in seed_nodes_addresses:
-                node.set_seed_flag(True)
+            node.set_seed_flag(node.scylla_listen_address in seed_nodes_addresses)
 
         assert seed_nodes_addresses, "We should have at least one selected seed by now"
 

--- a/sdcm/nemesis/__init__.py
+++ b/sdcm/nemesis/__init__.py
@@ -1291,6 +1291,19 @@ class NemesisRunner:
             self.set_target_node(allow_only_last_node_in_rack=True)
 
         target_is_seed = self.target_node.is_seed
+        replacement_should_be_seed = target_is_seed
+        if target_is_seed and len(self.cluster.seed_nodes) < 2:
+            seed_candidates = [node for node in self.cluster.nodes if node is not self.target_node]
+            if seed_candidates:
+                new_seed_node = self.random.choice(seed_candidates)
+                self.log.info(
+                    "Selecting %s as a seed before decommissioning the last seed node %s",
+                    new_seed_node.name,
+                    self.target_node.name,
+                )
+                new_seed_node.set_seed_flag(True)
+                self.cluster.update_seed_provider()
+                replacement_should_be_seed = False
         with (
             suppress_expected_unavailability_errors(),
             self.action_log_scope(
@@ -1310,8 +1323,8 @@ class NemesisRunner:
             # after decomission and add_node, the left nodes have data that isn't part of their tokens anymore.
             # In order to eliminate cases that we miss a "data loss" bug because of it, we cleanup this data.
             # This fix important when just user profile is run in the test and "keyspace1" doesn't exist.
-            if new_node.is_seed != target_is_seed:
-                new_node.set_seed_flag(target_is_seed)
+            if new_node.is_seed != replacement_should_be_seed:
+                new_node.set_seed_flag(replacement_should_be_seed)
                 self.cluster.update_seed_provider()
             self.actions_log.info(f"new node added: {new_node.name}")
             if dc_topology_rf_change:

--- a/sdcm/nemesis/__init__.py
+++ b/sdcm/nemesis/__init__.py
@@ -1291,19 +1291,6 @@ class NemesisRunner:
             self.set_target_node(allow_only_last_node_in_rack=True)
 
         target_is_seed = self.target_node.is_seed
-        replacement_should_be_seed = target_is_seed
-        if target_is_seed and len(self.cluster.seed_nodes) < 2:
-            seed_candidates = [node for node in self.cluster.nodes if node is not self.target_node]
-            if seed_candidates:
-                new_seed_node = self.random.choice(seed_candidates)
-                self.log.info(
-                    "Selecting %s as a seed before decommissioning the last seed node %s",
-                    new_seed_node.name,
-                    self.target_node.name,
-                )
-                new_seed_node.set_seed_flag(True)
-                self.cluster.update_seed_provider()
-                replacement_should_be_seed = False
         with (
             suppress_expected_unavailability_errors(),
             self.action_log_scope(
@@ -1323,8 +1310,8 @@ class NemesisRunner:
             # after decomission and add_node, the left nodes have data that isn't part of their tokens anymore.
             # In order to eliminate cases that we miss a "data loss" bug because of it, we cleanup this data.
             # This fix important when just user profile is run in the test and "keyspace1" doesn't exist.
-            if new_node.is_seed != replacement_should_be_seed:
-                new_node.set_seed_flag(replacement_should_be_seed)
+            if new_node.is_seed != target_is_seed:
+                new_node.set_seed_flag(target_is_seed)
                 self.cluster.update_seed_provider()
             self.actions_log.info(f"new node added: {new_node.name}")
             if dc_topology_rf_change:

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -870,10 +870,16 @@ class SCTConfiguration(BaseModel):
          """,
     )
     seeds_selector: Literal["random", "first", "all"] = SctField(
-        description="""How to select the seeds. Expected values: random/first/all""",
+        description="""How to select the seeds. Expected values: random/first/all.
+        According to ScyllaDB docs (https://opensource.docs.scylladb.com/stable/kb/seed-nodes.html),
+        since ScyllaDB OSS 4.3 / Enterprise 2021.1 seeds are only used as the initial contact point
+        for nodes joining the cluster (gossip convergence assistance was removed). Once joined,
+        seed nodes have no special role. 'first' (the default) selects a minimal fixed set of seeds,
+        which is the recommended approach. 'all' marks every node as a seed, which is unnecessary
+        overhead and was forbidden in older ScyllaDB versions.""",
     )
     seeds_num: int = SctField(
-        description="""Number of seeds to select""",
+        description="""Number of seeds to select (used when seeds_selector is 'first' or 'random')""",
     )
     email_recipients: StringOrList = SctField(
         description="""list of email of send the performance regression test to""",

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -3924,13 +3924,6 @@ class SCTConfiguration(BaseModel):
         seeds_num = self.get("seeds_num")
         assert seeds_num > 0, "Seed number should be at least one"
 
-        num_of_db_nodes = sum(
-            self.get("n_db_nodes") if isinstance(self.get("n_db_nodes"), list) else [self.get("n_db_nodes")]
-        )
-        assert not num_of_db_nodes or seeds_num <= num_of_db_nodes, (
-            f"Seeds number ({seeds_num}) should be not more then nodes number ({num_of_db_nodes})"
-        )
-
     def _validate_nemesis_can_run_on_non_seed(self) -> None:
         if self.get("nemesis_filter_seeds") is False or self.get("nemesis_class_name") == ["NoOpMonkey"]:
             return

--- a/unit_tests/unit/test_seed_selector.py
+++ b/unit_tests/unit/test_seed_selector.py
@@ -112,3 +112,21 @@ class TestSeedSelector:
         assert self.cluster.seed_nodes == [self.cluster.nodes[0]]
         assert self.cluster.non_seed_nodes == []
         assert self.cluster.seed_nodes_addresses == [self.cluster.nodes[0].ip_address]
+
+    def test_random_seeds_num_is_capped_by_nodes_count(self):
+        self.setup_cluster(nodes_number=2)
+        self.cluster.set_test_params(seeds_selector="random", seeds_num=3, db_type="scylla")
+        self.cluster.set_seeds()
+        assert len(self.cluster.seed_nodes) == 2
+        assert self.cluster.non_seed_nodes == []
+
+    def test_set_seeds_replaces_previous_seed_flags(self):
+        self.setup_cluster(nodes_number=3)
+        self.cluster.set_test_params(seeds_selector="all", seeds_num=3, db_type="scylla")
+        self.cluster.set_seeds()
+        assert len(self.cluster.seed_nodes) == 3
+
+        self.cluster.set_test_params(seeds_selector="first", seeds_num=1, db_type="scylla")
+        self.cluster.set_seeds()
+        assert self.cluster.seed_nodes == [self.cluster.nodes[0]]
+        assert self.cluster.non_seed_nodes == [self.cluster.nodes[1], self.cluster.nodes[2]]


### PR DESCRIPTION
## Summary

- Changes the default seed selection from all nodes to up to 3 random seed nodes
- Caps `seeds_num` by the current cluster size so 1-node/2-node tests remain valid with the default `seeds_num: 3`
- Makes `set_seeds()` replace the seed set instead of accumulating stale seed flags across reselection
- Adds unit coverage for capped random seed selection and seed flag replacement

## Motivation

According to the [ScyllaDB official docs on seed nodes](https://opensource.docs.scylladb.com/stable/kb/seed-nodes.html):

> Since ScyllaDB OSS 4.3 / Enterprise 2021.1, a seed node is **only used as the initial contact point** for a new node joining the cluster to discover ring topology. Once the nodes have joined the cluster, the seed node has no function.

The previous default of `seeds_selector: "all"` marks **every** node in the cluster as a seed. This is unnecessary for modern ScyllaDB and was explicitly forbidden in older versions, where at least one non-seed node was required.

Using only one seed is minimal, but it is fragile in SCT: several nemesis operations can terminate, decommission, remove, or replace the seed node. If that happens before a new node is added, SCT may no longer have a valid seed node configured for the new node bootstrap.

## Change

| | Before | After |
|---|---|---|
| `seeds_selector` default | `"all"` | `"random"` |
| `seeds_num` default | `1` (ignored when selector is `"all"`) | `3` |

With `seeds_selector: "random"` and `seeds_num: 3`, SCT keeps a bounded set of seed nodes that is more resilient to nemesis operations than a single seed, while avoiding the unnecessary all-nodes-as-seeds configuration.

## Small clusters

`seeds_num` now behaves as a maximum for `first`/`random` selection. If a cluster has fewer than 3 nodes, SCT selects all available nodes instead of failing config validation or `random.sample()`.

## Testing

- `uv run sct.py unit-tests -t unit/test_seed_selector.py`