### PR TITLE
fix(tls): include broadcast_rpc_address in client-facing cert SANs for split-network topology

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import contextlib
 import copy
+import ipaddress
 import queue
 import logging
 import os
@@ -2323,7 +2324,15 @@ class BaseNode(AutoSshContainerMixin):
     def config_client_encrypt(self):
         install_client_certificate(self.remoter, self.ip_address)
 
-    def create_node_certificate(self, cert_file, cert_key, csr_file=None):
+    def create_node_certificate(
+        self, cert_file, cert_key, csr_file=None, extra_ip_addresses=None, extra_dns_names=None
+    ):
+        ip_addresses = [self.ip_address, self.public_ip_address]
+        if extra_ip_addresses:
+            ip_addresses.extend(extra_ip_addresses)
+        dns_names = [self.public_dns_name, self.private_dns_name]
+        if extra_dns_names:
+            dns_names.extend(extra_dns_names)
         create_certificate(
             cert_file,
             cert_key,
@@ -2331,8 +2340,8 @@ class BaseNode(AutoSshContainerMixin):
             ca_cert_file=CA_CERT_FILE,
             ca_key_file=CA_KEY_FILE,
             server_csr_file=csr_file,
-            ip_addresses=[self.ip_address, self.public_ip_address],
-            dns_names=[self.public_dns_name, self.private_dns_name],
+            ip_addresses=ip_addresses,
+            dns_names=dns_names,
         )
 
     @cached_property
@@ -6276,9 +6285,30 @@ class BaseScyllaCluster:
             cert_key=node.ssl_conf_dir / TLSAssets.DB_KEY,
             csr_file=node.ssl_conf_dir / TLSAssets.DB_CSR,
         )
+        # For the client-facing certificate, include broadcast_rpc_address identities
+        # in the SANs. In split-network topologies (e.g. scylla_addresses_on_different_interfaces),
+        # broadcast_rpc_address is on a different NIC than broadcast_address, and the Java
+        # driver verifies the TLS cert against the RPC endpoint it connects to.
+        extra_ip_addresses = []
+        extra_dns_names = []
+        if node.scylla_network_configuration:
+            broadcast_rpc_addr = node.scylla_network_configuration.broadcast_rpc_address
+            if broadcast_rpc_addr and broadcast_rpc_addr != node.ip_address:
+                # broadcast_rpc_address may be a DNS name (when use_dns_names is enabled)
+                # or an IP address. Route it to the appropriate SAN list.
+                try:
+                    ipaddress.ip_address(broadcast_rpc_addr)
+                    extra_ip_addresses.append(broadcast_rpc_addr)
+                except ValueError:
+                    extra_dns_names.append(broadcast_rpc_addr)
+            dns_rpc_name = node.scylla_network_configuration.dns_broadcast_rpc_name
+            if dns_rpc_name and dns_rpc_name != node.private_dns_name:
+                extra_dns_names.append(dns_rpc_name)
         node.create_node_certificate(
             node.ssl_conf_dir / TLSAssets.DB_CLIENT_FACING_CERT,
             node.ssl_conf_dir / TLSAssets.DB_CLIENT_FACING_KEY,
+            extra_ip_addresses=extra_ip_addresses,
+            extra_dns_names=extra_dns_names,
         )
         for src in (CA_CERT_FILE, JKS_TRUSTSTORE_FILE):
             shutil.copy(src, node.ssl_conf_dir)

--- a/sdcm/cluster_oci.py
+++ b/sdcm/cluster_oci.py
@@ -265,7 +265,9 @@ class OciNode(cluster.BaseNode):
             )
             return private_ip_address
 
