### PR TITLE
fix(azure): raise SpotTerminationEvent when spot VM evicted during provisioning

### DIFF
--- a/sdcm/provision/azure/provisioner.py
+++ b/sdcm/provision/azure/provisioner.py
@@ -213,13 +213,13 @@ class AzureProvisioner(Provisioner):
                         message="recovering stuck VM (redeploy, recreate on failure)",
                         severity=Severity.NORMAL,
                     ).publish_or_dump(default_logger=LOGGER)
-                    if not self._redeploy_stuck_node(vm_name):
+                    if not self._redeploy_stuck_node(vm_name, pricing_model):
                         LOGGER.warning(
                             "Redeploy did not rescue VM %s; deleting it to recreate on fresh capacity", vm_name
                         )
                         self._delete_stuck_node(vm_name)
 
-    def _redeploy_stuck_node(self, name: str) -> bool:
+    def _redeploy_stuck_node(self, name: str, pricing_model: PricingModel) -> bool:
         """Redeploy VM to a new node.
 
         Returns True if the VM reached the 'Succeeded' provisioning state; False if the redeploy
@@ -235,7 +235,7 @@ class AzureProvisioner(Provisioner):
         if not poller.done():
             LOGGER.warning("Redeploy of stuck VM %s did not complete within %ss", name, DEFAULT_REDEPLOY_TIMEOUT)
             return False
-        return self._vm_provider.recheck_provisioned(name) is not None
+        return self._vm_provider.recheck_provisioned(name, pricing_model) is not None
 
     def _delete_stuck_node(self, name: str) -> None:
         """Delete a stuck VM and its network resources."""

--- a/sdcm/provision/azure/virtual_machine_provider.py
+++ b/sdcm/provision/azure/virtual_machine_provider.py
@@ -33,6 +33,7 @@ from sdcm.provision.provisioner import (
     StuckVMProvisioningError,
 )
 from sdcm.provision.user_data import UserDataBuilder
+from sdcm.sct_events.system import SpotTerminationEvent
 from sdcm.utils.azure_utils import AzureService
 from sdcm.wait import wait_for
 from sdcm.exceptions import WaitForTimeoutError
@@ -182,7 +183,7 @@ class VirtualMachineProvider:
                 LOGGER.error("Error when waiting for creation of VM %s: %s", definition.name, str(err))
                 error_to_raise = err
                 continue
-            v_m = self._wait_until_provisioned(definition.name)
+            v_m = self._wait_until_provisioned(definition.name, pricing_model)
             if v_m is None:
                 # accepted by Azure but never reached Succeeded within the timeout (i.e. stuck);
                 # do NOT cache or return it; the provisioner will redeploy it to a new node
@@ -197,10 +198,13 @@ class VirtualMachineProvider:
             raise StuckVMProvisioningError(stuck_vm_names)
         return v_ms
 
-    def _wait_until_provisioned(self, name: str) -> Optional[VirtualMachine]:
+    def _wait_until_provisioned(self, name: str, pricing_model: PricingModel) -> Optional[VirtualMachine]:
         """Wait until the VM reaches ProvisioningState=Succeeded.
 
         Returns the VM on success, or None if the stuck-VM timeout expires first.
+        Raises OperationPreemptedError if a spot VM vanishes (404): Azure accepts the create, then
+        deletes the VM on spot eviction / capacity-allocation failure (evictionPolicy=Delete), so
+        get() returns ResourceNotFound.
         """
 
         def get_provisioned_vm() -> Optional[VirtualMachine]:
@@ -228,10 +232,19 @@ class VirtualMachineProvider:
             )
         except WaitForTimeoutError:
             return None
+        except ResourceNotFoundError as exc:
+            if not pricing_model.is_spot():
+                raise
+            message = (
+                "Azure removed the spot VM during provisioning (ResourceNotFound 404) - "
+                "spot eviction / capacity-allocation failure"
+            )
+            SpotTerminationEvent(node=name, message=message).publish_or_dump(default_logger=LOGGER)
+            raise OperationPreemptedError(f"spot VM {name} evicted during provisioning: {message}") from exc
 
-    def recheck_provisioned(self, name: str) -> Optional[VirtualMachine]:
+    def recheck_provisioned(self, name: str, pricing_model: PricingModel) -> Optional[VirtualMachine]:
         """Re-poll a VM after an unplanned action (e.g. redeploy); cache and return it if it reaches 'Succeeded'."""
-        v_m = self._wait_until_provisioned(name)
+        v_m = self._wait_until_provisioned(name, pricing_model)
         if v_m is not None:
             self._cache[v_m.name] = v_m
         return v_m

--- a/unit_tests/unit/provisioner/fake_azure_service.py
+++ b/unit_tests/unit/provisioner/fake_azure_service.py
@@ -471,11 +471,14 @@ class VMCreateBehavior:
     If ``recover_after_polls`` is set, the VM recovers after that many instance-view polls.
     If it is ``None``, the VM stays stuck until it is deleted and recreated.
     If ``redeploy_fails`` is True, a redeploy of this VM raises an error.
+    If ``disappear_after_polls`` is set, the VM is deleted after that many instance-view polls so
+    subsequent get() calls return 404 - simulating an Azure spot eviction during provisioning.
     """
 
     stuck: bool = False
     recover_after_polls: int | None = None
     redeploy_fails: bool = False
