### PR TITLE
ci(provision-test): append Argus test runs to Jenkins job description

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -374,6 +374,17 @@ pipeline {
                                         }
                                         try {
                                             wrap([$class: 'BuildUser']) {
+                                                dir(working_dir) {
+                                                    timeout(time: 5, unit: 'MINUTES') {
+                                                        createArgusTestRun(curr_params)
+                                                    }
+                                                }
+                                            }
+                                        } catch(Exception err) {
+                                            echo "${err}"
+                                        }
+                                        try {
+                                            wrap([$class: 'BuildUser']) {
                                                 env.BUILD_USER_ID=env.CHANGE_AUTHOR
                                                 timeout(time: 300, unit: 'MINUTES') {
                                                     dir(working_dir) {
@@ -434,6 +445,17 @@ pipeline {
                                                 result = 'FAILURE'
                                                 pullRequestSetResult('failure', "jenkins/provision_${backend}", 'Some test cases are failed during cluster reuse test')
                                             }
+                                        }
+                                        try {
+                                            wrap([$class: 'BuildUser']) {
+                                                dir(working_dir) {
+                                                    timeout(time: 5, unit: 'MINUTES') {
+                                                        finishArgusTestRun(curr_params, currentBuild)
+                                                    }
+                                                }
+                                            }
+                                        } catch(Exception err) {
+                                            echo "${err}"
                                         }
                                         try {
                                             wrap([$class: 'BuildUser']) {


### PR DESCRIPTION
## Summary

Adds `createArgusTestRun` and `finishArgusTestRun` calls to the provision test stage in the root Jenkinsfile.

## Problem

When provision tests run, Argus test runs are created by the test framework but the Jenkins build description never shows the Argus links. All other SCT pipelines (longevity, manager, artifacts, rolling-upgrade, jepsen, perf-regression, operator-upgrade) already call `createArgusTestRun` to append clickable Argus links to the build description — this pipeline was the only one missing it.

## Changes

- Added `createArgusTestRun(curr_params)` call before `runSctTest` in each parallel backend run — this creates the Argus test run and appends the HTML link to `currentBuild.description`
- Added `finishArgusTestRun(curr_params, currentBuild)` call after test execution / reuse test but before resource cleanup — this properly closes the Argus test run with the final build status

Both calls are wrapped in `try/catch` with 5-minute timeouts, matching the pattern used in other pipelines.

## Backends Affected

- All provision test backends (aws, gce, oci, docker, k8s, azure, xcloud, vs-docker, vs-aws)