### PR TITLE
feat(docker): inject simulated rack via --rack entrypoint arg

### DIFF
--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -4786,7 +4786,7 @@ Number of simulated regions for the test
 
 ## **simulated_racks** / SCT_SIMULATED_RACKS
 
-Forces GossipingPropertyFileSnitch (regardless `endpoint_snitch`) to simulate racks.<br>Provide number of racks to simulate.
+Forces GossipingPropertyFileSnitch (regardless `endpoint_snitch`) to simulate racks.<br>Provide number of racks to simulate. Takes effect only with more than one DB node: a<br>single-node cluster stays in one rack and `endpoint_snitch` is left alone. On the docker<br>backend the rack is passed to the image entrypoint as `--dc/--rack`, which requires Scylla<br>>= 2026.1; an older image fails the configuration, so set 1 to opt out.
 
 **default:** 3
 

--- a/docs/docker-backend-overview.md
+++ b/docs/docker-backend-overview.md
@@ -6,7 +6,33 @@ That said, there are a few differences and specifics to be aware of when using t
 
 ## Running Nemeses
 Not all nemeses are supported or run successfully on the Docker backend.<br>
-The full list of supported, unsupported or failing nemeses (due to know issues) can be found on the [Individual Nemesis status on Docker backend](docs/docker-backend-nemesis.md) page.
+The full list of supported, unsupported or failing nemeses (due to know issues) can be found on the [Individual Nemesis status on Docker backend](docker-backend-nemesis.md) page.
+
+## Simulated racks require Scylla 2026.1 or newer
+On the cloud backends a rack maps onto a real availability zone. Containers have no such thing, so on
+the Docker backend the rack is passed to the Scylla image entrypoint as `--dc=datacenter1
+--rack=RACK<n>` when the container is created, and the entrypoint writes `cassandra-rackdc.properties`
+before Scylla first boots. Those arguments were added in **Scylla 2026.1**; an older entrypoint
+forwards them to the Scylla binary, which rejects them and exits, so the container never comes up.
+
+`simulated_racks` defaults to 3 for every backend, and racks take effect only when the test-case has
+**more than one DB node** — a single-node cluster stays in one rack, and `endpoint_snitch` is left
+alone, so nothing reads the rack. That combination is therefore accepted on any Scylla version.
+
+Racks that would take effect on a pre-2026.1 image fail when the configuration is built, before any
+container is created:
+
+```
+ValueError: simulated_racks=3 is not supported on Scylla 2025.1.0 (docker backend): the --dc/--rack
+entrypoint arguments were added in 2026.1.0-dev. Use a 2026.1+ image or set simulated_racks: 1.
+```
+
+Either run a 2026.1+ image, or set `simulated_racks: 1` in the test-case if it has no interest in
+racks. Branch versions such as `master:latest` are assumed new enough.
+
+Note that a multi-node Docker test which does not mention `simulated_racks` inherits 3 and therefore
+does get racks on a 2026.1+ image — rack-aware CQL routing, `GossipingPropertyFileSnitch` and one
+rack per node — which is how the rack-aware code paths get cheap local coverage.
 
 ## Monitoring stack is on the Docker host machine
 SCT does not support creating a dedicated monitoring node when using the Docker backend. As a result, the monitoring stack is installed directly on the host machine, not on a dedicated Docker instance.

--- a/sdcm/cluster_docker.py
+++ b/sdcm/cluster_docker.py
@@ -28,6 +28,7 @@ from sdcm.provision.helpers.certificate import (
 )
 from sdcm.remote import LOCALRUNNER
 from sdcm.remote.docker_cmd_runner import DockerCmdRunner
+from sdcm.sct_config import simulated_racks_enabled
 from sdcm.sct_events.database import DatabaseLogEvent
 from sdcm.sct_events.filters import DbEventsFilter
 from sdcm.utils.docker_utils import get_docker_bridge_gateway, Container, ContainerManager, DockerException
@@ -75,10 +76,16 @@ class NodeContainerMixin:
             smp_match = re.search(r"--smp\s(\d+)", scylla_args)
             smp = int(smp_match.group(1)) if smp_match else 1
 
+        command_parts = []
+        if seed_ip:
+            command_parts.append(f'--seeds="{seed_ip}"')
+        if self.node_type == "db" and simulated_racks_enabled(self.parent_cluster.params):
+            command_parts.extend(["--dc=datacenter1", f"--rack=RACK{self.rack}"])
+
         return dict(
             name=self.name,
             image=self.node_container_image_tag,
-            command=f'--seeds="{seed_ip}"' if seed_ip else None,
+            command=" ".join(command_parts) if command_parts else None,
             volumes=volumes,
             network=self.parent_cluster.params.get("docker_network"),
             nano_cpus=smp * 10**9,
@@ -95,6 +102,7 @@ class DockerNode(cluster.BaseNode, NodeContainerMixin):
         ssh_login_info: Optional[dict] = None,
         node_index: int = 1,
         after_config=None,
+        rack: int = 0,
     ) -> None:
         super().__init__(
             name=f"{node_prefix}-{node_index}",
@@ -102,6 +110,7 @@ class DockerNode(cluster.BaseNode, NodeContainerMixin):
             ssh_login_info=ssh_login_info,
             base_logdir=base_logdir,
             node_prefix=node_prefix,
+            rack=rack,
             after_config=after_config,
         )
         self.node_index = node_index
@@ -308,6 +317,7 @@ class VectorStoreDockerNode(VectorStoreNodeMixin, DockerNode):
         ssh_login_info: Optional[dict] = None,
         node_index: int = 1,
         after_config=None,
+        rack: int = 0,
     ) -> None:
         super().__init__(
             parent_cluster=parent_cluster,
@@ -317,6 +327,7 @@ class VectorStoreDockerNode(VectorStoreNodeMixin, DockerNode):
             ssh_login_info=ssh_login_info,
             node_index=node_index,
             after_config=after_config,
+            rack=rack,
         )
 
     def node_container_run_args(self, seed_ip=None):
@@ -376,7 +387,7 @@ class DockerCluster(cluster.BaseCluster):
             os.path.dirname(__file__), "../docker/scylla-sct", self.params.get("scylla_linux_distro").split("-")[0]
         )
 
-    def _create_node(self, node_index, container=None, after_config=None):
+    def _create_node(self, node_index, container=None, after_config=None, rack=0):
         node = DockerNode(
             parent_cluster=self,
             container=container,
@@ -384,6 +395,7 @@ class DockerCluster(cluster.BaseCluster):
             base_logdir=self.logdir,
             node_prefix=self.node_prefix,
             node_index=node_index,
+            rack=rack,
             after_config=after_config,
         )
 
@@ -402,10 +414,11 @@ class DockerCluster(cluster.BaseCluster):
 
         return sorted(set(range(len(self.nodes) + count)) - set(node.node_index for node in self.nodes))
 
-    def _create_nodes(self, count, enable_auto_bootstrap=False):
+    def _create_nodes(self, count, enable_auto_bootstrap=False, after_config=None, rack=None):
         new_nodes = []
         for node_index in self._get_new_node_indexes(count):
-            node = self._create_node(node_index)
+            node_rack = node_index % self.racks_count if rack is None else rack
+            node = self._create_node(node_index, rack=node_rack, after_config=after_config)
             node.enable_auto_bootstrap = enable_auto_bootstrap
             self.nodes.append(node)
             new_nodes.append(node)
@@ -415,7 +428,8 @@ class DockerCluster(cluster.BaseCluster):
         containers = ContainerManager.get_containers_by_prefix(self.node_prefix)
         for node_index, container in sorted(((int(c.labels["NodeIndex"]), c) for c in containers), key=lambda x: x[0]):
             LOGGER.debug("Found container %s with name `%s' and index=%d", container, container.name, node_index)
-            node = self._create_node(node_index, container)
+            node_rack = node_index % self.racks_count
+            node = self._create_node(node_index, container, rack=node_rack)
             self.nodes.append(node)
         return self.nodes
 
