### PR TITLE
fix(gce_builder): make Jenkins builder agents single-use to avoid stuck launching

### DIFF
--- a/sdcm/utils/gce_builder.py
+++ b/sdcm/utils/gce_builder.py
@@ -54,7 +54,7 @@ gcpCloud.setNoDelayProvisioning(true)
 
 InstanceConfiguration instanceConfiguration = new InstanceConfiguration()
 instanceConfiguration.setNumExecutorsStr("1")
-instanceConfiguration.setOneShot(false)
+instanceConfiguration.setOneShot(true)
 instanceConfiguration.setNamePrefix("builders")
 instanceConfiguration.setDescription("SCT Jenkins builders")
 instanceConfiguration.setRegion("https://www.googleapis.com/compute/v1/projects/{project_id}/regions/{region_name}")


### PR DESCRIPTION
## Summary
Dozens of SCT Jenkins `builders-*` agents were stuck in the `launching` state (RELENG-686).

The stuck nodes are **GCP Compute Engine** agents (`com.google.jenkins.plugins.computeengine.ComputeEngineComputer`), provisioned by the `ComputeEngineCloud` / `InstanceConfiguration` defined in `sdcm/utils/gce_builder.py` (`setNamePrefix("builders")`).

### Root cause
The Google Compute Engine plugin **does not terminate an instance when its SSH/agent launch fails or times out**. In `ComputeEngineComputerLauncher.launch()`, the outer SSH-connection path logs the exception but never calls `terminateNode()`. With reusable agents (`oneShot=false`), every instance whose SSH launch timed out (`launchTimeoutSeconds=300`) or failed was left:
- as a Jenkins node stuck in `connecting`/`launching` (`offline=true, connecting=true, offlineCause=null`), and
- as a running GCP VM.

Because the per-attempt `connectTime` resets on each reconnect, the idle-retention strategy never reaped them, so they accumulated into the "dozens" seen in the ticket. The config has been unchanged since 2023 — this is latent behavior that surfaced at scale, not a regression.

## Fix
Set `instanceConfiguration.setOneShot(true)` so each builder VM is **single-use**. One-shot agents are reaped aggressively and never reused into a stuck state, which prevents the zombie pile-up. Trade-off: a fresh VM per build (higher instance churn), acceptable for short CI builder jobs.

## Backport
**Not required (`backport/none`).** The Jenkins builder cloud is a single global configuration applied via the manually-run `sct.py configure-jenkins-builders` hydra command, executed from `master`. Release branches carry the identical config line but do not independently provision the builder cloud, so a backport would have no operational effect.

## Verification
Config-only change to the GCE cloud `InstanceConfiguration`. No automated SCT test covers Jenkins cloud provisioning; effect is validated operationally after re-running `configure-jenkins-builders` and confirming that failed/never-connecting builder VMs no longer linger in `launching`.

> Existing stuck nodes were cleared separately via a one-time Jenkins Script Console cleanup (terminating the orphaned `ComputeEngineInstance` nodes). This PR prevents recurrence.

Fixes: RELENG-686 (https://scylladb.atlassian.net/browse/RELENG-686)