### PR TITLE
fix(azure-provision): wrap storageProfile under properties for SDK v38

### DIFF
--- a/sdcm/provision/azure/virtual_machine_provider.py
+++ b/sdcm/provision/azure/virtual_machine_provider.py
@@ -257,7 +257,9 @@ class VirtualMachineProvider:
         self._azure_service.compute.virtual_machines.begin_update(
             self._resource_group_name,
             vm_name=name,
-            parameters={"storageProfile": {"osDisk": {"createOption": "FromImage", "deleteOption": "Delete"}}},
+            parameters={
+                "properties": {"storageProfile": {"osDisk": {"createOption": "FromImage", "deleteOption": "Delete"}}}
+            },
         )
 
         task = self._azure_service.compute.virtual_machines.begin_delete(self._resource_group_name, vm_name=name)


### PR DESCRIPTION
## Summary

Fixes [SCT-522](https://scylladb.atlassian.net/browse/SCT-522): Azure provisioning fails with `InvalidRequestContent: Could not find member 'storageProfile' on object of type 'ResourceDefinition'`.

## Root Cause

The `delete()` method in `VirtualMachineProvider` passes `{"storageProfile": ...}` directly at the top level of the `begin_update` parameters dict. With `azure-mgmt-compute` v38 (hybrid models), VM-specific fields must be nested under `"properties"` in the REST body. Without this wrapper, Azure ARM rejects the request.

This only manifests during the **stuck-VM recovery path**: when a VM gets stuck in provisioning → redeploy fails → `_delete_stuck_node()` calls `delete()` → the malformed `begin_update` is sent. This explains the intermittent nature — most provisioning succeeds, but when a VM gets stuck, the recovery path fails.

## Fix

Wrap `storageProfile` under `"properties"` to match the v38 format used everywhere else in the creation path.

## Other Issues Found (separate PR)

`sdcm/utils/azure_region.py` has similar problems:
- `create_virtual_machine()` uses shallow `dict |` merges with multiple `{"properties": {...}}` dicts — the last one clobbers previous nested properties (osProfile replaces hardwareProfile/storageProfile/networkProfile)
- `create_gallery_image_version()` uses snake_case `"storage_profile"` without `"properties"` wrapper

These affect the image management utility (not provisioning) and will be addressed separately.

## Backends Affected
- [x] Azure


[SCT-522]: https://scylladb.atlassian.net/browse/SCT-522?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