### PR TITLE
test(skills): trigger skill review workflow

### DIFF
--- a/skills/writing-unit-tests/SKILL.md
+++ b/skills/writing-unit-tests/SKILL.md
@@ -3,9 +3,10 @@ name: writing-unit-tests
 description: >-
   Guides writing and debugging unit tests for the SCT framework using
   pytest conventions. Use when creating new test files in unit_tests/,
-  adding test cases, mocking external services, setting up fixtures, or
-  reviewing test coverage. Covers network-blocking patterns, FakeRemoter,
-  moto for AWS mocking, monkeypatch, and common pitfalls.
+  adding test cases, mocking external services, setting up fixtures,
+  reviewing test coverage, or verifying test isolation. Covers
+  network-blocking patterns, FakeRemoter, moto for AWS mocking,
+  monkeypatch, and common pitfalls.
 ---
 
 # Writing Unit Tests for SCT


### PR DESCRIPTION
Test PR to verify the new skill review workflow (SkillForge + Claude quality judge) runs correctly on fork PRs.

Minor description improvement to `writing-unit-tests` skill — adds "verifying test isolation" as a trigger phrase.

**Expected behavior**: The `Skill Quality Review` workflow should trigger and:
1. Run SkillForge lint + security scan on all skills
2. Run Claude quality judge (if `ANTHROPIC_API_KEY` is configured)
3. Post a single updatable PR comment with results

This PR can be closed after verifying the workflow runs.