### PR TITLE
fix(nemesis): use dedicated keyspace for refresh/load-and-stream to avoid stress conflicts

### DIFF
--- a/sdcm/nemesis/__init__.py
+++ b/sdcm/nemesis/__init__.py
@@ -1674,10 +1674,12 @@ class NemesisRunner:
         self._major_compaction()
 
     def disrupt_load_and_stream(self):
-        # Checking the columns number of keyspace1.standard1
-        self.log.debug("Prepare keyspace1.standard1 if it does not exist")
-        self._prepare_test_table(ks="keyspace1")
-        column_num = SstableLoadUtils.calculate_columns_count_in_table(self.target_node)
+        # Checking the columns number of keyspace_refresh.standard1
+        self.log.debug("Prepare keyspace_refresh.standard1 if it does not exist")
+        self._prepare_test_table(ks="keyspace_refresh")
+        column_num = SstableLoadUtils.calculate_columns_count_in_table(
+            self.target_node, keyspace_name="keyspace_refresh"
+        )
 
         # Run load-and-stream test on regular standard1 table of cassandra-stress.
         if column_num < 5:
@@ -1685,26 +1687,32 @@ class NemesisRunner:
 
         test_data = SstableLoadUtils.get_load_test_data_inventory(column_num, big_sstable=False, load_and_stream=True)
 
-        result = self.target_node.run_nodetool(sub_cmd="cfstats", args="keyspace1.standard1")
+        result = self.target_node.run_nodetool(sub_cmd="cfstats", args="keyspace_refresh.standard1")
 
-        if result is not None and result.exit_status == 0:
-            map_files_to_node = SstableLoadUtils.distribute_test_files_to_cluster_nodes(
-                nodes=self.cluster.data_nodes, test_data=test_data
+        if result is None or result.exit_status != 0:
+            raise UnsupportedNemesis("cfstats failed for keyspace_refresh.standard1, table may not exist yet")
+
+        map_files_to_node = SstableLoadUtils.distribute_test_files_to_cluster_nodes(
+            nodes=self.cluster.data_nodes, test_data=test_data
+        )
+        for sstables_info, load_on_node in map_files_to_node:
+            self.actions_log.info(f"Uploading sstables to {load_on_node.name}")
+            SstableLoadUtils.upload_sstables(
+                load_on_node, test_data=sstables_info, keyspace_name="keyspace_refresh", table_name="standard1"
             )
-            for sstables_info, load_on_node in map_files_to_node:
-                self.actions_log.info(f"Uploading sstables to {load_on_node.name}")
-                SstableLoadUtils.upload_sstables(load_on_node, test_data=sstables_info, table_name="standard1")
-                # NOTE: on K8S logs may appear with a delay, so add a bigger timeout for it.
-                #       See https://github.com/scylladb/scylla-cluster-tests/issues/6314
-                kwargs = {"start_timeout": 1800, "end_timeout": 1800} if self._is_it_on_kubernetes() else {}
-                with self.action_log_scope(f"Loading and streaming sstables on {load_on_node.name} node"):
-                    SstableLoadUtils.run_load_and_stream(load_on_node, **kwargs)
+            # NOTE: on K8S logs may appear with a delay, so add a bigger timeout for it.
+            #       See https://github.com/scylladb/scylla-cluster-tests/issues/6314
+            kwargs = {"start_timeout": 1800, "end_timeout": 1800} if self._is_it_on_kubernetes() else {}
+            with self.action_log_scope(f"Loading and streaming sstables on {load_on_node.name} node"):
+                SstableLoadUtils.run_load_and_stream(load_on_node, **kwargs)
 
     def disrupt_nodetool_refresh(self, big_sstable: bool = False):
-        # Checking the columns number of keyspace1.standard1
-        self.log.debug("Prepare keyspace1.standard1 if it does not exist")
-        self._prepare_test_table(ks="keyspace1")
-        column_num = SstableLoadUtils.calculate_columns_count_in_table(self.target_node)
+        # Checking the columns number of keyspace_refresh.standard1
+        self.log.debug("Prepare keyspace_refresh.standard1 if it does not exist")
+        self._prepare_test_table(ks="keyspace_refresh")
+        column_num = SstableLoadUtils.calculate_columns_count_in_table(
+            self.target_node, keyspace_name="keyspace_refresh", table_name="standard1"
+        )
 
         # Note: when issue #6617 is fixed, we can try to load snapshot (cols=5) to a table (1 < cols < 5),
         #       expect that refresh will fail (no serious db error).
@@ -1715,43 +1723,43 @@ class NemesisRunner:
             column_num, big_sstable=big_sstable, load_and_stream=False
         )
 