+    disappear_after_polls: int | None = None
 
 
 class FakeVirtualMachines:
@@ -577,6 +580,10 @@ class FakeVirtualMachines:
             return raw
 
         sim["polls_seen"] += 1
+        disappear_after = sim.get("disappear_after_polls")
+        if disappear_after is not None and sim["polls_seen"] >= disappear_after:
+            os.remove(self._vm_path(resource_group_name, vm_name))
+            raise ResourceNotFoundError("Virtual Machine not found")
         recover_after = sim.get("recover_after_polls")
         if recover_after is not None and sim["polls_seen"] >= recover_after:
             sim["stuck"] = False
@@ -694,6 +701,7 @@ class FakeVirtualMachines:
             base["_simulation"] = {
                 "stuck": True,
                 "recover_after_polls": behavior.recover_after_polls,
+                "disappear_after_polls": behavior.disappear_after_polls,
                 "polls_seen": 0,
             }
         with open(self.path / resource_group_name / f"vm-{vm_name}.json", "w", encoding="utf-8") as file:

--- a/unit_tests/unit/provisioner/test_stuck_vm_recreate.py
+++ b/unit_tests/unit/provisioner/test_stuck_vm_recreate.py
@@ -17,11 +17,14 @@ import uuid
 from unittest.mock import patch
 
 import pytest
