### PR TITLE
feature(trigger-matrix): add use_job_throttling parameter to triggerMatrixPipeline

### DIFF
--- a/configurations/triggers/perf-regression.yaml
+++ b/configurations/triggers/perf-regression.yaml
@@ -49,6 +49,8 @@ defaults:
   post_behavior_db_nodes: "destroy"
   post_behavior_loader_nodes: "destroy"
   post_behavior_monitor_nodes: "destroy"
+  use_job_throttling: true
+  billing_project: "weekly performance regression"
 
 jobs:
   # === i8g vnodes (aarch64) ===

--- a/sct.py
+++ b/sct.py
@@ -3116,7 +3116,13 @@ def hdr_investigate(
     help="Scylla repo URL for rolling-upgrade jobs (RPM .repo or DEB .list). Overrides per-job template values.",
 )
 @click.option("--dry-run", is_flag=True, default=False, help="Preview mode — do not trigger jobs")
+@click.option(
+    "--use-job-throttling/--no-use-job-throttling",
+    default=None,
+    help="Override use_job_throttling parameter for triggered jobs",
+)
 @click.option("--requested-by-user", default=None, type=str, help="User requesting the run")
+@click.option("--billing-project", default=None, type=str, help="Billing project for resource tagging")
 @click.option(
     "--email-recipients", default=None, type=str, help="Comma-separated email recipients for wait-mode results report"
 )
@@ -3138,7 +3144,9 @@ def trigger_matrix_cmd(  # noqa: PLR0912, PLR0913
     unified_package,
     new_scylla_repo,
     dry_run,
+    use_job_throttling,
     requested_by_user,
+    billing_project,
     email_recipients,
 ):
     add_file_logger()
@@ -3198,10 +3206,14 @@ def trigger_matrix_cmd(  # noqa: PLR0912, PLR0913
         overrides["provision_type"] = provision_type
     if requested_by_user:
         overrides["requested_by_user"] = requested_by_user
+    if billing_project:
+        overrides["billing_project"] = billing_project
     if unified_package:
         overrides["unified_package"] = unified_package
     if new_scylla_repo:
         overrides["new_scylla_repo"] = new_scylla_repo
+    if use_job_throttling is not None:
+        overrides["use_job_throttling"] = use_job_throttling
 
     try:
         results = run_trigger_matrix(

--- a/vars/triggerMatrixPipeline.groovy
+++ b/vars/triggerMatrixPipeline.groovy
@@ -72,8 +72,12 @@ def call(Map pipelineParams = [:]) {
                    description: 'Scylla repo URL for rolling-upgrade jobs (RPM .repo or DEB .list). Overrides per-job template values when set.')
             string(name: 'requested_by_user', defaultValue: '',
                    description: 'User requesting the run')
+            string(name: 'billing_project', defaultValue: '',
+                   description: 'Billing project for resource tagging')
             string(name: 'email_recipients', defaultValue: 'qa@scylladb.com',
                    description: 'Comma-separated email recipients for wait-mode results report')
+            booleanParam(name: 'use_job_throttling', defaultValue: true,
+                   description: 'If true, use job throttling to limit the number of concurrent builds')
             booleanParam(name: 'dry_run', defaultValue: false,
                    description: 'Preview mode — do not trigger jobs')
         }
@@ -128,6 +132,7 @@ def call(Map pipelineParams = [:]) {
                             'oci_image_db': params.oci_image_db,
                             'unified_package': params.unified_package,
                             'requested_by_user': params.requested_by_user,
+                            'billing_project': params.billing_project,
                             'email_recipients': params.email_recipients,
                         ]
 
@@ -196,8 +201,16 @@ def call(Map pipelineParams = [:]) {
                         if (params.requested_by_user?.trim()) {
                             cmd += " --requested-by-user '${params.requested_by_user}'"
                         }
+                        if (params.billing_project?.trim()) {
+                            cmd += " --billing-project '${params.billing_project}'"
+                        }
                         if (params.email_recipients?.trim()) {
                             cmd += " --email-recipients '${params.email_recipients}'"
+                        }
+                        if (params.use_job_throttling) {
+                            cmd += " --use-job-throttling"
+                        } else {
+                            cmd += " --no-use-job-throttling"
                         }
                         if (params.dry_run) {
                             cmd += " --dry-run"


### PR DESCRIPTION
## Summary

Adds `use_job_throttling` parameter to `vars/triggerMatrixPipeline.groovy` so operators can control job throttling from the Jenkins UI when triggering perf regression jobs via the matrix pipeline.

## Changes

- **`vars/triggerMatrixPipeline.groovy`**: Added `use_job_throttling` booleanParam (default: `true`) and passes it to the CLI as `--use-job-throttling` / `--no-use-job-throttling`
- **`sct.py`**: Added `--use-job-throttling/--no-use-job-throttling` click option to `trigger-matrix` command, wired into overrides dict
- **`configurations/triggers/perf-regression.yaml`**: Already has `use_job_throttling: true` in defaults (no change needed)

## Parameter Flow

```
Jenkins UI (booleanParam) → Groovy CLI builder → --use-job-throttling/--no-use-job-throttling → Python overrides → triggered child jobs
```

## Manual Testing Required

- [ ] Trigger the matrix pipeline with `use_job_throttling=true` (default) and verify child jobs receive the parameter
- [ ] Trigger with `use_job_throttling=false` and verify throttling is disabled on child jobs
- [ ] Run with `--dry-run` to confirm the CLI flag is passed correctly