-        result = self.target_node.run_nodetool(sub_cmd="cfstats", args="keyspace1.standard1")
+        result = self.target_node.run_nodetool(sub_cmd="cfstats", args="keyspace_refresh.standard1")
 
-        if result is not None and result.exit_status == 0:
-            key = "0x32373131364f334f3830"
-            # Check one special key before refresh, we will verify refresh by query in the end
-            # Note: we can't DELETE the key before refresh, otherwise the old sstable won't be loaded
-            #       TRUNCATE can be used the clean the table, but we can't do it for keyspace1.standard1
-            query_verify = f"SELECT * FROM keyspace1.standard1 WHERE key={key}"
-            result = self.target_node.run_cqlsh(query_verify)
-            if "(0 rows)" in result.stdout:
-                self.log.debug("Key %s does not exist before refresh", key)
-            else:
-                self.log.debug("Key %s already exists before refresh", key)
+        if result is None or result.exit_status != 0:
+            raise UnsupportedNemesis("cfstats failed for keyspace_refresh.standard1, table may not exist yet")
 
-            # Executing rolling refresh one by one
-            shards_num = self.cluster.data_nodes[0].scylla_shards
-            for node in self.cluster.data_nodes:
-                SstableLoadUtils.upload_sstables(
-                    node,
-                    test_data=test_data[0],
-                    table_name="standard1",
-                    is_cloud_cluster=self.cluster.params.get("db_type") == "cloud_scylla",
-                )
-                with self.action_log_scope(f"Running nodetool refresh on {node.name} node"):
-                    system_log_follower = SstableLoadUtils.run_refresh(node, test_data=test_data[0])
-                # NOTE: resharding happens only if we have more than 1 core.
-                #       We may have 1 core in a K8S setup.
-                # If tablets in use, skipping resharding validation since it doesn't work the same as vnodes
-                if shards_num > 1 and not is_tablets_feature_enabled(self.cluster.data_nodes[0]):
-                    self.actions_log.info(f"Validating resharding after refresh on {node.name}")
-                    SstableLoadUtils.validate_resharding_after_refresh(
-                        node=node, system_log_follower=system_log_follower
-                    )
+        key = "0x32373131364f334f3830"
+        # Check one special key before refresh, we will verify refresh by query in the end
+        # Note: we can't DELETE the key before refresh, otherwise the old sstable won't be loaded
+        #       TRUNCATE can be used the clean the table, but we can't do it for keyspace_refresh.standard1
+        query_verify = f"SELECT * FROM keyspace_refresh.standard1 WHERE key={key}"
+        result = self.target_node.run_cqlsh(query_verify)
+        if "(0 rows)" in result.stdout:
+            self.log.debug("Key %s does not exist before refresh", key)
+        else:
+            self.log.debug("Key %s already exists before refresh", key)
 
-            # Verify that the special key is loaded by SELECT query
-            result = self.target_node.run_cqlsh(query_verify)
-            assert "(1 rows)" in result.stdout, f"The key {key} is not loaded by `nodetool refresh`"
+        # Executing rolling refresh one by one
+        shards_num = self.cluster.data_nodes[0].scylla_shards
+        for node in self.cluster.data_nodes:
+            SstableLoadUtils.upload_sstables(
+                node,
+                test_data=test_data[0],
+                table_name="standard1",
+                is_cloud_cluster=self.cluster.params.get("db_type") == "cloud_scylla",
+            )
+            with self.action_log_scope(f"Running nodetool refresh on {node.name} node"):
+                system_log_follower = SstableLoadUtils.run_refresh(node, test_data=test_data[0])
+            # NOTE: resharding happens only if we have more than 1 core.
+            #       We may have 1 core in a K8S setup.
+            # If tablets in use, skipping resharding validation since it doesn't work the same as vnodes
+            if shards_num > 1 and not is_tablets_feature_enabled(self.cluster.data_nodes[0]):
+                self.actions_log.info(f"Validating resharding after refresh on {node.name}")
+                SstableLoadUtils.validate_resharding_after_refresh(node=node, system_log_follower=system_log_follower)
+
+        # Verify that the special key is loaded by SELECT query
+        result = self.target_node.run_cqlsh(query_verify)
+        assert "(1 rows)" in result.stdout, f"The key {key} is not loaded by `nodetool refresh`"
 
     def _k8s_fake_enospc_error(self, node):
         """Fakes ENOSPC error for scylla container (for /var/lib/scylla dir) using chaos-mesh without filling up disk."""
