### PR TITLE
feature(lint): add cyclic import detection 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,6 +49,14 @@ repos:
 
 -   repo: local
     hooks:
+    -   id: cyclic-imports
+        name: Cyclic Import Detection
+        language: system
+        entry: ./scripts/detect_cyclic_imports.py
+        files: \.py$
+        pass_filenames: false
+        always_run: true
+
     -   id: ruff-format
         name: ruff-format
         entry: ruff format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,6 +49,15 @@ repos:
 
 -   repo: local
     hooks:
+    -   id: cyclic-imports
+        name: Cyclic Import Detection
+        language: system
+        entry: ./scripts/detect_cyclic_imports.py
+        pass_filenames: false
+        # always_run (no `files` filter): the whole graph is rebuilt every time, and a
+        # plain .py deletion is not in pre-commit's changed-file list yet can break a cycle.
+        always_run: true
+
     -   id: ruff-format
         name: ruff-format
         entry: ruff format

--- a/data/known_cyclic_imports.yml
+++ b/data/known_cyclic_imports.yml
@@ -1,0 +1,5 @@
+# Auto-generated allowlist of known cyclic import edges.
+# Each entry is a directed edge (source -> target) that forms part of a cycle.
+# To add: run `python scripts/detect_cyclic_imports.py --update-allowlist`
+# To fix: resolve the cycle and remove both directional edges.
+edges: []

--- a/data/known_cyclic_imports.yml
+++ b/data/known_cyclic_imports.yml
@@ -1,0 +1,7 @@
+# Auto-generated allowlist of known cyclic import edges.
+# Each entry is a directed edge (source -> target) that forms part of a cycle.
+# An empty list means the repository has no import-time cycles left to grandfather;
+# deferred (function-level) imports are out of scope, see --include-deferred.
+# To add: run `python scripts/detect_cyclic_imports.py --update-allowlist`
+# To fix: resolve the cycle and remove both directional edges.
+edges: []

