### PR TITLE
fix(mgmt): use regex to extract date from client version string

### DIFF
--- a/sdcm/mgmt/cli.py
+++ b/sdcm/mgmt/cli.py
@@ -1570,11 +1570,17 @@ class SCTool:
 
     @property
     def client_version_timestamp(self) -> int:
-        """Gets the timestamp of the client version
+        """Gets the timestamp of the client version.
 
-        Example, for client version `3.3.3-0.20240912.924034e0d` the timestamp is `1726099200` (2024-09-12 00:00:00)
+        Examples:
+            - `3.3.3-0.20240912.924034e0d`               -> 1726099200 (2024-09-12)
+            - `3.12.0-dev-0.20260622.462bd8021-SNAPSHOT` -> 1750550400 (2026-06-22)
+            - `3.12.0-dev.0.20260629.d78e5dcc9.SNAPSHOT` -> 1751155200 (2026-06-29)
         """
-        date_str = self.client_version.split(".")[-2]
+        match = re.search(r"\b\d{8}\b", self.client_version)
+        if not match:
+            raise ValueError(f"Cannot find YYYYMMDD date segment in client version: {self.client_version!r}")
+        date_str = match.group()
         date_obj = datetime.datetime.strptime(date_str, "%Y%m%d")
         timestamp = int(date_obj.timestamp())
         return timestamp


### PR DESCRIPTION
Use regex to get the timestamp, as delimiters may change. The regex looks for 8 consecutive digits, delimited by non-alpha-numeric chars.

e.g.
`3.12.0-dev-0.20260622.462bd8021-SNAPSHOT` vs `3.12.0-dev.0.20260629.d78e5dcc9.SNAPSHOT`

Error looks like
```
(TestFrameworkEvent Severity.ERROR) period_type=one-time event_id=2d0501bd-4a0d-437b-b730-1acd71f2b682, source=ManagerRestoreBenchmarkTests.test_restore_benchmark()
exception=self = <mgmt_cli_test.ManagerRestoreBenchmarkTests testMethod=test_restore_benchmark>

    def test_restore_benchmark(self):
        """Benchmark restore operation using configured method.
    
        The test suggests two flows - populate the cluster with data, create the backup, and then restore it or
        restore from a pre-created backup.
        """
        if manager_backup_restore_method := self.params.get("manager_backup_restore_method"):
            manager_backup_restore_method = ObjectStorageUploadMode(manager_backup_restore_method)
        if reuse_snapshot_name := self.params.get("mgmt_reuse_backup_snapshot_name"):
            self.log.info("Executing test_restore_from_precreated_backup...")
>           self.test_restore_from_precreated_backup(
                reuse_snapshot_name, manager_backup_restore_method=manager_backup_restore_method
            )

mgmt_cli_test.py:1405: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
mgmt_cli_test.py:1380: in test_restore_from_precreated_backup
    manager_version_timestamp = mgr_cluster.sctool.client_version_timestamp
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
sdcm/mgmt/cli.py:1578: in client_version_timestamp
    date_obj = datetime.datetime.strptime(date_str, "%Y%m%d")
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/usr/local/lib/python3.14/_strptime.py:815: in _strptime_datetime_datetime
    tt, fraction, gmtoff_fraction = _strptime(data_string, format)
                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

data_string = 'd78e5dcc9', format = '%Y%m%d'

    def _strptime(data_string, format="%a %b %d %H:%M:%S %Y"):
        """Return a 2-tuple consisting of a time struct and an int containing
        the number of microseconds based on the input string and the
        format string."""
    
        for index, arg in enumerate([data_string, format]):
            if not isinstance(arg, str):
                msg = "strptime() argument {} must be str, not {}"
                raise TypeError(msg.format(index, type(arg)))
    
        global _TimeRE_cache, _regex_cache
        with _cache_lock:
            locale_time = _TimeRE_cache.locale_time
            if (_getlang() != locale_time.lang or
                time.tzname != locale_time.tzname or
                time.daylight != locale_time.daylight):
                _TimeRE_cache = TimeRE()
                _regex_cache.clear()
                locale_time = _TimeRE_cache.locale_time
            if len(_regex_cache) > _CACHE_MAX_SIZE:
                _regex_cache.clear()
            format_regex = _regex_cache.get(format)
            if not format_regex:
                try:
                    format_regex = _TimeRE_cache.compile(format)
                # KeyError raised when a bad format is found; can be specified as
                # \\, in which case it was a stray % but with a space after it
                except KeyError as err:
                    bad_directive = err.args[0]
                    del err
                    bad_directive = bad_directive.replace('\\s', '')
                    if not bad_directive:
                        raise ValueError("stray %% in format '%s'" % format) from None
                    bad_directive = bad_directive.replace('\\', '', 1)
                    raise ValueError("'%s' is a bad directive in format '%s'" %
                                        (bad_directive, format)) from None
                _regex_cache[format] = format_regex
        found = format_regex.match(data_string)
        if not found:
>           raise ValueError("time data %r does not match format %r" %
                             (data_string, format))
E           ValueError: time data 'd78e5dcc9' does not match format '%Y%m%d'

/usr/local/lib/python3.14/_strptime.py:555: ValueError
```

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
