### PR TITLE
fix(monitor): show non-DB node metrics on xcloud dashboards

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -7249,6 +7249,24 @@ class BaseMonitorSet:
         """)
         node.remoter.run(f"bash -ce '{script}'")
 
+    @staticmethod
+    def _build_xcloud_scrape_config(promproxy_config):
+        """Build the scrape job from the Scylla Cloud promproxy config."""
+        scrape_configs = (yaml.safe_load(promproxy_config) or {}).get("scrape_configs") or []
+        return scrape_configs[0] if scrape_configs else None
+
+    @staticmethod
+    def _build_xcloud_cluster_relabel_config(xcloud_scrape_config):
+        """Create a relabel rule that adds the Scylla Cloud cluster label to SCT-scraped metrics."""
+        if match := re.search(r"/cluster/(\d+)/", xcloud_scrape_config.get("metrics_path") or ""):
+            return {
+                "source_labels": ["cluster"],
+                "regex": "^$",
+                "target_label": "cluster",
+                "replacement": f"#{match[1]}",
+            }
+        return None
+
     def configure_scylla_monitoring(self, node, sct_metrics=True, alert_manager=True):  # noqa: PLR0914
         cloud_prom_bearer_token = self.params.get("cloud_prom_bearer_token")
 
@@ -7309,9 +7327,18 @@ class BaseMonitorSet:
                 )
 
             if self.params.get("cluster_backend") == "xcloud" and self.promproxy_config:
-                yaml_from_xcloud = yaml.safe_load(self.promproxy_config)
-                xcloud_config = next(iter(yaml_from_xcloud.get("scrape_configs", [])), None)
-                scrape_configs.append(xcloud_config)
+                if xcloud_config := self._build_xcloud_scrape_config(self.promproxy_config):
+                    scrape_configs.append(xcloud_config)
+                    if cluster_relabel := self._build_xcloud_cluster_relabel_config(xcloud_config):
+                        for scrape_config in scrape_configs:
+                            if scrape_config.get("job_name") == "node_exporter":
+                                scrape_config.setdefault("metric_relabel_configs", []).append(cluster_relabel)
+                                break
+                    else:
+                        self.log.warning(
+                            "Could not derive cluster id from promproxy config; "
+                            "non-DB node metrics will not be visible on host dashboards"
+                        )
 
             if self.params.get("gemini_cmd"):
                 gemini_loader_targets_list = [


### PR DESCRIPTION
On xcloud backend DB host metrics come from the Scylla Cloud promproxy labeled as `cluster=#<id>`. SCT non-DB nodes (loader, monitor, sct-runner) have no cluster label, so the host dashboards (where filter by `cluster` is applied) hides them.
The fix is dropping `cluster` label from host metrics so xcloud matches every other backend in SCT.

Fixes: SCT-244

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :green_circle: [xcloud backend cluster on AWS provider](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/xcloud-test/13/)
The `OS metrics` dashboard in Grafana now has metrics for all node - DB nodes + lodaer + monitor + sct-runner. Previously it was displaying only DB nodes metrics as the others were filtered out by cluster ID.
<img width="1258" height="805" alt="Screenshot from 2026-06-30 16-30-04" src="https://github.com/user-attachments/assets/95cd9087-8102-4d52-a413-7d92d3f851bc" />


### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
