### PR TITLE
ci(rolling-upgrade): add YAML-driven trigger matrix for weekly and release rolling upgrades

### DIFF
--- a/configurations/triggers/rolling-upgrade.yaml
+++ b/configurations/triggers/rolling-upgrade.yaml
@@ -1,0 +1,211 @@
+# Rolling upgrade trigger matrix — single source of truth for all rolling-upgrade jobs.
+#
+# Replaces:
+#   - jenkins-pipelines/master-triggers/sct_triggers/weekly-master-images-rolling-upgrades-trigger.xml
+#
+# Also serves as the target for scylla-pkg release triggers. When scylla-pkg builds
+# packages/images for a release, it calls this trigger with explicit new_scylla_repo
+# and/or image params.
+#
+# Usage patterns:
+#   Weekly (cron):    scylla_version={branch}:latest, labels_selector=weekly
+#   Release (manual): new_scylla_repo=<url>, scylla_version=<tag>
+#   Image-based:      scylla_ami_id=<id>, backend=aws (or gce_image_db, azure_image_db)
+
+cron_triggers:
+  - schedule: "00 06 * * 6"  # Saturday 6am UTC — same as old trigger
+    params:
+      scylla_version: "{branch}:latest"
+      labels_selector: "weekly"
+      requested_by_user: "fruch"
+
+defaults:
+  provision_type: "on_demand"
+  post_behavior_db_nodes: "destroy"
+  post_behavior_loader_nodes: "destroy"
+  post_behavior_monitor_nodes: "destroy"
+  gce_project: "gcp-sct-project-1"
+
+jobs:
+  # ===========================================================================
+  # RPM-based rolling upgrades
+  # ===========================================================================
+
+  - job_name: "rolling-upgrade/rolling-upgrade-rocky10-test"
+    backend: "gce"
+    region: "us-central1"
+    labels:
+      - "weekly"
+      - "rpm"
+    exclude_versions: []
+    params:
+      new_scylla_repo: "http://downloads.scylladb.com/unstable/scylla/{branch}/rpm/centos/latest/scylla.repo"
+
+  # ===========================================================================
+  # DEB-based rolling upgrades
+  # ===========================================================================
+
+  - job_name: "rolling-upgrade/rolling-upgrade-debian13-test"
+    backend: "gce"
+    region: "us-central1"
+    labels:
+      - "weekly"
+      - "deb"
+    exclude_versions: []
+    params:
+      new_scylla_repo: "http://downloads.scylladb.com.s3.amazonaws.com/unstable/scylla/{branch}/deb/unified/latest/scylladb-{branch}/scylla.list"
+
+  - job_name: "rolling-upgrade/rolling-upgrade-ubuntu2404-test"
+    backend: "gce"
+    region: "us-central1"
+    labels:
+      - "weekly"
+      - "deb"
+    exclude_versions: []
+    params:
+      new_scylla_repo: "http://downloads.scylladb.com.s3.amazonaws.com/unstable/scylla/{branch}/deb/unified/latest/scylladb-{branch}/scylla.list"
+
+  - job_name: "rolling-upgrade/rolling-upgrade-ubuntu2604-test"
+    backend: "gce"
+    region: "us-central1"
+    labels:
+      - "weekly"
+      - "deb"
+    exclude_versions: []
+    params:
+      new_scylla_repo: "http://downloads.scylladb.com.s3.amazonaws.com/unstable/scylla/{branch}/deb/unified/latest/scylladb-{branch}/scylla.list"
+
+  # ===========================================================================
+  # Image-based rolling upgrades (AMI / GCE / Azure)
+  # ===========================================================================
+
+  - job_name: "rolling-upgrade/rolling-upgrade-ami-test"
+    backend: "aws"
+    region: "eu-west-1"
+    labels:
+      - "weekly"
+      - "image"
+      - "ami"
+    exclude_versions: []
+    params:
+      new_scylla_repo: "http://downloads.scylladb.com.s3.amazonaws.com/unstable/scylla/{branch}/deb/unified/latest/scylladb-{branch}/scylla.list"
+
+  - job_name: "rolling-upgrade/rolling-upgrade-ami-arm-test"
+    backend: "aws"
+    region: "eu-west-1"
+    labels:
+      - "weekly"
+      - "image"
+      - "ami"
+    exclude_versions: []
+    params:
+      new_scylla_repo: "http://downloads.scylladb.com.s3.amazonaws.com/unstable/scylla/{branch}/deb/unified/latest/scylladb-{branch}/scylla.list"
+
+  - job_name: "rolling-upgrade/rolling-upgrade-gce-image-test"
+    backend: "gce"
+    region: "us-central1"
+    labels:
+      - "weekly"
+      - "image"
+      - "gce"
+    exclude_versions: []
+    params:
+      new_scylla_repo: "http://downloads.scylladb.com.s3.amazonaws.com/unstable/scylla/{branch}/deb/unified/latest/scylladb-{branch}/scylla.list"
+
+  - job_name: "rolling-upgrade/rolling-upgrade-azure-image-test"
+    backend: "azure"
+    region: "eastus"
+    labels:
+      - "weekly"
+      - "image"
+      - "azure"
+    exclude_versions: []
+    params:
+      new_scylla_repo: "http://downloads.scylladb.com.s3.amazonaws.com/unstable/scylla/{branch}/deb/unified/latest/scylladb-{branch}/scylla.list"
+
+  # ===========================================================================
+  # Feature/scenario rolling upgrades
+  # ===========================================================================
+
+  - job_name: "rolling-upgrade/rolling-upgrade-alternator-test"
+    backend: "gce"
+    region: "us-east1"
+    labels:
+      - "weekly"
+      - "deb"
+    exclude_versions: []
+    params:
+      new_scylla_repo: "http://downloads.scylladb.com.s3.amazonaws.com/unstable/scylla/{branch}/deb/unified/latest/scylladb-{branch}/scylla.list"
+
+  # --- Non-weekly jobs (triggered by scylla-pkg on release only) ---
+
+  - job_name: "rolling-upgrade/rolling-upgrade-multidc-test"
+    backend: "aws"
+    region: "eu-west-1"
+    labels:
+      - "release"
+      - "deb"
+    exclude_versions: []
+    params:
+      new_scylla_repo: "http://downloads.scylladb.com.s3.amazonaws.com/unstable/scylla/{branch}/deb/unified/latest/scylladb-{branch}/scylla.list"
+
+  - job_name: "rolling-upgrade/rolling-upgrade-with-sla-test"
+    backend: "gce"
+    region: "us-east1"
+    labels:
+      - "release"
+      - "deb"
+    exclude_versions: []
+    params:
+      new_scylla_repo: "http://downloads.scylladb.com.s3.amazonaws.com/unstable/scylla/{branch}/deb/unified/latest/scylladb-{branch}/scylla.list"
+
+  - job_name: "rolling-upgrade/rolling-upgrade-with-sla-no-shares-test"
+    backend: "gce"
+    region: "us-east1"
+    labels:
+      - "release"
+      - "deb"
+    exclude_versions: []
+    params:
+      new_scylla_repo: "http://downloads.scylladb.com.s3.amazonaws.com/unstable/scylla/{branch}/deb/unified/latest/scylladb-{branch}/scylla.list"
+
+  - job_name: "rolling-upgrade/rolling-upgrade-with-null-inserts-test"
+    backend: "gce"
+    region: "us-east1"
+    labels:
+      - "release"
+      - "deb"
+    exclude_versions: []
+    params:
+      new_scylla_repo: "http://downloads.scylladb.com.s3.amazonaws.com/unstable/scylla/{branch}/deb/unified/latest/scylladb-{branch}/scylla.list"
+
+  - job_name: "rolling-upgrade/rolling-upgrade-with-enable-tablets-test"
+    backend: "gce"
+    region: "us-east1"
+    labels:
+      - "release"
+      - "image"
+      - "gce"
+    exclude_versions: []
+    params:
+      new_scylla_repo: "http://downloads.scylladb.com.s3.amazonaws.com/unstable/scylla/{branch}/deb/unified/latest/scylladb-{branch}/scylla.list"
+
+  - job_name: "rolling-upgrade/rolling-upgrade-debian11-test"
+    backend: "gce"
+    region: "us-central1"
+    labels:
+      - "release"
+      - "deb"
+    exclude_versions: []
+    params:
+      new_scylla_repo: "http://downloads.scylladb.com.s3.amazonaws.com/unstable/scylla/{branch}/deb/unified/latest/scylladb-{branch}/scylla.list"
+
+  - job_name: "rolling-upgrade/rolling-upgrade-ubuntu22.04-ldap-authorization-test"
+    backend: "gce"
+    region: "us-east1"
+    labels:
+      - "release"
+      - "deb"
+    exclude_versions: []
+    params:
+      new_scylla_repo: "http://downloads.scylladb.com.s3.amazonaws.com/unstable/scylla/{branch}/deb/unified/latest/scylladb-{branch}/scylla.list"