--- a/docs/cyclic-import-detection.md
+++ b/docs/cyclic-import-detection.md
@@ -1,0 +1,233 @@
+# Cyclic Import Detection
+
+SCT uses a pre-commit hook to detect cyclic imports in `sdcm/`. This prevents new circular dependencies from being introduced while allowing existing ones to be fixed incrementally.
+
+## Quick Reference
+
+```bash
+# Check for new cyclic imports (what pre-commit runs):
+uv run python scripts/detect_cyclic_imports.py
+
+# Show all existing cycles:
+uv run python scripts/detect_cyclic_imports.py --verbose
+
+# Regenerate allowlist after fixing a cycle:
+uv run python scripts/detect_cyclic_imports.py --update-allowlist
+```
+
+## How It Works
+
+1. The script parses every `.py` file under `sdcm/` using Python's `ast` module
+2. Builds a directed graph of internal (`sdcm.*`) import edges
+3. Finds strongly connected components (cycles) via Tarjan's algorithm
+4. Compares found cyclic edges against the allowlist (`data/known_cyclic_imports.yml`)
+5. If any NEW edge participates in a cycle that isn't allowlisted — **exit 1** (blocks commit)
+
+Key behaviors:
+- **TYPE_CHECKING-guarded imports are excluded** — these don't create runtime cycles
+- **Function-level (lazy) imports are excluded** — imports inside `def`/`async def` bodies are deferred to call time and don't cause import-time cycles
+- **Only `sdcm.*` internal imports are tracked** — stdlib and third-party are ignored
+- **Relative imports are resolved** — `from .base import X` is correctly mapped to its full module path
+
+## Fixing a Cyclic Import
+
+### Workflow
+
+```bash
+# 1. See what cycles exist:
+uv run python scripts/detect_cyclic_imports.py --verbose | grep "sdcm.X"
+
+# 2. Investigate a specific cycle:
+python3 -c "
+import ast
+from pathlib import Path
+tree = ast.parse(Path('sdcm/module_a.py').read_text())
+for node in ast.walk(tree):
+    if isinstance(node, ast.ImportFrom) and node.module and 'module_b' in node.module:
+        names = [a.name for a in node.names]
+        print(f'line {node.lineno}: from {node.module} import {\", \".join(names)}')
+"
+
+# 3. Apply one of the fix strategies below
+
+# 4. Regenerate the allowlist (edge count should decrease):
+uv run python scripts/detect_cyclic_imports.py --update-allowlist
+
+# 5. Verify the fix:
+uv run python scripts/detect_cyclic_imports.py
+# Exit 0 = good
+
+# 6. Commit both the code fix AND the updated allowlist:
+git add sdcm/... data/known_cyclic_imports.yml
+git commit -m "fix(imports): break cyclic import between module_a and module_b"
+```
+
+### Strategy 1: Move to `TYPE_CHECKING` guard (most common)
+
+**When**: The import is only needed for type annotations, not called at runtime.
+
+```python
+# BEFORE — creates cycle:
+from sdcm.cluster import BaseCluster
+
+def restart_node(cluster: BaseCluster) -> None:
+    cluster.restart()
+
+# AFTER — breaks cycle:
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sdcm.cluster import BaseCluster
+
+def restart_node(cluster: BaseCluster) -> None:
+    cluster.restart()  # still works — object is passed in at runtime
+```
+
+**Why it works**: `from __future__ import annotations` makes all type annotations lazy strings. The actual class is never imported at module load time — it's only used by type checkers (mypy, pyright) and IDE tooling.
+
+**Requirements**:
+- Add `from __future__ import annotations` at the top of the file (after the license header)
+- The imported symbol must NOT be used at runtime (no `isinstance()`, no calling constructors, no accessing class attributes directly)
+
+### Strategy 2: Lazy import inside a function
+
+**When**: You need the symbol at runtime, but only in one specific function.
+
+```python
+# BEFORE — creates cycle at module load:
+from sdcm.cluster import TestConfig
+
+def get_skip_stages():
+    return TestConfig().tester_obj().skip_test_stages
+
+# AFTER — defers import to call time:
+def get_skip_stages():
+    from sdcm.cluster import TestConfig  # noqa: PLC0415
+    return TestConfig().tester_obj().skip_test_stages
+```
+
+**Why it works**: The import only executes when the function is called, by which time both modules are fully loaded.
+
+**Note**: The detection script correctly recognizes function-level imports as NOT creating import-time cycles — they won't appear in the dependency graph or trigger the pre-commit hook. This is the most common pattern used in SCT to break cycles.
+
+### Strategy 3: Extract shared code to a third module
+
+**When**: Two modules legitimately need each other's functionality at runtime.
+
+```
+BEFORE (cycle):
+  sdcm/utils/aws_region.py  →  imports tags_as_ec2_tags from aws_utils
+  sdcm/utils/aws_utils.py   →  imports AwsRegion from aws_region
+
+AFTER (no cycle):
+  sdcm/utils/aws_tags.py    ←  new file, contains tags_as_ec2_tags
+  sdcm/utils/aws_region.py  →  imports from aws_tags (no cycle)
+  sdcm/utils/aws_utils.py   →  imports from aws_tags + aws_region (one-way)
+```
+
+**Why it works**: The shared dependency is moved to a leaf module that doesn't import back.
+
+**When to use this**:
+- Both imports are used at runtime (can't use TYPE_CHECKING)
+- The imported function/class logically belongs in a shared utility anyway
+- Multiple modules need the same symbol
+
+### Strategy 4: Pass dependencies as parameters (dependency injection)
+
+**When**: A utility function imports a heavy module just to access one thing.
+
+```python
+# BEFORE — decorators.py imports cluster.py for check_cluster_layout:
+from sdcm.cluster import BaseCluster
+
+def validate(cluster: BaseCluster):
+    if not cluster.is_ready():
+        raise RuntimeError("Cluster not ready")
+
+# AFTER — accept the check as a callable parameter:
+from typing import Protocol
+
+class ClusterLike(Protocol):
+    def is_ready(self) -> bool: ...
+
+def validate(cluster: ClusterLike):
+    if not cluster.is_ready():
+        raise RuntimeError("Cluster not ready")
+```
+
+**Why it works**: The function depends on an interface (Protocol), not a concrete class. No import needed.
+
+## Understanding the Allowlist
+
+The file `data/known_cyclic_imports.yml` contains directed edges:
+
+```yaml
+edges:
+  - source: sdcm.cluster
+    target: sdcm.utils.decorators
+  - source: sdcm.utils.decorators
+    target: sdcm.cluster
+```
+
+Each entry means "module `source` imports module `target` AND this edge is part of a cycle." A mutual cycle (A→B and B→A) has TWO entries.
+
+**Rules**:
+- Never edit the allowlist manually — always use `--update-allowlist`
+- When you fix a cycle, the edge count should **decrease** after regeneration
+- If you accidentally introduce a new cycle, the pre-commit hook will block your commit
+
+## Common Scenarios
+
+### "I'm adding a new import and pre-commit fails"
+
+```
+ERROR: New cyclic import edge(s) detected in sdcm/:
+  sdcm.foo -> sdcm.bar (NEW — not in allowlist)
+```
+
+Options:
+1. **Fix it**: Use `TYPE_CHECKING` or lazy import (preferred)
+2. **Allowlist it**: `uv run python scripts/detect_cyclic_imports.py --update-allowlist` — but this should be a last resort
+
+### "I fixed a cycle but the edge count didn't change"
+
+The cycle may be part of a larger strongly connected component. Example: if A→B→C→A exists, fixing A→B might still leave B→C→A→...→B as a cycle through other paths. Use `--verbose` to trace the full cycle.
+
+### "I want to see which cycles involve my module"
+
+```bash
+uv run python scripts/detect_cyclic_imports.py --verbose | grep "sdcm.my_module"
+```
+
+### "I moved code and the allowlist needs updating"
+
+```bash
+uv run python scripts/detect_cyclic_imports.py --update-allowlist
+git add data/known_cyclic_imports.yml
+# Include in the same commit as the code move
+```
+
+## Picking Low-Hanging Fruit
+
+The simplest cycles to fix are 2-node mutual cycles where one direction is typing-only:
+
+```bash
+# Find simple A <-> B mutual cycles:
+uv run python scripts/detect_cyclic_imports.py --verbose | sort | \
+  python3 -c "
+import sys
+from collections import defaultdict
+edges = set()
+for line in sys.stdin:
+    if ' -> ' in line.strip():
+        s, t = line.strip().split(' -> ')
+        edges.add((s, t))
+mutual = [(a,b) for a,b in edges if (b,a) in edges and a < b]
+print(f'Found {len(mutual)} mutual (2-node) cycles:')
+for a, b in sorted(mutual):
+    print(f'  {a} <-> {b}')
+"
+```
+
+For each mutual pair, check if one direction is only used for type annotations — that's a quick `TYPE_CHECKING` fix.

--- a/docs/cyclic-import-detection.md
+++ b/docs/cyclic-import-detection.md
@@ -1,0 +1,257 @@
+# Cyclic Import Detection
+
+SCT uses a pre-commit hook to detect cyclic imports between the repository's own Python modules. This prevents new circular dependencies from being introduced while allowing existing ones to be fixed incrementally.
+
+## Quick Reference
+
+```bash
+# Check for new cyclic imports (what pre-commit runs):
+uv run python scripts/detect_cyclic_imports.py
+
+# Show all existing cycles:
+uv run python scripts/detect_cyclic_imports.py --verbose
+
+# Regenerate allowlist after fixing a cycle:
+uv run python scripts/detect_cyclic_imports.py --update-allowlist
+
+# Diagnostics: also count imports inside functions (not used by pre-commit):
+uv run python scripts/detect_cyclic_imports.py --verbose --include-deferred
+```
+
+## How It Works
+
+1. The script parses every `.py` file in the repository using Python's `ast` module
+2. Builds a directed graph of project-internal import edges (any module that maps to a file in the repo — `sdcm/`, top-level test files, `utils/`, …)
+3. Finds strongly connected components (cycles) via Tarjan's algorithm
+4. Compares found cyclic edges against the allowlist (`data/known_cyclic_imports.yml`)
+5. If any NEW edge participates in a cycle that isn't allowlisted — **exit 1** (blocks commit)
+
+Key behaviors:
+- **TYPE_CHECKING-guarded imports are excluded** — these don't create runtime cycles
+- **Function-level (lazy) imports are excluded** — imports inside `def`/`async def` bodies are deferred to call time and don't cause import-time cycles
+- **Only project-internal imports are tracked** — stdlib and third-party are ignored
+- **Relative imports are resolved** — `from .base import X` is correctly mapped to its full module path
+- **Package-style imports edge to the submodule** — `from sdcm.utils.alternator import api` records an edge to `sdcm.utils.alternator.api`, not only to the package. Names that are not submodules (classes, constants) stay as an edge to the package itself
+- **Edges to a module's own ancestor packages are excluded** — importing `sdcm.pkg.sub` always initialises `sdcm.pkg` first, so `sub -> sdcm.pkg` is structural. Counting it would make every re-exporting `__init__.py` look cyclic
+
+### Scope limitation: parent/child ordering
+
+The detector finds cycles **between peer modules**. It deliberately does not model the
+parent/child relationship, because a re-exporting package is cyclic by construction:
+
+```python
+# sdcm/pkg/__init__.py
+from sdcm.pkg import sub      # pkg -> pkg.sub
+# sdcm/pkg/sub.py
+from sdcm.pkg import helper   # pkg.sub -> pkg  (implicit anyway)
+```
+
+Python executes this fine as long as `__init__.py` defines `helper` *before* importing
+`sub`. Whether it does is an ordering question, not a graph question, so no cycle
+detector can answer it — flagging the shape would only mean flagging every package in
+the repo. If you hit an `AttributeError: partially initialized module ...` on a
+parent/child import, reorder `__init__.py` or move the symbol to a leaf module.
+
+## Fixing a Cyclic Import
+
+### Workflow
+
+```bash
+# 1. See what cycles exist:
+uv run python scripts/detect_cyclic_imports.py --verbose | grep "sdcm.X"
+
+# 2. Investigate a specific cycle:
+python3 -c "
+import ast
+from pathlib import Path
+tree = ast.parse(Path('sdcm/module_a.py').read_text())
+for node in ast.walk(tree):
+    if isinstance(node, ast.ImportFrom) and node.module and 'module_b' in node.module:
+        names = [a.name for a in node.names]
+        print(f'line {node.lineno}: from {node.module} import {\", \".join(names)}')
+"
+
+# 3. Apply one of the fix strategies below
+
+# 4. Regenerate the allowlist (edge count should decrease):
+uv run python scripts/detect_cyclic_imports.py --update-allowlist
+
+# 5. Verify the fix:
+uv run python scripts/detect_cyclic_imports.py
+# Exit 0 = good
+
+# 6. Commit both the code fix AND the updated allowlist:
+git add sdcm/... data/known_cyclic_imports.yml
+git commit -m "fix(imports): break cyclic import between module_a and module_b"
+```
+
+### Strategy 1: Move to `TYPE_CHECKING` guard (most common)
+
+**When**: The import is only needed for type annotations, not called at runtime.
+
+```python
+# BEFORE — creates cycle:
+from sdcm.cluster import BaseCluster
+
+def restart_node(cluster: BaseCluster) -> None:
+    cluster.restart()
+
+# AFTER — breaks cycle:
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sdcm.cluster import BaseCluster
+
+def restart_node(cluster: BaseCluster) -> None:
+    cluster.restart()  # still works — object is passed in at runtime
+```
+
+**Why it works**: `from __future__ import annotations` makes all type annotations lazy strings. The actual class is never imported at module load time — it's only used by type checkers (mypy, pyright) and IDE tooling.
+
+**Requirements**:
+- Add `from __future__ import annotations` at the top of the file (after the license header)
+- The imported symbol must NOT be used at runtime (no `isinstance()`, no calling constructors, no accessing class attributes directly)
+
+### Strategy 2: Lazy import inside a function
+
+**When**: You need the symbol at runtime, but only in one specific function.
+
+```python
+# BEFORE — creates cycle at module load:
+from sdcm.cluster import TestConfig
+
+def get_skip_stages():
+    return TestConfig().tester_obj().skip_test_stages
+
+# AFTER — defers import to call time:
+def get_skip_stages():
+    from sdcm.cluster import TestConfig  # noqa: PLC0415
+    return TestConfig().tester_obj().skip_test_stages
+```
+
+**Why it works**: The import only executes when the function is called, by which time both modules are fully loaded.
+
+**Note**: The detection script correctly recognizes function-level imports as NOT creating import-time cycles — they won't appear in the dependency graph or trigger the pre-commit hook. This is the most common pattern used in SCT to break cycles.
+
+### Strategy 3: Extract shared code to a third module
+
+**When**: Two modules legitimately need each other's functionality at runtime.
+
+```
+BEFORE (cycle):
+  sdcm/utils/aws_region.py  →  imports tags_as_ec2_tags from aws_utils
+  sdcm/utils/aws_utils.py   →  imports AwsRegion from aws_region
+
+AFTER (no cycle):
+  sdcm/utils/aws_tags.py    ←  new file, contains tags_as_ec2_tags
+  sdcm/utils/aws_region.py  →  imports from aws_tags (no cycle)
+  sdcm/utils/aws_utils.py   →  imports from aws_tags + aws_region (one-way)
+```
+
+**Why it works**: The shared dependency is moved to a leaf module that doesn't import back.
+
+**When to use this**:
+- Both imports are used at runtime (can't use TYPE_CHECKING)
+- The imported function/class logically belongs in a shared utility anyway
+- Multiple modules need the same symbol
+
+### Strategy 4: Pass dependencies as parameters (dependency injection)
+
+**When**: A utility function imports a heavy module just to access one thing.
+
+```python
+# BEFORE — decorators.py imports cluster.py for check_cluster_layout:
+from sdcm.cluster import BaseCluster
+
+def validate(cluster: BaseCluster):
+    if not cluster.is_ready():
+        raise RuntimeError("Cluster not ready")
+
+# AFTER — accept the check as a callable parameter:
+from typing import Protocol
+
+class ClusterLike(Protocol):
+    def is_ready(self) -> bool: ...
+
+def validate(cluster: ClusterLike):
+    if not cluster.is_ready():
+        raise RuntimeError("Cluster not ready")
+```
+
+**Why it works**: The function depends on an interface (Protocol), not a concrete class. No import needed.
+
+## Understanding the Allowlist
+
+The file `data/known_cyclic_imports.yml` contains directed edges:
+
+```yaml
+edges:
+  - source: sdcm.cluster
+    target: sdcm.utils.decorators
+  - source: sdcm.utils.decorators
+    target: sdcm.cluster
+```
+
+Each entry means "module `source` imports module `target` AND this edge is part of a cycle." A mutual cycle (A→B and B→A) has TWO entries.
+
+**Rules**:
+- Never edit the allowlist manually — always use `--update-allowlist`
+- When you fix a cycle, the edge count should **decrease** after regeneration
+- If you accidentally introduce a new cycle, the pre-commit hook will block your commit
+
+## Common Scenarios
+
+### "I'm adding a new import and pre-commit fails"
+
+```
+ERROR: New cyclic import edge(s) detected:
+
+  sdcm.foo -> sdcm.bar  (sdcm/foo.py:12)
+  sdcm.bar -> sdcm.foo  (sdcm/bar.py:8)
+```
+
+Options:
+1. **Fix it**: Use `TYPE_CHECKING` or lazy import (preferred)
+2. **Allowlist it**: `uv run python scripts/detect_cyclic_imports.py --update-allowlist` — but this should be a last resort
+
+### "I fixed a cycle but the edge count didn't change"
+
+The cycle may be part of a larger strongly connected component. Example: if A→B→C→A exists, fixing A→B might still leave B→C→A→...→B as a cycle through other paths. Use `--verbose` to trace the full cycle.
+
+### "I want to see which cycles involve my module"
+
+```bash
+uv run python scripts/detect_cyclic_imports.py --verbose | grep "sdcm.my_module"
+```
+
+### "I moved code and the allowlist needs updating"
+
+```bash
+uv run python scripts/detect_cyclic_imports.py --update-allowlist
+git add data/known_cyclic_imports.yml
+# Include in the same commit as the code move
+```
+
+## Picking Low-Hanging Fruit
+
+The simplest cycles to fix are 2-node mutual cycles where one direction is typing-only:
+
+```bash
+# Find simple A <-> B mutual cycles:
+uv run python scripts/detect_cyclic_imports.py --verbose | sort | \
+  python3 -c "
+import sys
+edges = set()
+for line in sys.stdin:
+    if ' -> ' in line.strip():
+        s, t = line.strip().split(' -> ')
+        edges.add((s, t.split()[0]))  # strip the trailing (file:line)
+mutual = [(a,b) for a,b in edges if (b,a) in edges and a < b]
+print(f'Found {len(mutual)} mutual (2-node) cycles:')
+for a, b in sorted(mutual):
+    print(f'  {a} <-> {b}')
+"
+```
+
+For each mutual pair, check if one direction is only used for type annotations — that's a quick `TYPE_CHECKING` fix.

--- a/scripts/detect_cyclic_imports.py
+++ b/scripts/detect_cyclic_imports.py
@@ -1,0 +1,382 @@
+#!/usr/bin/env python3
+"""Detect cyclic imports among project Python modules.
+
+Statically parses Python files with ast, builds a directed graph of
+project-internal imports, and reports import edges that belong to
+strongly connected components.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import os
+import sys
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_ALLOWLIST = REPO_ROOT / "data" / "known_cyclic_imports.yml"
+ALLOWLIST_HEADER = """\
+# Auto-generated allowlist of known cyclic import edges.
+# Each entry is a directed edge (source -> target) that forms part of a cycle.
+# To add: run `python scripts/detect_cyclic_imports.py --update-allowlist`
+# To fix: resolve the cycle and remove both directional edges.
+"""
+
+EXCLUDED_DIRS = frozenset(
+    {
+        "__pycache__",
+        "node_modules",
+        "docker",
+        "docs",
+        "jenkins-pipelines",
+        "test-cases",
+        "configurations",
+        "defaults",
+        "data",
+        "data_dir",
+        "templates",
+        "argus_report_templates",
+        "rule-tests",
+        "rules",
+        "skills",
+        "tree-sitter-groovy",
+        "kafka-stack-docker-compose",
+        "jupyter",
+        "examples",
+        "scylla-qa-internal",
+    }
+)
+
+
+@dataclass
+class ImportEdge:
+    source: str
+    target: str
+    file: str
+    line: int
+
+
+@dataclass
+class ModuleImports:
+    targets: dict[str, list[int]] = field(default_factory=dict)
+
+    def add(self, target: str, line: int) -> None:
+        self.targets.setdefault(target, []).append(line)
+
+
+class ImportVisitor(ast.NodeVisitor):
+    """Collect import targets with line numbers.
+
+    Excludes:
+    - Imports inside TYPE_CHECKING guards (not runtime imports)
+    - Imports inside function/method bodies (deferred, not import-time cycles)
+      unless include_deferred=True
+    """
+
+    def __init__(self, source: str, package: str, *, include_deferred: bool = False) -> None:
+        self.source = source
+        self.package = package
+        self.imports = ModuleImports()
+        self._include_deferred = include_deferred
+
+    def visit_Import(self, node: ast.Import) -> None:  # noqa: N802
+        for alias in node.names:
+            self._add_target(alias.name, node.lineno)
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:  # noqa: N802
+        target = self._resolve_import_from(node)
+        if target:
+            self._add_target(target, node.lineno)
+
+    def visit_If(self, node: ast.If) -> None:  # noqa: N802
+        if _is_type_checking_guard(node.test):
+            for item in node.orelse:
+                self.visit(item)
+            return
+        self.generic_visit(node)
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:  # noqa: N802
+        if self._include_deferred:
+            self.generic_visit(node)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:  # noqa: N802
+        if self._include_deferred:
+            self.generic_visit(node)
+
+    def _add_target(self, target: str, line: int) -> None:
+        if target != self.source:
+            self.imports.add(target, line)
+
+    def _resolve_import_from(self, node: ast.ImportFrom) -> str | None:
+        module = node.module or ""
+        if node.level == 0:
+            return module
+
+        package_parts = self.package.split(".")
+        if node.level > len(package_parts):
+            return None
+
+        base_parts = package_parts[: len(package_parts) - node.level + 1]
+        if module:
+            base_parts.extend(module.split("."))
+        return ".".join(base_parts)
+
+
+def extract_imports(
+    project_root: Path,
+    *,
+    include_deferred: bool = False,
+) -> tuple[dict[str, set[str]], list[ImportEdge]]:
+    """Walk project Python files, return (adjacency dict, list of edges with locations)."""
+    graph: dict[str, set[str]] = {}
+    edges: list[ImportEdge] = []
+    project_root = project_root.resolve()
+
+    internal_modules = _discover_internal_modules(project_root)
+
+    for path in sorted(_iter_python_files(project_root)):
+        source = _module_name(path, project_root)
+        package = source if path.name == "__init__.py" else source.rsplit(".", 1)[0] if "." in source else ""
+        graph.setdefault(source, set())
+
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        except SyntaxError as exc:
+            print(f"WARNING: failed to parse {path}: {exc}", file=sys.stderr)
+            continue
+
+        visitor = ImportVisitor(source=source, package=package, include_deferred=include_deferred)
+        visitor.visit(tree)
+
+        rel_path = str(path.relative_to(project_root))
+        for target, lines in visitor.imports.targets.items():
+            if target in internal_modules and target != source:
+                graph[source].add(target)
+                for line in lines:
+                    edges.append(ImportEdge(source=source, target=target, file=rel_path, line=line))
+
+    for targets in list(graph.values()):
+        for target in targets:
+            graph.setdefault(target, set())
+
+    return graph, edges
+
+
+def find_cycles(graph: dict[str, set[str]]) -> list[tuple[str, str]]:
+    """Return list of (source, target) edges that participate in any cycle."""
+    components = _strongly_connected_components(graph)
+    cyclic_nodes = {node for component in components if len(component) > 1 for node in component}
+    cyclic_edges = [
+        (source, target)
+        for source, targets in graph.items()
+        if source in cyclic_nodes
+        for target in targets
+        if target in cyclic_nodes
+    ]
+    return sorted(cyclic_edges)
+
+
+def load_allowlist(path: Path) -> set[tuple[str, str]]:
+    """Load known_cyclic_imports.yml, return set of (source, target) pairs."""
+    if not path.exists():
+        return set()
+
+    data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    allowlist_edges = data.get("edges") or []
+    return {
+        (edge["source"], edge["target"])
+        for edge in allowlist_edges
+        if isinstance(edge, dict) and edge.get("source") and edge.get("target")
+    }
+
+
+def main() -> int:
+    """CLI entry point. Returns exit code."""
+    parser = argparse.ArgumentParser(description="Detect cyclic imports in Python project.")
+    parser.add_argument("--update-allowlist", action="store_true", help="write current cyclic edges to allowlist")
+    parser.add_argument("--verbose", action="store_true", help="print all cyclic edges with file locations")
+    parser.add_argument(
+        "--include-deferred",
+        action="store_true",
+        help="also count imports inside functions (for diagnostics, not used by pre-commit)",
+    )
+    parser.add_argument("--allowlist", type=Path, default=DEFAULT_ALLOWLIST, help="override allowlist path")
+    args = parser.parse_args()
+
+    graph, all_edges = extract_imports(REPO_ROOT, include_deferred=args.include_deferred)
+    cyclic_edges = find_cycles(graph)
+
+    if args.update_allowlist:
+        _write_allowlist(args.allowlist, cyclic_edges)
+        print(f"Wrote {len(cyclic_edges)} cyclic import edge(s) to {args.allowlist}")
+        return 0
+
+    allowlist = load_allowlist(args.allowlist)
+    new_edges = sorted(set(cyclic_edges) - allowlist)
+
+    if args.verbose:
+        _print_verbose_cycles(cyclic_edges, all_edges)
+
+    if new_edges:
+        _print_new_cycles_error(new_edges, graph, all_edges)
+        return 1
+
+    return 0
+
+
+def _is_type_checking_guard(test: ast.expr) -> bool:
+    return (isinstance(test, ast.Name) and test.id == "TYPE_CHECKING") or (
+        isinstance(test, ast.Attribute) and test.attr == "TYPE_CHECKING"
+    )
+
+
+def _discover_internal_modules(project_root: Path) -> set[str]:
+    """Build the set of all module names that correspond to project files."""
+    modules = set()
+    for path in _iter_python_files(project_root):
+        modules.add(_module_name(path, project_root))
+    return modules
+
+
+def _iter_python_files(project_root: Path) -> Iterator[Path]:
+    """Yield .py files in the project, excluding non-source directories."""
+    for dirpath, dirnames, filenames in os.walk(project_root):
+        dirnames[:] = [
+            d
+            for d in dirnames
+            if not d.startswith(".") and "venv" not in d and d not in EXCLUDED_DIRS and d != "__pycache__"
+        ]
+        for filename in sorted(filenames):
+            if filename.endswith(".py"):
+                yield Path(dirpath) / filename
+
+
+def _module_name(path: Path, project_root: Path) -> str:
+    relative = path.relative_to(project_root).with_suffix("")
+    parts = list(relative.parts)
+    if parts[-1] == "__init__":
+        parts = parts[:-1]
+    return ".".join(parts) if parts else path.stem
+
+
+def _strongly_connected_components(graph: dict[str, set[str]]) -> list[set[str]]:
+    index = 0
+    stack: list[str] = []
+    indices: dict[str, int] = {}
+    lowlinks: dict[str, int] = {}
+    on_stack: set[str] = set()
+    components: list[set[str]] = []
+
+    def strongconnect(node: str) -> None:
+        nonlocal index
+        indices[node] = index
+        lowlinks[node] = index
+        index += 1
+        stack.append(node)
+        on_stack.add(node)
+
+        for target in graph.get(node, set()):
+            if target not in indices:
+                strongconnect(target)
+                lowlinks[node] = min(lowlinks[node], lowlinks[target])
+            elif target in on_stack:
+                lowlinks[node] = min(lowlinks[node], indices[target])
+
+        if lowlinks[node] == indices[node]:
+            component = set()
+            while True:
+                target = stack.pop()
+                on_stack.remove(target)
+                component.add(target)
+                if target == node:
+                    break
+            components.append(component)
+
+    for node in sorted(graph):
+        if node not in indices:
+            strongconnect(node)
+
+    return components
+
+
+def _edges_by_pair(all_edges: list[ImportEdge]) -> dict[tuple[str, str], list[ImportEdge]]:
+    by_pair: dict[tuple[str, str], list[ImportEdge]] = {}
+    for edge in all_edges:
+        by_pair.setdefault((edge.source, edge.target), []).append(edge)
+    return by_pair
+
+
+def _write_allowlist(path: Path, edges: list[tuple[str, str]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    data = {"edges": [{"source": source, "target": target} for source, target in sorted(edges)]}
+    path.write_text(ALLOWLIST_HEADER + yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+
+
+def _print_verbose_cycles(cyclic_edges: list[tuple[str, str]], all_edges: list[ImportEdge]) -> None:
+    by_pair = _edges_by_pair(all_edges)
+    for source, target in cyclic_edges:
+        locations = by_pair.get((source, target), [])
+        if locations:
+            for loc in locations:
+                print(f"{source} -> {target}  ({loc.file}:{loc.line})")
+        else:
+            print(f"{source} -> {target}")
+
+
+def _print_new_cycles_error(
+    new_edges: list[tuple[str, str]],
+    graph: dict[str, set[str]],
+    all_edges: list[ImportEdge],
+) -> None:
+    by_pair = _edges_by_pair(all_edges)
+    print("ERROR: New cyclic import edge(s) detected:\n", file=sys.stderr)
+    for source, target in new_edges:
+        locations = by_pair.get((source, target), [])
+        if locations:
+            for loc in locations:
+                print(f"  {source} -> {target}  ({loc.file}:{loc.line})", file=sys.stderr)
+        else:
+            print(f"  {source} -> {target} (NEW — not in allowlist)", file=sys.stderr)
+    print(file=sys.stderr)
+
+    cycle_path = _find_cycle_path(new_edges[0][0], new_edges[0][1], graph)
+    if cycle_path:
+        print(f"Cycle path: {' -> '.join(cycle_path)}\n", file=sys.stderr)
+
+    print("To add to allowlist: uv run python scripts/detect_cyclic_imports.py --update-allowlist", file=sys.stderr)
+    print("To fix: break the cycle by making one import lazy or moving it under TYPE_CHECKING.", file=sys.stderr)
+
+
+def _find_cycle_path(source: str, target: str, graph: dict[str, set[str]]) -> list[str]:
+    path = _find_path(target, source, graph)
+    if not path:
+        return []
+    return [source, *path]
+
+
+def _find_path(start: str, end: str, graph: dict[str, set[str]]) -> list[str]:
+    stack: list[tuple[str, Iterator[str], list[str]]] = [(start, iter(sorted(graph.get(start, set()))), [start])]
+    visited = {start}
+
+    while stack:
+        node, targets, path = stack[-1]
+        if node == end:
+            return path
+        for target in targets:
+            if target not in visited:
+                visited.add(target)
+                stack.append((target, iter(sorted(graph.get(target, set()))), [*path, target]))
+                break
+        else:
+            stack.pop()
+    return []
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/detect_cyclic_imports.py
+++ b/scripts/detect_cyclic_imports.py
@@ -1,0 +1,425 @@
+#!/usr/bin/env python3
+"""Detect cyclic imports among project Python modules.
+
+Statically parses Python files with ast, builds a directed graph of
+project-internal imports, and reports import edges that belong to
+strongly connected components.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import os
+import sys
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_ALLOWLIST = REPO_ROOT / "data" / "known_cyclic_imports.yml"
+ALLOWLIST_HEADER = """\
+# Auto-generated allowlist of known cyclic import edges.
+# Each entry is a directed edge (source -> target) that forms part of a cycle.
+# An empty list means the repository has no import-time cycles left to grandfather;
+# deferred (function-level) imports are out of scope, see --include-deferred.
+# To add: run `python scripts/detect_cyclic_imports.py --update-allowlist`
+# To fix: resolve the cycle and remove both directional edges.
+"""
+
+# Pruned only at the repository root, so that a nested package sharing one of these
+# names (e.g. unit_tests/unit/docker/) still takes part in the graph.
+EXCLUDED_TOP_LEVEL_DIRS = frozenset(
+    {
+        "docker",
+        "docs",
+        "jenkins-pipelines",
+        "test-cases",
+        "configurations",
+        "defaults",
+        "data",
+        "data_dir",
+        "templates",
+        "argus_report_templates",
+        "rule-tests",
+        "rules",
+        "skills",
+        "tree-sitter-groovy",
+        "kafka-stack-docker-compose",
+        "jupyter",
+        "examples",
+        "scylla-qa-internal",
+    }
+)
+
+# Pruned at any depth — these never hold importable project modules.
+EXCLUDED_DIR_NAMES = frozenset({"__pycache__", "node_modules"})
+
+
+@dataclass
+class ImportEdge:
+    source: str
+    target: str
+    file: str
+    line: int
+
+
+@dataclass
+class ModuleImports:
+    targets: dict[str, list[int]] = field(default_factory=dict)
+
+    def add(self, target: str, line: int) -> None:
+        self.targets.setdefault(target, []).append(line)
+
+
+class ImportVisitor(ast.NodeVisitor):
+    """Collect import targets with line numbers.
+
+    Excludes:
+    - Imports inside TYPE_CHECKING guards (not runtime imports)
+    - Imports inside function/method bodies (deferred, not import-time cycles)
+      unless include_deferred=True
+    - Edges from a module to its own ancestor packages (implicit, never a real cycle)
+    """
+
+    def __init__(self, source: str, package: str, *, include_deferred: bool = False) -> None:
+        self.source = source
+        self.package = package
+        self.imports = ModuleImports()
+        self._include_deferred = include_deferred
+
+    def visit_Import(self, node: ast.Import) -> None:  # noqa: N802
+        for alias in node.names:
+            self._add_target(alias.name, node.lineno)
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:  # noqa: N802
+        target = self._resolve_import_from(node)
+        if not target:
+            return
+        self._add_target(target, node.lineno)
+        # `from pkg import mod` binds the submodule `pkg.mod`, not just `pkg`, so the
+        # real edge points at `pkg.mod`. Names that are plain attributes (classes,
+        # constants) resolve to module names that do not exist and get dropped by the
+        # internal-module filter in extract_imports().
+        for alias in node.names:
+            if alias.name != "*":
+                self._add_target(f"{target}.{alias.name}", node.lineno)
+
+    def visit_If(self, node: ast.If) -> None:  # noqa: N802
+        if _is_type_checking_guard(node.test):
+            for item in node.orelse:
+                self.visit(item)
+            return
+        self.generic_visit(node)
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:  # noqa: N802
+        if self._include_deferred:
+            self.generic_visit(node)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:  # noqa: N802
+        if self._include_deferred:
+            self.generic_visit(node)
+
+    def _add_target(self, target: str, line: int) -> None:
+        # Importing a module always initialises its ancestor packages first, so an edge
+        # from a module up to one of its own ancestors is structural rather than a real
+        # dependency. Keeping it would make every re-exporting `__init__.py` look cyclic.
+        if target == self.source or self.source.startswith(f"{target}."):
+            return
+        self.imports.add(target, line)
+
+    def _resolve_import_from(self, node: ast.ImportFrom) -> str | None:
+        module = node.module or ""
+        if node.level == 0:
+            return module
+
+        package_parts = self.package.split(".")
+        if node.level > len(package_parts):
+            return None
+
+        base_parts = package_parts[: len(package_parts) - node.level + 1]
+        if module:
+            base_parts.extend(module.split("."))
+        return ".".join(base_parts)
+
+
+def extract_imports(
+    project_root: Path,
+    *,
+    include_deferred: bool = False,
+) -> tuple[dict[str, set[str]], list[ImportEdge], list[str]]:
+    """Walk project Python files.
+
+    Returns (adjacency dict, edges with locations, unparseable files). A file that
+    cannot be parsed contributes no edges, so the caller must treat a non-empty
+    third element as "the graph is incomplete" rather than ignoring it.
+    """
+    graph: dict[str, set[str]] = {}
+    edges: list[ImportEdge] = []
+    parse_errors: list[str] = []
+    project_root = project_root.resolve()
+
+    internal_modules = _discover_internal_modules(project_root)
+
+    for path in sorted(_iter_python_files(project_root)):
+        source = _module_name(path, project_root)
+        package = source if path.name == "__init__.py" else source.rsplit(".", 1)[0] if "." in source else ""
+        graph.setdefault(source, set())
+
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        except SyntaxError as exc:
+            parse_errors.append(f"{path.relative_to(project_root)}: {exc}")
+            continue
+
+        visitor = ImportVisitor(source=source, package=package, include_deferred=include_deferred)
+        visitor.visit(tree)
+
+        rel_path = str(path.relative_to(project_root))
+        for target, lines in visitor.imports.targets.items():
+            if target in internal_modules and target != source:
+                graph[source].add(target)
+                for line in lines:
+                    edges.append(ImportEdge(source=source, target=target, file=rel_path, line=line))
+
+    for targets in list(graph.values()):
+        for target in targets:
+            graph.setdefault(target, set())
+
+    return graph, edges, parse_errors
+
+
+def find_cycles(graph: dict[str, set[str]]) -> list[tuple[str, str]]:
+    """Return list of (source, target) edges that participate in any cycle.
+
+    An edge is cyclic only when both ends sit in the *same* strongly connected
+    component. Testing against the union of all components would also report
+    one-way bridges between two disjoint cycles, which are not cyclic themselves.
+    """
+    cyclic_edges = [
+        (source, target)
+        for component in _strongly_connected_components(graph)
+        if len(component) > 1
+        for source in component
+        for target in graph.get(source, set()) & component
+    ]
+    return sorted(cyclic_edges)
+
+
+def load_allowlist(path: Path) -> set[tuple[str, str]]:
+    """Load known_cyclic_imports.yml, return set of (source, target) pairs."""
+    if not path.exists():
+        return set()
+
+    data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    allowlist_edges = data.get("edges") or []
+    return {
+        (edge["source"], edge["target"])
+        for edge in allowlist_edges
+        if isinstance(edge, dict) and edge.get("source") and edge.get("target")
+    }
+
+
+def main() -> int:
+    """CLI entry point. Returns exit code."""
+    parser = argparse.ArgumentParser(description="Detect cyclic imports in Python project.")
+    parser.add_argument("--update-allowlist", action="store_true", help="write current cyclic edges to allowlist")
+    parser.add_argument("--verbose", action="store_true", help="print all cyclic edges with file locations")
+    parser.add_argument(
+        "--include-deferred",
+        action="store_true",
+        help="also count imports inside functions (for diagnostics, not used by pre-commit)",
+    )
+    parser.add_argument("--allowlist", type=Path, default=DEFAULT_ALLOWLIST, help="override allowlist path")
+    args = parser.parse_args()
+
+    if args.update_allowlist and args.include_deferred:
+        # The pre-commit check always runs without --include-deferred, so writing the
+        # deferred-inclusive edge set would grandfather import-time cycles that were
+        # never actually present, silently disabling the hook.
+        parser.error("--update-allowlist cannot be combined with --include-deferred")
+
+    graph, all_edges, parse_errors = extract_imports(REPO_ROOT, include_deferred=args.include_deferred)
+    if parse_errors:
+        print("ERROR: could not parse the following file(s), import graph is incomplete:\n", file=sys.stderr)
+        for message in parse_errors:
+            print(f"  {message}", file=sys.stderr)
+        return 1
+
+    cyclic_edges = find_cycles(graph)
+
+    if args.update_allowlist:
+        _write_allowlist(args.allowlist, cyclic_edges)
+        print(f"Wrote {len(cyclic_edges)} cyclic import edge(s) to {args.allowlist}")
+        return 0
+
+    allowlist = load_allowlist(args.allowlist)
+    new_edges = sorted(set(cyclic_edges) - allowlist)
+
+    if args.verbose:
+        _print_verbose_cycles(cyclic_edges, all_edges)
+
+    if new_edges:
+        _print_new_cycles_error(new_edges, graph, all_edges)
+        return 1
+
+    return 0
+
+
+def _is_type_checking_guard(test: ast.expr) -> bool:
+    return (isinstance(test, ast.Name) and test.id == "TYPE_CHECKING") or (
+        isinstance(test, ast.Attribute) and test.attr == "TYPE_CHECKING"
+    )
+
+
+def _discover_internal_modules(project_root: Path) -> set[str]:
+    """Build the set of all module names that correspond to project files."""
+    modules = set()
+    for path in _iter_python_files(project_root):
+        modules.add(_module_name(path, project_root))
+    return modules
+
+
+def _iter_python_files(project_root: Path) -> Iterator[Path]:
+    """Yield .py files in the project, excluding non-source directories."""
+    for dirpath, dirnames, filenames in os.walk(project_root):
+        at_root = Path(dirpath) == project_root
+        dirnames[:] = [
+            d
+            for d in dirnames
+            if not d.startswith(".")
+            and "venv" not in d
+            and d not in EXCLUDED_DIR_NAMES
+            and not (at_root and d in EXCLUDED_TOP_LEVEL_DIRS)
+        ]
+        for filename in sorted(filenames):
+            if filename.endswith(".py"):
+                yield Path(dirpath) / filename
+
+
+def _module_name(path: Path, project_root: Path) -> str:
+    relative = path.relative_to(project_root).with_suffix("")
+    parts = list(relative.parts)
+    if parts[-1] == "__init__":
+        parts = parts[:-1]
+    return ".".join(parts) if parts else path.stem
+
+
+def _strongly_connected_components(graph: dict[str, set[str]]) -> list[set[str]]:
+    index = 0
+    stack: list[str] = []
+    indices: dict[str, int] = {}
+    lowlinks: dict[str, int] = {}
+    on_stack: set[str] = set()
+    components: list[set[str]] = []
+
+    def strongconnect(node: str) -> None:
+        nonlocal index
+        indices[node] = index
+        lowlinks[node] = index
+        index += 1
+        stack.append(node)
+        on_stack.add(node)
+
+        for target in graph.get(node, set()):
+            if target not in indices:
+                strongconnect(target)
+                lowlinks[node] = min(lowlinks[node], lowlinks[target])
+            elif target in on_stack:
+                lowlinks[node] = min(lowlinks[node], indices[target])
+
+        if lowlinks[node] == indices[node]:
+            component = set()
+            while True:
+                target = stack.pop()
+                on_stack.remove(target)
+                component.add(target)
+                if target == node:
+                    break
+            components.append(component)
+
+    for node in sorted(graph):
+        if node not in indices:
+            strongconnect(node)
+
+    return components
+
+
+def _edges_by_pair(all_edges: list[ImportEdge]) -> dict[tuple[str, str], list[ImportEdge]]:
+    by_pair: dict[tuple[str, str], list[ImportEdge]] = {}
+    for edge in all_edges:
+        by_pair.setdefault((edge.source, edge.target), []).append(edge)
+    return by_pair
+
+
+def _write_allowlist(path: Path, edges: list[tuple[str, str]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    data = {"edges": [{"source": source, "target": target} for source, target in sorted(edges)]}
+    path.write_text(ALLOWLIST_HEADER + yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+
+
+def _print_verbose_cycles(cyclic_edges: list[tuple[str, str]], all_edges: list[ImportEdge]) -> None:
+    by_pair = _edges_by_pair(all_edges)
+    for source, target in cyclic_edges:
+        locations = by_pair.get((source, target), [])
+        if locations:
+            for loc in locations:
+                print(f"{source} -> {target}  ({loc.file}:{loc.line})")
+        else:
+            print(f"{source} -> {target}")
+
+
+def _print_new_cycles_error(
+    new_edges: list[tuple[str, str]],
+    graph: dict[str, set[str]],
+    all_edges: list[ImportEdge],
+) -> None:
+    by_pair = _edges_by_pair(all_edges)
+    print("ERROR: New cyclic import edge(s) detected:\n", file=sys.stderr)
+    for source, target in new_edges:
+        locations = by_pair.get((source, target), [])
+        if locations:
+            for loc in locations:
+                print(f"  {source} -> {target}  ({loc.file}:{loc.line})", file=sys.stderr)
+        else:
+            print(f"  {source} -> {target} (NEW — not in allowlist)", file=sys.stderr)
+    print(file=sys.stderr)
+
+    cycle_path = _find_cycle_path(new_edges[0][0], new_edges[0][1], graph)
+    if cycle_path:
+        print(f"Cycle path: {' -> '.join(cycle_path)}\n", file=sys.stderr)
+
+    print("To add to allowlist: uv run python scripts/detect_cyclic_imports.py --update-allowlist", file=sys.stderr)
+    print("To fix: break the cycle by making one import lazy or moving it under TYPE_CHECKING.", file=sys.stderr)
+
+
+def _find_cycle_path(source: str, target: str, graph: dict[str, set[str]]) -> list[str]:
+    path = _find_path(target, source, graph)
+    if not path:
+        return []
+    return [source, *path]
+
+
+def _find_path(start: str, end: str, graph: dict[str, set[str]]) -> list[str]:
+    stack: list[tuple[str, Iterator[str], list[str]]] = [(start, iter(sorted(graph.get(start, set()))), [start])]
+    visited = {start}
+
+    while stack:
+        node, targets, path = stack[-1]
+        if node == end:
+            return path
+        for target in targets:
+            if target not in visited:
+                visited.add(target)
+                stack.append((target, iter(sorted(graph.get(target, set()))), [*path, target]))
+                break
+        else:
+            stack.pop()
+    return []
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/unit_tests/unit/test_detect_cyclic_imports.py
+++ b/unit_tests/unit/test_detect_cyclic_imports.py
@@ -1,0 +1,289 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2024 ScyllaDB
+
+"""Unit tests for scripts/detect_cyclic_imports.py."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import yaml
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+from detect_cyclic_imports import extract_imports, find_cycles, load_allowlist  # noqa: E402
+
+
+def _make_project(tmp_path: Path) -> Path:
+    """Create a fake project root with a sdcm/ package. Returns the project root (tmp_path)."""
+    sdcm_dir = tmp_path / "sdcm"
+    sdcm_dir.mkdir(parents=True, exist_ok=True)
+    return tmp_path
+
+
+def _graph(tmp_path: Path) -> dict[str, set[str]]:
+    """Extract imports and return just the graph dict."""
+    graph, _edges = extract_imports(tmp_path)
+    return graph
+
+
+# ---------------------------------------------------------------------------
+# Scenario 1 — basic import extraction
+# ---------------------------------------------------------------------------
+
+
+def test_extract_imports_basic(tmp_path):
+    """extract_imports returns edge sdcm.foo -> sdcm.bar for a simple import."""
+    root = _make_project(tmp_path)
+    sdcm = root / "sdcm"
+    (sdcm / "foo.py").write_text("from sdcm.bar import X\n", encoding="utf-8")
+    (sdcm / "bar.py").write_text("", encoding="utf-8")
+
+    graph = _graph(root)
+
+    assert "sdcm.foo" in graph
+    assert "sdcm.bar" in graph["sdcm.foo"]
+
+
+# ---------------------------------------------------------------------------
+# Scenario 2 — TYPE_CHECKING guard excluded
+# ---------------------------------------------------------------------------
+
+
+def test_type_checking_imports_excluded(tmp_path):
+    """Imports inside 'if TYPE_CHECKING:' must NOT appear as graph edges."""
+    root = _make_project(tmp_path)
+    sdcm = root / "sdcm"
+    (sdcm / "foo.py").write_text(
+        "from typing import TYPE_CHECKING\nif TYPE_CHECKING:\n    from sdcm.bar import Baz\n",
+        encoding="utf-8",
+    )
+    (sdcm / "bar.py").write_text("", encoding="utf-8")
+
+    graph = _graph(root)
+
+    assert "sdcm.foo" in graph
+    assert "sdcm.bar" not in graph.get("sdcm.foo", set())
+
+
+# ---------------------------------------------------------------------------
+# Scenario 3 — relative import resolution
+# ---------------------------------------------------------------------------
+
+
+def test_relative_import_resolution(tmp_path):
+    """'from .base import Foo' in sdcm.pkg.sub resolves to sdcm.pkg.base."""
+    root = _make_project(tmp_path)
+    sdcm = root / "sdcm"
+    pkg_dir = sdcm / "pkg"
+    pkg_dir.mkdir()
+    (pkg_dir / "__init__.py").write_text("", encoding="utf-8")
+    (pkg_dir / "sub.py").write_text("from .base import Foo\n", encoding="utf-8")
+    (pkg_dir / "base.py").write_text("", encoding="utf-8")
+
+    graph = _graph(root)
+
+    assert "sdcm.pkg.sub" in graph
+    assert "sdcm.pkg.base" in graph["sdcm.pkg.sub"]
+
+
+# ---------------------------------------------------------------------------
+# Scenario 4 — cycle detection
+# ---------------------------------------------------------------------------
+
+
+def test_find_cycles_detects_cycle():
+    """find_cycles reports both directed edges of a two-node cycle."""
+    graph: dict[str, set[str]] = {
+        "sdcm.a": {"sdcm.b"},
+        "sdcm.b": {"sdcm.a"},
+    }
+
+    edges = find_cycles(graph)
+
+    assert ("sdcm.a", "sdcm.b") in edges
+    assert ("sdcm.b", "sdcm.a") in edges
+
+
+# ---------------------------------------------------------------------------
+# Scenario 5 — DAG has no false positives
+# ---------------------------------------------------------------------------
+
+
+def test_find_cycles_no_false_positives():
+    """A simple directed acyclic graph must produce no cyclic edges."""
+    graph: dict[str, set[str]] = {
+        "sdcm.a": {"sdcm.b"},
+        "sdcm.b": {"sdcm.c"},
+        "sdcm.c": set(),
+    }
+
+    assert find_cycles(graph) == []
+
+
+# ---------------------------------------------------------------------------
+# Scenario 6 — allowlist suppresses known edges
+# ---------------------------------------------------------------------------
+
+
+def test_allowlist_suppresses_known_edges(tmp_path):
+    """Edges present in the allowlist are excluded from new_edges."""
+    allowlist_path = tmp_path / "known_cyclic_imports.yml"
+    graph: dict[str, set[str]] = {
+        "sdcm.a": {"sdcm.b"},
+        "sdcm.b": {"sdcm.a"},
+    }
+    cyclic_edges = find_cycles(graph)
+
+    data = {"edges": [{"source": src, "target": tgt} for src, tgt in cyclic_edges]}
+    allowlist_path.write_text(yaml.safe_dump(data), encoding="utf-8")
+
+    allowlist = load_allowlist(allowlist_path)
+    new_edges = sorted(set(cyclic_edges) - allowlist)
+
+    assert new_edges == []
+
+
+def test_allowlist_reports_unlisted_edge(tmp_path):
+    """An edge absent from the allowlist is reported as a new cycle."""
+    allowlist_path = tmp_path / "known_cyclic_imports.yml"
+    graph: dict[str, set[str]] = {
+        "sdcm.a": {"sdcm.b"},
+        "sdcm.b": {"sdcm.c"},
+        "sdcm.c": {"sdcm.a"},
+    }
+    cyclic_edges = find_cycles(graph)
+
+    partial_data = {
+        "edges": [
+            {"source": "sdcm.a", "target": "sdcm.b"},
+            {"source": "sdcm.b", "target": "sdcm.a"},
+        ]
+    }
+    allowlist_path.write_text(yaml.safe_dump(partial_data), encoding="utf-8")
+
+    allowlist = load_allowlist(allowlist_path)
+    new_edges = sorted(set(cyclic_edges) - allowlist)
+
+    assert len(new_edges) > 0
+    assert any("sdcm.c" in (src, tgt) for src, tgt in new_edges)
+
+
+# ---------------------------------------------------------------------------
+# Scenario 7 — __init__.py treated as package name
+# ---------------------------------------------------------------------------
+
+
+def test_init_py_treated_as_package(tmp_path):
+    """__init__.py files appear as 'sdcm.pkg', never as 'sdcm.pkg.__init__'."""
+    root = _make_project(tmp_path)
+    sdcm = root / "sdcm"
+    pkg_dir = sdcm / "pkg"
+    pkg_dir.mkdir()
+    (pkg_dir / "__init__.py").write_text("from sdcm.other import X\n", encoding="utf-8")
+    (sdcm / "other.py").write_text("", encoding="utf-8")
+
+    graph = _graph(root)
+
+    assert "sdcm.pkg" in graph
+    assert "sdcm.pkg.__init__" not in graph
+    assert "sdcm.other" in graph["sdcm.pkg"]
+
+
+# ---------------------------------------------------------------------------
+# Bonus — stdlib / third-party imports not in graph
+# ---------------------------------------------------------------------------
+
+
+def test_stdlib_imports_not_in_graph(tmp_path):
+    """Standard-library imports must not create graph edges."""
+    root = _make_project(tmp_path)
+    sdcm = root / "sdcm"
+    (sdcm / "foo.py").write_text("import os\nimport sys\n", encoding="utf-8")
+
+    graph = _graph(root)
+
+    assert "os" not in graph
+    assert "sys" not in graph
+    assert graph.get("sdcm.foo", set()) == set()
+
+
+def test_third_party_imports_not_in_graph(tmp_path):
+    """Third-party imports must not create graph edges."""
+    root = _make_project(tmp_path)
+    sdcm = root / "sdcm"
+    (sdcm / "foo.py").write_text("import boto3\nimport yaml\n", encoding="utf-8")
+
+    graph = _graph(root)
+
+    assert "boto3" not in graph
+    assert "yaml" not in graph
+    assert graph.get("sdcm.foo", set()) == set()
+
+
+def test_syntax_error_file_skipped(tmp_path):
+    """Files with SyntaxErrors are silently skipped; other files still processed."""
+    root = _make_project(tmp_path)
+    sdcm = root / "sdcm"
+    (sdcm / "bad.py").write_text("def broken(:\n    pass\n", encoding="utf-8")
+    (sdcm / "good.py").write_text("from sdcm.other import X\n", encoding="utf-8")
+    (sdcm / "other.py").write_text("", encoding="utf-8")
+
+    graph = _graph(root)
+
+    assert "sdcm.good" in graph
+    assert "sdcm.other" in graph["sdcm.good"]
+    assert graph.get("sdcm.bad", set()) == set()
+
+
+def test_function_level_imports_excluded(tmp_path):
+    """Imports inside function bodies are deferred and don't create import-time cycles."""
+    root = _make_project(tmp_path)
+    sdcm = root / "sdcm"
+    (sdcm / "foo.py").write_text(
+        "from sdcm.bar import top_level_thing\n"
+        "\n"
+        "def some_function():\n"
+        "    from sdcm.baz import deferred_thing\n"
+        "    return deferred_thing()\n",
+        encoding="utf-8",
+    )
+    (sdcm / "bar.py").write_text("", encoding="utf-8")
+    (sdcm / "baz.py").write_text("", encoding="utf-8")
+
+    graph = _graph(root)
+
+    assert "sdcm.bar" in graph["sdcm.foo"]
+    assert "sdcm.baz" not in graph["sdcm.foo"]
+
+
+def test_method_level_imports_excluded(tmp_path):
+    """Imports inside class methods are also deferred and excluded."""
+    root = _make_project(tmp_path)
+    sdcm = root / "sdcm"
+    (sdcm / "foo.py").write_text(
+        "from sdcm.bar import X\n"
+        "\n"
+        "class MyClass:\n"
+        "    def method(self):\n"
+        "        from sdcm.baz import Y\n"
+        "        return Y()\n",
+        encoding="utf-8",
+    )
+    (sdcm / "bar.py").write_text("", encoding="utf-8")
+    (sdcm / "baz.py").write_text("", encoding="utf-8")
+
+    graph = _graph(root)
+
+    assert "sdcm.bar" in graph["sdcm.foo"]
+    assert "sdcm.baz" not in graph["sdcm.foo"]

--- a/unit_tests/unit/test_detect_cyclic_imports.py
+++ b/unit_tests/unit/test_detect_cyclic_imports.py
@@ -1,0 +1,428 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2024 ScyllaDB
+
+"""Unit tests for scripts/detect_cyclic_imports.py."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import yaml
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+from detect_cyclic_imports import extract_imports, find_cycles, load_allowlist  # noqa: E402
+
+
+def _make_project(tmp_path: Path) -> Path:
+    """Create a fake project root with a sdcm/ package. Returns the project root (tmp_path)."""
+    sdcm_dir = tmp_path / "sdcm"
+    sdcm_dir.mkdir(parents=True, exist_ok=True)
+    return tmp_path
+
+
+def _graph(tmp_path: Path) -> dict[str, set[str]]:
+    """Extract imports and return just the graph dict."""
+    graph, _edges, _parse_errors = extract_imports(tmp_path)
+    return graph
+
+
+# ---------------------------------------------------------------------------
+# Scenario 1 — basic import extraction
+# ---------------------------------------------------------------------------
+
+
+def test_extract_imports_basic(tmp_path):
+    """extract_imports returns edge sdcm.foo -> sdcm.bar for a simple import."""
+    root = _make_project(tmp_path)
+    sdcm = root / "sdcm"
+    (sdcm / "foo.py").write_text("from sdcm.bar import X\n", encoding="utf-8")
+    (sdcm / "bar.py").write_text("", encoding="utf-8")
+
+    graph = _graph(root)
+
+    assert "sdcm.foo" in graph
+    assert "sdcm.bar" in graph["sdcm.foo"]
+
+
+# ---------------------------------------------------------------------------
+# Scenario 2 — TYPE_CHECKING guard excluded
+# ---------------------------------------------------------------------------
+
+
+def test_type_checking_imports_excluded(tmp_path):
+    """Imports inside 'if TYPE_CHECKING:' must NOT appear as graph edges."""
+    root = _make_project(tmp_path)
+    sdcm = root / "sdcm"
+    (sdcm / "foo.py").write_text(
+        "from typing import TYPE_CHECKING\nif TYPE_CHECKING:\n    from sdcm.bar import Baz\n",
+        encoding="utf-8",
+    )
+    (sdcm / "bar.py").write_text("", encoding="utf-8")
+
+    graph = _graph(root)
+
+    assert "sdcm.foo" in graph
+    assert "sdcm.bar" not in graph.get("sdcm.foo", set())
+
+
+# ---------------------------------------------------------------------------
+# Scenario 3 — relative import resolution
+# ---------------------------------------------------------------------------
+
+
+def test_relative_import_resolution(tmp_path):
+    """'from .base import Foo' in sdcm.pkg.sub resolves to sdcm.pkg.base."""
+    root = _make_project(tmp_path)
+    sdcm = root / "sdcm"
+    pkg_dir = sdcm / "pkg"
+    pkg_dir.mkdir()
+    (pkg_dir / "__init__.py").write_text("", encoding="utf-8")
+    (pkg_dir / "sub.py").write_text("from .base import Foo\n", encoding="utf-8")
+    (pkg_dir / "base.py").write_text("", encoding="utf-8")
+
+    graph = _graph(root)
+
+    assert "sdcm.pkg.sub" in graph
+    assert "sdcm.pkg.base" in graph["sdcm.pkg.sub"]
+
+
+# ---------------------------------------------------------------------------
+# Scenario 4 — cycle detection
+# ---------------------------------------------------------------------------
+
+
+def test_find_cycles_detects_cycle():
+    """find_cycles reports both directed edges of a two-node cycle."""
+    graph: dict[str, set[str]] = {
+        "sdcm.a": {"sdcm.b"},
+        "sdcm.b": {"sdcm.a"},
+    }
+
+    edges = find_cycles(graph)
+
+    assert ("sdcm.a", "sdcm.b") in edges
+    assert ("sdcm.b", "sdcm.a") in edges
+
+
+# ---------------------------------------------------------------------------
+# Scenario 5 — DAG has no false positives
+# ---------------------------------------------------------------------------
+
+
+def test_find_cycles_no_false_positives():
+    """A simple directed acyclic graph must produce no cyclic edges."""
+    graph: dict[str, set[str]] = {
+        "sdcm.a": {"sdcm.b"},
+        "sdcm.b": {"sdcm.c"},
+        "sdcm.c": set(),
+    }
+
+    assert find_cycles(graph) == []
+
+
+# ---------------------------------------------------------------------------
+# Scenario 6 — allowlist suppresses known edges
+# ---------------------------------------------------------------------------
+
+
+def test_allowlist_suppresses_known_edges(tmp_path):
+    """Edges present in the allowlist are excluded from new_edges."""
+    allowlist_path = tmp_path / "known_cyclic_imports.yml"
+    graph: dict[str, set[str]] = {
+        "sdcm.a": {"sdcm.b"},
+        "sdcm.b": {"sdcm.a"},
+    }
+    cyclic_edges = find_cycles(graph)
+
+    data = {"edges": [{"source": src, "target": tgt} for src, tgt in cyclic_edges]}
+    allowlist_path.write_text(yaml.safe_dump(data), encoding="utf-8")
+
+    allowlist = load_allowlist(allowlist_path)
+    new_edges = sorted(set(cyclic_edges) - allowlist)
+
+    assert new_edges == []
+
+
+def test_allowlist_reports_unlisted_edge(tmp_path):
+    """An edge absent from the allowlist is reported as a new cycle."""
+    allowlist_path = tmp_path / "known_cyclic_imports.yml"
+    graph: dict[str, set[str]] = {
+        "sdcm.a": {"sdcm.b"},
+        "sdcm.b": {"sdcm.c"},
+        "sdcm.c": {"sdcm.a"},
+    }
+    cyclic_edges = find_cycles(graph)
+
+    partial_data = {
+        "edges": [
+            {"source": "sdcm.a", "target": "sdcm.b"},
+            {"source": "sdcm.b", "target": "sdcm.a"},
+        ]
+    }
+    allowlist_path.write_text(yaml.safe_dump(partial_data), encoding="utf-8")
+
+    allowlist = load_allowlist(allowlist_path)
+    new_edges = sorted(set(cyclic_edges) - allowlist)
+
+    assert len(new_edges) > 0
+    assert any("sdcm.c" in (src, tgt) for src, tgt in new_edges)
+
+
+# ---------------------------------------------------------------------------
+# Scenario 7 — __init__.py treated as package name
+# ---------------------------------------------------------------------------
+
+
+def test_init_py_treated_as_package(tmp_path):
+    """__init__.py files appear as 'sdcm.pkg', never as 'sdcm.pkg.__init__'."""
+    root = _make_project(tmp_path)
+    sdcm = root / "sdcm"
+    pkg_dir = sdcm / "pkg"
+    pkg_dir.mkdir()
+    (pkg_dir / "__init__.py").write_text("from sdcm.other import X\n", encoding="utf-8")
+    (sdcm / "other.py").write_text("", encoding="utf-8")
+
+    graph = _graph(root)
+
+    assert "sdcm.pkg" in graph
+    assert "sdcm.pkg.__init__" not in graph
+    assert "sdcm.other" in graph["sdcm.pkg"]
+
+
+# ---------------------------------------------------------------------------
+# Bonus — stdlib / third-party imports not in graph
+# ---------------------------------------------------------------------------
+
+
+def test_stdlib_imports_not_in_graph(tmp_path):
+    """Standard-library imports must not create graph edges."""
+    root = _make_project(tmp_path)
+    sdcm = root / "sdcm"
+    (sdcm / "foo.py").write_text("import os\nimport sys\n", encoding="utf-8")
+
+    graph = _graph(root)
+
+    assert "os" not in graph
+    assert "sys" not in graph
+    assert graph.get("sdcm.foo", set()) == set()
+
+
+def test_third_party_imports_not_in_graph(tmp_path):
+    """Third-party imports must not create graph edges."""
+    root = _make_project(tmp_path)
+    sdcm = root / "sdcm"
+    (sdcm / "foo.py").write_text("import boto3\nimport yaml\n", encoding="utf-8")
+
+    graph = _graph(root)
+
+    assert "boto3" not in graph
+    assert "yaml" not in graph
+    assert graph.get("sdcm.foo", set()) == set()
+
+
+def test_syntax_error_file_skipped(tmp_path):
+    """Files with SyntaxErrors are silently skipped; other files still processed."""
+    root = _make_project(tmp_path)
+    sdcm = root / "sdcm"
+    (sdcm / "bad.py").write_text("def broken(:\n    pass\n", encoding="utf-8")
+    (sdcm / "good.py").write_text("from sdcm.other import X\n", encoding="utf-8")
+    (sdcm / "other.py").write_text("", encoding="utf-8")
+
+    graph, _edges, parse_errors = extract_imports(root)
+
+    assert "sdcm.good" in graph
+    assert "sdcm.other" in graph["sdcm.good"]
+    assert graph.get("sdcm.bad", set()) == set()
+    assert len(parse_errors) == 1
+    assert "bad.py" in parse_errors[0]
+
+
+def test_function_level_imports_excluded(tmp_path):
+    """Imports inside function bodies are deferred and don't create import-time cycles."""
+    root = _make_project(tmp_path)
+    sdcm = root / "sdcm"
+    (sdcm / "foo.py").write_text(
+        "from sdcm.bar import top_level_thing\n"
+        "\n"
+        "def some_function():\n"
+        "    from sdcm.baz import deferred_thing\n"
+        "    return deferred_thing()\n",
+        encoding="utf-8",
+    )
+    (sdcm / "bar.py").write_text("", encoding="utf-8")
+    (sdcm / "baz.py").write_text("", encoding="utf-8")
+
+    graph = _graph(root)
+
+    assert "sdcm.bar" in graph["sdcm.foo"]
+    assert "sdcm.baz" not in graph["sdcm.foo"]
+
+
+def test_method_level_imports_excluded(tmp_path):
+    """Imports inside class methods are also deferred and excluded."""
+    root = _make_project(tmp_path)
+    sdcm = root / "sdcm"
+    (sdcm / "foo.py").write_text(
+        "from sdcm.bar import X\n"
+        "\n"
+        "class MyClass:\n"
+        "    def method(self):\n"
+        "        from sdcm.baz import Y\n"
+        "        return Y()\n",
+        encoding="utf-8",
+    )
+    (sdcm / "bar.py").write_text("", encoding="utf-8")
+    (sdcm / "baz.py").write_text("", encoding="utf-8")
+
+    graph = _graph(root)
+
+    assert "sdcm.bar" in graph["sdcm.foo"]
+    assert "sdcm.baz" not in graph["sdcm.foo"]
+
+
+# ---------------------------------------------------------------------------
+# Scenario 8 — package-style imports (`from pkg import mod`)
+# ---------------------------------------------------------------------------
+
+
+def test_package_style_import_creates_submodule_edge(tmp_path):
+    """'from sdcm.pkg import mod' edges to sdcm.pkg.mod, not just to sdcm.pkg."""
+    root = _make_project(tmp_path)
+    sdcm = root / "sdcm"
+    pkg_dir = sdcm / "pkg"
+    pkg_dir.mkdir()
+    (pkg_dir / "__init__.py").write_text("", encoding="utf-8")
+    (pkg_dir / "mod.py").write_text("", encoding="utf-8")
+    (sdcm / "foo.py").write_text("from sdcm.pkg import mod\n", encoding="utf-8")
+
+    graph = _graph(root)
+
+    assert "sdcm.pkg.mod" in graph["sdcm.foo"]
+    assert "sdcm.pkg" in graph["sdcm.foo"]
+
+
+def test_relative_package_style_import_creates_submodule_edge(tmp_path):
+    """'from . import sibling' edges to the sibling module, not to the package."""
+    root = _make_project(tmp_path)
+    pkg_dir = root / "sdcm" / "pkg"
+    pkg_dir.mkdir(parents=True)
+    (pkg_dir / "__init__.py").write_text("", encoding="utf-8")
+    (pkg_dir / "sub.py").write_text("from . import sibling\n", encoding="utf-8")
+    (pkg_dir / "sibling.py").write_text("", encoding="utf-8")
+
+    graph = _graph(root)
+
+    assert "sdcm.pkg.sibling" in graph["sdcm.pkg.sub"]
+
+
+def test_attribute_import_keeps_package_edge_only(tmp_path):
+    """'from sdcm.bar import SomeClass' must not invent an sdcm.bar.SomeClass node."""
+    root = _make_project(tmp_path)
+    sdcm = root / "sdcm"
+    (sdcm / "foo.py").write_text("from sdcm.bar import SomeClass\n", encoding="utf-8")
+    (sdcm / "bar.py").write_text("SomeClass = object\n", encoding="utf-8")
+
+    graph = _graph(root)
+
+    assert graph["sdcm.foo"] == {"sdcm.bar"}
+    assert "sdcm.bar.SomeClass" not in graph
+
+
+def test_package_style_cycle_detected(tmp_path):
+    """Two siblings importing each other package-style form a detectable cycle."""
+    root = _make_project(tmp_path)
+    pkg_dir = root / "sdcm" / "pkg"
+    pkg_dir.mkdir(parents=True)
+    (pkg_dir / "__init__.py").write_text("", encoding="utf-8")
+    (pkg_dir / "a.py").write_text("from sdcm.pkg import b\n", encoding="utf-8")
+    (pkg_dir / "b.py").write_text("from sdcm.pkg import a\n", encoding="utf-8")
+
+    cyclic_edges = find_cycles(_graph(root))
+
+    assert ("sdcm.pkg.a", "sdcm.pkg.b") in cyclic_edges
+    assert ("sdcm.pkg.b", "sdcm.pkg.a") in cyclic_edges
+
+
+# ---------------------------------------------------------------------------
+# Scenario 9 — ancestor packages are not cycle participants
+# ---------------------------------------------------------------------------
+
+
+def test_ancestor_package_edge_excluded(tmp_path):
+    """A submodule importing through its own package is structural, not a cycle."""
+    root = _make_project(tmp_path)
+    pkg_dir = root / "sdcm" / "pkg"
+    pkg_dir.mkdir(parents=True)
+    (pkg_dir / "__init__.py").write_text("from sdcm.pkg import api\n", encoding="utf-8")
+    (pkg_dir / "api.py").write_text("from sdcm.pkg import consts\n", encoding="utf-8")
+    (pkg_dir / "consts.py").write_text("", encoding="utf-8")
+
+    graph = _graph(root)
+
+    assert "sdcm.pkg" not in graph["sdcm.pkg.api"]
+    assert "sdcm.pkg.consts" in graph["sdcm.pkg.api"]
+    assert find_cycles(graph) == []
+
+
+def test_import_of_own_ancestor_excluded(tmp_path):
+    """'import sdcm.pkg' inside sdcm.pkg.sub does not create a self-referential edge."""
+    root = _make_project(tmp_path)
+    pkg_dir = root / "sdcm" / "pkg"
+    pkg_dir.mkdir(parents=True)
+    (pkg_dir / "__init__.py").write_text("", encoding="utf-8")
+    (pkg_dir / "sub.py").write_text("import sdcm.pkg\n", encoding="utf-8")
+
+    graph = _graph(root)
+
+    assert graph["sdcm.pkg.sub"] == set()
+
+
+# ---------------------------------------------------------------------------
+# Scenario 10 — cross-component edges are not cycles
+# ---------------------------------------------------------------------------
+
+
+def test_bridge_between_two_cycles_not_reported():
+    """A one-way edge linking two disjoint cycles is not itself cyclic."""
+    graph: dict[str, set[str]] = {
+        "sdcm.a": {"sdcm.b"},
+        "sdcm.b": {"sdcm.a", "sdcm.c"},
+        "sdcm.c": {"sdcm.d"},
+        "sdcm.d": {"sdcm.c"},
+    }
+
+    edges = find_cycles(graph)
+
+    assert ("sdcm.b", "sdcm.c") not in edges
+    assert sorted(edges) == [
+        ("sdcm.a", "sdcm.b"),
+        ("sdcm.b", "sdcm.a"),
+        ("sdcm.c", "sdcm.d"),
+        ("sdcm.d", "sdcm.c"),
+    ]
+
+
+def test_three_node_cycle_fully_reported():
+    """Every edge of a 3-node cycle is reported."""
+    graph: dict[str, set[str]] = {
+        "sdcm.a": {"sdcm.b"},
+        "sdcm.b": {"sdcm.c"},
+        "sdcm.c": {"sdcm.a"},
+    }
+
+    assert sorted(find_cycles(graph)) == [
+        ("sdcm.a", "sdcm.b"),
+        ("sdcm.b", "sdcm.c"),
+        ("sdcm.c", "sdcm.a"),
+    ]


### PR DESCRIPTION
## Summary

Adds a pre-commit hook that detects cyclic imports using Python's `ast` module and Tarjan's SCC algorithm. Blocks new cycles from being introduced while grandfathering existing ones via an edge-level allowlist.

## Motivation

Cyclic imports in Python cause subtle runtime errors and import failures. This tooling prevents new ones from being introduced, with a path to fixing existing ones incrementally.

## Implementation

- **`scripts/detect_cyclic_imports.py`**: Standalone detector using Python `ast` module + Tarjan SCC
  - TYPE_CHECKING-guarded imports excluded (avoids false positives)
  - Function-level (deferred) imports excluded — they cannot cause an import-time cycle
  - Relative imports resolved via file path context
  - `from pkg import mod` resolves to the submodule `pkg.mod`, not just the package
  - Edges from a module up to its own ancestor packages are dropped (structural, not cyclic)
  - An edge counts only when both ends are in the *same* SCC, so a one-way bridge between two disjoint cycles is not reported
  - A file that fails to parse is an error, not a silent skip — the graph would be incomplete
  - Only project-internal edges analyzed (stdlib + third-party ignored)
  - Runtime: ~1s for a full scan
  - CLI: `--update-allowlist`, `--verbose`, `--include-deferred`
- **`data/known_cyclic_imports.yml`**: allowlist — **currently empty**. Once deferred (function-level) imports are excluded, the repo has no import-time cycles left to grandfather. Deferred-inclusive mode still reports 657 edges; fixing those is follow-up work and deliberately out of scope here.
- **`unit_tests/unit/test_detect_cyclic_imports.py`**: 21 pytest tests (extraction, TYPE_CHECKING exclusion, relative + package-style imports, ancestor edges, cross-SCC bridges, cycle detection, allowlist, edge cases)
- **`docs/cyclic-import-detection.md`**: usage, cycle-breaking strategies, and the parent/child scope limitation
- **`.pre-commit-config.yaml`**: New `cyclic-imports` hook (`language: system`)

## Design Decisions

- **Python `ast` over ast-grep**: Natively handles TYPE_CHECKING guards, relative imports, try/except — ast-grep cannot distinguish these
- **No new dependencies**: Tarjan SCC is ~40 lines of Python. The first iteration pulled in networkx, which was overkill. PyYAML is the only import beyond the stdlib and is already a hard dependency of SCT
- **Edge-level allowlist**: More stable across refactors than cycle-path-level; pairs of (source, target) modules
- **Whole-repo scan, not `sdcm/`-only**: cycles between top-level test modules and `sdcm/` matter too
- **Import-time cycles first**: deferred imports are a much larger, lower-priority backlog; surfacing the ones that actually break at import time is the point

## Usage

```bash
# Check for new cycles (used by pre-commit):
uv run python scripts/detect_cyclic_imports.py

# Regenerate allowlist after intentionally adding a cycle:
uv run python scripts/detect_cyclic_imports.py --update-allowlist

# Show all known cycles:
uv run python scripts/detect_cyclic_imports.py --verbose

# Diagnostics: include function-level imports (not used by pre-commit):
uv run python scripts/detect_cyclic_imports.py --verbose --include-deferred
```

Ref: SCT-531

### Testing
- [x] 21 unit tests pass
- [x] Pre-commit hook passes on current codebase
- [x] Synthetic cycle injection correctly detected and blocked (both `from pkg import mod` and `from . import mod` forms)

### PR pre-checks (self review)
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code
