### PR TITLE
fix(gemini): custom command inherits --duration from configured gemini_cmd

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -171,6 +171,7 @@ from sdcm.stress_thread import (
     apply_gemini_stress_duration,
     extract_gemini_seed,
     get_timeout_from_stress_cmd,
+    stress_cmd_get_duration_pattern,
 )
 from sdcm.gemini_thread import GeminiStressThread
 from sdcm.utils.log_time_consistency import DbLogTimeConsistencyAnalyzer
@@ -3118,10 +3119,18 @@ class ClusterTester(unittest.TestCase):
     def run_gemini(self, cmd, duration=None):
         if duration:
             timeout = self.get_duration(duration)
+            cmd = apply_gemini_stress_duration(cmd, duration)
         elif self._stress_duration:
             timeout = self.get_duration(self._stress_duration)
             cmd = apply_gemini_stress_duration(cmd, self._stress_duration)
         else:
+            if "--duration" not in cmd:
+                # When the custom command has no --duration, extract it from the configured
+                # gemini_cmd (the "previous command") so the test doesn't silently run for
+                # the Gemini CLI default of 30s.
+                default_cmd = self.params.get("gemini_cmd") or ""
+                if duration_match := stress_cmd_get_duration_pattern.search(default_cmd):
+                    cmd += f" --duration {duration_match.group(1)}"
             timeout = get_timeout_from_stress_cmd(cmd) or self.get_duration(duration)
         return GeminiStressThread(
             test_cluster=self.db_cluster,

--- a/unit_tests/unit/test_stress_thread_functions.py
+++ b/unit_tests/unit/test_stress_thread_functions.py
@@ -18,6 +18,7 @@ from sdcm.stress_thread import (
     apply_gemini_stress_duration,
     extract_gemini_seed,
     get_timeout_from_stress_cmd,
+    stress_cmd_get_duration_pattern,
 )
 from sdcm.utils.common import time_period_str_to_seconds
 
@@ -321,3 +322,39 @@ def test_apply_gemini_stress_duration(original_cmd, stress_duration, expected_cm
 )
 def test_extract_gemini_seed(gemini_cmd, expected_seed):
     assert extract_gemini_seed(gemini_cmd) == expected_seed
+
+
+@pytest.mark.parametrize(
+    "default_cmd, expected_duration",
+    [
+        pytest.param(
+            "--duration 3h\n--concurrency 100\n--mode mixed",
+            "3h",
+            id="yaml-block-scalar",
+        ),
+        pytest.param(
+            " --duration 30m --concurrency 50",
+            "30m",
+            id="space-delimited",
+        ),
+        pytest.param(
+            "--duration=8h --mode mixed",
+            "8h",
+            id="equals-form",
+        ),
+        pytest.param(
+            "--concurrency 50 --mode mixed",
+            None,
+            id="no-duration-returns-none",
+        ),
+    ],
+)
+def test_stress_cmd_get_duration_pattern_group1(default_cmd, expected_duration):
+    """Verify the pattern used by run_gemini to extract --duration from the configured
+    gemini_cmd (previous command) when the custom command has no --duration."""
+    match = stress_cmd_get_duration_pattern.search(default_cmd)
+    if expected_duration is None:
+        assert match is None
+    else:
+        assert match is not None
+        assert match.group(1) == expected_duration


### PR DESCRIPTION

When a custom gemini command omits --duration, run_gemini now extracts the duration from the configured gemini_cmd param (the previous command) and appends it, preventing silent fallback to the Gemini CLI default of 30s.

Also fixes the explicit duration= override branch to inject --duration into the command string, not just set the timeout.

Closes SCT-556

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
