### PR TITLE
fix(kms): properly filter DB nodes in the `_rotate_kms_key`

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -5874,9 +5874,13 @@ class BaseScyllaCluster:
                         traceback=traceback.format_exc(),
                     ).publish()
                 try:
+                    ready_nodes = [node for node in db_cluster.data_nodes if node.remoter and node.db_up()]
+                    if not ready_nodes:
+                        self.log.warning("No ready nodes available for KMS encryption check, skipping this iteration")
+                        continue
                     nemesis_node_allocator = self.test_config.tester_obj().nemesis_allocator
                     with nemesis_node_allocator.run_nemesis(
-                        nemesis_label="KMS encryption check", node_list=db_cluster.data_nodes
+                        nemesis_label="KMS encryption check", node_list=ready_nodes
                     ) as target_node:
                         self.log.debug("Target node for 'rotate_kms_key' is %s", target_node.name)
 


### PR DESCRIPTION
The `_rotate_kms_key` method may pick up a DB node that is still being provisioned.
So, fix by filtering DB nodes out before picking up.

Fixes: SCT-451

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
