### PR TITLE
fix(longevity_oos_test): check mean usage after prepare

### DIFF
--- a/longevity_oos_test.py
+++ b/longevity_oos_test.py
@@ -186,14 +186,13 @@ class LongevityOutOfSpaceTest(LongevityTest):
 
     def prepare(self):
         self.run_prepare_write_cmd()
-        for node in self.db_cluster.nodes:
-            usage = self.get_disk_usage(node)
-            if usage <= 85:
-                TestFrameworkEvent(
-                    source=self.__class__.__name__,
-                    message=f"Node {node.name} ({node.private_ip_address}) max disk is only {usage:.2f}% after prepare.",
-                    severity=Severity.CRITICAL,
-                ).publish()
+        mean_usage = sum(self.get_disk_usage(node) for node in self.db_cluster.nodes) / len(self.db_cluster.nodes)
+        if mean_usage <= 85:
+            TestFrameworkEvent(
+                source=self.__class__.__name__,
+                message=f"Mean disk usage is only {mean_usage:.2f}% after prepare.",
+                severity=Severity.ERROR,
+            ).publish()
 
     def test_oos_write(self):
         """


### PR DESCRIPTION
The usage my be imbalanced, so a scenario like 81-92-92, with a mean of 88% usage would fail the test, instead of continuing.
Check the mean usage instead.
Raise an ERROR event, not CRITICAL, so the test can continue.

For example, this test failed, when it should have continued.
<img width="868" height="220" alt="image" src="https://github.com/user-attachments/assets/21da1b1c-54bd-4d2c-a502-abd76106eae5" />
https://argus.scylladb.com/tests/scylla-cluster-tests/90ac0f5e-9247-4cdd-b500-f3cd046d41e2/screenshots

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
