### PR TITLE
fix(trigger-matrix): resolve {branch} placeholder in scylla_version parameter

### DIFF
--- a/utils/build_system/create_test_release_jobs.py
+++ b/utils/build_system/create_test_release_jobs.py
@@ -385,10 +385,11 @@ class JenkinsPipelines:
             for job_file in job_files:
                 job_file = Path(root) / job_file  # noqa: PLW2901
                 if (job_file.suffix == ".jenkinsfile") and create_pipelines_jobs:
+                    suffix = "" if job_file.stem.endswith("-trigger") else job_name_suffix
                     self.create_pipeline_job(
                         job_file,
                         group_name=jenkins_path,
-                        job_name_suffix=job_name_suffix,
+                        job_name_suffix=suffix,
                         defines={**defines, **self.locate_job_overrides(job_file.stem, job_overrides)},
                     )
                 if (job_file.suffix == ".xml") and create_freestyle_jobs:

--- a/vars/triggerMatrixPipeline.groovy
+++ b/vars/triggerMatrixPipeline.groovy
@@ -90,11 +90,28 @@ def call(Map pipelineParams = [:]) {
             stage('Trigger Matrix') {
                 steps {
                     script {
+                        // Resolve {branch} placeholder in scylla_version.
+                        // Cron triggers pass "{branch}:latest" literally; resolve
+                        // it from job_folder (e.g. "scylla-master" -> "master",
+                        // "scylla-2026.2" -> "branch-2026.2") or from JOB_NAME.
+                        def scyllaVersion = params.scylla_version ?: ''
+                        if (scyllaVersion.contains('{branch}')) {
+                            def folder = (params.job_folder?.trim()) ?: env.JOB_NAME?.split('/')[0] ?: ''
+                            def branch = folder.replaceFirst(/^scylla-/, '')
+                            if (branch && branch != 'master') {
+                                branch = "branch-${branch}"
+                            }
+                            if (branch) {
+                                scyllaVersion = scyllaVersion.replace('{branch}', branch)
+                                println("Resolved {branch} placeholder: scylla_version='${scyllaVersion}'")
+                            }
+                        }
+
                         // Input sanitization — allow only safe characters
                         def safePattern = ~/^[a-zA-Z0-9_.:\-\/,@\s]*$/
                         def paramChecks = [
                             'matrix_file': params.matrix_file,
-                            'scylla_version': params.scylla_version,
+                            'scylla_version': scyllaVersion,
                             'labels_selector': params.labels_selector,
                             'backend': params.backend,
                             'skip_jobs': params.skip_jobs,
@@ -122,15 +139,15 @@ def call(Map pipelineParams = [:]) {
                             error("'matrix_file' parameter is required")
                         }
                         def hasImageParam = params.scylla_ami_id?.trim() || params.gce_image_db?.trim() || params.azure_image_db?.trim() || params.oci_image_db?.trim() || params.unified_package?.trim()
-                        if (!params.scylla_version?.trim() && !hasImageParam) {
+                        if (!scyllaVersion?.trim() && !hasImageParam) {
                             error("Either 'scylla_version' or an image/package param (scylla_ami_id, gce_image_db, azure_image_db, oci_image_db, unified_package) is required")
                         }
 
                         // Build CLI command
                         def cmd = "./docker/env/hydra.sh trigger-matrix"
                         cmd += " --matrix '${params.matrix_file}'"
-                        if (params.scylla_version?.trim()) {
-                            cmd += " --scylla-version '${params.scylla_version}'"
+                        if (scyllaVersion?.trim()) {
+                            cmd += " --scylla-version '${scyllaVersion}'"
                         }
                         if (params.job_folder?.trim()) {
                             cmd += " --job-folder '${params.job_folder}'"


### PR DESCRIPTION
The parameterized cron triggers pass `scylla_version="{branch}:latest"` as a literal string (from `configurations/triggers/perf-regression.yaml` and `tier1.yaml`). The `triggerMatrixPipeline` input sanitization rejects curly braces, causing all timer-triggered perf-regression builds to fail with:

```
ERROR: Invalid characters in parameter 'scylla_version': {branch}:latest
```

**Root cause:** The `{branch}` placeholder is embedded in the Jenkinsfile cron spec by the generator script. When Jenkins fires the timer, it passes the value literally. The `safePattern` regex (`^[a-zA-Z0-9_.:\-\/,@\s]*$`) does not allow `{` or `}`.

**Fix:** Resolve `{branch}` from the `job_folder` parameter (e.g. `scylla-master` → `master`) or from `JOB_NAME` before validation runs.

**Failing build:** https://jenkins.scylladb.com/job/scylla-master/job/sct_triggers/job/perf-regression-trigger-test/471/

## Manual Testing Required

### What could not be tested locally

- [x] **Timer-triggered perf-regression build**: Requires Jenkins timer to fire with `{branch}:latest` in parameters
  - Verify: Retrigger build 471 or wait for next weekly schedule
  - Expected: `{branch}` resolves to `master`, validation passes, downstream jobs triggered
  - https://jenkins.scylladb.com/job/scylla-master/job/sct_triggers/job/perf-regression-trigger-test/477/

### Suggested manual verification

```bash
# Build the job manually with the same params the timer sends:
# scylla_version={branch}:latest, job_folder=scylla-master, labels_selector=master-weekly
```
