### PR TITLE
fix(tier1): Restore tuned tier1 instances

### DIFF
--- a/configurations/2TB_high_disk_used_capacity.yaml
+++ b/configurations/2TB_high_disk_used_capacity.yaml
@@ -18,6 +18,7 @@ stress_cmd: ["cassandra-stress mixed cl=QUORUM duration=6800m -schema 'replicati
              "cassandra-stress user profile=/tmp/cs_mv_profile.yaml ops'(insert=3,read1=1,read2=1,read3=1)' cl=QUORUM duration=6800m -mode cql3 native -rate threads=10",
              "cassandra-stress read cl=QUORUM duration=6800m -mode cql3 native  -rate threads=10 -pop seq=1..1840000000  -log interval=5 -col 'size=FIXED(200) n=FIXED(5)'" ]
 
+instance_type_db: 'i8g.2xlarge'
 # i8g.2xlarge: 8 vCPU, 64 GB RAM, 1x1,875 GB NVMe SSD (~1,750 GiB formatted)
 sizing_db:  # no OCI match (min 16 vCPUs in OCI catalog)
   vcpu: 8

--- a/test-cases/features/elasticity/elasticity-90-percent-with-nemesis.yaml
+++ b/test-cases/features/elasticity/elasticity-90-percent-with-nemesis.yaml
@@ -17,13 +17,7 @@ pre_create_keyspace: "CREATE KEYSPACE IF NOT EXISTS keyspace1 WITH replication =
 n_db_nodes: 6
 n_loaders: 4
 nemesis_grow_shrink_instance_type: 'i8g.2xlarge'
-
-sizing_db:  # no GCE/OCI match (DenseIO min 16 vCPUs on OCI, z3 min 8 vCPUs on GCE)
-  vcpu: 2
-  memory: '>=16'
-sizing_loader:
-  vcpu: 8
-  memory: '>=8'
+instance_type_db: 'i8g.large'
 
 nemesis_class_name: 'SisyphusMonkey'
 nemesis_selector: 'supports_high_disk_utilization'


### PR DESCRIPTION
For tests that were tuned to specific disk usage, restore the hardcoded instances so the tuning is adhered to now and in the future. I do not want these tests changing without us knowing. Leave the sizing info so it can be still used cross cloud, just the tuning probably wont be exact, but that is expected.

To make these cases use dynamic sizing, we need to parametrize command based on disk size, which is possible but will require additional effort (plan in progress)

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] none

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

