### PR TITLE
fix(migrator): mirror Spark 4.x to S3

### DIFF
--- a/sdcm/provision/aws/emr_provisioner.py
+++ b/sdcm/provision/aws/emr_provisioner.py
@@ -32,6 +32,16 @@ EMR_PROVISIONING_STATES = ("STARTING", "BOOTSTRAPPING", "RUNNING")
 EMR_TERMINAL_STATES = ("TERMINATED", "TERMINATED_WITH_ERRORS")
 
 
+class EmrClusterTerminatedError(Exception):
+    """Raised when an EMR cluster reaches a terminal state (TERMINATED / TERMINATED_WITH_ERRORS)
+    and should not be retried.
+    """
+
+
+class EmrClusterNotReadyError(Exception):
+    """Raised while an EMR cluster is still provisioning (not yet WAITING). Retryable."""
+
+
 class EmrClusterProvisioner:
     """Provisions and manages Amazon EMR clusters for spark-migrator testing.
 
@@ -152,7 +162,12 @@ class EmrClusterProvisioner:
 
         return instance_groups
 
-    @retrying(n=60, sleep_time=30, message="Waiting for EMR cluster to be ready...")
+    @retrying(
+        n=60,
+        sleep_time=30,
+        allowed_exceptions=(EmrClusterNotReadyError,),
+        message="Waiting for EMR cluster to be ready...",
+    )
     def wait_for_emr_cluster_ready(self, cluster_id=None):
         """Wait until EMR cluster reaches WAITING state.
 
@@ -163,7 +178,9 @@ class EmrClusterProvisioner:
             dict: Cluster description.
 
         Raises:
-            AssertionError: If cluster enters a terminal state.
+            EmrClusterTerminatedError: If the cluster enters a terminal state. Not retried — a
+                self-terminated cluster never recovers, so the wait fails fast.
+            EmrClusterNotReadyError: If the cluster is still provisioning. Retried by the decorator.
         """
         cluster_id = cluster_id or self.cluster_id
         status = self.get_emr_cluster_status(cluster_id)
@@ -173,12 +190,15 @@ class EmrClusterProvisioner:
             LOGGER.info("EMR cluster %s is ready (state: %s)", cluster_id, state)
             return status
 
-        assert state not in EMR_TERMINAL_STATES, (
-            f"EMR cluster {cluster_id} entered terminal state: {state}. "
-            f"Reason: {status.get('StateChangeReason', {}).get('Message', 'unknown')}"
-        )
-        assert state in EMR_PROVISIONING_STATES, f"EMR cluster {cluster_id} in unexpected state: {state}"
-        raise RuntimeError(f"EMR cluster {cluster_id} still provisioning (state: {state})")
+        if state in EMR_TERMINAL_STATES:
+            reason = status.get("StateChangeReason", {}).get("Message", "unknown")
+            raise EmrClusterTerminatedError(
+                f"EMR cluster {cluster_id} entered terminal state: {state}. Reason: {reason}"
+            )
+
+        if state not in EMR_PROVISIONING_STATES:
+            LOGGER.warning("EMR cluster %s in unexpected non-terminal state: %s", cluster_id, state)
+        raise EmrClusterNotReadyError(f"EMR cluster {cluster_id} still provisioning (state: {state})")
 
     def get_emr_cluster_status(self, cluster_id=None):
         """Get current EMR cluster status.

--- a/sdcm/spark_migrator.py
+++ b/sdcm/spark_migrator.py
@@ -36,20 +36,29 @@ MIGRATOR_JAR_NAME = "scylla-migrator-assembly.jar"
 # The workaround installs Spark 4.x via a bootstrap action and uses a wrapper shell script
 # (through script-runner.jar) instead of a native Spark step.
 # Once Amazon EMR is bundled with Spark 4.x out of the box, this workaround can be removed.
