### PR TITLE
fix(unit-tests): remove orphaned baremetal tests from branch-2026.2

### DIFF
--- a/unit_tests/test_log_collector.py
+++ b/unit_tests/test_log_collector.py
@@ -12,7 +12,7 @@
 # Copyright (c) 2022 ScyllaDB
 
 import uuid
-from unittest.mock import patch, MagicMock, Mock
+from unittest.mock import Mock
 
 import pytest
 
@@ -152,115 +152,6 @@ def test_failure_statistics_collector_does_not_raise_when_no_files(tmp_path):
     # collect_logs should return empty list when no files exist, NOT raise an exception
     result = collector.collect_logs(local_search_path=str(tmp_path))
     assert result == []
-
-
-def test_get_baremetal_instances_by_testid(test_id, tmp_path_factory, baremetal_config):
-    """Test that baremetal instances are correctly collected from config."""
-    test_dir = tmp_path_factory.mktemp("log-collector-baremetal")
-
-    mock_keystore = MagicMock()
-    mock_keystore.get_baremetal_config.return_value = baremetal_config
-
-    params = {
-        "cluster_backend": "baremetal",
-        "use_cloud_manager": False,
-        "s3_baremetal_config": "test_baremetal_config",
-        "user_credentials_path": "~/.ssh/test_key",
-        "ip_ssh_connections": "public",
-    }
-
-    with patch("sdcm.logcollector.KeyStore", return_value=mock_keystore):
-        collector = Collector(test_id=test_id, test_dir=test_dir, params=params)
-        collector.get_baremetal_instances_by_testid()
-
-    # Verify db_cluster nodes
-    assert len(collector.db_cluster) == 3
-    for idx, node in enumerate(collector.db_cluster):
-        assert node.ssh_login_info["user"] == "scylla"
-        assert node.ssh_login_info["hostname"] == f"10.0.0.{idx + 1}"
-        assert node.tags["NodeType"] == "scylla-db"
-
-    # Verify loader_set nodes
-    assert len(collector.loader_set) == 2
-    for idx, node in enumerate(collector.loader_set):
-        assert node.ssh_login_info["user"] == "loader_user"
-        assert node.ssh_login_info["hostname"] == f"10.0.1.{idx + 1}"
-        assert node.tags["NodeType"] == "loader"
-
-    # Verify monitor_set nodes
-    assert len(collector.monitor_set) == 1
-    assert collector.monitor_set[0].ssh_login_info["user"] == "monitor_user"
-    assert collector.monitor_set[0].ssh_login_info["hostname"] == "10.0.2.1"
-    assert collector.monitor_set[0].tags["NodeType"] == "monitor"
-
-
-def test_get_baremetal_instances_uses_private_ip(test_id, tmp_path_factory, baremetal_config):
-    """Test that baremetal uses private IPs when configured."""
-    test_dir = tmp_path_factory.mktemp("log-collector-baremetal-private")
-
-    mock_keystore = MagicMock()
-    mock_keystore.get_baremetal_config.return_value = baremetal_config
-
-    params = {
-        "cluster_backend": "baremetal",
-        "use_cloud_manager": False,
-        "s3_baremetal_config": "test_baremetal_config",
-        "user_credentials_path": "~/.ssh/test_key",
-        "ip_ssh_connections": "private",
-    }
-
-    with patch("sdcm.logcollector.KeyStore", return_value=mock_keystore):
-        collector = Collector(test_id=test_id, test_dir=test_dir, params=params)
-        collector.get_baremetal_instances_by_testid()
-
-    # Verify db_cluster nodes use private IPs
-    assert len(collector.db_cluster) == 3
-    for idx, node in enumerate(collector.db_cluster):
-        assert node.ssh_login_info["hostname"] == f"192.168.1.{idx + 1}"
-
-
-def test_get_baremetal_instances_no_config(test_id, tmp_path_factory):
-    """Test graceful handling when s3_baremetal_config is not set."""
-    test_dir = tmp_path_factory.mktemp("log-collector-baremetal-noconfig")
-
-    params = {
-        "cluster_backend": "baremetal",
-        "use_cloud_manager": False,
-        "s3_baremetal_config": None,
-        "user_credentials_path": "~/.ssh/test_key",
-    }
-
-    collector = Collector(test_id=test_id, test_dir=test_dir, params=params)
-    collector.get_baremetal_instances_by_testid()
-
-    # Should not raise, but also should not populate any nodes
-    assert len(collector.db_cluster) == 0
-    assert len(collector.loader_set) == 0
-    assert len(collector.monitor_set) == 0
-
-
-def test_get_running_cluster_sets_baremetal(test_id, tmp_path_factory, baremetal_config):
-    """Test that get_running_cluster_sets dispatches to baremetal correctly."""
-    test_dir = tmp_path_factory.mktemp("log-collector-baremetal-dispatch")
-
-    mock_keystore = MagicMock()
-    mock_keystore.get_baremetal_config.return_value = baremetal_config
-
-    params = {
-        "cluster_backend": "baremetal",
-        "use_cloud_manager": False,
-        "s3_baremetal_config": "test_baremetal_config",
-        "user_credentials_path": "~/.ssh/test_key",
-    }
-
-    with patch("sdcm.logcollector.KeyStore", return_value=mock_keystore):
-        collector = Collector(test_id=test_id, test_dir=test_dir, params=params)
-        collector.get_running_cluster_sets("baremetal")
-
-    # Verify nodes were collected via the baremetal method
-    assert len(collector.db_cluster) == 3
-    assert len(collector.loader_set) == 2
-    assert len(collector.monitor_set) == 1
 
 
 def test_monitoring_entities_skip_when_no_monitor_nodes(tmp_path):


### PR DESCRIPTION
Remove 4 baremetal test functions that were accidentally included during the cherry-pick of commit 2bca67a5b8f1 (PR #14981). The tests reference Collector.get_baremetal_instances_by_testid and a baremetal_config fixture, neither of which exist on branch-2026.2. The corresponding implementation was added on master by commit 2382552804 (feature(baremetal): enhance cluster management and configuration) which has not been backported.

Failing tests removed:
- test_get_baremetal_instances_by_testid (ERROR: missing fixture)
- test_get_baremetal_instances_uses_private_ip (ERROR: missing fixture)
- test_get_baremetal_instances_no_config (FAILED: missing method)
- test_get_running_cluster_sets_baremetal (ERROR: missing fixture)

(cherry picked from commit bd9d0e4be02d5b79cf81345fe5c22cc8298f1dfc)

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
