### PR TITLE
feature(mgmt): report actual restore method to Argus benchmark results

### DIFF
--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -13,7 +13,9 @@
 #
 # Copyright (c) 2016 ScyllaDB
 
+import os
 import random
+import re
 import shutil
 import threading
 import time
@@ -53,6 +55,7 @@ from sdcm.utils.alternator.table_setup import alternator_backuped_tables
 from sdcm.utils.aws_utils import AwsIAM
 from sdcm.utils.features import is_tablets_feature_enabled
 from sdcm.utils.common import reach_enospc_on_node, clean_enospc_on_node
+from sdcm.utils.file import File
 from sdcm.utils.time_utils import ExecutionTimer
 from sdcm.mgmt.operations import ManagerTestFunctionsMixIn, SnapshotData
 from sdcm.sct_events.system import InfoEvent
@@ -1199,6 +1202,43 @@ class ManagerRestoreBenchmarkTests(ManagerTestFunctionsMixIn):
         extra_params = self.params.get("mgmt_restore_extra_params")
         return extra_params if extra_params else None
 
+    def _detect_actual_restore_method(self, manager_backup_restore_method=None) -> str:
+        """Detect the actual restore method used by Scylla Manager from its log.
+
+        The requested method (e.g. 'native') can be internally overridden by SM
+        (e.g. to 'tablet' when the cluster supports tablets). This method reads the
+        locally-collected SM log to determine the real mode used.
+
+        Note: The entire SM log is scanned without timestamp or task-id filtering.
+        This assumes a single restore task per test run. If multiple restore tasks
+        are ever executed in the same session, earlier tablet-aware entries could
+        cause false positives.
+
+        Once SM fully supports exposing the actual method via its CLI or task
+        properties, this log-parsing workaround can be replaced with a simpler
+        getter from the task/progress output.
+
+        Returns:
+            One of "Tablet", "Native", or "Rclone".
+        """
+        monitor_node = self.monitors.nodes[0]
+        sm_log_path = os.path.join(monitor_node.logdir, "scylla_manager.log")
+        try:
+            with File(sm_log_path) as sm_log:
+                tablet_lines = list(sm_log.read_lines_filtered(re.compile(r"tablet aware restore")))
+        except OSError as err:
+            self.log.warning("Could not read SM log at %s: %s", sm_log_path, err)
+            tablet_lines = []
+
+        if tablet_lines:
+            return "Tablet"
+
+        method_value = manager_backup_restore_method.value if manager_backup_restore_method else None
+
+        if method_value == "rclone":
+            return "Rclone"
+        return "Native"
+
     def _get_restore_results(self, task: RestoreTask, node) -> dict:
         """Extract restore results from a RestoreTask.
 
@@ -1304,6 +1344,7 @@ class ManagerRestoreBenchmarkTests(ManagerTestFunctionsMixIn):
 
         manager_version_timestamp = manager_tool.sctool.client_version_timestamp
         results = self._get_restore_results(task, node=self.db_cluster.nodes[0])
+        results["method"] = self._detect_actual_restore_method(manager_backup_restore_method)
         self._send_restore_results_to_argus(results, manager_version_timestamp)
 
         self.run_verification_read_stress()
@@ -1381,6 +1422,7 @@ class ManagerRestoreBenchmarkTests(ManagerTestFunctionsMixIn):
 
             # Get restore results including backup dataset size
             results = self._get_restore_results(task, node=self.db_cluster.nodes[0])
+            results["method"] = self._detect_actual_restore_method(manager_backup_restore_method)
             self._send_restore_results_to_argus(results, manager_version_timestamp, dataset_label=snapshot_name)
 
         self.manager_test_metrics.restore_time = restore_time

--- a/sdcm/argus_results.py
+++ b/sdcm/argus_results.py
@@ -136,6 +136,7 @@ class ManagerRestoreBenchmarkResult(StaticGenericResultTable):
             ColumnMetadata(name="repair time", unit="s", type=ResultType.DURATION, higher_is_better=False),
             ColumnMetadata(name="total", unit="s", type=ResultType.DURATION, higher_is_better=False),
             ColumnMetadata(name="size", unit="GB", type=ResultType.INTEGER, higher_is_better=False),
+            ColumnMetadata(name="method", unit="", type=ResultType.TEXT),
         ]
         ValidationRules = {
             "restore time": ValidationRule(best_pct=10),


### PR DESCRIPTION
Add a 'method' column to ManagerRestoreBenchmarkResult to report the actual Scylla Manager restore mode (Tablet/Native/Rclone) used during restore benchmark tests.

The detection reads the locally-collected scylla_manager.log using the existing File utility, looking for 'tablet aware restore' log entries that indicate SM internally used tablet-aware restore.

This is needed because SM does not yet expose the actual restore method through its CLI or progress output. When 'native' is requested via --method, SM may internally override it to use tablet-aware restore on clusters that support tablets. This override currently happens in private SM builds as a temporary workaround and is not reflected in the sctool restore progress output or task properties. Therefore, the only reliable way to determine the real method is by inspecting the SM log for tablet_restore activity.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- https://jenkins.scylladb.com/job/scylla-staging/job/yarongilor/job/restore-benchmark-test-tablets-aware/93/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