--- a/jenkins-pipelines/master-triggers/sct_triggers/_deprecated_jobs.yaml
+++ b/jenkins-pipelines/master-triggers/sct_triggers/_deprecated_jobs.yaml
@@ -7,3 +7,5 @@ jobs:
     reason: "Replaced by perf-regression-matrix-trigger using triggerMatrixPipeline (configurations/triggers/perf-regression.yaml)"
   - name: "tier1-custom-time-trigger"
     reason: "Replaced by oss/sct_triggers/tier1-trigger using triggerMatrixPipeline (configurations/triggers/tier1.yaml)"
+  - name: "weekly-master-images-rolling-upgrades-trigger"
+    reason: "Replaced by oss/sct_triggers/rolling-upgrade-trigger using triggerMatrixPipeline (configurations/triggers/rolling-upgrade.yaml)"

--- a/jenkins-pipelines/master-triggers/sct_triggers/weekly-master-images-rolling-upgrades-trigger.xml
+++ b/jenkins-pipelines/master-triggers/sct_triggers/weekly-master-images-rolling-upgrades-trigger.xml
@@ -34,7 +34,7 @@ UPDATE 02/02/2023: Removed rolling-upgrade-multi-dc-ami-test and rolling-upgrade
   </properties>
   <scm class="hudson.scm.NullSCM"/>
   <canRoam>true</canRoam>
