### PR TITLE
fix(skill-review): allow checkout of fork PR code in pull_request_target

### DIFF
--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -16,6 +16,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          allow-unsafe-pr-checkout: true
 
       - name: SkillForge lint and security scan
         uses: LiqunChen0606/skillforge@v0.6.4
@@ -80,5 +81,5 @@ jobs:
             gh api "repos/${{ github.repository }}/issues/comments/${EXISTING}" \
               -X PATCH -f body="$BODY"
           else
-            gh pr comment "$PR_NUMBER" --body "$BODY"
+            gh pr comment "$PR_NUMBER" --repo "${{ github.repository }}" --body "$BODY"
           fi


### PR DESCRIPTION
## Problem

The skill review workflow fails on fork PRs with:

```
Refusing to check out fork pull request code from a 'pull_request_target' workflow.
```

`actions/checkout@v7` now requires explicit opt-in (`allow-unsafe-pr-checkout: true`) when checking out fork PR code in `pull_request_target` workflows due to security concerns around "pwn request" attacks.

## Fix

Add `allow-unsafe-pr-checkout: true` to the checkout step. This is safe because:
- We only **read** SKILL.md files for linting/scoring
- No code from the PR is executed (SkillForge is a static linter, Claude judge only reads markdown)
- The only secrets exposed are `ANTHROPIC_API_KEY` (for quality scoring) and `GITHUB_TOKEN` (for PR comments)

## References
- https://gh.io/securely-using-pull_request_target
- Failed run: https://github.com/scylladb/scylla-cluster-tests/actions/runs/28583764879