### PR TITLE
feature(provision/aws): enable region fallback by default

### DIFF
--- a/defaults/aws_config.yaml
+++ b/defaults/aws_config.yaml
@@ -36,6 +36,7 @@ data_volume_disk_size: 500
 data_volume_disk_iops: 10000 # depend on type iops could be 100-16000 for io2|io3 and 3000-16000 for gp3
 
 fallback_to_next_availability_zone: true
+fallback_to_next_region: true
 
 kms_key_rotation_interval: 60
 

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -4235,6 +4235,9 @@ On capacity errors, after all AZs in the configured region are exhausted, reloca
 
 **type:** bool
 
+**backend overrides:**
+- `True`: aws, aws-siren, k8s-local-kind-aws, k8s-eks
+
 
 ## **num_nodes_to_rollback** / SCT_NUM_NODES_TO_ROLLBACK
 


### PR DESCRIPTION
Enable fallback_to_next_region in aws_config.yaml, so AWS clusters relocate to another region on capacity exhaustion.

Refs: SCT-406

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