+#
+# The Spark 4.x tarball is mirrored into the SCT-owned S3 bucket on first use, and the bootstrap pulls it
+# from there via `aws s3 cp`. This avoids depending on the Apache live mirror (downloads.apache.org), which
+# serves only current releases and returns 404 once a version is superseded. The one-time mirror upload reads
+# from the Apache archive (archive.apache.org), which retains every release permanently.
 SPARK4_VERSION = "4.0.2"
 SPARK4_INSTALL_DIR = "/opt/spark4"
 _BOOTSTRAP_SCRIPT_S3_KEY = "scripts/bootstrap-spark4.sh"
 _SPARK4_PACKAGE = f"spark-{SPARK4_VERSION}-bin-hadoop3"
-_SPARK4_URL = f"https://downloads.apache.org/spark/spark-{SPARK4_VERSION}/{_SPARK4_PACKAGE}.tgz"
+_SPARK4_ARCHIVE_URL = f"https://archive.apache.org/dist/spark/spark-{SPARK4_VERSION}/{_SPARK4_PACKAGE}.tgz"
+_SPARK4_S3_KEY = f"spark/{_SPARK4_PACKAGE}.tgz"
 _RUNNER_SCRIPT_S3_KEY = "scripts/run-migrator.sh"
 _VALIDATOR_SCRIPT_S3_KEY = "scripts/run-validator.sh"
 _MIGRATOR_MAIN_CLASS = "com.scylladb.migrator.Migrator"
 _VALIDATOR_MAIN_CLASS = "com.scylladb.migrator.Validator"
 
-_BOOTSTRAP_SCRIPT_CONTENT = f"""#!/bin/bash
+
+def _build_bootstrap_script(s3_bucket):
+    """Return the Spark 4.x install bootstrap script that pulls the tarball from the SCT S3 mirror."""
+    return f"""#!/bin/bash
 set -ex
 cd /tmp
-wget -q "{_SPARK4_URL}"
+aws s3 cp "s3://{s3_bucket}/{_SPARK4_S3_KEY}" "{_SPARK4_PACKAGE}.tgz"
 tar xzf "{_SPARK4_PACKAGE}.tgz"
 sudo mv /tmp/{_SPARK4_PACKAGE} {SPARK4_INSTALL_DIR}
 sudo chown -R hadoop:hadoop {SPARK4_INSTALL_DIR}
@@ -81,12 +90,55 @@ def _ensure_s3_bucket(s3_client, bucket_name, region_name):
 
 
 # TODO: Spark 4.x workaround
-def build_spark4_bootstrap_actions(region_name, s3_bucket=None):
-    """Upload Spark 4.x bootstrap script to S3 and return EMR bootstrap actions."""
-    s3_bucket = s3_bucket or f"sct-emr-spark-migrator-{region_name}"
+def upload_spark4_tarball_to_s3(s3_bucket, region_name):
+    """Mirror the Spark 4.x tarball into S3 if absent, and return its S3 URI.
+
+    Downloads from the Apache archive (which retains all releases) on first use, then caches it in the SCT
+    bucket so the EMR bootstrap can pull it from S3 - independent of Apache live-mirror rotation for latest release.
+
+    Args:
+        s3_bucket: Target S3 bucket name.
+        region_name: AWS region for the S3 client.
+
+    Returns:
+        str: S3 URI of the Spark tarball.
+    """
+    s3_uri = f"s3://{s3_bucket}/{_SPARK4_S3_KEY}"
     s3_client = boto3.client("s3", region_name=region_name)
     _ensure_s3_bucket(s3_client, s3_bucket, region_name)