@@ -2169,12 +2177,10 @@ class NemesisRunner:
         """Populate ``ks.standard1`` with 400 K rows via cassandra-stress."""
         stress_cmd = (
             "cassandra-stress write n=400000 cl=QUORUM -mode native cql3 "
-            f"-schema 'replication(strategy=NetworkTopologyStrategy,"
+            f"-schema 'keyspace={ks} replication(strategy=NetworkTopologyStrategy,"
             f"replication_factor={self.tester.reliable_replication_factor})' -log interval=5"
         )
-        cs_thread = self.tester.run_stress_thread(
-            stress_cmd=stress_cmd, keyspace_name=ks, stop_test_on_failure=False, round_robin=True
-        )
+        cs_thread = self.tester.run_stress_thread(stress_cmd=stress_cmd, stop_test_on_failure=False, round_robin=True)
         self.tester.verify_stress_thread(cs_thread, error_handler=self._nemesis_stress_failure_handler)
 
     def _nemesis_stress_failure_handler(self, stress_pool, errors):

--- a/sdcm/remote/local_cmd_runner.py
+++ b/sdcm/remote/local_cmd_runner.py
@@ -56,6 +56,7 @@ class LocalCmdRunner(CommandRunner):
         watchers: Optional[List[StreamWatcher]] = None,
         change_context: bool = False,
         timestamp_logs: bool = False,
