### PR TITLE
ci(backport): disable AI conflict resolver for this repo

### DIFF
--- a/.github/workflows/call_backport_with_jira.yaml
+++ b/.github/workflows/call_backport_with_jira.yaml
@@ -46,7 +46,7 @@ jobs:
   # Adds promoted-to-* labels and triggers/continues the backports for merged commits.
   backport-on-push:
     if: github.event_name == 'push'
-    uses: scylladb/github-automation/.github/workflows/backport-with-jira.yaml@2e3189423c3199d71f214da853bb9651a0a1037c # main
+    uses: scylladb/github-automation/.github/workflows/backport-with-jira.yaml@8641631b6b7a9c06e341de25e875974a4f029cbc # main
     with:
       event_type: 'push'
       base_branch: ${{ github.ref }}
@@ -60,7 +60,7 @@ jobs:
   # A backport/* label was added to a (closed) PR: create the backport PR(s).
   backport-on-label:
     if: github.event_name == 'pull_request_target' && github.event.action == 'labeled'
-    uses: scylladb/github-automation/.github/workflows/backport-with-jira.yaml@2e3189423c3199d71f214da853bb9651a0a1037c # main
+    uses: scylladb/github-automation/.github/workflows/backport-with-jira.yaml@8641631b6b7a9c06e341de25e875974a4f029cbc # main
     with:
       event_type: 'labeled'
       base_branch: refs/heads/${{ github.event.pull_request.base.ref }}
@@ -78,7 +78,7 @@ jobs:
   # for the always-parallel model, but kept for parity with the shared workflow).
   backport-chain:
     if: github.event_name == 'pull_request_target' && github.event.action == 'closed' && github.event.pull_request.merged == true
-    uses: scylladb/github-automation/.github/workflows/backport-with-jira.yaml@2e3189423c3199d71f214da853bb9651a0a1037c # main
+    uses: scylladb/github-automation/.github/workflows/backport-with-jira.yaml@8641631b6b7a9c06e341de25e875974a4f029cbc # main
     with:
       event_type: 'chain'
       base_branch: refs/heads/${{ github.event.pull_request.base.ref }}


### PR DESCRIPTION
## What

Bumps the `scylladb/github-automation` reusable-workflow pin in `call_backport_with_jira.yaml` from `2e31894` to `8641631`.

That github-automation commit adds `scylladb/scylla-cluster-tests` to the opt-out list of the shared workflow's `resolve-conflicts` job.

## Why / effect

The OpenCode AI **resolve-conflicts** skill will **no longer run** for backport PRs in this repo. Conflicted backports stay as drafts with the `conflicts` label for manual resolution (e.g. via the repo's own `fix-backport-conflicts` skill), instead of being auto-resolved by AI.

Backport PR creation, Jira sub-tasks, and labeling are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)