### PR TITLE
improvement(test-cases): retune longevity-change-cluster-size-by-2-times

### DIFF
--- a/data_dir/cs_mv_si_keyspace1.yaml
+++ b/data_dir/cs_mv_si_keyspace1.yaml
@@ -29,25 +29,25 @@ extra_definitions:
 columnspec:
   - name: key
     size: fixed(10)
-    population: uniform(1..10M)
+    population: uniform(1..2M)
 
   - name: key2
     cluster: uniform(1..100)
 
   - name: c0
-    size: fixed(1024)
+    size: fixed(128)
 
   - name: c1
-    size: fixed(1024)
+    size: fixed(128)
 
   - name: c2
-    size: fixed(1024)
+    size: fixed(128)
 
   - name: c3
-    size: fixed(1024)
+    size: fixed(128)
 
   - name: c4
-    size: fixed(1024)
+    size: fixed(128)
 
 
 ### Batch Ratio Distribution Specifications ###

--- a/test-cases/longevity/longevity-change-cluster-size-by-2-times.yaml
+++ b/test-cases/longevity/longevity-change-cluster-size-by-2-times.yaml
@@ -1,22 +1,65 @@
 test_duration: 900
 
-prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=20971520 no-warmup -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..20971520 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5",
-                     "cassandra-stress user profile=/tmp/cs_mv_si_keyspace1.yaml n=3000000 no-warmup ops'(insert=1)' -mode cql3 native -rate threads=40 -log interval=5"
-                    ]
+prepare_write_cmd:
+  - >-
+    cassandra-stress write cl=QUORUM no-warmup
+    n=2M
+    -pop seq=1..2M
+    -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=LeveledCompactionStrategy)'
+    -col 'n=FIXED(5) size=FIXED(128)'
+    -mode cql3 native
+    -log interval=5
+    -rate threads=2
+  - >-
+    cassandra-stress user profile=/tmp/cs_mv_si_keyspace1.yaml no-warmup ops'(insert=1)'
+    n=2M
+    -mode cql3 native
+    -log interval=5
+    -rate threads=2
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=720m no-warmup -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native -rate threads=40 -pop 'dist=uniform(1..20971520)' -col 'n=FIXED(10) size=FIXED(512)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=720m no-warmup -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native -rate threads=40 -pop 'dist=uniform(1..20971520)' -col 'n=FIXED(10) size=FIXED(512)' -log interval=5",
-             "cassandra-stress user profile=/tmp/cs_mv_si_keyspace1.yaml duration=700m no-warmup ops'(insert=1,read=1,mv_read1=1,mv_read2=1)' -mode cql3 native -rate threads=40 -log interval=5",
-             "cassandra-stress user profile=/tmp/cs_mv_si_keyspace1.yaml duration=700m no-warmup ops'(insert=1,read=1,si_read1=1,si_read2=1)' -mode cql3 native -rate threads=40 -log interval=5"
-             ]
+stress_cmd:
+  - >-
+    cassandra-stress write cl=QUORUM no-warmup
+    duration=720m
+    -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=LeveledCompactionStrategy)'
+    -col 'n=FIXED(5) size=FIXED(128)'
+    -mode cql3 native
+    -log interval=5
+    -rate threads=1
+    -pop 'dist=uniform(1..2M)'
+  - >-
+    cassandra-stress read cl=QUORUM no-warmup
+    duration=720m
+    -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=LeveledCompactionStrategy)'
+    -col 'n=FIXED(5) size=FIXED(128)'
+    -mode cql3 native
+    -log interval=5
+    -rate threads=1
+    -pop 'dist=uniform(1..2M)'
+  - >-
+    cassandra-stress user profile=/tmp/cs_mv_si_keyspace1.yaml no-warmup ops'(insert=1,read=1,mv_read1=1,mv_read2=1)'
+    duration=700m
+    -mode cql3 native
+    -log interval=5
+    -rate threads=1
+  - >-
+    cassandra-stress user profile=/tmp/cs_mv_si_keyspace1.yaml no-warmup ops'(insert=1,read=1,si_read1=1,si_read2=1)'
+    duration=700m
+    -mode cql3 native
+    -log interval=5
+    -rate threads=1
+
 
 n_db_nodes: 3
 n_loaders: 2
 
-# Note: the instance of i8ge is not supported on all region and not on all availability zones.
-# Example: i8ge.2xlarge is currently supported on us-east-1b,us-east-1c,us-east-1d. And not on us-east-1a.
-instance_type_db: 'i8ge.2xlarge'
-
+sizing_db:
+  # Use >=4 (not exact 4) so OCI and GCE can match:
+  # OCI DenseIO starts at 16 vCPU .
+  # GCE z3-highmem starts at 8 vCPUs.
+  # AWS/Azure still resolve to their 4-vCPU instances (smallest fitting).
+  vcpu: ">=4"
+  memory: ">=32"
 
 nemesis_class_name: ['SisyphusMonkey', 'SisyphusMonkey']
 nemesis_selector: ["GrowShrinkClusterNemesis","schema_changes and not disruptive"]

--- a/test-cases/longevity/longevity-change-cluster-size-by-2-times.yaml
+++ b/test-cases/longevity/longevity-change-cluster-size-by-2-times.yaml
@@ -1,22 +1,64 @@
 test_duration: 900
 
-prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=20971520 no-warmup -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..20971520 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5",
-                     "cassandra-stress user profile=/tmp/cs_mv_si_keyspace1.yaml n=3000000 no-warmup ops'(insert=1)' -mode cql3 native -rate threads=40 -log interval=5"
-                    ]
+prepare_write_cmd:
+  - >-
+    cassandra-stress write cl=QUORUM no-warmup
+    n=20971520
+    -pop seq=1..20971520
+    -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=LeveledCompactionStrategy)'
+    -col 'n=FIXED(5) size=FIXED(128)'
+    -mode cql3 native
+    -log interval=5
+    -rate threads=10
+  - >-
+    cassandra-stress user profile=/tmp/cs_mv_si_keyspace1.yaml no-warmup ops'(insert=1)'
+    n=3000000
+    -mode cql3 native
+    -log interval=5
+    -rate threads=10
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=720m no-warmup -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native -rate threads=40 -pop 'dist=uniform(1..20971520)' -col 'n=FIXED(10) size=FIXED(512)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=720m no-warmup -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native -rate threads=40 -pop 'dist=uniform(1..20971520)' -col 'n=FIXED(10) size=FIXED(512)' -log interval=5",
-             "cassandra-stress user profile=/tmp/cs_mv_si_keyspace1.yaml duration=700m no-warmup ops'(insert=1,read=1,mv_read1=1,mv_read2=1)' -mode cql3 native -rate threads=40 -log interval=5",
-             "cassandra-stress user profile=/tmp/cs_mv_si_keyspace1.yaml duration=700m no-warmup ops'(insert=1,read=1,si_read1=1,si_read2=1)' -mode cql3 native -rate threads=40 -log interval=5"
-             ]
+stress_cmd:
+  - >-
+    cassandra-stress write cl=QUORUM no-warmup
+    duration=720m
+    -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=LeveledCompactionStrategy)'
+    -col 'n=FIXED(5) size=FIXED(128)'
+    -mode cql3 native
+    -log interval=5
+    -rate threads=5
+    -pop 'dist=uniform(1..20971520)'
+  - >-
+    cassandra-stress read cl=QUORUM no-warmup
+    duration=720m
+    -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=LeveledCompactionStrategy)'
+    -col 'n=FIXED(5) size=FIXED(128)'
+    -mode cql3 native
+    -log interval=5
+    -rate threads=5
+    -pop 'dist=uniform(1..20971520)'
+  - >-
+    cassandra-stress user profile=/tmp/cs_mv_si_keyspace1.yaml no-warmup ops'(insert=1,read=1,mv_read1=1,mv_read2=1)'
+    duration=700m
+    -mode cql3 native
+    -log interval=5
+    -rate threads=5
+  - >-
+    cassandra-stress user profile=/tmp/cs_mv_si_keyspace1.yaml no-warmup ops'(insert=1,read=1,si_read1=1,si_read2=1)'
+    duration=700m
+    -mode cql3 native
+    -log interval=5
+    -rate threads=5
+
 
 n_db_nodes: 3
 n_loaders: 2
 
-# Note: the instance of i8ge is not supported on all region and not on all availability zones.
-# Example: i8ge.2xlarge is currently supported on us-east-1b,us-east-1c,us-east-1d. And not on us-east-1a.
-instance_type_db: 'i8ge.2xlarge'
-
+sizing_db:
+  # Use >=8 (not exact 8) so OCI can match:
+  # OCI DenseIO starts at 16 vCPU .
+  # AWS/Azure/GCE still resolve to their 8-vCPU instances (smallest fitting).
+  vcpu: ">=8"
+  memory: ">=64"
 
 nemesis_class_name: ['SisyphusMonkey', 'SisyphusMonkey']
 nemesis_selector: ["GrowShrinkClusterNemesis","schema_changes and not disruptive"]


### PR DESCRIPTION
This test had 100% load.
<img width="500" height="250" alt="image" src="https://github.com/user-attachments/assets/e126f6a1-56e7-4453-9b5c-325c9a52104d" />
causing high latencies
<img width="340" height="252" alt="image" src="https://github.com/user-attachments/assets/bf735aed-d653-43a8-b2d8-745583f457dc" />
which let to timeouts
> (CassandraStressLogEvent Severity.CRITICAL) period_type=one-time event_id=a67452dc-8a19-4e5e-a20a-783acf3f0fe4 during_nemesis=GrowShrinkClusterNemesis: type=OperationOnKey regex=Operation x10 on key\(s\) \[ line_number=8711 node=Node raft-double-cluster-size-with-schem-loader-node-a5a85827-0-1 [35.245.79.88 | 10.150.15.211] (Type: e2-standard-2) (rack: b)
[2026-05-19 13:52:18.210] java.io.IOException: Operation x10 on key(s) [3930344b4f4f4b4c3331]: Error executing: (WriteTimeoutException): Cassandra timeout during SIMPLE write query at consistency QUORUM (2 replica were required but only 1 acknowledged the write)

- reduce the load by reducing the number of threads
- use smaller instances to reduce costs
  - also don't use i8ge family, which caused the GrowShrinkNemesis to be skipped a lot due to capacity issues
  - don't use arm instances, as they may run into capacity issues (e.g. https://argus.scylladb.com/tests/scylla-cluster-tests/dbebd513-240a-46c1-b191-d1b803cc6e8b/nemesis)
- re-write the stress commands using multi-line strings for clarity (and better diffs in the future).

Closes: SCT-380
Closes: SCT-497

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://argus.scylladb.com/tests/scylla-cluster-tests/a25db33d-8623-4bf1-bf0a-ddafae25d444

Load
<img width="1038" height="495" alt="image" src="https://github.com/user-attachments/assets/a7ed69ea-37cb-45c1-9053-cb6ecf5372c7" />

Disk Usage
<img width="270" height="242" alt="image" src="https://github.com/user-attachments/assets/5969bd5f-b75a-4776-a77e-03eacfa207b5" />

Latencies
<img width="353" height="254" alt="Screenshot From 2026-07-23 13-40-31" src="https://github.com/user-attachments/assets/f516f2ae-547b-4aea-982d-5deeb5ad66db" />



### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
