### PR TITLE
refactor(scale): Refactor scale tests to run faster

### DIFF
--- a/configurations/scale/scale-180-200.yaml
+++ b/configurations/scale/scale-180-200.yaml
@@ -1,11 +1,9 @@
 test_duration: 600 # (120min for 180 nodes creation + 240min for add 20 new nodes + 240min to run nemesis after the cluster was grown)
 n_db_nodes: 180
 cluster_target_size: 200
+add_node_cnt: 20
 
 user_prefix: 'cluster-scale-180-200-test'
-
-# This is in order to start the basic cluster faster
-use_legacy_cluster_init: true
 
 # Takes too long on big clusters
 cluster_health_check: false

--- a/configurations/scale/scale-40-60.yaml
+++ b/configurations/scale/scale-40-60.yaml
@@ -1,11 +1,9 @@
 test_duration: 600
 n_db_nodes: 40
 cluster_target_size: 60
+add_node_cnt: 10
 
 user_prefix: 'cluster-scale-40-60-test'
-
-# This is in order to start the basic cluster faster
-use_legacy_cluster_init: true
 
 # Takes too long on big clusters
 cluster_health_check: false

--- a/configurations/scale/scale-450-500.yaml
+++ b/configurations/scale/scale-450-500.yaml
@@ -1,11 +1,9 @@
 test_duration: 30240 # (60min * 500 nodes) + 240min to run nemesis after the cluster was grown
 n_db_nodes: 450
 cluster_target_size: 500
+add_node_cnt: 50
 
 user_prefix: 'cluster-scale-450-500-test'
-
-# This is in order to start the basic cluster faster
-use_legacy_cluster_init: true
 
 # Takes too long on big clusters
 cluster_health_check: false

--- a/test-cases/scale/scale-cluster.yaml
+++ b/test-cases/scale/scale-cluster.yaml
@@ -1,23 +1,19 @@
 test_duration: 600
 # 128KB row (16 * 8192), 244GB dataset (2M rows * 128KB)
-prepare_write_cmd:  [ "cassandra-stress write cl=ALL n=500000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=25 -pop seq=1..500000          -col 'n=FIXED(16) size=FIXED(8192)' -log interval=5",
-                      "cassandra-stress write cl=ALL n=500000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=25 -pop seq=500001..1000000   -col 'n=FIXED(16) size=FIXED(8192)' -log interval=5",
-                      "cassandra-stress write cl=ALL n=500000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=25 -pop seq=1000001..1500000  -col 'n=FIXED(16) size=FIXED(8192)' -log interval=5",
-                      "cassandra-stress write cl=ALL n=500000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=25 -pop seq=1500001..2000000  -col 'n=FIXED(16) size=FIXED(8192)' -log interval=5"
+prepare_write_cmd:  [ "cassandra-stress write cl=ALL n=1000000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=25 -pop seq=1..1000000          -col 'n=FIXED(16) size=FIXED(8192)' -log interval=5",
+                      "cassandra-stress write cl=ALL n=1000000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=25 -pop seq=1000001..2000000   -col 'n=FIXED(16) size=FIXED(8192)' -log interval=5"
                     ]
 
-stress_cmd: [ "cassandra-stress mixed cl=QUORUM duration=180m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=25 -pop seq=1..500000          -col 'n=FIXED(16) size=FIXED(8192)' -log interval=5",
-              "cassandra-stress mixed cl=QUORUM duration=180m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=25 -pop seq=500001..1000000   -col 'n=FIXED(16) size=FIXED(8192)' -log interval=5",
-              "cassandra-stress mixed cl=QUORUM duration=180m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=25 -pop seq=1000001..1500000  -col 'n=FIXED(16) size=FIXED(8192)' -log interval=5",
-              "cassandra-stress mixed cl=QUORUM duration=180m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=25 -pop seq=1500001..2000000  -col 'n=FIXED(16) size=FIXED(8192)' -log interval=5"
+stress_cmd: [ "cassandra-stress mixed cl=QUORUM duration=30m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=25 -pop seq=1..1000000          -col 'n=FIXED(16) size=FIXED(8192)' -log interval=5",
+              "cassandra-stress mixed cl=QUORUM duration=30m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=25 -pop seq=1000001..2000000   -col 'n=FIXED(16) size=FIXED(8192)' -log interval=5"
              ]
 
 round_robin: true
 
 n_db_nodes: 15
-add_node_cnt: 1
+add_node_cnt: 5
 cluster_target_size: 25
-n_loaders: 4
+n_loaders: 2
 
 # AWS
 instance_type_db: 'i7i.large'


### PR DESCRIPTION
Reduced the number of cassandra-stress prepare and stress operations
from 4 to 2, doubling the workload per command (500K to 1M rows per
operation). This consolidation reduces coordination overhead while
maintaining the same total dataset size of 244GB (2M rows * 128KB).

Optimizations made:
- Removed use_legacy_cluster_init from all scale configurations
- Reduced stress duration from 180m to 30m for faster iterations
- Increased add_node_cnt for faster scale-up (40-60: 1→10, 180-200:
  implicit→20, 450-500: implicit→50, scale-cluster: 1→5)
- Halved n_loaders from 4 to 2 in scale-cluster base config
- Maintained cluster_health_check: false for large clusters

Files modified:
- configurations/scale/scale-40-60.yaml
- configurations/scale/scale-180-200.yaml
- configurations/scale/scale-450-500.yaml
- test-cases/scale/scale-cluster.yaml

Testing:
Due to the cost will be done after merge.