-  <disabled>false</disabled>
+  <disabled>true</disabled>
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
   <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
   <triggers>

--- a/jenkins-pipelines/oss/sct_triggers/rolling-upgrade-trigger.jenkinsfile
+++ b/jenkins-pipelines/oss/sct_triggers/rolling-upgrade-trigger.jenkinsfile
@@ -1,0 +1,5 @@
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+triggerMatrixPipeline(
+    matrix_file: 'configurations/triggers/rolling-upgrade.yaml',
+    cron: '00 06 * * 6 % scylla_version={branch}:latest;labels_selector=weekly;requested_by_user=fruch'
+)

--- a/sct.py
+++ b/sct.py
@@ -3109,12 +3109,18 @@ def hdr_investigate(
     type=str,
     help="Unified package URL (for PGO offline installer jobs that don't need scylla_version)",
 )
+@click.option(
+    "--new-scylla-repo",
+    default=None,
+    type=str,
+    help="Scylla repo URL for rolling-upgrade jobs (RPM .repo or DEB .list). Overrides per-job template values.",
+)
 @click.option("--dry-run", is_flag=True, default=False, help="Preview mode — do not trigger jobs")
 @click.option("--requested-by-user", default=None, type=str, help="User requesting the run")
 @click.option(
     "--email-recipients", default=None, type=str, help="Comma-separated email recipients for wait-mode results report"
 )
