### PR TITLE
improvement(adaptive-timeouts): calculate cleanup timeout from node data size

### DIFF
--- a/sdcm/utils/adaptive_timeouts/__init__.py
+++ b/sdcm/utils/adaptive_timeouts/__init__.py
@@ -180,6 +180,36 @@ def _get_compaction_timeout(
         return timeout, {}
 
 
+def _get_cleanup_timeout(node_info_service, timeout=None):
+    """Calculate cleanup timeout based on node data size.
+    After decommission/topology change, cleanup removes data that no longer
+    belongs to a node. The amount of data to process is proportional to total
+    node data size divided by the number of nodes (since only the reshuffled
+    portion needs cleanup).
+
+    Ref: https://scylladb.atlassian.net/browse/SCT-247
+
+    Formula:
+        timeout = max(MIN_CLEANUP_TIMEOUT, data_size_mb / throughput_mb_s * safety_factor)
+    Where:
+        - data_size_mb: total data on the node (from node_info_service)
+        - throughput_mb_s: expected I/O throughput for the instance type
+        - safety_factor: 2.0 (accounts for compaction contention, I/O variability)
+        - MIN_CLEANUP_TIMEOUT: 120 seconds (floor for small datasets)
+    """
+    MIN_CLEANUP_TIMEOUT = 120  # seconds
+    SAFETY_FACTOR = 2.0
+    data_size_mb = node_info_service.node_data_size_mb
+    throughput = node_info_service.expected_throughput  # MB/s
+    if data_size_mb and throughput:
+        calculated = (data_size_mb / throughput) * SAFETY_FACTOR
+        timeout = max(MIN_CLEANUP_TIMEOUT, calculated)
+    else:
+        timeout = timeout or MIN_CLEANUP_TIMEOUT
+    return timeout, node_info_service.as_dict()
+
+
+
 class Operations(Enum):
     """Available operations for adaptive timeouts. Each operation maps to a function to calculate timeout based on node load info.
 
@@ -197,7 +227,7 @@ class Operations(Enum):
     BACKUP = ("backup", _get_soft_timeout, ("timeout",))
     RESTORE = ("restore", _get_soft_timeout, ("timeout",))
     REBUILD = ("rebuild", _get_soft_timeout, ("timeout",))
-    CLEANUP = ("cleanup", _get_soft_timeout, ("timeout",))
+    CLEANUP = ("cleanup", _get_cleanup_timeout, ("timeout",))
     REMOVE_NODE = ("remove_node", _get_soft_timeout, ("timeout",))
     SCRUB = ("scrub", _get_soft_timeout, ("timeout",))
     SOFT_TIMEOUT = ("soft_timeout", _get_soft_timeout, ("timeout",))

--- a/sdcm/utils/adaptive_timeouts/__init__.py
+++ b/sdcm/utils/adaptive_timeouts/__init__.py
@@ -199,15 +199,18 @@ def _get_cleanup_timeout(node_info_service, timeout=None):
     """
     MIN_CLEANUP_TIMEOUT = 120  # seconds
     SAFETY_FACTOR = 2.0
-    data_size_mb = node_info_service.node_data_size_mb
-    throughput = node_info_service.expected_throughput  # MB/s
-    if data_size_mb and throughput:
-        calculated = (data_size_mb / throughput) * SAFETY_FACTOR
-        timeout = max(MIN_CLEANUP_TIMEOUT, calculated)
-    else:
-        timeout = timeout or MIN_CLEANUP_TIMEOUT
-    return timeout, node_info_service.as_dict()
-
+    try:
+        data_size_mb = node_info_service.node_data_size_mb
+        throughput = node_info_service.expected_throughput  # MB/s
+        if data_size_mb and throughput:
+            calculated = (data_size_mb / throughput) * SAFETY_FACTOR
+            timeout = max(MIN_CLEANUP_TIMEOUT, calculated)
+        else:
+            timeout = timeout or MIN_CLEANUP_TIMEOUT
+        return timeout, node_info_service.as_dict()
+    except Exception as exc:  # noqa: BLE001
+        LOGGER.warning("Failed to calculate cleanup timeout: \n%s \nDefaulting to %s seconds", exc, MIN_CLEANUP_TIMEOUT)
+        return timeout or MIN_CLEANUP_TIMEOUT, {}
 
 
 class Operations(Enum):


### PR DESCRIPTION
## Summary

The `CLEANUP` adaptive-timeout operation previously fell through to the
generic `_get_soft_timeout` passthrough, so callers had to supply a static
timeout with no awareness of actual data volume on the node.

This PR adds `_get_cleanup_timeout()` which computes the timeout from the
node's current data size and expected I/O throughput:

```
timeout = max(120 s, data_size_mb / throughput_mb_s × 2.0)
```

| Parameter | Value | Rationale |
|-----------|-------|-----------|
| `MIN_CLEANUP_TIMEOUT` | 120 s | Floor for small/empty datasets |
| `SAFETY_FACTOR` | 2.0 | Accounts for compaction contention & I/O variability |

When data size or throughput is unavailable the function falls back to the
caller-supplied value or the 120-second minimum.

## Changes

- **`sdcm/utils/adaptive_timeouts/__init__.py`**
  - Added `_get_cleanup_timeout(node_info_service, timeout)` function
  - Changed `Operations.CLEANUP` to use `_get_cleanup_timeout` instead of `_get_soft_timeout`

Fixes: [SCT-247](https://scylladb.atlassian.net/browse/SCT-247)

## Manual Testing Required

### What cannot be tested automatically

- [x] **End-to-end cleanup after decommission**: Requires a multi-node cluster
      with significant data.  Run a longevity test with `DecommissionMonkey`
      and verify cleanup completes within the adaptive timeout.
- [x] **Fallback path**: Start a cluster without `adaptive_timeout_store_metrics`
      enabled and verify cleanup still uses the caller-supplied timeout or the
      120 s floor.

[SCT-247]: https://scylladb.atlassian.net/browse/SCT-247?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

### Testing

- [x] 🟢 [oss/nemesis/longevity-5gb-1h-NodeToolCleanupMonkey-aws-test #2](https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/oss/job/nemesis/job/longevity-5gb-1h-NodeToolCleanupMonkey-aws-test/2/)
