### PR TITLE
fix(config): disable simulated racks for RF=1 use case

### DIFF
--- a/configurations/rf1-non-disruptive.yaml
+++ b/configurations/rf1-non-disruptive.yaml
@@ -6,6 +6,10 @@ stress_cmd:
   - "cassandra-stress write cl=ONE duration=240m  -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=1)' -mode cql3 native -rate threads=250  -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=400200300..600200300 -log interval=15"
 run_fullscan: ['{"mode": "table_and_aggregate", "ks_cf": "keyspace1.standard1", "interval": 5}']
 
+# Disable simulated racks for RF=1 — rack simulation is meaningless with a single replica.
+# See: https://scylladb.atlassian.net/browse/SCYLLADB-2896
+simulated_racks: 0
+
 nemesis_class_name: 'SisyphusMonkey'
 nemesis_selector: "not disruptive"
 nemesis_seed: '24325345'


### PR DESCRIPTION
Rack simulation is meaningless with `replication_factor=1` since there is only a single replica and no benefit from rack-aware placement. This sets `simulated_racks: 0` in the `rf1-non-disruptive` configuration fragment.

**Changes:**
- `configurations/rf1-non-disruptive.yaml`: Added `simulated_racks: 0` with comment linking to the Jira issue

Fixes: [SCYLLADB-2896](https://scylladb.atlassian.net/browse/SCYLLADB-2896)

[SCYLLADB-2896]: https://scylladb.atlassian.net/browse/SCYLLADB-2896?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