### PR TITLE
fix(cloud-catalog): drop Azure Dpdsv5 from pricing/sizing

### DIFF
--- a/data/instance_catalog/azure.yaml
+++ b/data/instance_catalog/azure.yaml
@@ -32,14 +32,6 @@ instances:
   local_disk_count: 0
   arch: x86_64
   price_per_hour: 0.726
-- instance_type: Standard_D16pds_v5
-  family: Standard_D
-  vcpus: 16
-  memory_gb: 64.0
-  local_disk_gb: 600.0
-  local_disk_count: 1
-  arch: arm64
-  price_per_hour: 0.723
 - instance_type: Standard_D16pds_v6
   family: Standard_D
   vcpus: 16
@@ -96,14 +88,6 @@ instances:
   local_disk_count: 0
   arch: x86_64
   price_per_hour: 0.0908
-- instance_type: Standard_D2pds_v5
-  family: Standard_D
-  vcpus: 2
-  memory_gb: 8.0
-  local_disk_gb: 75.0
-  local_disk_count: 1
-  arch: arm64
-  price_per_hour: 0.0904
 - instance_type: Standard_D2pds_v6
   family: Standard_D
   vcpus: 2
@@ -160,14 +144,6 @@ instances:
   local_disk_count: 0
   arch: x86_64
   price_per_hour: 1.453
-- instance_type: Standard_D32pds_v5
-  family: Standard_D
-  vcpus: 32
-  memory_gb: 128.0
-  local_disk_gb: 1200.0
-  local_disk_count: 1
-  arch: arm64
-  price_per_hour: 1.446
 - instance_type: Standard_D32pds_v6
   family: Standard_D
   vcpus: 32
@@ -224,14 +200,6 @@ instances:
   local_disk_count: 0
   arch: x86_64
   price_per_hour: 2.179
-- instance_type: Standard_D48pds_v5
-  family: Standard_D
-  vcpus: 48
-  memory_gb: 192.0
-  local_disk_gb: 1800.0
-  local_disk_count: 2
-  arch: arm64
-  price_per_hour: 2.17
 - instance_type: Standard_D48pds_v6
   family: Standard_D
   vcpus: 48
@@ -288,14 +256,6 @@ instances:
   local_disk_count: 0
   arch: x86_64
   price_per_hour: 0.182
-- instance_type: Standard_D4pds_v5
-  family: Standard_D
-  vcpus: 4
-  memory_gb: 16.0
-  local_disk_gb: 150.0
-  local_disk_count: 1
-  arch: arm64
-  price_per_hour: 0.181
 - instance_type: Standard_D4pds_v6
   family: Standard_D
   vcpus: 4
@@ -352,14 +312,6 @@ instances:
   local_disk_count: 0
   arch: x86_64
   price_per_hour: 2.906
-- instance_type: Standard_D64pds_v5
-  family: Standard_D
-  vcpus: 64
-  memory_gb: 256.0
-  local_disk_gb: 2400.0
-  local_disk_count: 2
-  arch: arm64
-  price_per_hour: 2.893
 - instance_type: Standard_D64pds_v6
   family: Standard_D
   vcpus: 64
@@ -416,14 +368,6 @@ instances:
   local_disk_count: 0
   arch: x86_64
   price_per_hour: 0.363
-- instance_type: Standard_D8pds_v5
-  family: Standard_D
-  vcpus: 8
-  memory_gb: 32.0
-  local_disk_gb: 300.0
-  local_disk_count: 1
-  arch: arm64
-  price_per_hour: 0.362
 - instance_type: Standard_D8pds_v6
   family: Standard_D
   vcpus: 8

--- a/data/instance_catalog/sizing_config.yaml
+++ b/data/instance_catalog/sizing_config.yaml
@@ -145,7 +145,7 @@ clouds:
       - "^Standard_D\\d+s_v[45]$"
       - "^Standard_D\\d+as_v[56]$"
       - "^Standard_D\\d+_v[45]$"
-      - "^Standard_D\\d+pds_v[56]$"
+      - "^Standard_D\\d+pds_v6$"
       - "^Standard_E\\d+s_v[45]$"
       - "^Standard_E\\d+as_v[56]$"
       - "^Standard_F\\d+s_v2$"

--- a/sdcm/utils/cloud_catalog/catalog_generator.py
+++ b/sdcm/utils/cloud_catalog/catalog_generator.py
@@ -623,13 +623,10 @@ _AZURE_FAMILY_SPECS: dict[str, dict[str, Any]] = {
 # In Azure naming, "d" before "s" in the suffix (e.g. "pds", "ds", "ads")
 # indicates the VM has local NVMe temp storage.
 # Source: https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/general-purpose/dpdsv6-series
-#         https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/general-purpose/dpdsv5-series
 # Used as fallback when Azure Compute Management API is unavailable.
 _AZURE_LOCAL_DISK_SUFFIX_SPECS: dict[str, dict[str, float]] = {
     # Dpdsv6: ARM Cobalt 100 + NVMe, 55 GiB per vCPU, 1 disk per 8 vCPUs
     "pds_v6": {"local_disk_per_vcpu": 55.0, "disk_count_divisor": 8},
-    # Dpdsv5: ARM Ampere Altra + NVMe, 37.5 GiB per vCPU, 1 disk per 24 vCPUs
-    "pds_v5": {"local_disk_per_vcpu": 37.5, "disk_count_divisor": 24},
 }
 
 # Regex to extract vCPU count from Azure SKU names.

--- a/unit_tests/unit/test_instance_catalog.py
+++ b/unit_tests/unit/test_instance_catalog.py
@@ -232,6 +232,15 @@ def test_get_instances_by_family(multi_cloud_dir: Path, cloud: str, family: str,
     assert all(inst.cloud == cloud and inst.family == family for inst in result)
 
 
+def test_real_azure_catalog_excludes_scsi_only_dpdsv5():
+    # Dpdsv5 (Ampere Altra) exposes local disk via SCSI (not NVMe), so it must not
+    # appear in the Azure pricing/sizing catalog
+    catalog_dir = Path(__file__).parents[2] / "data" / "instance_catalog"
+    catalog = InstanceCatalog.from_directory(catalog_dir)
+    dpdsv5 = [inst.instance_type for inst in catalog.get_instances("azure") if "pds_v5" in inst.instance_type]
+    assert not dpdsv5, f"SCSI-only Dpdsv5 types must not appear in the Azure catalog: {dpdsv5}"
+
+
 def test_instance_type_info_is_dataclass():
     info = InstanceTypeInfo(
         instance_type="t3.micro",


### PR DESCRIPTION
Dpdsv5 instance type has no local NVMe disk (SCSI only), so scylla-machine-image setup can't use it.
The change removes the Dpdsv5 catalog entries, and drops the pds_v5 disk-spec fallback.

Refs: SMI-298

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :green_circle: [artifacts-azure-image-arm-test](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/artifacts/job/artifacts-azure-image-arm-test/2/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