-def trigger_matrix_cmd(  # noqa: PLR0913
+def trigger_matrix_cmd(  # noqa: PLR0912, PLR0913
     matrix,
     scylla_version,
     job_folder,
@@ -3130,6 +3136,7 @@ def trigger_matrix_cmd(  # noqa: PLR0913
     azure_image_db,
     oci_image_db,
     unified_package,
+    new_scylla_repo,
     dry_run,
     requested_by_user,
     email_recipients,
@@ -3143,11 +3150,14 @@ def trigger_matrix_cmd(  # noqa: PLR0913
         if unified_package:
             # PGO jobs only need unified_package, no version resolution needed
             pass
+        elif new_scylla_repo:
+            # Rolling upgrade jobs can be triggered with just new_scylla_repo
+            pass
         elif not has_image:
             click.echo(
                 "Error: Either --scylla-version, an image param "
                 "(--scylla-ami-id, --gce-image-db, --azure-image-db, --oci-image-db), "
-                "or --unified-package is required",
+                "--new-scylla-repo, or --unified-package is required",
                 err=True,
             )
             sys.exit(1)
@@ -3190,6 +3200,8 @@ def trigger_matrix_cmd(  # noqa: PLR0913
         overrides["requested_by_user"] = requested_by_user
     if unified_package:
         overrides["unified_package"] = unified_package
+    if new_scylla_repo:
+        overrides["new_scylla_repo"] = new_scylla_repo
 
     try:
         results = run_trigger_matrix(

--- a/sdcm/utils/trigger_matrix.py
+++ b/sdcm/utils/trigger_matrix.py
@@ -613,6 +613,43 @@ def _is_pre_release_match(scylla_version: str, resolved_version: str, pre_releas
     return any(f"-{tag}" in resolved_version for tag in pre_release)
 
 
+def _extract_branch_from_version(scylla_version: str) -> str:
+    """Extract branch name from a scylla_version string for template resolution.
+
+    Examples:
+        >>> _extract_branch_from_version("master:latest")
+        'master'
+        >>> _extract_branch_from_version("2025.4.1-0.20250601.abc123def456-1")
+        '2025.4'
+        >>> _extract_branch_from_version("")
+        ''
+    """
+    if not scylla_version:
+        return ""
+
+    branch_match = BRANCH_VERSION_RE.match(scylla_version)
+    if branch_match:
+        return branch_match.group("branch")
+
+    full_match = FULL_VERSION_TAG_RE.match(scylla_version)
+    if not full_match:
+        full_match = SIMPLE_VERSION_RE.match(scylla_version)
+    if full_match:
+        return f"{full_match.group('major')}.{full_match.group('minor')}"
+
+    if scylla_version.strip().lower() == "master":
+        return "master"
+
+    return ""
+
+
+def _resolve_templates(value: object, branch: str) -> object:
+    """Replace {branch} placeholder in a string value."""
+    if isinstance(value, str) and "{branch}" in value:
+        return value.replace("{branch}", branch)
+    return value
+
+
 def build_job_parameters(
     job: JobConfig,
     defaults: dict,
@@ -624,6 +661,9 @@ def build_job_parameters(
     Priority: cli_overrides > job.params > defaults.
     Always includes scylla_version. Downstream jobs resolve their
     own backend-specific images from the version.
+
+    Template variables in parameter values are resolved:
+      {branch} — extracted from scylla_version (e.g., "master" from "master:latest")
 
     Args:
         job: Job configuration.
@@ -643,6 +683,11 @@ def build_job_parameters(
         params["scylla_version"] = scylla_version
     if job.region:
         params.setdefault("region", job.region)
+
+    # Resolve {branch} templates in param values
+    branch = _extract_branch_from_version(scylla_version)
+    if branch:
+        params = {k: _resolve_templates(v, branch) for k, v in params.items()}
 
     return params
 

--- a/unit_tests/trigger_matrix/test_rolling_upgrade.py
+++ b/unit_tests/trigger_matrix/test_rolling_upgrade.py
@@ -1,0 +1,131 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2026 ScyllaDB
+
+from pathlib import Path
+
+import pytest
+
+from sdcm.utils.trigger_matrix import (
+    JobConfig,
+    _extract_branch_from_version,
+    build_job_parameters,
+    filter_jobs,
+    load_matrix_config,
+)
+
+ROLLING_UPGRADE_YAML = Path(__file__).parent.parent.parent / "configurations" / "triggers" / "rolling-upgrade.yaml"
+
+
+@pytest.mark.parametrize(
+    "version,expected",
+    [
+        ("master:latest", "master"),
+        ("branch-2025.4:latest", "branch-2025.4"),
+        ("2025.4", "2025.4"),
+        ("2025.4.1-0.20250601.abc123def456-1", "2025.4"),
+        ("2026.2.0~dev-0.20260322.f51126483167", "2026.2"),
+        ("master", "master"),
+        ("", ""),
+    ],
+)
+def test_extract_branch_from_version(version, expected):
+    assert _extract_branch_from_version(version) == expected
+
+
+def test_branch_template_resolved_in_params():
+    job = JobConfig(
+        job_name="rolling-upgrade/test",
+        backend="gce",
+        region="us-central1",
+        params={
+            "new_scylla_repo": "http://downloads.scylladb.com/unstable/scylla/{branch}/rpm/centos/latest/scylla.repo"
+        },
+    )
+    params = build_job_parameters(job, {}, "master:latest", {})
+    assert (
+        params["new_scylla_repo"]
+        == "http://downloads.scylladb.com/unstable/scylla/master/rpm/centos/latest/scylla.repo"
+    )
+
+
+def test_branch_template_from_simple_version():
+    job = JobConfig(
+        job_name="rolling-upgrade/test",
+        backend="gce",
+        region="us-central1",
+        params={"new_scylla_repo": "http://repo/{branch}/deb/scylla.list"},
+    )
+    params = build_job_parameters(job, {}, "2025.4", {})
+    assert params["new_scylla_repo"] == "http://repo/2025.4/deb/scylla.list"
+
+
+def test_branch_template_from_full_version_tag():
+    job = JobConfig(
+        job_name="rolling-upgrade/test",
+        backend="aws",
+        region="eu-west-1",
+        params={"new_scylla_repo": "http://repo/{branch}/rpm/scylla.repo"},
+    )
+    params = build_job_parameters(job, {}, "2025.4.1-0.20250601.abc123def456-1", {})
+    assert params["new_scylla_repo"] == "http://repo/2025.4/rpm/scylla.repo"
+
+
+def test_no_template_no_change():
+    job = JobConfig(
+        job_name="rolling-upgrade/test",
+        backend="aws",
+        region="eu-west-1",
+        params={"new_scylla_repo": "http://explicit-repo/scylla.repo"},
+    )
+    params = build_job_parameters(job, {}, "master:latest", {})
+    assert params["new_scylla_repo"] == "http://explicit-repo/scylla.repo"
+
+
+def test_cli_override_wins_over_template():
+    job = JobConfig(
+        job_name="rolling-upgrade/test",
+        backend="gce",
+        region="us-central1",
+        params={"new_scylla_repo": "http://downloads/{branch}/rpm/scylla.repo"},
+    )
+    params = build_job_parameters(job, {}, "master:latest", {"new_scylla_repo": "http://custom/release/scylla.repo"})
+    assert params["new_scylla_repo"] == "http://custom/release/scylla.repo"
+
+
+def test_empty_version_no_resolution():
+    job = JobConfig(
+        job_name="rolling-upgrade/test",
+        backend="gce",
+        region="us-central1",
+        params={"new_scylla_repo": "http://downloads/{branch}/rpm/scylla.repo"},
+    )
+    params = build_job_parameters(job, {}, "", {})
+    assert params["new_scylla_repo"] == "http://downloads/{branch}/rpm/scylla.repo"
+
+
+def test_rolling_upgrade_yaml_loads():
+    config = load_matrix_config(ROLLING_UPGRADE_YAML)
+    assert len(config.jobs) > 0
+    assert config.cron_triggers[0].schedule == "00 06 * * 6"
+
+
+def test_all_jobs_have_new_scylla_repo():
+    config = load_matrix_config(ROLLING_UPGRADE_YAML)
+    for job in config.jobs:
+        assert "new_scylla_repo" in job.params, f"Job {job.job_name} missing new_scylla_repo param"
+
+
+def test_weekly_label_filter():
+    config = load_matrix_config(ROLLING_UPGRADE_YAML)
+    weekly_jobs = filter_jobs(config.jobs, scylla_version="master:latest", labels_selector="weekly")
+    assert len(weekly_jobs) >= 9

--- a/vars/triggerMatrixPipeline.groovy
+++ b/vars/triggerMatrixPipeline.groovy
@@ -68,6 +68,8 @@ def call(Map pipelineParams = [:]) {
                    description: 'Scylla OCI image OCID — passed to OCI jobs. Use with backend=oci to run only OCI jobs.')
             string(name: 'unified_package', defaultValue: '',
                    description: 'URL to unified (relocatable) Scylla package — for PGO offline installer triggers')
+            string(name: 'new_scylla_repo', defaultValue: '',
+                   description: 'Scylla repo URL for rolling-upgrade jobs (RPM .repo or DEB .list). Overrides per-job template values when set.')
             string(name: 'requested_by_user', defaultValue: '',
                    description: 'User requesting the run')
             string(name: 'email_recipients', defaultValue: 'qa@scylladb.com',
@@ -138,9 +140,9 @@ def call(Map pipelineParams = [:]) {
                         if (!params.matrix_file?.trim()) {
                             error("'matrix_file' parameter is required")
                         }
-                        def hasImageParam = params.scylla_ami_id?.trim() || params.gce_image_db?.trim() || params.azure_image_db?.trim() || params.oci_image_db?.trim() || params.unified_package?.trim()
+                        def hasImageParam = params.scylla_ami_id?.trim() || params.gce_image_db?.trim() || params.azure_image_db?.trim() || params.oci_image_db?.trim() || params.unified_package?.trim() || params.new_scylla_repo?.trim()
                         if (!scyllaVersion?.trim() && !hasImageParam) {
-                            error("Either 'scylla_version' or an image/package param (scylla_ami_id, gce_image_db, azure_image_db, oci_image_db, unified_package) is required")
+                            error("Either 'scylla_version' or an image/package param (scylla_ami_id, gce_image_db, azure_image_db, oci_image_db, unified_package, new_scylla_repo) is required")
                         }
 
                         // Build CLI command
@@ -187,6 +189,9 @@ def call(Map pipelineParams = [:]) {
                         }
                         if (params.unified_package?.trim()) {
                             cmd += " --unified-package '${params.unified_package}'"
+                        }
+                        if (params.new_scylla_repo?.trim()) {
+                            cmd += " --new-scylla-repo '${params.new_scylla_repo}'"
                         }
                         if (params.requested_by_user?.trim()) {
                             cmd += " --requested-by-user '${params.requested_by_user}'"


### PR DESCRIPTION
## Summary

Consolidates rolling upgrade triggers into a single source of truth using the trigger matrix system. Replaces the XML-based `weekly-master-images-rolling-upgrades-trigger` with a YAML matrix that serves both weekly cron runs and release triggers from scylla-pkg.

## What Changed

| File | Purpose |
|------|---------|
| `configurations/triggers/rolling-upgrade.yaml` | Single source of truth — all rolling upgrade jobs |
| `jenkins-pipelines/oss/sct_triggers/rolling-upgrade-trigger.jenkinsfile` | Thin wrapper calling `triggerMatrixPipeline()` |
| `vars/triggerMatrixPipeline.groovy` | Added `new_scylla_repo` parameter |
| `sdcm/utils/trigger_matrix.py` | `{branch}` template resolution in job params |
| `sct.py` | `--new-scylla-repo` CLI option |
| `unit_tests/trigger_matrix/test_rolling_upgrade.py` | 16 tests for templates + YAML validation |
| `weekly-master-images-rolling-upgrades-trigger.xml` | Disabled |
| `_deprecated_jobs.yaml` | Old trigger listed as deprecated |

## How It Works

The YAML defines all rolling upgrade jobs with `{branch}` templates in `new_scylla_repo` URLs. The trigger matrix Python code resolves `{branch}` from `scylla_version` automatically.

| Scenario | How to call |
|----------|-------------|
| Weekly master (cron) | `scylla_version={branch}:latest`, `labels_selector=weekly` |
| Release (scylla-pkg) | `new_scylla_repo=<explicit-url>`, `scylla_version=<tag>` |
| Filter by type | `labels_selector=rpm` / `deb` / `image` / `ami` / `gce` / `azure` |

## scylla-pkg Integration

scylla-pkg replaces its rolling-upgrade trigger logic with a single call:
```groovy
build job: "scylla-${branch}/sct_triggers/rolling-upgrade-trigger",
    parameters: [
        string(name: "new_scylla_repo", value: repoUrl),
        string(name: "scylla_version", value: fullVersion),
        string(name: "labels_selector", value: "rpm"),  // or "deb", "image"
    ]
```

## Follow-up

- SCT-579: Add OCI image-based rolling upgrade job (2026.2+)

## Tests

16 new tests pass — template resolution, YAML validation, weekly filter.