+from azure.core.exceptions import ResourceNotFoundError
 
 from sdcm.keystore import KeyStore
 from sdcm.provision.azure.virtual_machine_provider import VirtualMachineProvider
 from sdcm.provision.provisioner import (
     InstanceDefinition,
+    OperationPreemptedError,
+    PricingModel,
     ProvisionError,
     ProvisionUnrecoverableError,
     provisioner_factory,
@@ -89,7 +92,7 @@ def test_stuck_vm_is_redeployed_and_succeeds(azure_service, events_function_scop
         instances = provisioner.get_or_create_instances([_definition("node-stuck")])
 
     assert [instance.name for instance in instances] == ["node-stuck"]
-    redeploy_spy.assert_called_once_with("node-stuck")
+    redeploy_spy.assert_called_once_with("node-stuck", PricingModel.SPOT)
     delete_spy.assert_not_called()
     assert len(_stuck_events(events_function_scope, "NORMAL")) == 1
     assert _stuck_events(events_function_scope, "WARNING") == []
@@ -109,7 +112,7 @@ def test_stuck_vm_redeploy_fails_then_recreated_and_succeeds(azure_service, even
         instances = provisioner.get_or_create_instances([_definition("node-x")])
 
     assert [instance.name for instance in instances] == ["node-x"]
-    redeploy_spy.assert_called_once_with("node-x")
+    redeploy_spy.assert_called_once_with("node-x", PricingModel.SPOT)
     delete_spy.assert_called_once_with("node-x")
     assert len(_stuck_events(events_function_scope, "NORMAL")) == 1
     assert _stuck_events(events_function_scope, "WARNING") == []
@@ -140,8 +143,45 @@ def test_only_stuck_vm_in_mixed_batch_is_redeployed(azure_service, events_functi
         instances = provisioner.get_or_create_instances(definitions)
 
     assert [instance.name for instance in instances] == ["node-good-1", "node-bad", "node-good-2"]
-    redeploy_spy.assert_called_once_with("node-bad")
+    redeploy_spy.assert_called_once_with("node-bad", PricingModel.SPOT)
     assert len(_stuck_events(events_function_scope, "NORMAL")) == 1
+
+
+def _spot_termination_events(events) -> list[str]:
+    by_category = events.get_events_by_category()
+    return [line for line in by_category.get("CRITICAL", []) if "SpotTerminationEvent" in line]
+
+
+def _vm_provider_with_vanishing_vm(azure_service, vm_name: str, timeout: float = 0.5, poll: float = 0.01):
+    """Create a VM that reports Creating then vanishes (404) - an Azure spot eviction during provisioning."""
+    resource_group = f"SCT-{uuid.uuid4()}-eastus"
+    azure_service.resource.resource_groups.create_or_update(resource_group, {"location": "eastus"})
+    FakeVirtualMachines.set_provision_script(vm_name, [VMCreateBehavior(stuck=True, disappear_after_polls=2)])
+    provider = VirtualMachineProvider(resource_group, "eastus", "", False, azure_service)
+    provider._stuck_vm_timeout = timeout
+    provider._stuck_vm_poll_interval = poll
+    azure_service.compute.virtual_machines.begin_create_or_update(
+        resource_group,
+        vm_name,
+        {"location": "eastus", "tags": {"NodeType": "scylla-db"}, "properties": {}},
+    )
+    return provider
+
+
+def test_vanishing_spot_vm_raises_preempted_and_publishes_spot_termination(azure_service, events_function_scope):
+    """A spot VM removed by Azure mid-provisioning (404) must raise OperationPreemptedError and a SpotTerminationEvent."""
+    provider = _vm_provider_with_vanishing_vm(azure_service, "node-evicted")
+    with pytest.raises(OperationPreemptedError):
+        provider._wait_until_provisioned("node-evicted", PricingModel.SPOT)
+    assert len(_spot_termination_events(events_function_scope)) == 1
+
+
+def test_vanishing_on_demand_vm_is_not_treated_as_eviction(azure_service, events_function_scope):
+    """A non-spot VM that 404s mid-provisioning is not an eviction: the 404 propagates, no SpotTerminationEvent."""
+    provider = _vm_provider_with_vanishing_vm(azure_service, "node-gone")
+    with pytest.raises(ResourceNotFoundError):
+        provider._wait_until_provisioned("node-gone", PricingModel.ON_DEMAND)
+    assert _spot_termination_events(events_function_scope) == []
 
 
 def test_discovery_does_not_cache_still_creating_vm(azure_service):


### PR DESCRIPTION
Fixes https://scylladb.atlassian.net/browse/SCT-530

## Problem (SCT-530)

An Azure spot VM can be accepted by ARM, report `Creating` for a few minutes, then be deleted asynchronously by Azure on spot eviction / capacity-allocation failure (`evictionPolicy=Delete`). After that, `virtual_machines.get()` returns `404 ResourceNotFound`.

Previously the 404 was retried until the stuck-VM timeout and then re-raised as an **unclassified `TestFrameworkEvent` ERROR**, hiding the real cause and (with `instance_provision_fallback_on_demand: false`) failing `setUp` with a misleading error.

## Fix

`_wait_until_provisioned`, for spot pricing, now:
- publishes a `SpotTerminationEvent` — already matched by `tester._is_test_error`, so the run classifies as an infra `TEST_ERROR` rather than a Scylla bug;
- raises `OperationPreemptedError`, reusing the existing spot → on-demand fallback path.

On-demand 404s re-raise unchanged.

## Notes

We still poll for the full timeout duration before classifying the 404 as an eviction, for simplicity — this happens usually just once during first cluster setup, so the wasted wait is not worth optimizing. Polling the whole timeout is also robust against a transient propagation 404 right after create: a real eviction is a 404 that persists for the entire timeout, while a too-early 404 resolves on a later poll (and the create poller is already awaited once before the first `get()`, so the VM exists by the time we start polling).

## Tests

- fake Azure service gained `disappear_after_polls` to simulate a VM that vanishes mid-provisioning;
- added a spot-eviction case (asserts `OperationPreemptedError` + one `SpotTerminationEvent`) and an on-demand-404 case (asserts the 404 propagates, no event);
- updated `_redeploy_stuck_node` call assertions for the new `pricing_model` argument.