-    def create_node_certificate(self, cert_file, cert_key, csr_file=None):
+    def create_node_certificate(
+        self, cert_file, cert_key, csr_file=None, extra_ip_addresses=None, extra_dns_names=None
+    ):
         """Create OCI node certificate with both short and FQDN hostname SANs when available."""
         dns_names = {
             self.public_dns_name,
@@ -290,6 +292,13 @@ class OciNode(cluster.BaseNode):
             except ValueError:
                 pass
 
+        if extra_dns_names:
+            dns_names.update(extra_dns_names)
+
+        ip_addresses = [self.ip_address, self.public_ip_address]
+        if extra_ip_addresses:
+            ip_addresses.extend(extra_ip_addresses)
+
         create_certificate(
             cert_file,
             cert_key,
@@ -297,7 +306,7 @@ class OciNode(cluster.BaseNode):
             ca_cert_file=CA_CERT_FILE,
             ca_key_file=CA_KEY_FILE,
             server_csr_file=csr_file,
-            ip_addresses=[self.ip_address, self.public_ip_address],
+            ip_addresses=ip_addresses,
             dns_names=sorted(dns for dns in dns_names if dns),
         )
 

--- a/sdcm/provision/network_configuration.py
+++ b/sdcm/provision/network_configuration.py
@@ -96,6 +96,32 @@ class ScyllaNetworkConfiguration:
         return self.network_interfaces[0].dns_private_name
 
     @property
+    def dns_broadcast_rpc_name(self):
+        """Return the DNS private name of the NIC used for broadcast_rpc_address.
+
+        In split-network topologies, broadcast_rpc_address is on a different NIC
+        than broadcast_address, so the client-facing certificate must include
+        the DNS name of the RPC NIC for TLS hostname verification.
+        """
+        if broadcast_rpc_address_config := [
+            conf for conf in self.scylla_network_config if conf["address"] == "broadcast_rpc_address"
+        ]:
+            if not (
+                interface := [
+                    conf
+                    for conf in self.network_interfaces
+                    if broadcast_rpc_address_config[0]["nic"] == conf.device_index
+                ]
+            ):
+                raise NetworkInterfaceNotFound(
+                    f"Not found network interface with device_index {broadcast_rpc_address_config[0]['nic']}. "
+                    f"Check 'scylla_network_config' definition in the test configuration"
+                )
+            return interface[0].dns_private_name
+
+        return self.dns_private_name
+
+    @property
     def broadcast_address_ip_type(self):
         # If multiple network interface is defined on the node, private address in the `nodetool status` is IP that defined in
         # broadcast_address. Keep this output in correlation with `nodetool status`


### PR DESCRIPTION
In splitted-networks configurations (`scylla_addresses_on_different_interfaces`), `broadcast_rpc_address` is on a different NIC (`eth1`) than `broadcast_address `(`eth0`). The client-facing TLS certificate SANs were only populated with eth0 identities, causing the Java driver to fail hostname verification when connecting to the eth1 endpoint advertised by broadcast_rpc_address.

Failed test: https://argus.scylladb.com/tests/scylla-cluster-tests/0679cc5b-68c3-41fe-a2ec-ad1d25f152bf

**Why it happened.**

[PR #7450](https://github.com/scylladb/scylla-cluster-tests/pull/7450) (splitted-networks test) merged on `2024-06-03`, but [PR #7436](https://github.com/scylladb/scylla-cluster-tests/pull/7436) (per-node TLS certificate generation with SAN hostname verification) merged on `2024-06-17` — two weeks later.
When PR #7450 was tested and merged, SCT was still using the old shared static certificates created in 2016 that did not use SAN-based hostname verification at all. The Java driver didn't verify SANs, so it didn't matter which IP was in the cert.

PR #7436 introduced per-node certificates with proper SAN extensions (IP + DNS names tied to each specific node) and enabled hostname verification in stress tools. But it only considered the ip_address (= broadcast_address, NIC 0) and private_dns_name (also NIC 0) when building SANs — it didn't account for the split-network case where the client-facing endpoint (broadcast_rpc_address) is on a different NIC.

The two PRs were developed in parallel and merged close together without accounting for their interaction. The splitted-networks test passed originally because hostname verification wasn't enforced. Once per-node certs with SAN verification landed, the combination broke — but likely wasn't caught immediately because this specific test may not have run frequently or the failure wasn't triaged until now.

**The fix**

Add the `broadcast_rpc_address` IP and its DNS hostname to the client-facing certificate SANs when they differ from the broadcast_address identities.

Fixes: https://scylladb.atlassian.net/browse/SCT-529

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [longevity-100gb-splitted-networks-4h-test](https://argus.scylladb.com/tests/scylla-cluster-tests/ae855383-5b3e-45d1-bc90-fa22b4e03093)
- [x] [longevity-50gb-two-interfaces-test with "use_dns_name"](https://argus.scylladb.com/tests/scylla-cluster-tests/baacd88b-dc5b-4bb0-9318-8690d8218886)
- [x] AWS provision

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