@@ -431,7 +445,11 @@ class DockerCluster(cluster.BaseCluster):
         after_config=None,
     ):
         assert instance_type is None, "docker can't provision different instance types"
-        return self._get_nodes() if self.test_config.REUSE_CLUSTER else self._create_nodes(count, enable_auto_bootstrap)
+        return (
+            self._get_nodes()
+            if self.test_config.REUSE_CLUSTER
+            else self._create_nodes(count, enable_auto_bootstrap, after_config, rack=rack)
+        )
 
 
 class ScyllaDockerCluster(cluster.BaseScyllaCluster, DockerCluster):
@@ -460,6 +478,16 @@ class ScyllaDockerCluster(cluster.BaseScyllaCluster, DockerCluster):
         self.vector_store_cluster = None
 
     def node_setup(self, node, verbose=False, timeout=3600):
+        if self.test_config.REUSE_CLUSTER:
+            self._reuse_cluster_setup(node)
+            if (
+                any([self.params.get("server_encrypt"), self.params.get("client_encrypt")])
+                and not (node.ssl_conf_dir / TLSAssets.DB_CERT).exists()
+            ):
+                self._generate_db_node_certs(node)
+                install_client_certificate(node.remoter, node.ip_address, force=True)
+            return
+
         node.is_scylla_installed(raise_if_not_installed=True)
         self.check_aio_max_nr(node)
         if self.test_config.BACKTRACE_DECODING:
@@ -597,7 +625,7 @@ class CassandraDockerCluster(BaseCassandraCluster, DockerCluster):
             params=params,
         )
 
-    def _create_node(self, node_index, container=None, after_config=None):
+    def _create_node(self, node_index, container=None, after_config=None, rack=0):
         node = CassandraDockerNode(
             parent_cluster=self,
             container=container,
@@ -605,6 +633,7 @@ class CassandraDockerCluster(BaseCassandraCluster, DockerCluster):
             base_logdir=self.logdir,
             node_prefix=self.node_prefix,
             node_index=node_index,
+            rack=rack,
             after_config=after_config,
         )
 
@@ -697,13 +726,14 @@ class VectorStoreSetDocker(VectorStoreClusterMixin, DockerCluster):
                 self.log.error("Failed to reconfigure container %s: %s", node.name, e)
                 raise
 
-    def _create_node(self, node_index, container=None, after_config=None):
+    def _create_node(self, node_index, container=None, after_config=None, rack=0):
         node = VectorStoreDockerNode(
             parent_cluster=self,
             container=container,
             node_prefix=self.node_prefix,
             base_logdir=self.logdir,
             node_index=node_index,
+            rack=rack,
         )
 
         if container is None:
@@ -825,7 +855,9 @@ class LoaderSetDocker(cluster.BaseLoaderSet, DockerCluster):
             params=params,
         )
 
-    def _create_node(self, node_index, container=None, after_config=None):
+    def _create_node(self, node_index, container=None, after_config=None, rack=0):
+        # Loaders run directly on the host and have no rack semantics; the rack
+        # argument is accepted only to match the base _create_nodes() contract.
         node = DockerLoaderNode(
             parent_cluster=self,
             base_logdir=self.logdir,
@@ -880,6 +912,7 @@ class DockerMonitoringNode(cluster.BaseNode):
         node_index: int = 1,
         ssh_login_info: Optional[dict] = None,
         after_config=None,
+        rack: int = 0,
     ) -> None:
         super().__init__(
             name=f"{node_prefix}-{node_index}",
@@ -888,6 +921,7 @@ class DockerMonitoringNode(cluster.BaseNode):
             node_prefix=node_prefix,
             ssh_login_info=ssh_login_info,
             after_config=after_config,
+            rack=rack,
         )
         self.node_index = node_index
 
@@ -968,13 +1002,14 @@ class MonitorSetDocker(cluster.BaseMonitorSet, DockerCluster):
             params=params,
         )
 
-    def _create_node(self, node_index, container=None, after_config=None):
+    def _create_node(self, node_index, container=None, after_config=None, rack=0):
         node = DockerMonitoringNode(
             parent_cluster=self,
             base_logdir=self.logdir,
             node_prefix=self.node_prefix,
             node_index=node_index,
             ssh_login_info=None,
+            rack=rack,
         )
         node.init()
         return node
@@ -990,7 +1025,7 @@ class MonitorSetDocker(cluster.BaseMonitorSet, DockerCluster):
         after_config=None,
     ):
         assert instance_type is None, "docker can provision different instance types"
-        return self._create_nodes(count, enable_auto_bootstrap)
+        return self._create_nodes(count, enable_auto_bootstrap, rack=rack)
 
     @staticmethod
     def install_scylla_monitoring_prereqs(node):

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -597,6 +597,27 @@ def _load_docker_images_defaults_cached():
     return None
 
 
+#: First Scylla release whose Docker image entrypoint accepts the `--dc`/`--rack` arguments.
+DOCKER_RACK_ARG_MIN_VERSION = "2026.1.0-dev"
+
+
+def simulated_racks_enabled(params) -> bool:
+    """True when simulated racks actually take effect.
+
+    Racks need both more than one rack and more than one DB node to spread over.  A single-node
+    cluster stays in one rack whatever `simulated_racks` says: the snitch auto-resolution leaves
+    `endpoint_snitch` alone, so nothing ever reads the rack.  It must therefore not pay any of the
+    cost of racks either -- in particular the Scylla >= 2026.1 requirement of the Docker
+    `--dc`/`--rack` entrypoint arguments, which older images reject outright.
+
+    Kept in one place because three call sites have to agree on it: the Docker version check and
+    the snitch auto-resolution in `SCTConfiguration.__init__`, and the `--dc`/`--rack` injection in
+    `NodeContainerMixin.node_container_run_args`.  `n_db_nodes` is the configured topology and is
+    never mutated at runtime, so growing a cluster does not change the answer mid-test.
+    """
+    return (params.get("simulated_racks") or 0) > 1 and sum(params.get("n_db_nodes") or []) > 1
+
+
 class SCTConfiguration(BaseModel):
     """
     Class the hold the SCT configuration
@@ -2459,7 +2480,10 @@ class SCTConfiguration(BaseModel):
     )
     simulated_racks: int = SctField(
         description="""Forces GossipingPropertyFileSnitch (regardless `endpoint_snitch`) to simulate racks.
