### PR TITLE
feature(adaptive_timeouts): add adaptive timeout for MAJOR_COMPACTION

### DIFF
--- a/sdcm/utils/adaptive_timeouts/__init__.py
+++ b/sdcm/utils/adaptive_timeouts/__init__.py
@@ -143,6 +143,43 @@ def _get_service_level_propagation_timeout(
     return timeout, stats
 
 
+def _get_compaction_timeout(
+    node_info_service: NodeLoadInfoService, timeout: int | float = None
+) -> tuple[int | float, dict[str, Any]]:
+    """
+    Experimentally got these timings
+    Using the estimate = (MB / shards) / 25 + 120
+    we ensure we always overshoot the actual duration
+
+    Shards | MB     | Time     | Actual(s) | Est(s) | Diff(s) | Diff(%)
+    -------+--------+----------+-----------+--------+---------+--------
+    2      | 53084  | 00:18:05 |      1085 |   1182 |      97 |   8.9%
+    4      | 51814  | 00:08:47 |       527 |    638 |     111 |  21.1%
+    7      | 50698  | 00:04:25 |       265 |    410 |     145 |  54.7%
+
+    2      | 217528 | 00:59:36 |      3576 |   4471 |     895 |  25.0%
+    4      | 204093 | 00:30:53 |      1853 |   2161 |     308 |  16.6%
+    7      | 187566 | 00:14:27 |       867 |   1192 |     325 |  37.5%
+
+    2      | 340346 | 01:43:14 |      6194 |   6927 |     733 |  11.8%
+    4      | 335093 | 00:49:18 |      2958 |   3471 |     513 |  17.3%
+    7      | 272496 | 00:21:07 |      1267 |   1677 |     410 |  32.4%
+    """
+    COMPACTION_SPEED = 25  # MB/s per shard
+    FIXED_OVERHEAD = 120  # seconds
+    SAFETY_FACTOR = 2  # timeout is doubled to account for load, instance type, etc. variations
+    try:
+        data_size = node_info_service.node_data_size_mb  # MB
+        shards = node_info_service.shards_count
+        if data_size and shards:
+            estimated = int((data_size / shards) / COMPACTION_SPEED) + FIXED_OVERHEAD
+            timeout = estimated * SAFETY_FACTOR
+        return timeout, node_info_service.as_dict()
+    except Exception as exc:  # noqa: BLE001
+        LOGGER.warning("Failed to get node info for timeout: \n%s", exc)
+        return timeout, {}
+
+
 class Operations(Enum):
     """Available operations for adaptive timeouts. Each operation maps to a function to calculate timeout based on node load info.
 
@@ -154,7 +191,7 @@ class Operations(Enum):
     START_SCYLLA = ("start_scylla", _get_soft_timeout, ("timeout",))
     RESTART_SCYLLA = ("restart_scylla", _get_soft_timeout, ("timeout",))
     CREATE_MV = ("create_mv", _get_soft_timeout, ("timeout",))
-    MAJOR_COMPACT = ("major_compact", _get_soft_timeout, ("timeout",))
+    MAJOR_COMPACT = ("major_compact", _get_compaction_timeout, ("timeout",))
     REPAIR = ("repair", _get_soft_timeout, ("timeout",))
     MGMT_REPAIR = ("mgmt_repair", _get_soft_timeout, ("timeout",))
     BACKUP = ("backup", _get_soft_timeout, ("timeout",))


### PR DESCRIPTION
For `MAJOR_COMPACTION`, instead of using a fixed timeout, estimate using the amount of data and the number of shards.

Fixes: SCT-435

    Experimentally got these timings
    Using the estimate = 0.04 * MB / shards + 120
    we ensure we always overshoot the estimate

    Shards | MB     | Time     | Actual(s) | Est(s) | Diff(s) | Diff(%)
    -------+--------+----------+-----------+--------+---------+--------
    2      | 53084  | 00:18:05 |      1085 |   1182 |      97 |   8.9%
    4      | 51814  | 00:08:47 |       527 |    638 |     111 |  21.1%
    7      | 50698  | 00:04:25 |       265 |    410 |     145 |  54.7%

    2      | 217528 | 00:59:36 |      3576 |   4471 |     895 |  25.0%
    4      | 204093 | 00:30:53 |      1853 |   2161 |     308 |  16.6%
    7      | 187566 | 00:14:27 |       867 |   1192 |     325 |  37.5%

    2      | 340346 | 01:43:14 |      6194 |   6927 |     733 |  11.8%
    4      | 335093 | 00:49:18 |      2958 |   3471 |     513 |  17.3%
    7      | 272496 | 00:21:07 |      1267 |   1677 |     410 |  32.4%

### Testing

> [!NOTE]
> Timeout is more than 2x the actual duration
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://argus.scylladb.com/tests/scylla-cluster-tests/cdc10297-24d0-4143-9758-78d11eecac76/results
> Rising amount of data per node

|  | duration [HH:MM:SS] | timeout [HH:MM:SS] | end_time | node_idx |
| --- | --- | --- | --- | --- |
| #&#8203;1 | $${\color{green}00:00:07}$$ | 00:04:00 | 10:14:43 | 6 |
| #&#8203;2 | $${\color{green}00:00:48}$$ | 00:05:08 | 10:19:08 | 6 |
| #&#8203;3 | $${\color{green}00:01:31}$$ | 00:06:34 | 10:24:16 | 1 |
| #&#8203;4 | $${\color{green}00:02:27}$$ | 00:08:18 | 10:30:20 | 4 |
| #&#8203;5 | $${\color{green}00:03:35}$$ | 00:10:26 | 10:37:33 | 6 |
| #&#8203;6 | $${\color{green}00:04:52}$$ | 00:13:24 | 10:46:02 | 1 |
| #&#8203;7 | $${\color{green}00:06:38}$$ | 00:16:42 | 10:56:19 | 3 |
| #&#8203;8 | $${\color{green}00:09:06}$$ | 00:21:22 | 11:09:02 | 1 |
| #&#8203;9 | $${\color{green}00:11:27}$$ | 00:25:30 | 11:24:07 | 2 |
| #&#8203;10 | $${\color{green}00:15:01}$$ | 00:32:44 | 11:45:00 | 5 |
| #&#8203;11 | $${\color{green}00:19:29}$$ | 00:41:18 | 12:10:23 | 5 |
| #&#8203;12 | $${\color{green}00:24:17}$$ | 00:51:16 | 12:40:32 | 3 |
| #&#8203;13 | $${\color{green}00:29:47}$$ | 01:01:24 | 13:16:16 | 1 |
| #&#8203;14 | $${\color{green}00:36:39}$$ | 01:17:44 | 13:58:46 | 5 |


>300GB per node, different instance sizes
- [x] `ii8g.large` [2 shards]  https://argus.scylladb.com/tests/scylla-cluster-tests/9891fca2-3f61-4168-b383-04d367329c16

|  | duration [HH:MM:SS] | timeout [HH:MM:SS] | end_time | node_idx |
| --- | --- | --- | --- | --- |
| #&#8203;1 | $${\color{green}01:43:14}$$ | 03:50:12 | 20:21:00 | 3 |

- [x] `i8g.xlarge` [4 shards] https://argus.scylladb.com/tests/scylla-cluster-tests/7d70a586-f24b-4d50-a092-f6b41406795b

|  | duration [HH:MM:SS] | timeout [HH:MM:SS] | end_time | node_idx |
| --- | --- | --- | --- | --- |
| #&#8203;1 | $${\color{green}00:49:18}$$ | 01:55:00 | 19:05:52 | 4 |

- [x] `i8g.2xlarge` [7 shards] https://argus.scylladb.com/tests/scylla-cluster-tests/e4847b14-0bd8-4ffe-b4a3-69deea4fd7c8

|  | duration [HH:MM:SS] | timeout [HH:MM:SS] | end_time | node_idx |
| --- | --- | --- | --- | --- |
| #&#8203;1 | $${\color{green}00:21:07}$$ | 00:55:14 | 18:18:53 | 2 |


### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
