### PR TITLE
fix(config): disable simulated_racks for multi-dc-rackaware-validation test

### DIFF
--- a/test-cases/longevity/longevity-multi-dc-rackaware-validation.yaml
+++ b/test-cases/longevity/longevity-multi-dc-rackaware-validation.yaml
@@ -9,6 +9,7 @@ stress_cmd: ["cassandra-stress write cl=LOCAL_QUORUM duration=120m -schema 'repl
 rack_aware_loader: true
 n_db_nodes: '6 6'
 n_loaders: '1 1'
+simulated_racks: 0
 
 instance_type_db: 'i4i.2xlarge'
 


### PR DESCRIPTION
The multi-dc-rackaware-validation test runs across 2 regions with 3 AZs (a,b,c) and uses real rack placement via availability zones. Since the default simulated_racks was changed to 3, this test broke because simulated_racks forces all instances into the same AZ (az=0), conflicting with the real multi-AZ rack-aware topology the test is designed to validate.

Set simulated_racks: 0 to disable rack simulation and preserve the original behavior of distributing nodes across real AZs.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://argus.scylladb.com/tests/scylla-cluster-tests/c26a1c04-0d32-4fb4-91c6-4b9ba7e13ec6

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