-         Provide number of racks to simulate.""",
+         Provide number of racks to simulate. Takes effect only with more than one DB node: a
+         single-node cluster stays in one rack and `endpoint_snitch` is left alone. On the docker
+         backend the rack is passed to the image entrypoint as `--dc/--rack`, which requires Scylla
+         >= 2026.1; an older image fails the configuration, so set 1 to opt out.""",
     )
     rack_aware_loader: Boolean = SctField(
         description="When enabled, loaders will look for nodes on the same rack.",
@@ -3344,15 +3368,14 @@ class SCTConfiguration(BaseModel):
                 except TypeError as exp:
                     raise ValueError(f" Got error: {exp!r}, on item '{param}'") from exp
 
+        # 14.1 On Docker, simulated racks are injected as --dc/--rack entrypoint arguments at container
+        #      creation, which the Scylla image entrypoint only understands since 2026.1. Check it here,
+        #      before section 15 forces the snitch and before any container is created.
+        if cluster_backend == "docker" and simulated_racks_enabled(self):
+            self._validate_docker_simulated_racks()
+
         # 15 Force endpoint_snitch to GossipingPropertyFileSnitch if using simulated_regions or simulated_racks
-        n_db_nodes = self.get("n_db_nodes")
-        num_of_db_nodes = sum(n_db_nodes or [])
-        if (
-            (self.get("simulated_regions") or 0) > 1
-            or (self.get("simulated_racks") or 0) > 1
-            and num_of_db_nodes > 1
-            and cluster_backend != "docker"
-        ):
+        if (self.get("simulated_regions") or 0) > 1 or simulated_racks_enabled(self):
             if snitch := self.get("endpoint_snitch"):
                 assert snitch.endswith("GossipingPropertyFileSnitch"), (
                     f"Simulating racks requires endpoint_snitch to be GossipingPropertyFileSnitch while it set to {self['endpoint_snitch']}"
@@ -4172,6 +4195,37 @@ class SCTConfiguration(BaseModel):
                         f"perf_gradual_threads for {workload} should be a single-element, integer or list, "
                         f"or a list with the same length as perf_gradual_throttle_steps for {workload}"
                     )
+
+    def _validate_docker_simulated_racks(self) -> None:
+        """Reject `simulated_racks` on Docker images that predate the --dc/--rack entrypoint arguments.
+
+        On Docker a rack is injected as a `--dc`/`--rack` entrypoint argument at container creation.
+        Scylla 2026.1 is the first release whose entrypoint accepts them and writes
+        `cassandra-rackdc.properties` before the first boot; older images forward the arguments
+        verbatim to the Scylla binary, which rejects them and exits, so the container never comes up.
+
+        The configuration is unrunnable, so fail here rather than at container creation: an error
+        naming the version requirement beats a container that dies on startup with no explanation.
+        A Docker test-case that must run on older images sets `simulated_racks: 1` itself.
+        """
+        scylla_version = self.get("scylla_version") or ""
+        try:
+            image_version = ComparableScyllaVersion(scylla_version)
+        except ValueError:
+            # Branched versions ('master:latest' and friends) are not comparable and are always new enough.
+            self.log.debug(
+                "Cannot determine whether Scylla docker image '%s' supports the --rack entrypoint argument "
+                "(scylla_version=%r); assuming it does.",
+                self.get("docker_image"),
+                scylla_version,
+            )
+            return
+        if image_version < DOCKER_RACK_ARG_MIN_VERSION:
+            raise ValueError(
+                f"simulated_racks={self.get('simulated_racks')} is not supported on Scylla {scylla_version} "
+                f"(docker backend): the --dc/--rack entrypoint arguments were added in "
+                f"{DOCKER_RACK_ARG_MIN_VERSION}. Use a 2026.1+ image or set simulated_racks: 1."
+            )
 
     def _replace_docker_image_latest_tag(self):
         docker_repo = self.get("docker_image")

--- a/sdcm/utils/lint/env_builder.py
+++ b/sdcm/utils/lint/env_builder.py
@@ -21,10 +21,13 @@ logger = logging.getLogger(__name__)
 #   - scylla_version: chosen so resolution stays offline —
 #     get_scylla_docker_repo_from_version() maps it to a nightly repo and
 #     _replace_docker_image_latest_tag() only hits the network for "latest".
+#     The numeric part must stay representative of what an unpinned pipeline actually
+#     runs (master / latest release), because validations may compare it: a 0.0.0
+#     placeholder read as "ancient Scylla" and failed every version-gated check.
 #   - k8s_scylla_operator_docker_image: only k8s-eks requires it; a plain image
 #     reference is enough for the structural check.
 _RUNTIME_REQUIRED_PARAM_PLACEHOLDERS: dict[str, tuple[str, str]] = {
-    "scylla_version": ("SCT_SCYLLA_VERSION", "0.0.0-lint-placeholder"),
+    "scylla_version": ("SCT_SCYLLA_VERSION", "2026.1.0-lint-placeholder"),
     "k8s_scylla_operator_docker_image": (
         "SCT_K8S_SCYLLA_OPERATOR_DOCKER_IMAGE",
         "scylladb/scylla-operator:lint-placeholder",

--- a/unit_tests/integration/conftest.py
+++ b/unit_tests/integration/conftest.py
@@ -128,10 +128,15 @@ def configure_scylla_node(docker_scylla_args: dict, params, ssl_dir: Path | None
     ssl_mount = f" -v {ssl_dir}:{SCYLLA_SSL_CONF_DIR}:z" if ssl else ""
 
     env_vars = "-e VECTOR_SEARCH_TEST=true" if docker_scylla_args.get("scylla_docker_image") else ""
+    # native_entrypoint=True bypasses the SCT entry.sh wrapper (which enables
+    # PasswordAuthenticator) and lets the image's own entrypoint run, so the node
+    # boots without authentication. Used by rack tests against Scylla >= 2026.1.
+    if docker_scylla_args.get("native_entrypoint"):
+        entry_opts = ""
+    else:
+        entry_opts = f"-v {entryfile_path}:/entry.sh:z --entrypoint /entry.sh"
     extra_docker_opts = (
-        f'-p {ALTERNATOR_PORT} -p {BaseNode.CQL_PORT} --cpus="1" -v {entryfile_path}:/entry.sh:z'
-        f"{ssl_mount}"
-        f" --user root {env_vars} --entrypoint /entry.sh"
+        f'-p {ALTERNATOR_PORT} -p {BaseNode.CQL_PORT} --cpus="1" {entry_opts}{ssl_mount} --user root {env_vars}'
     )
 
     if seeds := docker_scylla_args.get("seeds"):
@@ -139,10 +144,14 @@ def configure_scylla_node(docker_scylla_args: dict, params, ssl_dir: Path | None
     else:
         seeds = ""
 
+    rack = docker_scylla_args.get("rack")
+    dc = docker_scylla_args.get("dc", "datacenter1")
+    rack_args = f" --dc={dc} --rack=RACK{rack}" if rack is not None else ""
+
     scylla = RemoteDocker(
         LocalNode("scylla", cluster),
         image_name=docker_version,
-        command_line=f"--smp 1 {alternator_flags}{seeds}",
+        command_line=f"--smp 1 {alternator_flags}{seeds}{rack_args}",
         extra_docker_opts=extra_docker_opts,
         docker_network=docker_network,
     )

--- a/unit_tests/integration/test_docker_simulated_racks.py
+++ b/unit_tests/integration/test_docker_simulated_racks.py
@@ -1,0 +1,133 @@
+"""Integration tests for Docker simulated racks via entrypoint arguments.
+
+External services: Docker (two Scylla containers)
+
+Validates that passing --rack/--dc to the Docker entrypoint at container
+creation time causes each node to report a distinct rack (RACK0, RACK1)
+in system.local.  Uses Scylla >= 2026.1 images where the entrypoint
+natively supports these arguments.
+
+Also validates the REUSE_CLUSTER path: after initial rack setup, calling
+node_setup with REUSE_CLUSTER=True must skip full setup while preserving
+rack assignments.
+"""
+
+import pytest
+
+from unit_tests.integration.conftest import configure_scylla_node
+from unit_tests.lib.fake_docker_cluster import DummyDockerNode, DummyScyllaDockerCluster
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.xdist_group("docker_heavy"),
+]
+
+
+# Rolling tag of the 2026.1 branch -- the first release whose Docker entrypoint
+# accepts --rack/--dc.  The patch level is irrelevant to what this test asserts,
+# so track the branch instead of pinning a single release.
+_RACK_CAPABLE_IMAGE = "docker.io/scylladb/scylla:2026.1"
+
+
+@pytest.fixture(scope="function")
+def configure_racks(params, events):
+    """Create a two-node cluster with racks configured via entrypoint args.
+
+    Each container is started with --rack=RACKn --dc=datacenter1 passed to
+    the Docker entrypoint, which writes cassandra-rackdc.properties and sets
+    the snitch before the first Scylla boot.  No post-start reconfiguration
+    or data wipe is needed.
+
+    Uses native_entrypoint=True to bypass the SCT entry.sh which sets
+    PasswordAuthenticator with ``authenticator_user``/``authenticator_password``
+    scylla.yaml options that were removed in Scylla 2026.1.
+    """
+    # Clear auth params so run_cqlsh does not pass -u/-p credentials.
+    # Use dict() to avoid Pydantic model_copy() since configure_scylla_node
+    # only needs dict-like access.
+    noauth_overrides = {"authenticator_user": "", "authenticator_password": ""}
+    params_dict = dict(params)
+    params_dict.update(noauth_overrides)
+
+    containers = []
+    try:
+        containers.append(
+            configure_scylla_node(
+                {"rack": 0, "image": _RACK_CAPABLE_IMAGE, "native_entrypoint": True},
+                {**params_dict},
+            )
+        )
+        containers.append(
+            configure_scylla_node(
+                {"rack": 1, "seeds": containers[0].ip_address, "image": _RACK_CAPABLE_IMAGE, "native_entrypoint": True},
+                {**params_dict},
+            )
+        )
+        yield tuple(DummyDockerNode(container, rack=rack, node_index=rack) for rack, container in enumerate(containers))
+    finally:
+        # Kill whatever came up: collecting the containers as they start means the first one is
+        # not leaked when the second fails, which would happen if teardown waited for `yield`.
+        for container in reversed(containers):
+            container.kill()
+
+
+def test_rack_visibility(configure_racks):
+    """Each node must report its assigned rack in system.local."""
+    node1, node2 = configure_racks
+    result = node1.run_cqlsh("SELECT rack FROM system.local")
+    assert "RACK0" in result.stdout
+
+    result = node2.run_cqlsh("SELECT rack FROM system.local")
+    assert "RACK1" in result.stdout
+
+
+def test_keyspace_creation_with_rf2(configure_racks):
+    """A NetworkTopologyStrategy keyspace with RF=2 must be creatable across racks."""
+    node1, _ = configure_racks
+    create_ks = (
+        "CREATE KEYSPACE IF NOT EXISTS rack_test_ks "
+        "WITH replication = {'class': 'NetworkTopologyStrategy', 'datacenter1': 2}"
+    )
+    result = node1.run_cqlsh(create_ks)
+    assert result.ok, f"Failed to create keyspace: {result.stderr}"
+
+
+def test_reuse_cluster_preserves_racks(tmp_path, configure_racks):
+    """After initial rack setup, node_setup with REUSE_CLUSTER=True must
+    skip full setup (no restart, no config_setup) while preserving the
+    rack assignments that were written during the initial setup.
+    """
+    node1, node2 = configure_racks
+
+    # Verify racks are correct before the reuse run
+    result = node1.run_cqlsh("SELECT rack FROM system.local")
+    assert "RACK0" in result.stdout
+
+    result = node2.run_cqlsh("SELECT rack FROM system.local")
+    assert "RACK1" in result.stdout
+
+    # Simulate a REUSE_CLUSTER run: create a new cluster object with
+    # reuse_cluster=True and call node_setup on the same nodes.
+    reuse_cluster = DummyScyllaDockerCluster(
+        params={"simulated_racks": 2, "docker_image": _RACK_CAPABLE_IMAGE},
+        logdir=tmp_path,
+        reuse_cluster=True,
+    )
+
+    reuse_cluster.node_setup(node1)
+    reuse_cluster.node_setup(node2)
+
+    # Racks must still be the same after the reuse node_setup (no restart happened)
+    result = node1.run_cqlsh("SELECT rack FROM system.local")
+    assert "RACK0" in result.stdout, f"Rack changed after reuse node_setup: {result.stdout}"
+
+    result = node2.run_cqlsh("SELECT rack FROM system.local")
+    assert "RACK1" in result.stdout, f"Rack changed after reuse node_setup: {result.stdout}"
+
+    # The keyspace created by a previous test (or create it now) must still work
+    create_ks = (
+        "CREATE KEYSPACE IF NOT EXISTS reuse_rack_test_ks "
+        "WITH replication = {'class': 'NetworkTopologyStrategy', 'datacenter1': 2}"
+    )
+    result = node1.run_cqlsh(create_ks)
+    assert result.ok, f"Failed to create keyspace after reuse: {result.stderr}"

--- a/unit_tests/lib/fake_docker_cluster.py
+++ b/unit_tests/lib/fake_docker_cluster.py
@@ -1,0 +1,94 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2025 ScyllaDB
+
+"""Lightweight ScyllaDockerCluster test double for unit and integration tests.
+
+Provides a thin subclass that bypasses the heavy DockerCluster / BaseCluster
+constructor chain while keeping real method implementations like ``node_setup``,
+``_create_nodes``, and ``_get_nodes``.
+"""
+
+import logging
+from pathlib import Path
+from types import SimpleNamespace
+
+from sdcm.cluster_docker import ScyllaDockerCluster
+
+
+class DummyScyllaDockerCluster(ScyllaDockerCluster):
+    """Minimal ScyllaDockerCluster stub for testing.
+
+    Bypasses the full ``DockerCluster`` / ``BaseCluster`` ``__init__`` chain
+    and wires only the attributes that tested methods actually read.
+
+    Supports:
+    - ``node_setup`` (needs ``params``, ``logdir``, ``test_config``)
+    - ``_create_nodes`` / ``_get_nodes`` (need ``racks_count``, ``nodes``,
+      ``node_prefix``)
+    """
+
+    # noinspection PyMissingConstructor
+    def __init__(
+        self,
+        params: dict,
+        logdir: str | Path,
+        racks_count: int = 0,
+        node_prefix: str = "dummy-node",
+        reuse_cluster: bool = False,
+    ):
+        self.params = params
+        # ``logdir`` must be an isolated, per-test directory (e.g. pytest's
+        # ``tmp_path``).  A shared world-writable location like ``/tmp`` lets
+        # parallel tests collide and makes the inherited ``node_setup`` log
+        # paths predictable/redirectable, so callers are required to pass one.
+        self.logdir = str(logdir)
+        self.log = logging.getLogger(self.__class__.__name__)
+        self.name = "dummy-scylla-docker-cluster"
+        self.vector_store_cluster = None
+        self.racks_count = racks_count
+        self.nodes = []
+        self.node_prefix = node_prefix
+        # Set as instance attribute to shadow the cached_property descriptor,
+        # allowing per-instance configuration of REUSE_CLUSTER for tests.
+        self.test_config = SimpleNamespace(BACKTRACE_DECODING=False, REUSE_CLUSTER=reuse_cluster)
+
+    @staticmethod
+    def check_aio_max_nr(node, recommended_value=0):
+        pass
+
+    def _generate_db_node_certs(self, node):
+        pass
+
+    def get_scylla_args(self):
+        return ""
+
+    def _create_node(self, node_index, container=None, after_config=None, rack=0):
+        return SimpleNamespace(node_index=node_index, rack=rack, enable_auto_bootstrap=False)
+
+
+class DummyDockerNode:
+    """Base wrapper around a ``RemoteDocker`` for use in integration tests.
+
+    The ``docker_scylla`` fixture yields ``RemoteDocker`` instances, not
+    ``DockerNode``.  This base class provides ``__init__`` and attribute
+    delegation via ``__getattr__``.  Subclasses override specific methods
+    that ``node_setup`` (or other cluster methods) call on the node.
+    """
+
+    def __init__(self, remote_docker, rack=0, node_index=0):
+        self._remote_docker = remote_docker
+        self.rack = rack
+        self.node_index = node_index
+
+    def __getattr__(self, name):
+        return getattr(self._remote_docker, name)

--- a/unit_tests/lint/test_env_builder.py
+++ b/unit_tests/lint/test_env_builder.py
@@ -276,7 +276,7 @@ def test_build_env_xcloud_params():
     assert env["SCT_XCLOUD_PROVIDER"] == "aws"
     assert env["SCT_XCLOUD_ENV"] == "staging"
     # xcloud requires scylla_version (injected by Jenkins at runtime) — lint fills a placeholder
-    assert env["SCT_SCYLLA_VERSION"] == "0.0.0-lint-placeholder"
+    assert env["SCT_SCYLLA_VERSION"] == "2026.1.0-lint-placeholder"
 
 
 @pytest.mark.parametrize(
@@ -293,7 +293,7 @@ def test_build_env_injects_scylla_version_placeholder(backend):
     """Backends that require scylla_version get a working placeholder for linting."""
     config = _make_config(params={"backend": backend})
     env = build_env(config)
-    assert env["SCT_SCYLLA_VERSION"] == "0.0.0-lint-placeholder"
+    assert env["SCT_SCYLLA_VERSION"] == "2026.1.0-lint-placeholder"
 
 
 def test_build_env_injects_operator_docker_image_for_eks():

--- a/unit_tests/unit/docker/__init__.py
+++ b/unit_tests/unit/docker/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for the Docker backend (cluster_docker)."""

--- a/unit_tests/unit/docker/test_docker_rack_assignment.py
+++ b/unit_tests/unit/docker/test_docker_rack_assignment.py
@@ -1,0 +1,185 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2025 ScyllaDB
+
+"""Tests for DockerCluster rack assignment and node_container_run_args."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from sdcm.cluster_docker import NodeContainerMixin
+from unit_tests.lib.fake_docker_cluster import DummyScyllaDockerCluster
+
+
+@pytest.mark.parametrize(
+    "racks_count, node_count, expected_racks",
+    [
+        pytest.param(3, 6, [0, 1, 2, 0, 1, 2], id="3-racks-6-nodes"),
+        pytest.param(2, 5, [0, 1, 0, 1, 0], id="2-racks-5-nodes"),
+        pytest.param(1, 3, [0, 0, 0], id="1-rack-3-nodes"),
+    ],
+)
+def test_create_nodes_round_robin(tmp_path, racks_count, node_count, expected_racks):
+    """Verify that _create_nodes assigns racks in round-robin order.
+
+    Args:
+        racks_count: Number of racks configured on the cluster.
+        node_count: How many nodes to create.
+        expected_racks: Expected rack index for each created node.
+    """
+    cluster = DummyScyllaDockerCluster(params={}, logdir=tmp_path, racks_count=racks_count)
+    nodes = cluster._create_nodes(count=node_count)
+
+    assert [n.rack for n in nodes] == expected_racks
+    assert [n.node_index for n in nodes] == list(range(node_count))
+
+
+def test_create_nodes_explicit_rack(tmp_path):
+    """Verify that passing an explicit rack overrides round-robin assignment."""
+    cluster = DummyScyllaDockerCluster(params={}, logdir=tmp_path, racks_count=3)
+    nodes = cluster._create_nodes(count=3, rack=1)
+
+    assert [n.rack for n in nodes] == [1, 1, 1]
+    assert [n.node_index for n in nodes] == [0, 1, 2]
+
+
+def test_get_nodes_re_derives_racks(tmp_path):
+    """Verify that _get_nodes re-derives rack from node_index % racks_count."""
+    cluster = DummyScyllaDockerCluster(params={}, logdir=tmp_path, racks_count=3, node_prefix="test-node")
+
+    fake_containers = []
+    for idx in range(5):
+        container = MagicMock()
+        container.labels = {"NodeIndex": str(idx)}
+        container.name = f"test-node-{idx}"
+        fake_containers.append(container)
+
+    with patch("sdcm.cluster_docker.ContainerManager") as mock_cm:
+        mock_cm.get_containers_by_prefix.return_value = fake_containers
+        nodes = cluster._get_nodes()
+
+    assert [n.rack for n in nodes] == [0, 1, 2, 0, 1]
+    assert [n.node_index for n in nodes] == [0, 1, 2, 3, 4]
+
+
+# ---------------------------------------------------------------------------
+# node_container_run_args tests
+# ---------------------------------------------------------------------------
+
+
+def _make_mixin_node(rack=0, node_type="db", simulated_racks=0, seed_ip=None, n_db_nodes=None):
+    """Return a minimal NodeContainerMixin instance with stubbed attributes."""
+    node = object.__new__(NodeContainerMixin)
+    node.rack = rack
+    node.node_type = node_type
+    node.name = f"test-db-node-{rack}"
+    node.node_container_image_tag = "scylladb/scylla-nightly:test"
+    node.parent_cluster = SimpleNamespace(
+        params={
+            "simulated_racks": simulated_racks,
+            "n_db_nodes": n_db_nodes if n_db_nodes is not None else [3],
+            "docker_network": "bridge",
+            "append_scylla_args": "--smp 1",
+        }
+    )
+    return node
+
+
+def test_no_rack_args_when_simulated_racks_zero():
+    """simulated_racks=0 → command is None (no seed, no rack args)."""
+    node = _make_mixin_node(rack=0, simulated_racks=0)
+    result = node.node_container_run_args(seed_ip=None)
+    assert result["command"] is None
+
+
+def test_no_rack_args_when_simulated_racks_one():
+    """simulated_racks=1 → not > 1 → command is None."""
+    node = _make_mixin_node(rack=0, simulated_racks=1)
+    result = node.node_container_run_args(seed_ip=None)
+    assert result["command"] is None
+
+
+def test_rack_args_injected_when_simulated_racks_two():
+    """simulated_racks=2, rack=0 → command contains --dc and --rack=RACK0."""
+    node = _make_mixin_node(rack=0, simulated_racks=2)
+    result = node.node_container_run_args(seed_ip=None)
+    assert result["command"] is not None
+    assert "--dc=datacenter1" in result["command"]
+    assert "--rack=RACK0" in result["command"]
+
+
+def test_rack_index_used_correctly():
+    """rack=1 with simulated_racks=3 → command contains --rack=RACK1."""
+    node = _make_mixin_node(rack=1, simulated_racks=3)
+    result = node.node_container_run_args(seed_ip=None)
+    assert "--rack=RACK1" in result["command"]
+    assert "--rack=RACK0" not in result["command"]
+
+
+def test_seed_and_rack_combined():
+    """When seed_ip is set and simulated_racks=2, command has both --seeds and --rack."""
+    node = _make_mixin_node(rack=0, simulated_racks=2)
+    result = node.node_container_run_args(seed_ip="10.0.0.1")
+    cmd = result["command"]
+    assert '--seeds="10.0.0.1"' in cmd
+    assert "--dc=datacenter1" in cmd
+    assert "--rack=RACK0" in cmd
+
+
+def test_seed_only_when_no_simulated_racks():
+    """When seed_ip is set but simulated_racks=0, command contains only the seed arg."""
+    node = _make_mixin_node(rack=0, simulated_racks=0)
+    result = node.node_container_run_args(seed_ip="10.0.0.2")
+    assert result["command"] == '--seeds="10.0.0.2"'
+    assert "--rack" not in result["command"]
+
+
+def test_non_db_node_gets_no_rack_args():
+    """Non-db node types must never receive rack args regardless of simulated_racks."""
+    node = _make_mixin_node(rack=0, node_type="loader", simulated_racks=3)
+    result = node.node_container_run_args(seed_ip=None)
+    assert result["command"] is None
+
+
+def test_non_db_node_with_no_seed_and_no_racks():
+    """Non-db node, no seed, no simulated_racks → command is None."""
+    node = _make_mixin_node(rack=0, node_type="monitor", simulated_racks=0)
+    result = node.node_container_run_args(seed_ip=None)
+    assert result["command"] is None
+
+
+@pytest.mark.parametrize(
+    "n_db_nodes",
+    [pytest.param([1], id="single-dc"), pytest.param([1, 0], id="multi-dc")],
+)
+def test_no_rack_args_for_single_node_cluster(n_db_nodes):
+    """A one-node cluster gets no rack args, whatever simulated_racks says.
+
+    It cannot span racks, and the snitch auto-resolution leaves `endpoint_snitch` alone, so
+    the rack would never be read -- while the argument itself is fatal on a pre-2026.1 image.
+    """
+    node = _make_mixin_node(rack=0, simulated_racks=3, n_db_nodes=n_db_nodes)
+    result = node.node_container_run_args(seed_ip=None)
+    assert result["command"] is None
+
+
+def test_rack_args_survive_growing_past_the_configured_racks():
+    """A node added by a nemesis keeps getting rack args: `n_db_nodes` is the configured topology.
+
+    `_create_nodes` hands out `node_index % racks_count`, so the fourth node of a 3-node,
+    3-rack cluster lands back on RACK0.
+    """
+    node = _make_mixin_node(rack=0, simulated_racks=3, n_db_nodes=[3])
+    result = node.node_container_run_args(seed_ip="10.0.0.1")
+    assert "--rack=RACK0" in result["command"]

--- a/unit_tests/unit/docker/test_docker_reuse_cluster.py
+++ b/unit_tests/unit/docker/test_docker_reuse_cluster.py
@@ -1,0 +1,155 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2025 ScyllaDB
+
+"""Unit tests for ScyllaDockerCluster.node_setup REUSE_CLUSTER path.
+
+Validates that when REUSE_CLUSTER is True, node_setup takes the early-return
+path: calls _reuse_cluster_setup and skips the full setup
+(is_scylla_installed, check_aio_max_nr, config_setup, restart_scylla).
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from unit_tests.lib.fake_docker_cluster import DummyScyllaDockerCluster
+
+
+def _make_mock_node():
+    """Create a mock node with the attributes node_setup reads."""
+    node = MagicMock()
+    node.rack = 0
+    node.node_index = 0
+    node.ssl_conf_dir = Path("/tmp/fake_ssl")
+    return node
+
+
+def test_reuse_skips_full_setup(tmp_path):
+    """When REUSE_CLUSTER is True, node_setup must not call
+    is_scylla_installed, check_aio_max_nr, config_setup, or restart_scylla.
+    """
+    cluster = DummyScyllaDockerCluster(
+        params={"simulated_racks": 2},
+        logdir=tmp_path,
+        reuse_cluster=True,
+    )
+    node = _make_mock_node()
+
+    with patch.object(cluster, "_reuse_cluster_setup") as mock_reuse_setup:
+        cluster.node_setup(node)
+
+    mock_reuse_setup.assert_called_once_with(node)
+    node.is_scylla_installed.assert_not_called()
+    node.config_setup.assert_not_called()
+    node.restart_scylla.assert_not_called()
+
+
+def test_reuse_skips_certs_when_not_configured(tmp_path):
+    """When neither server_encrypt nor client_encrypt is set,
+    _generate_db_node_certs must not be called.
+    """
+    cluster = DummyScyllaDockerCluster(
+        params={},
+        logdir=tmp_path,
+        reuse_cluster=True,
+    )
+    node = _make_mock_node()
+
+    with (
+        patch.object(cluster, "_reuse_cluster_setup"),
+        patch.object(cluster, "_generate_db_node_certs") as mock_gen_certs,
+    ):
+        cluster.node_setup(node)
+
+    mock_gen_certs.assert_not_called()
+
+
+@pytest.mark.parametrize("encrypt_param", ["server_encrypt", "client_encrypt"])
+def test_reuse_generates_certs_when_missing(tmp_path, encrypt_param):
+    """When encryption is enabled and the DB cert is missing,
+    _generate_db_node_certs and install_client_certificate must be called.
+    """
+    cluster = DummyScyllaDockerCluster(
+        params={encrypt_param: True},
+        logdir=tmp_path,
+        reuse_cluster=True,
+    )
+    node = _make_mock_node()
+    # Make ssl_conf_dir / TLSAssets.DB_CERT return a Path whose .exists() is False
+    fake_ssl_dir = MagicMock(spec=Path)
+    cert_path = MagicMock()
+    cert_path.exists.return_value = False
+    fake_ssl_dir.__truediv__ = MagicMock(return_value=cert_path)
+    node.ssl_conf_dir = fake_ssl_dir
+
+    with (
+        patch.object(cluster, "_reuse_cluster_setup"),
+        patch.object(cluster, "_generate_db_node_certs") as mock_gen_certs,
+        patch("sdcm.cluster_docker.install_client_certificate") as mock_install_cert,
+    ):
+        cluster.node_setup(node)
+
+    mock_gen_certs.assert_called_once_with(node)
+    mock_install_cert.assert_called_once_with(node.remoter, node.ip_address, force=True)
+
+
+@pytest.mark.parametrize("encrypt_param", ["server_encrypt", "client_encrypt"])
+def test_reuse_skips_certs_when_already_present(tmp_path, encrypt_param):
+    """When encryption is enabled but the DB cert already exists,
+    _generate_db_node_certs must not be called.
+    """
+    cluster = DummyScyllaDockerCluster(
+        params={encrypt_param: True},
+        logdir=tmp_path,
+        reuse_cluster=True,
+    )
+    node = _make_mock_node()
+    fake_ssl_dir = MagicMock(spec=Path)
+    cert_path = MagicMock()
+    cert_path.exists.return_value = True
+    fake_ssl_dir.__truediv__ = MagicMock(return_value=cert_path)
+    node.ssl_conf_dir = fake_ssl_dir
+
+    with (
+        patch.object(cluster, "_reuse_cluster_setup"),
+        patch.object(cluster, "_generate_db_node_certs") as mock_gen_certs,
+    ):
+        cluster.node_setup(node)
+
+    mock_gen_certs.assert_not_called()
+
+
+@pytest.mark.parametrize("simulated_racks_value", [0, 2])
+def test_normal_setup_when_not_reusing(tmp_path, simulated_racks_value):
+    """When REUSE_CLUSTER is False, node_setup must call is_scylla_installed
+    and proceed with the full setup path for both simulated_racks=0 and
+    simulated_racks=2.  In both cases: config_setup called once,
+    restart_scylla(verify_up_before=True) called once, clean_scylla_data
+    never called.
+    """
+    cluster = DummyScyllaDockerCluster(
+        params={"simulated_racks": simulated_racks_value},
+        logdir=tmp_path,
+        reuse_cluster=False,
+    )
+    node = _make_mock_node()
+    node.is_scylla_installed.return_value = True
+
+    with patch.object(cluster, "_reuse_cluster_setup") as mock_reuse_setup:
+        cluster.node_setup(node)
+
+    mock_reuse_setup.assert_not_called()
+    node.is_scylla_installed.assert_called_once_with(raise_if_not_installed=True)
+    node.config_setup.assert_called_once()
+    node.restart_scylla.assert_called_once_with(verify_up_before=True)

--- a/unit_tests/unit/test_config.py
+++ b/unit_tests/unit/test_config.py
@@ -77,7 +77,7 @@ def test_02_verify_config(conf):
 def test_05_docker(monkeypatch):
     monkeypatch.setenv("SCT_CLUSTER_BACKEND", "docker")
     monkeypatch.setenv("SCT_USE_MGMT", "false")
-    monkeypatch.setenv("SCT_SCYLLA_VERSION", "2025.1.0")
+    monkeypatch.setenv("SCT_SCYLLA_VERSION", "2026.1.0")
     conf = sct_config.SCTConfiguration()
     conf.verify_configuration()
     assert "docker_image" in conf.dump_config()
@@ -780,8 +780,8 @@ def test_37_raises_error_for_invalid_thread_count_type(monkeypatch):
         ("k8s-gke", "2024.1.21", "scylladb/scylla-enterprise"),
         ("k8s-eks", "2025.4.0", "scylladb/scylla"),
         ("k8s-gke", "2025.4.0", "scylladb/scylla"),
-        ("docker", "2025.1.0", "scylladb/scylla"),
-        ("docker", "2025.1.0-dev", "scylladb/scylla-nightly"),
+        ("docker", "2026.1.0", "scylladb/scylla"),
+        ("docker", "2026.1.0-dev", "scylladb/scylla-nightly"),
     ),
 )
 def test_38_verify_scylla_version_lookup_k8s(monkeypatch, backend, version, expected_repo):
@@ -947,6 +947,8 @@ def test_migrator_source_hosts_and_test_id_mutually_exclusive(monkeypatch):
 def test_env_var_whitespace_is_stripped(monkeypatch, raw_value, expected):
     """Environment variable values with leading/trailing whitespace are trimmed (SCT-340)."""
     monkeypatch.setenv("SCT_SCYLLA_VERSION", raw_value)
+    # The versions under test predate the --dc/--rack Docker entrypoint args (Scylla 2026.1).
+    monkeypatch.setenv("SCT_SIMULATED_RACKS", "1")
     conf = sct_config.SCTConfiguration()
     assert conf.get("scylla_version") == expected
 
@@ -1339,3 +1341,126 @@ def test_keystore_env_is_exported_before_init_resolves_xcloud_version(monkeypatc
     sct_config.SCTConfiguration()
 
     assert seen == ["s3"], f"KeyStore built during __init__ saw {seen}, config file asked for s3"
+
+
+GOSSIPING_SNITCH = "org.apache.cassandra.locator.GossipingPropertyFileSnitch"
+
+
+@pytest.mark.parametrize(
+    "simulated_racks, n_db_nodes, expected",
+    [
+        pytest.param(3, [3], True, id="racks-and-nodes"),
+        pytest.param(3, [1], False, id="single-node-cannot-span-racks"),
+        pytest.param(1, [3], False, id="racks-off"),
+        pytest.param(0, [3], False, id="racks-zero"),  # configurations/disable_simulated_racks.yaml
+        pytest.param(3, [1, 1], True, id="multi-dc-two-nodes"),
+        pytest.param(3, [1, 0], False, id="multi-dc-one-node"),
+        pytest.param(None, [3], False, id="racks-unset"),
+        pytest.param(3, None, False, id="nodes-unset"),
+    ],
+)
+def test_simulated_racks_enabled(simulated_racks, n_db_nodes, expected):
+    """The predicate three call sites share.
+
+    The Docker version check and the snitch auto-resolution in `SCTConfiguration.__init__`,
+    and the --dc/--rack injection in `NodeContainerMixin.node_container_run_args`, all have to
+    agree on when simulated racks actually take effect.
+    """
+    params = {"simulated_racks": simulated_racks, "n_db_nodes": n_db_nodes}
+
+    assert sct_config.simulated_racks_enabled(params) is expected
+
+
+def test_simulated_racks_enabled_with_missing_keys():
+    """Absent options read the same as unset ones -- no KeyError, racks off."""
+    assert sct_config.simulated_racks_enabled({}) is False
+
+
+def _build_docker_config(monkeypatch, n_db_nodes, scylla_version, simulated_racks=None):
+    """Build an SCTConfiguration for the docker backend.
+
+    `simulated_racks=None` leaves the option unset, so it is inherited from
+    defaults/test_default.yaml (3) rather than supplied by the test-case.
+    """
+    monkeypatch.setenv("SCT_CLUSTER_BACKEND", "docker")
+    monkeypatch.setenv("SCT_SCYLLA_VERSION", scylla_version)
+    monkeypatch.setenv("SCT_N_DB_NODES", str(n_db_nodes))
+    monkeypatch.setenv("SCT_USE_MGMT", "false")
+    if simulated_racks is not None:
+        monkeypatch.setenv("SCT_SIMULATED_RACKS", str(simulated_racks))
+    return sct_config.SCTConfiguration()
+
+
+@pytest.mark.parametrize(
+    "n_db_nodes, simulated_racks, expected_snitch",
+    [
+        # Racks off: nothing to check, nothing to override.
+        pytest.param(1, 1, None, id="1-node-racks-off"),
+        pytest.param(3, 1, None, id="3-nodes-racks-off"),
+        # Racks on, but a single DB node never reaches the snitch auto-resolution.
+        pytest.param(1, 3, None, id="1-node-racks-on"),
+        # Racks on: several nodes, so the snitch must follow.
+        pytest.param(3, None, GOSSIPING_SNITCH, id="3-nodes-inherited-default"),
+        pytest.param(3, 2, GOSSIPING_SNITCH, id="3-nodes-racks-on"),
+    ],
+)
+def test_docker_simulated_racks_on_supported_image(monkeypatch, n_db_nodes, simulated_racks, expected_snitch):
+    """On a 2026.1+ image every (nodes, racks) combination builds, with `simulated_racks` untouched.
+
+    `simulated_racks` is the single source of truth downstream -- `BaseScyllaCluster.racks_count`,
+    the snitch auto-resolution and the --dc/--rack injection in `node_container_run_args` -- so
+    sct_config must not rewrite it behind the test-case's back.
+    """
+    conf = _build_docker_config(monkeypatch, n_db_nodes, "2026.1.0", simulated_racks)
+    conf.verify_configuration()
+
+    assert conf.get("simulated_racks") == (simulated_racks if simulated_racks is not None else 3)
+    assert conf.get("endpoint_snitch") == expected_snitch
+
+
+@pytest.mark.parametrize(
+    "n_db_nodes, simulated_racks",
+    [
+        pytest.param(3, None, id="3-nodes-inherited-default"),
+        pytest.param(3, 2, id="3-nodes-racks-on"),
+    ],
+)
+def test_docker_simulated_racks_rejected_on_old_image(monkeypatch, n_db_nodes, simulated_racks):
+    """Racks on a pre-2026.1 image are unrunnable, so fail at configuration time.
+
+    The entrypoint forwards --dc/--rack to the Scylla binary, which rejects them and exits;
+    failing here names the version requirement instead of leaving a container dead on startup.
+    A Docker test-case that must run on older images sets `simulated_racks: 1` itself.
+    """
+    with pytest.raises(ValueError, match="is not supported on Scylla 2025.1.0"):
+        _build_docker_config(monkeypatch, n_db_nodes, "2025.1.0", simulated_racks)
+
+
+@pytest.mark.parametrize(
+    "n_db_nodes, simulated_racks",
+    [
+        pytest.param(1, 1, id="1-node-racks-off"),
+        pytest.param(3, 1, id="3-nodes-racks-off"),
+        pytest.param(1, 3, id="1-node-racks-on"),
+        pytest.param(1, None, id="1-node-inherited-default"),
+    ],
+)
+def test_docker_no_version_requirement_without_effective_racks(monkeypatch, n_db_nodes, simulated_racks):
+    """Racks that cannot take effect impose no version requirement.
+
+    `simulated_racks: 1` opts out explicitly; a single DB node cannot span racks at all, so
+    no --dc/--rack argument is ever built and any image will do.
+    """
+    conf = _build_docker_config(monkeypatch, n_db_nodes, "2025.1.0", simulated_racks)
+    conf.verify_configuration()
+
+    assert conf.get("endpoint_snitch") is None
+
+
+def test_docker_simulated_racks_allowed_on_branched_version(monkeypatch):
+    """Branched versions are not comparable; assume they support --dc/--rack."""
+    monkeypatch.setenv("SCT_DOCKER_IMAGE", "scylladb/scylla-nightly")
+    conf = _build_docker_config(monkeypatch, n_db_nodes=3, scylla_version="master:latest", simulated_racks=2)
+
+    assert conf.get("simulated_racks") == 2
+    assert conf.get("endpoint_snitch") == GOSSIPING_SNITCH

--- a/unit_tests/unit/test_instance_sizing_config.py
+++ b/unit_tests/unit/test_instance_sizing_config.py
@@ -101,7 +101,7 @@ def test_literal_instance_type_passes_through_unchanged(monkeypatch):
 def test_docker_backend_skips_resolution(monkeypatch):
     monkeypatch.setenv("SCT_CLUSTER_BACKEND", "docker")
     monkeypatch.setenv("SCT_USE_MGMT", "false")
-    monkeypatch.setenv("SCT_SCYLLA_VERSION", "2025.1.0")
+    monkeypatch.setenv("SCT_SCYLLA_VERSION", "2026.1.0")
     monkeypatch.setenv("SCT_CONFIG_FILES", _MINIMAL_CONFIG)
 
     catalog_loaded = []
@@ -191,7 +191,7 @@ def test_missing_catalog_directory_logs_warning_and_skips(monkeypatch, caplog):
 def test_resolve_instance_sizes_method_direct(monkeypatch):
     monkeypatch.setenv("SCT_CLUSTER_BACKEND", "docker")
     monkeypatch.setenv("SCT_USE_MGMT", "false")
-    monkeypatch.setenv("SCT_SCYLLA_VERSION", "2025.1.0")
+    monkeypatch.setenv("SCT_SCYLLA_VERSION", "2026.1.0")
     monkeypatch.setenv("SCT_CONFIG_FILES", _MINIMAL_CONFIG)
 
     conf = sct_config.SCTConfiguration()

--- a/unit_tests/unit/test_sct_config_validators.py
+++ b/unit_tests/unit/test_sct_config_validators.py
@@ -171,7 +171,7 @@ def test_list_of_stress_tools_with_scalar_gemini_cmd(monkeypatch):
     """list_of_stress_tools must not iterate gemini_cmd char-by-char."""
     monkeypatch.setenv("SCT_CLUSTER_BACKEND", "docker")
     monkeypatch.setenv("SCT_USE_MGMT", "false")
-    monkeypatch.setenv("SCT_SCYLLA_VERSION", "2025.1.0")
+    monkeypatch.setenv("SCT_SCYLLA_VERSION", "2026.1.0")
     monkeypatch.setenv("SCT_CONFIG_FILES", "unit_tests/test_configs/minimal_test_case.yaml")
     monkeypatch.setenv("SCT_GEMINI_CMD", "gemini --duration 10m")
 
@@ -187,7 +187,7 @@ def test_list_of_stress_tools_with_list_stress_cmd(monkeypatch):
     """list_of_stress_tools works correctly with list[str] stress_cmd values."""
     monkeypatch.setenv("SCT_CLUSTER_BACKEND", "docker")
     monkeypatch.setenv("SCT_USE_MGMT", "false")
-    monkeypatch.setenv("SCT_SCYLLA_VERSION", "2025.1.0")
+    monkeypatch.setenv("SCT_SCYLLA_VERSION", "2026.1.0")
     monkeypatch.setenv("SCT_CONFIG_FILES", "unit_tests/test_configs/minimal_test_case.yaml")
     monkeypatch.setenv("SCT_STRESS_CMD", "cassandra-stress write n=1000000")
 


### PR DESCRIPTION
Configure the simulated rack through the native `--rack/--dc` Docker entrypoint arguments (available since Scylla 2026.1) instead of reconfiguring the node after it has started.

Why we need this
----------------
Rack awareness in SCT is gated on the cluster reporting more than one rack, so none of it can be exercised on a single-rack cluster:

* `sdcm/cluster.py`: the CQL connection only switches to `RackAwareRoundRobinPolicy` when `rack_aware_loader` is set and `racks_count > 1`, otherwise it stays on `WhiteListRoundRobinPolicy`.
* `sdcm/tester.py`: `is_rack_aware_validation_enabled` returns False unless `racks_count > 1`, which silently disables rack-aware validation.
* `sdcm/nemesis/`: the rack-aware nemesis paths are guarded by the same `racks_count > 1` condition.
* A node only reports its rack in its log/dc_info when `racks_count > 1`.

Until now the Docker backend was excluded from rack simulation -- the snitch auto-resolution in `sct_config.py` carried `and cluster_backend != docker` -- so `simulated_racks` was silently ignored there. Every rack-aware path above could therefore only be covered on a cloud backend with real availability zones: no local reproduction of a rack-aware bug, no cheap CI coverage, and any rack regression is only caught by a slow and costly cloud job.

Why through the entrypoint rather than after boot: since Scylla 2026.1 the image entrypoint accepts `--dc/--rack` and writes `cassandra-rackdc.properties` before the first boot. Doing it after the node is up means rewriting that file, wiping the data directory and restarting Scylla behind an event filter -- racy, slow, and the filter hides genuine errors that happen in the same window. Passing the rack at container creation removes all of it.

When simulated racks take effect
--------------------------------
Racks need more than one rack AND more than one DB node to spread over. A single-node cluster stays in one rack whatever `simulated_racks` says, because the snitch auto-resolution already leaves `endpoint_snitch` alone below two nodes, so nothing reads the rack. Three call sites have to agree on that condition, and they now share one predicate, `sct_config.simulated_racks_enabled()`:

* the Docker version check below,
* the snitch auto-resolution in `SCTConfiguration.__init__` (section 15),
* the `--dc/--rack` injection in `NodeContainerMixin.node_container_run_args()`.

Keeping them in sync is what makes a single-node Docker cluster run on any Scylla version: it never gets a rack argument it cannot use. It also holds while a cluster grows -- `n_db_nodes` is the configured topology and is never mutated at runtime, so a nemesis adding a node to a one-node cluster does not suddenly build `--rack=RACK1` and kill that container.

Racks that do take effect require Scylla >= 2026.1, and `sct_config` raises when the image is older, before any container is created:

```
ValueError: simulated_racks=3 is not supported on Scylla 2025.1.0 (docker
backend): the --dc/--rack entrypoint arguments were added in 2026.1.0-dev.
Use a 2026.1+ image or set simulated_racks: 1.
```

Failing at configuration time rather than at container startup is deliberate: an older entrypoint forwards the arguments to the Scylla binary, which rejects them and exits, leaving a dead container and no explanation. master runs the latest Scylla and this change is backported to 2026.1 and 2026.2, so racks are available wherever it lands; a Docker test-case that must run on older images sets `simulated_racks: 1` itself. Branch versions such as `master:latest` are not comparable and are assumed new enough.

Note that `simulated_racks` keeps the global default of 3 on Docker as on every other backend -- there is no backend override -- so a multi-node Docker test that never mentions racks does get them on a 2026.1+ image. That is how the rack-aware code paths get cheap coverage.

Production changes
------------------
* `sct_config.py`: add `simulated_racks_enabled()`; use it for the snitch auto-resolution (replacing its inline duplicate) and for the new Docker version check, which raises `ValueError` from `SCTConfiguration.__init__`. `DOCKER_RACK_ARG_MIN_VERSION` pins the requirement at 2026.1.0-dev.
* `cluster_docker.py`: `NodeContainerMixin.node_container_run_args()` appends `--dc=datacenter1 --rack=RACK{n}` for db nodes when racks are in effect, so the entrypoint writes `cassandra-rackdc.properties` before the first boot. The snitch itself is applied later by `config_setup()`, from the `endpoint_snitch` `sct_config` resolves.
* Add a trailing `rack` parameter to `DockerNode`, `VectorStoreDockerNode` and `DockerMonitoringNode` `__init__` and to every `_create_node` in `cluster_docker.py`, so existing positional calls are unaffected. Loaders accept and ignore it.
* Implement round-robin rack distribution in `_create_nodes` (`rack=None` means "spread across racks", matching aws/gce/azure/oci).
* Add a REUSE_CLUSTER early-return guard to `ScyllaDockerCluster.node_setup()`.

Documentation
-------------
* `docs/docker-backend-overview.md`: new section on how the rack reaches the container, the version requirement and the error it produces, and the single-node case that is accepted on any version.
* Extend the `simulated_racks` option description with the node-count condition and the Docker version requirement; regenerate `docs/configuration_options.md`.

Test changes
------------
* `configure_scylla_node()` (integration conftest): accept optional rack/dc in `docker_scylla_args` and append `--rack/--dc` to the container `command_line`.
* `test_docker_simulated_racks.py`: boots two containers with `--rack/--dc` and asserts the racks in `system.local`; also covers the REUSE_CLUSTER path. Tracks the rolling `scylladb/scylla:2026.1` tag, since the patch level is irrelevant to what it asserts.
* `DummyScyllaDockerCluster`: `ScyllaDockerCluster` test double in `unit_tests/lib/` that bypasses only the constructor, so `node_setup` and `_create_nodes` under test are the real implementations.
* `unit_tests/unit/docker/`: new package grouping the Docker unit tests. `test_docker_rack_assignment.py` covers round-robin distribution and rack injection, including that a single-node cluster gets no rack argument; `test_docker_reuse_cluster.py` covers the REUSE_CLUSTER guard.
* `test_config.py`: covers `simulated_racks_enabled()` directly -- including the multi-DC boundary where `[1, 1]` enables racks and `[1, 0]` does not -- plus the snitch resolution and the version check accepting and rejecting per image.
* Pre-existing tests that pinned an old Scylla on the docker backend for unrelated reasons (image lookup, instance sizing, stress-command validation) now pin 2026.1.0 instead, so they exercise the version SCT targets rather than opting out of the requirement. `test_env_var_whitespace_is_stripped` keeps `simulated_racks: 1`, because the shape of its old `'5.4.0'` input is the point of the test.

Fixes: SCT-270

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ Artifact tests - Passed ](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/aleksbykov/job/artifact_tests/job/artifacts-docker-test/5/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)