-    s3_client.put_object(Bucket=s3_bucket, Key=_BOOTSTRAP_SCRIPT_S3_KEY, Body=_BOOTSTRAP_SCRIPT_CONTENT.encode("utf-8"))
+
+    try:
+        s3_client.head_object(Bucket=s3_bucket, Key=_SPARK4_S3_KEY)
+        LOGGER.info("Spark 4.x tarball already exists at %s, skipping upload", s3_uri)
+        return s3_uri
+    except ClientError as exc:
+        if exc.response["Error"]["Code"] != "404":
+            raise
+
+    LOGGER.info("Downloading Spark 4.x tarball from %s", _SPARK4_ARCHIVE_URL)
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        local_path = os.path.join(tmp_dir, f"{_SPARK4_PACKAGE}.tgz")
+        response = requests.get(_SPARK4_ARCHIVE_URL, stream=True, timeout=600)
+        response.raise_for_status()
+        with open(local_path, "wb") as tarball_file:
+            tarball_file.writelines(response.iter_content(chunk_size=8192))
+
+        LOGGER.info("Uploading Spark 4.x tarball to %s", s3_uri)
+        s3_client.upload_file(local_path, s3_bucket, _SPARK4_S3_KEY)
+
+    LOGGER.info("Spark 4.x tarball uploaded to %s", s3_uri)
+    return s3_uri
+
+
+# TODO: Spark 4.x workaround
+def build_spark4_bootstrap_actions(region_name, s3_bucket=None):
+    """Mirror the Spark 4.x tarball to S3, upload the bootstrap script, and return EMR bootstrap actions."""
+    s3_bucket = s3_bucket or f"sct-emr-spark-migrator-{region_name}"
+    upload_spark4_tarball_to_s3(s3_bucket, region_name)
+    s3_client = boto3.client("s3", region_name=region_name)
+    s3_client.put_object(
+        Bucket=s3_bucket, Key=_BOOTSTRAP_SCRIPT_S3_KEY, Body=_build_bootstrap_script(s3_bucket).encode("utf-8")
+    )
     return [
         {
             "Name": f"Install Spark {SPARK4_VERSION}",

--- a/unit_tests/unit/test_emr_provisioner.py
+++ b/unit_tests/unit/test_emr_provisioner.py
@@ -16,6 +16,7 @@ from sdcm.provision.aws.emr_provisioner import (
     EMR_EC2_INSTANCE_PROFILE_NAME,
     EMR_SERVICE_ROLE_NAME,
     EmrClusterProvisioner,
+    EmrClusterTerminatedError,
     ensure_emr_roles,
     list_emr_clusters,
 )
@@ -295,3 +296,39 @@ def test_ensure_emr_roles_idempotent(moto_server, iam_roles):
         ensure_emr_roles(AWS_REGION)
 
     assert iam.get_role(RoleName=EMR_SERVICE_ROLE_NAME)["Role"]["RoleName"] == EMR_SERVICE_ROLE_NAME
+
+
+def test_wait_for_emr_cluster_ready_fails_fast_on_terminal_state(provisioner):
+    """A terminal TERMINATED_WITH_ERRORS state raises immediately — no retry, no ~30 min wait in SetUp."""
+    cluster_id = "j-CLUSTER"
+    terminal_message = "bootstrap action 1 returned a non-zero return code"
+    terminal_status = {
+        "State": "TERMINATED_WITH_ERRORS",
+        "StateChangeReason": {"Message": terminal_message},
+    }
+
+    with (
+        patch.object(provisioner, "get_emr_cluster_status", return_value=terminal_status) as mock_status,
+        patch("sdcm.utils.decorators.time.sleep") as mock_sleep,
+        pytest.raises(EmrClusterTerminatedError, match=terminal_message),
+    ):
+        provisioner.wait_for_emr_cluster_ready(cluster_id)
+
+    assert mock_status.call_count == 1
+    mock_sleep.assert_not_called()
+
+
+def test_wait_for_emr_cluster_ready_retries_while_provisioning(provisioner):
+    """A still-provisioning state is retried until the cluster reaches WAITING."""
+    cluster_id = "j-CLUSTER"
+    waiting_status = {"State": "WAITING"}
+    states = [{"State": "STARTING"}, {"State": "BOOTSTRAPPING"}, waiting_status]
+
+    with (
+        patch.object(provisioner, "get_emr_cluster_status", side_effect=states) as mock_status,
+        patch("sdcm.utils.decorators.time.sleep"),
+    ):
+        result = provisioner.wait_for_emr_cluster_ready(cluster_id)
+
+    assert result == waiting_status
+    assert mock_status.call_count == 3

--- a/unit_tests/unit/test_spark_migrator.py
+++ b/unit_tests/unit/test_spark_migrator.py
@@ -19,6 +19,7 @@ from sdcm.spark_migrator import (
     discover_cs_source_hosts,
     get_migrator_download_url,
     upload_migrator_jar_to_s3,
+    upload_spark4_tarball_to_s3,
 )
 import spark_migrator_test
 
@@ -188,11 +189,14 @@ def test_upload_migrator_jar_to_s3_downloads_and_uploads():
 # TODO: Spark 4.x workaround
 @mock_aws
 def test_build_spark4_bootstrap_actions():
-    """Test that bootstrap actions are built and script is uploaded to S3."""
+    """Bootstrap actions are built, the Spark tarball is mirrored to S3, and the script pulls it via aws s3 cp."""
     s3_client = boto3.client("s3", region_name="us-east-1")
     s3_client.create_bucket(Bucket="sct-emr-spark-migrator-us-east-1")
 
-    actions = build_spark4_bootstrap_actions("us-east-1")
+    mock_response = MagicMock()
+    mock_response.iter_content.return_value = [b"fake-spark-tarball"]
+    with patch("sdcm.spark_migrator.requests.get", return_value=mock_response):
+        actions = build_spark4_bootstrap_actions("us-east-1")
 
     assert len(actions) == 1
     assert actions[0]["Name"] == f"Install Spark {SPARK4_VERSION}"
@@ -205,7 +209,36 @@ def test_build_spark4_bootstrap_actions():
     )
     assert SPARK4_VERSION in body
     assert SPARK4_INSTALL_DIR in body
-    assert "wget" in body
+    assert "aws s3 cp" in body
+    assert "wget" not in body
+    assert "downloads.apache.org" not in body
+
+    tarball = s3_client.get_object(
+        Bucket="sct-emr-spark-migrator-us-east-1", Key=f"spark/spark-{SPARK4_VERSION}-bin-hadoop3.tgz"
+    )["Body"].read()
+    assert tarball == b"fake-spark-tarball"
+
+
+# TODO: Spark 4.x workaround
+@mock_aws
+def test_upload_spark4_tarball_to_s3_downloads_from_archive_and_uploads():
+    """Spark tarball is downloaded from the Apache archive (not the live mirror) and uploaded to S3 when absent."""
+    s3_client = boto3.client("s3", region_name="us-east-1")
+    s3_client.create_bucket(Bucket="sct-emr-spark-migrator-us-east-1")
+
+    mock_response = MagicMock()
+    mock_response.iter_content.return_value = [b"spark-tarball-bytes"]
+    with patch("sdcm.spark_migrator.requests.get", return_value=mock_response) as mock_get:
+        uri = upload_spark4_tarball_to_s3("sct-emr-spark-migrator-us-east-1", "us-east-1")
+        assert mock_get.call_count == 1
+        call_url = mock_get.call_args[0][0]
+        assert "archive.apache.org" in call_url
+        assert SPARK4_VERSION in call_url
+
+    key = f"spark/spark-{SPARK4_VERSION}-bin-hadoop3.tgz"
+    assert uri == f"s3://sct-emr-spark-migrator-us-east-1/{key}"
+    body = s3_client.get_object(Bucket="sct-emr-spark-migrator-us-east-1", Key=key)["Body"].read()
+    assert body == b"spark-tarball-bytes"
 
 
 @mock_aws


### PR DESCRIPTION
The EMR bootstrap was fetching Spark 4.0.2 from the Apache live mirror so far. But the mirror keeps only current releases. So once 4.0.3 was shipped, the 4.0.2 URL started return 404, which resulted in EMR provisioning failures.

The change adds logic for mirroring the tarball into the SCT S3 bucket (from archive.apache.org, which keeps all releases) and pulling it via `aws s3 cp`, thus no more dependency on live mirror rotation.
Additional improvement is making EMR cluster provisioning fail fast on terminal states, instead of retrying a dead cluster for ~30 min.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :green_circle: [scylla-migrator-test, small dataset](https://jenkins.scylladb.com/job/scylla-staging/job/dimakr/job/scylla-migrator-test/30/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
