### PR TITLE
feature(perf-config): add latency decorator error thresholds for microbenchmark

### DIFF
--- a/configurations/performance/perf_simple/latency-decorator-error-thresholds-perf-simple-query-microbenchmark_arm64.yaml
+++ b/configurations/performance/perf_simple/latency-decorator-error-thresholds-perf-simple-query-microbenchmark_arm64.yaml
@@ -1,6 +1,15 @@
 latency_decorator_error_thresholds:
+  write:
+      allocs_per_op:
+        fixed_limit: 61
+      cpu_cycles_per_op:
+        fixed_limit:  21130.00
+      instructions_per_op:
+        fixed_limit: 44440.00
   read:
-    instructions_per_op:
-      fixed_limit: 40000
-    allocs_per_op:
-      best_pct: 5
+      allocs_per_op:
+        fixed_limit: 66.19
+      cpu_cycles_per_op:
+        fixed_limit:  18500.00
+      instructions_per_op:
+        fixed_limit: 44440.00

--- a/configurations/performance/perf_simple/latency-decorator-error-thresholds-perf-simple-query-microbenchmark_x86_64.yaml
+++ b/configurations/performance/perf_simple/latency-decorator-error-thresholds-perf-simple-query-microbenchmark_x86_64.yaml
@@ -1,6 +1,15 @@
 latency_decorator_error_thresholds:
+  write:
+      allocs_per_op:
+        fixed_limit: 61
+      cpu_cycles_per_op:
+        fixed_limit:  21130.00
+      instructions_per_op:
+        fixed_limit: 44440.00
   read:
-    instructions_per_op:
-      fixed_limit: 40000
-    allocs_per_op:
-      best_pct: 5
+      allocs_per_op:
+        fixed_limit: 66.19
+      cpu_cycles_per_op:
+        fixed_limit:  17900.00
+      instructions_per_op:
+        fixed_limit: 40000.00

--- a/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-simple-query-weekly-microbenchmark_arm64-write.jenkinsfile
+++ b/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-simple-query-weekly-microbenchmark_arm64-write.jenkinsfile
@@ -8,6 +8,6 @@ longevityPipeline(
     region: 'eu-west-1',
     provision_type: 'on_demand',
     test_name: 'microbenchmarking_test.PerfSimpleQueryTest.test_perf_simple_query',
-    test_config: """[ 'test-cases/microbenchmarking/amazon_perf_simple_query_ARM.yaml', 'configurations/performance/perf_simple/perf_simple_write_option.yaml' ]""",
+    test_config: """[ 'test-cases/microbenchmarking/amazon_perf_simple_query_ARM.yaml', 'configurations/performance/perf_simple/perf_simple_write_option.yaml','configurations/performance/perf_simple/latency-decorator-error-thresholds-perf-simple-query-microbenchmark_arm64.yaml']""",
     email_recipients: "scylla-perf-results@scylladb.com",
 )

--- a/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-simple-query-weekly-microbenchmark_x86_64-write.jenkinsfile
+++ b/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-simple-query-weekly-microbenchmark_x86_64-write.jenkinsfile
@@ -8,6 +8,6 @@ longevityPipeline(
     region: 'eu-west-1',
     provision_type: 'on_demand',
     test_name: 'microbenchmarking_test.PerfSimpleQueryTest.test_perf_simple_query',
-    test_config: """[ 'test-cases/microbenchmarking/amazon_perf_simple_query_ARM.yaml', 'test-cases/microbenchmarking/amazon_perf_simple_query_x86.yaml', 'configurations/performance/perf_simple/perf_simple_write_option.yaml' ]""",
+    test_config: """[ 'test-cases/microbenchmarking/amazon_perf_simple_query_ARM.yaml', 'test-cases/microbenchmarking/amazon_perf_simple_query_x86.yaml', 'configurations/performance/perf_simple/perf_simple_write_option.yaml','configurations/performance/perf_simple/latency-decorator-error-thresholds-perf-simple-query-microbenchmark_x86_64.yaml' ]""",
     email_recipients: "scylla-perf-results@scylladb.com",
 )


### PR DESCRIPTION
Define latency_decorator_error_thresholds configuration for amd64 and x86 microbenchmark tests defining fixed limits for allocs_per_op, cpu_cycles_per_op, and instructions_per_op for both read and write operations.
Update weekly microbenchmark Jenkinsfiles to include the new thresholds configuration.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
