### PR TITLE
fix(xcloud): fix sizing to work for backend xcloud

### DIFF
--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -3428,6 +3428,7 @@ class SCTConfiguration(BaseModel):
             "k8s-gke": "gce",
             "azure": "azure",
             "oci": "oci",
+            "xcloud": env.get("xcloud_provider", None),
         }
         ROLE_PARAMS = {
             "aws": {
@@ -3463,7 +3464,7 @@ class SCTConfiguration(BaseModel):
 
         cloud = BACKEND_TO_CLOUD.get(backend)
         if not cloud:
-            self.log.info("Unknown backend %s — skipping instance size resolution", backend)
+            self.log.warning("Unknown backend %s — skipping instance size resolution", backend)
             return
 
         AGNOSTIC_FALLBACK = {


### PR DESCRIPTION
small part is missing, and it was causing the xcloud backend runs to fail with empty types fo monitor or other instances.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
