### PR TITLE
fix(nemesis): add timeout to repair nodetool commands to prevent indefinite hang

### DIFF
--- a/sdcm/nemesis/__init__.py
+++ b/sdcm/nemesis/__init__.py
@@ -1661,7 +1661,7 @@ class NemesisRunner:
                             SimpleStatement(f"DROP TABLE drop_table_during_repair_ks_{i}.standard1"), timeout=300
                         )
             finally:
-                thread.result()
+                thread.result(timeout=HOUR_IN_SEC * 8)
 
     def _major_compaction(self):
         with (
@@ -2086,21 +2086,37 @@ class NemesisRunner:
     def run_repair_nodetool(self, nodes: list, publish_event=True, timeout=HOUR_IN_SEC * 3):
         """
         Execute a repair using Nodetool, which runs both vnode repair (repair) and tablet repairs (cluster repair)
+
+        The adaptive_timeout yields the soft_timeout value. We use 2.5x that as the actual command
+        timeout so the SoftTimeoutEvent fires as a non-disruptive early warning well before the
+        command is killed.
         """
         for node in nodes:
             with (
-                adaptive_timeout(Operations.REPAIR, node, timeout=timeout),
+                adaptive_timeout(Operations.REPAIR, node, timeout=timeout) as soft_timeout,
                 self.action_log_scope(f"nodetool repair on {node.name} node"),
             ):
-                node.run_nodetool(sub_cmd="repair", publish_event=publish_event)
+                node.run_nodetool(
+                    sub_cmd="repair",
+                    publish_event=publish_event,
+                    timeout=soft_timeout * 2.5,
+                    long_running=True,
+                    retry=0,
+                )
 
         target_node = nodes[0]
         if is_tablets_feature_enabled(target_node):
             with (
-                adaptive_timeout(Operations.REPAIR, target_node, timeout=timeout),
+                adaptive_timeout(Operations.REPAIR, target_node, timeout=timeout) as soft_timeout,
                 self.action_log_scope("nodetool cluster repair", target=target_node.name),
             ):
-                target_node.run_nodetool(sub_cmd="cluster repair", publish_event=publish_event)
+                target_node.run_nodetool(
+                    sub_cmd="cluster repair",
+                    publish_event=publish_event,
+                    timeout=soft_timeout * 2.5,
+                    long_running=True,
+                    retry=0,
+                )
 
     @latency_calculator_decorator(legend="Run repair process through Scylla manager", cycle_name="_mgmt_repair_cli")
     def run_repair_manager(self, ignore_down_hosts: bool = False, timeout=HOUR_IN_SEC * 3):

--- a/sdcm/nemesis/__init__.py
+++ b/sdcm/nemesis/__init__.py
@@ -2141,21 +2141,37 @@ class NemesisRunner:
     def run_repair_nodetool(self, nodes: list, publish_event=True, timeout=HOUR_IN_SEC * 3):
         """
         Execute a repair using Nodetool, which runs both vnode repair (repair) and tablet repairs (cluster repair)
+
+        The command timeout is the repair adaptive timeout: the given `timeout` scaled by the
+        `adaptive_timeout_multipliers` config param (`{repair: N}`), so tests with longer repairs
+        tune it per-test yaml. On expiry the command fails and a SoftTimeoutEvent is emitted.
         """
         for node in nodes:
             with (
-                adaptive_timeout(Operations.REPAIR, node, timeout=timeout),
+                adaptive_timeout(Operations.REPAIR, node, timeout=timeout) as repair_timeout,
                 self.action_log_scope(f"nodetool repair on {node.name} node"),
             ):
-                node.run_nodetool(sub_cmd="repair", publish_event=publish_event)
+                node.run_nodetool(
+                    sub_cmd="repair",
+                    publish_event=publish_event,
+                    timeout=repair_timeout,
+                    long_running=True,
+                    retry=0,
+                )
 
         target_node = nodes[0]
         if is_tablets_feature_enabled(target_node):
             with (
-                adaptive_timeout(Operations.REPAIR, target_node, timeout=timeout),
+                adaptive_timeout(Operations.REPAIR, target_node, timeout=timeout) as repair_timeout,
                 self.action_log_scope("nodetool cluster repair", target=target_node.name),
             ):
-                target_node.run_nodetool(sub_cmd="cluster repair", publish_event=publish_event)
+                target_node.run_nodetool(
+                    sub_cmd="cluster repair",
+                    publish_event=publish_event,
+                    timeout=repair_timeout,
+                    long_running=True,
+                    retry=0,
+                )
 
     @latency_calculator_decorator(legend="Run repair process through Scylla manager", cycle_name="_mgmt_repair_cli")
     def run_repair_manager(self, ignore_down_hosts: bool = False, timeout=HOUR_IN_SEC * 3):

--- a/sdcm/remote/remote_long_running.py
+++ b/sdcm/remote/remote_long_running.py
@@ -4,11 +4,49 @@ from uuid import uuid4
 from pathlib import Path
 from contextlib import ExitStack
 
+from invoke.exceptions import CommandTimedOut as InvokeCommandTimedOut
+
 from sdcm.remote.remote_cmd_runner import RemoteCmdRunnerBase
 from sdcm.remote.libssh2_client.result import Result
-from sdcm.remote.libssh2_client.exceptions import UnexpectedExit
+from sdcm.remote.libssh2_client.exceptions import CommandTimedOut, UnexpectedExit
 
 logger = logging.getLogger(__name__)
+
+# a timeout is a deadline, not a transient failure — it must never be retried
+TIMEOUT_EXCEPTIONS = (CommandTimedOut, InvokeCommandTimedOut)
+POLL_MAX_SSH_FAILURES = 10
+
+
+def _poll_process(remoter: RemoteCmdRunnerBase, pid: str, cmd: str, deadline: float | None, timeout: float | None):
+    """Wait for the remote process to exit, treating `deadline` as a hard wall-clock limit.
+
+    An SSH disconnect resumes watching the same pid with the remaining time budget,
+    while a timeout is a deadline, not a transient failure — it is never retried.
+    """
+    poll_cmd = f"while [ -e /proc/{pid.strip()} ]; do sleep 0.1; done"
+    timed_out_result = Result(command=cmd, stdout="", stderr="", exited=-1, hide=("stderr", "stdout"), pty=False)
+    ssh_failures = 0
+    while True:
+        remaining = deadline - time.perf_counter() if deadline else None
+        if remaining is not None and remaining <= 0:
+            raise CommandTimedOut(result=timed_out_result, timeout=timeout)
+        try:
+            remoter.run(poll_cmd, timeout=remaining, retry=0, verbose=False)
+            return
+        except TIMEOUT_EXCEPTIONS as exc:
+            # report the actual command rather than the poll one-liner
+            raise CommandTimedOut(result=timed_out_result, timeout=timeout) from exc
+        except Exception:
+            ssh_failures += 1
+            if ssh_failures >= POLL_MAX_SSH_FAILURES:
+                raise
+            logger.warning(
+                "<%s> polling long running command was interrupted (attempt %d/%d), reconnecting",
+                remoter.hostname,
+                ssh_failures,
+                POLL_MAX_SSH_FAILURES,
+            )
+            time.sleep(5)
 
 
 def run_long_running_cmd(
@@ -54,7 +92,7 @@ def run_long_running_cmd(
             logger.debug("<%s> execute run_long_running_cmd: %s", remoter.hostname, remote_command)
         pid = remoter.run(remote_command, retry=0, verbose=verbose).stdout
 
-        remoter.run(f"while [ -e /proc/{pid.strip()} ]; do sleep 0.1; done", timeout=timeout, retry=10, verbose=False)
+        _poll_process(remoter, pid, cmd, deadline=start_time + timeout if timeout else None, timeout=timeout)
 
         stdout = str(remoter.run(f"cat {cmd_stdout_log}", verbose=False).stdout)
         stderr = str(remoter.run(f"cat {cmd_stderr_log}", verbose=False).stdout)

--- a/unit_tests/unit/test_remote_long_running.py
+++ b/unit_tests/unit/test_remote_long_running.py
@@ -1,3 +1,4 @@
+import time
 from pathlib import Path
 
 import pytest
@@ -5,6 +6,7 @@ import pytest
 from sdcm.remote import LOCALRUNNER
 from sdcm.remote.remote_long_running import run_long_running_cmd
 from sdcm.remote.libssh2_client import UnexpectedExit
+from sdcm.remote.libssh2_client.exceptions import CommandTimedOut
 
 
 @pytest.fixture(scope="function", autouse=True)
@@ -23,6 +25,24 @@ def test_long_command_failing():
     assert exc_info.value.result.exited == 127
     assert exc_info.value.result.return_code == 127
     assert exc_info.value.result.duration > 1
+
+
+def test_long_command_timeout():
+    start = time.perf_counter()
+    try:
+        with pytest.raises(CommandTimedOut) as exc_info:
+            run_long_running_cmd(LOCALRUNNER, cmd="sleep 30.123", timeout=2)
+    finally:
+        # the timed-out command keeps running in the background and would recreate its
+        # exit-code log after the cleanup callback ran — kill it and sweep the leftovers
+        LOCALRUNNER.run("pkill -f 'sleep 30.123'", ignore_status=True, verbose=False)
+        time.sleep(0.5)
+        LOCALRUNNER.run("rm -f /tmp/remoter_*", ignore_status=True, verbose=False)
+
+    # the timeout is a deadline: it must not be amplified by poll retries
+    assert time.perf_counter() - start < 15
+    assert exc_info.value.timeout == 2
+    assert exc_info.value.result.command == "sleep 30.123"
 
 
 def test_long_command_success():


### PR DESCRIPTION
fix(nemesis): enforce repair adaptive timeout to prevent indefinite hang

nodetool repair could hang indefinitely (24h+ test runs) because no
timeout was passed down to the repair command.

Use the value yielded by adaptive_timeout(Operations.REPAIR) as the
command timeout, as-is: the established 3h default, scaled per test by
the existing adaptive_timeout_multipliers config param ({repair: N}).
No hidden slack factors; tests whose repairs legitimately take longer
tune the multiplier in their yaml.

Run repair via long_running=True so SSH disconnects don't fail a
multi-hour repair, and fix run_long_running_cmd so the timeout is
actually enforced: the /proc poll used retry=10, which retries on any
exception - including CommandTimedOut - so a hung command would only
fail after ~10x the requested timeout. The poll is now deadline-based:
an SSH disconnect resumes watching the same pid with the remaining time
budget, while a timeout is terminal and never retried.



Fixes: https://scylladb.atlassian.net/browse/SCT-575
Fixes: https://scylladb.atlassian.net/browse/SCT-976
Refs: https://scylladb.atlassian.net/browse/SCT-964



### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