+        user: Optional[str] = None,
     ) -> Result:
         watchers = self._setup_watchers(
             verbose=verbose, log_file=log_file, additional_watchers=watchers, timestamp_logs=timestamp_logs

--- a/sdcm/utils/sstable/load_utils.py
+++ b/sdcm/utils/sstable/load_utils.py
@@ -32,7 +32,7 @@ class SstableLoadUtils:
 
     @staticmethod
     def calculate_columns_count_in_table(
-        target_node, keyspace_name: str = "keyspace1", table_name: str = "standard1"
+        target_node, keyspace_name: str = "keyspace_refresh", table_name: str = "standard1"
     ) -> int:
         query_cmd = f"SELECT * FROM {keyspace_name}.{table_name} LIMIT 1"
         result = target_node.run_cqlsh(query_cmd)
@@ -67,7 +67,7 @@ class SstableLoadUtils:
     def upload_sstables(
         node,
         test_data: TestDataInventory,
-        keyspace_name: str = "keyspace1",
+        keyspace_name: str = "keyspace_refresh",
         table_name=None,
         create_schema: bool = False,
         is_cloud_cluster=False,
@@ -129,7 +129,12 @@ class SstableLoadUtils:
 
     @classmethod
     def run_load_and_stream(
-        cls, node, keyspace_name: str = "keyspace1", table_name: str = "standard1", start_timeout=60, end_timeout=600
+        cls,
+        node,
+        keyspace_name: str = "keyspace_refresh",
+        table_name: str = "standard1",
+        start_timeout=60,
+        end_timeout=600,
     ):
         """runs load and stream using API request and waits for it to finish"""
         with wait_for_log_lines(
@@ -155,7 +160,7 @@ class SstableLoadUtils:
         # Find the compaction output that reported about the resharding
 
         system_log_follower = node.follow_system_log(patterns=[r"Resharded.*"])
-        node.run_nodetool(sub_cmd="refresh", args="-- keyspace1 standard1")
+        node.run_nodetool(sub_cmd="refresh", args="-- keyspace_refresh standard1")
         return system_log_follower
 
     @staticmethod
@@ -169,24 +174,24 @@ class SstableLoadUtils:
         # Validate that files after resharding were saved in the "upload" folder.
         # Example of compaction output:
 
-        #   scylla[6653]:  [shard 0] compaction - [Reshard keyspace1.standard1 3cad4140-f8c3-11ea-acb1-000000000002]
+        #   scylla[6653]:  [shard 0] compaction - [Reshard keyspace_refresh.standard1 3cad4140-f8c3-11ea-acb1-000000000002]
         #   Resharded 1 sstables to [
-        #   /var/lib/scylla/data/keyspace1/standard1-9fbed8d0f8c211ea9bb1000000000000/upload/md-9-big-Data.db:level=0,
-        #   /var/lib/scylla/data/keyspace1/standard1-9fbed8d0f8c211ea9bb1000000000000/upload/md-10-big-Data.db:level=0,
-        #   /var/lib/scylla/data/keyspace1/standard1-9fbed8d0f8c211ea9bb1000000000000/upload/md-11-big-Data.db:level=0,
-        #   /var/lib/scylla/data/keyspace1/standard1-9fbed8d0f8c211ea9bb1000000000000/upload/md-12-big-Data.db:level=0,
-        #   /var/lib/scylla/data/keyspace1/standard1-9fbed8d0f8c211ea9bb1000000000000/upload/md-13-big-Data.db:level=0,
-        #   /var/lib/scylla/data/keyspace1/standard1-9fbed8d0f8c211ea9bb1000000000000/upload/md-22-big-Data.db:level=0,
-        #   /var/lib/scylla/data/keyspace1/standard1-9fbed8d0f8c211ea9bb1000000000000/upload/md-15-big-Data.db:level=0,
-        #   /var/lib/scylla/data/keyspace1/standard1-9fbed8d0f8c211ea9bb1000000000000/upload/md-16-big-Data.db:level=0,
+        #   /var/lib/scylla/data/keyspace_refresh/standard1-9fbed8d0f8c211ea9bb1000000000000/upload/md-9-big-Data.db:level=0,
+        #   /var/lib/scylla/data/keyspace_refresh/standard1-9fbed8d0f8c211ea9bb1000000000000/upload/md-10-big-Data.db:level=0,
+        #   /var/lib/scylla/data/keyspace_refresh/standard1-9fbed8d0f8c211ea9bb1000000000000/upload/md-11-big-Data.db:level=0,
+        #   /var/lib/scylla/data/keyspace_refresh/standard1-9fbed8d0f8c211ea9bb1000000000000/upload/md-12-big-Data.db:level=0,
+        #   /var/lib/scylla/data/keyspace_refresh/standard1-9fbed8d0f8c211ea9bb1000000000000/upload/md-13-big-Data.db:level=0,
+        #   /var/lib/scylla/data/keyspace_refresh/standard1-9fbed8d0f8c211ea9bb1000000000000/upload/md-22-big-Data.db:level=0,
+        #   /var/lib/scylla/data/keyspace_refresh/standard1-9fbed8d0f8c211ea9bb1000000000000/upload/md-15-big-Data.db:level=0,
+        #   /var/lib/scylla/data/keyspace_refresh/standard1-9fbed8d0f8c211ea9bb1000000000000/upload/md-16-big-Data.db:level=0,
         #   ]. 91MB to 92MB (~100% of original) in 5009ms = 18MB/s. ~370176 total partitions merged to 370150
 
         Starting with Scylla 4.7 messages have changed to the following:
-        [shard 1] sstables_loader - Loading new SSTables for keyspace=keyspace1, table=standard1, ...
-        [shard 1] database - Resharding 223kB for keyspace1.standard1
-        [shard 1] database - Resharded 223kB for keyspace1.standard1 in 0.14 seconds, 1MB/s
-        [shard 1] database - Loaded 16 SSTables into /var/lib/scylla/data/keyspace1/standard1-eb0401905d8311ecb391aa52ebf0b3e1
-        [shard 1] sstables_loader - Done loading new SSTables for keyspace=keyspace1, table=standard1, ...
+        [shard 1] sstables_loader - Loading new SSTables for keyspace=keyspace_refresh, table=standard1, ...
+        [shard 1] database - Resharding 223kB for keyspace_refresh.standard1
+        [shard 1] database - Resharded 223kB for keyspace_refresh.standard1 in 0.14 seconds, 1MB/s
+        [shard 1] database - Loaded 16 SSTables into /var/lib/scylla/data/keyspace_refresh/standard1-eb0401905d8311ecb391aa52ebf0b3e1
+        [shard 1] sstables_loader - Done loading new SSTables for keyspace=keyspace_refresh, table=standard1, ...
 
         So, there is no per-file paths anymore for resharding log messages, only root dir path.
         """
@@ -230,7 +235,7 @@ class SstableLoadUtils:
     def create_keyspace(
         cls,
         node,
-        keyspace_name: str = "keyspace1",
+        keyspace_name: str = "keyspace_refresh",
         strategy: str = "NetworkTopologyStrategy",
         replication_factor: int = 1,
     ):
@@ -245,7 +250,7 @@ class SstableLoadUtils:
         session.execute(schema.replace("\n", ""))
 
     @classmethod
-    def validate_data_count_after_upload(cls, node, keyspace_name: str = "keyspace1", table_name: str = "standard1"):
+    def validate_data_count_after_upload(cls, node, keyspace_name: str = "keyspace1", table_name: str = "standard2"):
         result = node.run_cqlsh(f"consistency QUORUM;SELECT COUNT(*) FROM {keyspace_name}.{table_name}")
 
         next_line_is_result = False

--- a/unit_tests/integration/test_sstable_load_utils.py
+++ b/unit_tests/integration/test_sstable_load_utils.py
@@ -1,0 +1,64 @@
+import pytest
+
+from sdcm.utils.sstable.load_utils import SstableLoadUtils
+
+from sdcm.stress_thread import CassandraStressThread
+from unit_tests.lib.dummy_remote import LocalLoaderSetDummy
+
+pytestmark = [
+    pytest.mark.usefixtures("events"),
+    pytest.mark.integration,
+    pytest.mark.xdist_group("docker_heavy"),
+]
+
+
+@pytest.mark.integration
+def test_sstable_load_utils_usage(docker_scylla, params, request):
+    """test the sstable load utils base on the refrash monkey flow localy with a docker based scylla"""
+
+    loader_set = LocalLoaderSetDummy(params=params)
+
+    ks = "keyspace_refresh"
+    stress_cmd = (
+        "cassandra-stress write n=40000 cl=ONE -mode native cql3 "
+        f"-schema 'keyspace={ks} replication(strategy=NetworkTopologyStrategy,"
+        f"replication_factor=1)' -log interval=5"
+    )
+    cs_thread = CassandraStressThread(loader_set, stress_cmd, node_list=[docker_scylla], timeout=120, params=params)
+
+    def cleanup_thread():
+        cs_thread.kill()
+
+    request.addfinalizer(cleanup_thread)
+
+    cs_thread.run()
+
+    output, _ = cs_thread.parse_results()
+
+    column_num = SstableLoadUtils.calculate_columns_count_in_table(
+        docker_scylla, keyspace_name="keyspace_refresh", table_name="standard1"
+    )
+
+    assert column_num
+    test_data = SstableLoadUtils.get_load_test_data_inventory(column_num, big_sstable=False, load_and_stream=False)
+
+    result = docker_scylla.run_nodetool(sub_cmd="cfstats", args="keyspace_refresh.standard1")
+    assert result is not None and result.exit_status == 0, "cfstats failed, table keyspace_refresh.standard1 not ready"
+
+    key = "0x32373131364f334f3830"
+    query_verify = f"SELECT * FROM keyspace_refresh.standard1 WHERE key={key}"
+    result = docker_scylla.run_cqlsh(query_verify)
+    assert "(0 rows)" in result.stdout
+
+    # Executing refresh
+    SstableLoadUtils.upload_sstables(
+        docker_scylla,
+        test_data=test_data[0],
+        table_name="standard1",
+        is_cloud_cluster=False,
+    )
+    docker_scylla.run_nodetool(sub_cmd="refresh", args="-- keyspace_refresh standard1")
+
+    # Verify that the special key is loaded by SELECT query
+    result = docker_scylla.run_cqlsh(query_verify)
+    assert "(1 rows)" in result.stdout, f"The key {key} is not loaded by `nodetool refresh`"

--- a/unit_tests/lib/fake_cluster.py
+++ b/unit_tests/lib/fake_cluster.py
@@ -37,7 +37,7 @@ class FakeSstableRemoter:
     def run(self, *args, **kwargs):
         lines = [
             "[shard 11] sstables_loader - load_and_stream: started ops_uuid=a2661989-6836-418f-aa67-2c5466499848, process [0-1] out",
-            "[shard  2] sstables_loader - Done loading new SSTables for keyspace=keyspace1, table=standard1, load_and_stream=true, "
+            "[shard  2] sstables_loader - Done loading new SSTables for keyspace=keyspace_refresh, table=standard1, load_and_stream=true, "
             "primary_replica_only=false, status=succeeded",
         ]
         for line in lines:

--- a/unit_tests/test_data/load_and_stream.log
+++ b/unit_tests/test_data/load_and_stream.log
@@ -1,29 +1,29 @@
-2021-08-12T06:07:19+00:00  longevity-10gb-3h-load-and-db-node-65bd71ec-1 !INFO    | scylla:  [shard 7] compaction - [Compact keyspace1.standard1 8d418f80-fb33-11eb-9b17-403073af4e08] Compacting [/var/lib/scylla/
-data/keyspace1/standard1-501e29b0fb3311ebb71a4875c5785232/md-55-big-Data.db:level=0:origin=streaming,/var/lib/scylla/data/keyspace1/standard1-501e29b0fb3311ebb71a4875c5785232/md-47-big-Data.db:level=0:origin=com
+2021-08-12T06:07:19+00:00  longevity-10gb-3h-load-and-db-node-65bd71ec-1 !INFO    | scylla:  [shard 7] compaction - [Compact keyspace_refresh.standard1 8d418f80-fb33-11eb-9b17-403073af4e08] Compacting [/var/lib/scylla/
+data/keyspace_refresh/standard1-501e29b0fb3311ebb71a4875c5785232/md-55-big-Data.db:level=0:origin=streaming,/var/lib/scylla/data/keyspace_refresh/standard1-501e29b0fb3311ebb71a4875c5785232/md-47-big-Data.db:level=0:origin=com
 paction]
-2021-08-12T06:07:19+00:00  longevity-10gb-3h-load-and-db-node-65bd71ec-1 !INFO    | scylla:  [shard 7] storage_service - load_and_stream: ops_uuid=180d1761-f0f0-4527-a5aa-4b547b321adc, ks=keyspace1, table=standa
+2021-08-12T06:07:19+00:00  longevity-10gb-3h-load-and-db-node-65bd71ec-1 !INFO    | scylla:  [shard 7] storage_service - load_and_stream: ops_uuid=180d1761-f0f0-4527-a5aa-4b547b321adc, ks=keyspace_refresh, table=standa
 rd1, target_node=10.0.2.144, num_partitions_sent=47973, num_bytes_sent=25329744
-2021-08-12T06:07:19+00:00  longevity-10gb-3h-load-and-db-node-65bd71ec-1 !INFO    | scylla:  [shard 7] storage_service - load_and_stream: ops_uuid=180d1761-f0f0-4527-a5aa-4b547b321adc, ks=keyspace1, table=standa
+2021-08-12T06:07:19+00:00  longevity-10gb-3h-load-and-db-node-65bd71ec-1 !INFO    | scylla:  [shard 7] storage_service - load_and_stream: ops_uuid=180d1761-f0f0-4527-a5aa-4b547b321adc, ks=keyspace_refresh, table=standa
 rd1, target_node=10.0.1.134, num_partitions_sent=47973, num_bytes_sent=25329744
-2021-08-12T06:07:19+00:00  longevity-10gb-3h-load-and-db-node-65bd71ec-1 !INFO    | scylla:  [shard 7] storage_service - load_and_stream: ops_uuid=180d1761-f0f0-4527-a5aa-4b547b321adc, ks=keyspace1, table=standa
+2021-08-12T06:07:19+00:00  longevity-10gb-3h-load-and-db-node-65bd71ec-1 !INFO    | scylla:  [shard 7] storage_service - load_and_stream: ops_uuid=180d1761-f0f0-4527-a5aa-4b547b321adc, ks=keyspace_refresh, table=standa
 rd1, target_node=10.0.0.79, num_partitions_sent=47973, num_bytes_sent=25329744
-2021-08-12T06:07:19+00:00  longevity-10gb-3h-load-and-db-node-65bd71ec-1 !INFO    | scylla:  [shard 7] storage_service - load_and_stream: finished ops_uuid=180d1761-f0f0-4527-a5aa-4b547b321adc, ks=keyspace1, tab
+2021-08-12T06:07:19+00:00  longevity-10gb-3h-load-and-db-node-65bd71ec-1 !INFO    | scylla:  [shard 7] storage_service - load_and_stream: finished ops_uuid=180d1761-f0f0-4527-a5aa-4b547b321adc, ks=keyspace_refresh, tab
 le=standard1, partitions_processed=47973 partitions, bytes_processed=25329744 bytes, partitions_per_second=7844.177 partitions/s, bytes_per_second=3.949857 MiB/s, duration=6.115747 s, status=succeeded
-2021-08-12T06:07:20+00:00  longevity-10gb-3h-load-and-db-node-65bd71ec-1 !INFO    | scylla:  [shard 3] stream_session - [Stream #178968e4-4e41-4fe1-b11f-4c05eafc9868] Write to sstable for ks=keyspace1, cf=standa
+2021-08-12T06:07:20+00:00  longevity-10gb-3h-load-and-db-node-65bd71ec-1 !INFO    | scylla:  [shard 3] stream_session - [Stream #178968e4-4e41-4fe1-b11f-4c05eafc9868] Write to sstable for ks=keyspace_refresh, cf=standa
 rd1, estimated_partitions=47872, received_partitions=47859
-2021-08-12T06:07:20+00:00  longevity-10gb-3h-load-and-db-node-65bd71ec-1 !INFO    | scylla:  [shard 3] compaction - [Compact keyspace1.standard1 8d76a940-fb33-11eb-900d-403173af4e08] Compacting [/var/lib/scylla/
-data/keyspace1/standard1-501e29b0fb3311ebb71a4875c5785232/md-51-big-Data.db:level=0:origin=streaming,/var/lib/scylla/data/keyspace1/standard1-501e29b0fb3311ebb71a4875c5785232/md-43-big-Data.db:level=0:origin=com
+2021-08-12T06:07:20+00:00  longevity-10gb-3h-load-and-db-node-65bd71ec-1 !INFO    | scylla:  [shard 3] compaction - [Compact keyspace_refresh.standard1 8d76a940-fb33-11eb-900d-403173af4e08] Compacting [/var/lib/scylla/
+data/keyspace_refresh/standard1-501e29b0fb3311ebb71a4875c5785232/md-51-big-Data.db:level=0:origin=streaming,/var/lib/scylla/data/keyspace_refresh/standard1-501e29b0fb3311ebb71a4875c5785232/md-43-big-Data.db:level=0:origin=com
 paction]
-2021-08-12T06:07:20+00:00  longevity-10gb-3h-load-and-db-node-65bd71ec-1 !INFO    | scylla:  [shard 3] storage_service - load_and_stream: ops_uuid=178968e4-4e41-4fe1-b11f-4c05eafc9868, ks=keyspace1, table=standa
+2021-08-12T06:07:20+00:00  longevity-10gb-3h-load-and-db-node-65bd71ec-1 !INFO    | scylla:  [shard 3] storage_service - load_and_stream: ops_uuid=178968e4-4e41-4fe1-b11f-4c05eafc9868, ks=keyspace_refresh, table=standa
 rd1, target_node=10.0.2.144, num_partitions_sent=47859, num_bytes_sent=25269552
-2021-08-12T06:07:20+00:00  longevity-10gb-3h-load-and-db-node-65bd71ec-1 !INFO    | scylla:  [shard 3] storage_service - load_and_stream: ops_uuid=178968e4-4e41-4fe1-b11f-4c05eafc9868, ks=keyspace1, table=standa
+2021-08-12T06:07:20+00:00  longevity-10gb-3h-load-and-db-node-65bd71ec-1 !INFO    | scylla:  [shard 3] storage_service - load_and_stream: ops_uuid=178968e4-4e41-4fe1-b11f-4c05eafc9868, ks=keyspace_refresh, table=standa
 rd1, target_node=10.0.1.134, num_partitions_sent=47859, num_bytes_sent=25269552
-2021-08-12T06:07:20+00:00  longevity-10gb-3h-load-and-db-node-65bd71ec-1 !INFO    | scylla:  [shard 3] storage_service - load_and_stream: ops_uuid=178968e4-4e41-4fe1-b11f-4c05eafc9868, ks=keyspace1, table=standa
+2021-08-12T06:07:20+00:00  longevity-10gb-3h-load-and-db-node-65bd71ec-1 !INFO    | scylla:  [shard 3] storage_service - load_and_stream: ops_uuid=178968e4-4e41-4fe1-b11f-4c05eafc9868, ks=keyspace_refresh, table=standa
 rd1, target_node=10.0.0.79, num_partitions_sent=47859, num_bytes_sent=25269552
-2021-08-12T06:07:20+00:00  longevity-10gb-3h-load-and-db-node-65bd71ec-1 !INFO    | scylla:  [shard 3] storage_service - load_and_stream: finished ops_uuid=178968e4-4e41-4fe1-b11f-4c05eafc9868, ks=keyspace1, tab
+2021-08-12T06:07:20+00:00  longevity-10gb-3h-load-and-db-node-65bd71ec-1 !INFO    | scylla:  [shard 3] storage_service - load_and_stream: finished ops_uuid=178968e4-4e41-4fe1-b11f-4c05eafc9868, ks=keyspace_refresh, tab
 le=standard1, partitions_processed=47859 partitions, bytes_processed=25269552 bytes, partitions_per_second=7398.4717 partitions/s, bytes_per_second=3.7254267 MiB/s, duration=6.4687686 s, status=succeeded
-2021-08-12T06:07:20+00:00  longevity-10gb-3h-load-and-db-node-65bd71ec-1 !INFO    | scylla:  [shard 4] storage_service - Done loading new SSTables for keyspace=keyspace1, table=standard1, load_and_stream=true, primary_replica_only=false, status=succeeded
-2021-08-12T06:07:20+00:00  longevity-10gb-3h-load-and-db-node-65bd71ec-1 !INFO    | scylla:  [shard 5] compaction - [Compact keyspace1.standard1 8c410f70-fb33-11eb-a548-402e73af4e08] Compacted 2 sstables to [/var/lib/scylla/data/keyspace1/standard1-501e29b0fb3311ebb71a4875c5785232/md-61-big-Data.db:level=0]. 28MB to 15MB (~55% of original) in 2079ms = 7MB/s. ~110464 total partitions merged to 62353.
-2021-08-12T06:07:20+00:00  longevity-10gb-3h-load-and-db-node-65bd71ec-1 !INFO    | scylla:  [shard 6] compaction - [Compact keyspace1.standard1 8c42bd20-fb33-11eb-b3fa-402b73af4e08] Compacted 2 sstables to [/var/lib/scylla/data/keyspace1/standard1-501e29b0fb3311ebb71a4875c5785232/md-62-big-Data.db:level=0]. 28MB to 15MB (~55% of original) in 2142ms = 7MB/s. ~110848 total partitions merged to 62499.
+2021-08-12T06:07:20+00:00  longevity-10gb-3h-load-and-db-node-65bd71ec-1 !INFO    | scylla:  [shard 4] storage_service - Done loading new SSTables for keyspace=keyspace_refresh, table=standard1, load_and_stream=true, primary_replica_only=false, status=succeeded
+2021-08-12T06:07:20+00:00  longevity-10gb-3h-load-and-db-node-65bd71ec-1 !INFO    | scylla:  [shard 5] compaction - [Compact keyspace_refresh.standard1 8c410f70-fb33-11eb-a548-402e73af4e08] Compacted 2 sstables to [/var/lib/scylla/data/keyspace_refresh/standard1-501e29b0fb3311ebb71a4875c5785232/md-61-big-Data.db:level=0]. 28MB to 15MB (~55% of original) in 2079ms = 7MB/s. ~110464 total partitions merged to 62353.
+2021-08-12T06:07:20+00:00  longevity-10gb-3h-load-and-db-node-65bd71ec-1 !INFO    | scylla:  [shard 6] compaction - [Compact keyspace_refresh.standard1 8c42bd20-fb33-11eb-b3fa-402b73af4e08] Compacted 2 sstables to [/var/lib/scylla/data/keyspace_refresh/standard1-501e29b0fb3311ebb71a4875c5785232/md-62-big-Data.db:level=0]. 28MB to 15MB (~55% of original) in 2142ms = 7MB/s. ~110848 total partitions merged to 62499.
 2021-08-12T06:07:20+00:00  longevity-10gb-3h-load-and-db-node-65bd71ec-1 !NOTICE  | sudo: scyllaadm : TTY=unknown ; PWD=/home/scyllaadm ; USER=root ; COMMAND=/usr/bin/coredumpctl --no-pager --no-legend
 2021-08-12T06:07:20+00:00  longevity-10gb-3h-load-and-db-node-65bd71ec-1 !INFO    | sudo: pam_unix(sudo:session): session opened for user root by (uid=0)


### PR DESCRIPTION
## Fixes SCT-555

Refresh and load-and-stream nemesis operations use `keyspace1.standard1` which is the same table used by the main stress command (`cassandra-stress`). This causes conflicts — the nemesis operations interfere with ongoing stress writes, leading to failures.

## What

Move refresh/load-and-stream nemesis to use a dedicated `keyspace_refresh.standard1` table instead of `keyspace1.standard1`, so these nemesis operations no longer conflict with the main stress workload.

## Changes

- **`sdcm/nemesis/__init__.py`** — switch `disrupt_nodetool_refresh` and `disrupt_load_and_stream` from `keyspace1` to `keyspace_refresh`; pass explicit `keyspace` to `_prepare_test_table` and `SstableLoadUtils` calls
- **`sdcm/utils/sstable/load_utils.py`** — update default `keyspace_name` parameter from `keyspace1` to `keyspace_refresh` across `calculate_columns_count_in_table`, `upload_sstables`, `load_and_stream`, and `run_refresh`
- **`sdcm/remote/local_cmd_runner.py`** — add missing `user` parameter to `run` method signature
- **`unit_tests/integration/test_nemesis_refresh.py`** — new integration test (`test_refresh_monkey_flow`) that validates the refresh flow end-to-end using Docker
- **`unit_tests/lib/fake_cluster.py`** — test fixture update
- **`unit_tests/test_data/load_and_stream.log`** — updated test data to match new keyspace name

## Testing

```bash
uv run python -m pytest unit_tests/integration/test_nemesis_refresh.py -x -q --no-header --tb=short -n0
# 1 passed in 35.30s
```

### Testing

- [x] 🟢 [oss/nemesis/longevity-5gb-1h-RefreshMonkey-aws-test #3](https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/oss/job/nemesis/job/longevity-5gb-1h-RefreshMonkey-aws-test/3/)
