### PR TITLE
fix(skill-review): use claude-sonnet-4-6 model and surface errors in PR comment

### DIFF
--- a/.github/scripts/skill-quality-judge.py
+++ b/.github/scripts/skill-quality-judge.py
@@ -54,7 +54,7 @@ def read_skill(skill_dir: Path) -> str | None:
 
 
 def judge_skill(client, skill_name: str, content: str) -> dict:
-    model = os.environ.get("ANTHROPIC_MODEL", "claude-sonnet-4-20250514")
+    model = os.environ.get("ANTHROPIC_MODEL", "claude-sonnet-4-6")
     message = client.messages.create(
         model=model,
         max_tokens=512,
@@ -84,6 +84,7 @@ def main():
         skill_dirs = sorted(Path("skills").iterdir())
 
     results = []
+    errors = []
     failed = False
     threshold = int(os.environ.get("SKILL_QUALITY_THRESHOLD", "70"))
 
@@ -116,7 +117,9 @@ def main():
                 failed = True
                 print(f"::error file=skills/{skill_name}/SKILL.md::Score {score} below threshold {threshold}")
         except (json.JSONDecodeError, KeyError, IndexError, TypeError, anthropic.APIError) as e:
-            print(f"::warning::Failed to judge {skill_name}: {e}")
+            print(f"::error file=skills/{skill_name}/SKILL.md::Failed to judge: {e}")
+            errors.append({"skill": skill_name, "error": str(e)})
+            failed = True
             continue
 
     print(f"\n{'=' * 60}")
@@ -133,30 +136,40 @@ def main():
 
     report_path = os.environ.get("SKILL_REVIEW_REPORT")
     if report_path:
-        write_markdown_report(results, threshold, avg, Path(report_path))
+        write_markdown_report(results, errors, threshold, avg, Path(report_path))
 
     sys.exit(1 if failed else 0)
 
 
-def write_markdown_report(results: list, threshold: int, avg: float, path: Path):
+def write_markdown_report(results: list, errors: list, threshold: int, avg: float, path: Path):
     lines = []
-    lines.append(f"**{len(results)} skills** reviewed | Average: **{avg:.0f}/100** | Threshold: {threshold}\n")
-    lines.append("| Skill | Description | Content | Overall | Status |")
-    lines.append("|-------|-------------|---------|---------|--------|")
-    for r in sorted(results, key=lambda x: x["overall_score"]):
-        score = r["overall_score"]
-        icon = "\u2705" if score >= threshold else "\u274c"
-        lines.append(f"| {r['skill']} | {r['description_score']} | {r['content_score']} | **{score}** | {icon} |")
 
-    below = [r for r in results if r["overall_score"] < threshold]
-    if below:
-        lines.append("\n<details><summary>Suggestions for skills below threshold</summary>\n")
-        for r in below:
-            lines.append(f"**{r['skill']}** ({r['overall_score']}/100): {r['summary']}")
-            for s in r.get("suggestions", []):
-                lines.append(f"- {s}")
-            lines.append("")
-        lines.append("</details>")
+    if errors:
+        lines.append(f":x: **{len(errors)} skill(s) failed** to evaluate\n")
+        for e in errors:
+            lines.append(f"- `{e['skill']}`: {e['error']}")
+        lines.append("")
+
+    if results:
+        lines.append(f"**{len(results)} skills** reviewed | Average: **{avg:.0f}/100** | Threshold: {threshold}\n")
+        lines.append("| Skill | Description | Content | Overall | Status |")
+        lines.append("|-------|-------------|---------|---------|--------|")
+        for r in sorted(results, key=lambda x: x["overall_score"]):
+            score = r["overall_score"]
+            icon = "\u2705" if score >= threshold else "\u274c"
+            lines.append(f"| {r['skill']} | {r['description_score']} | {r['content_score']} | **{score}** | {icon} |")
+
+        below = [r for r in results if r["overall_score"] < threshold]
+        if below:
+            lines.append("\n<details><summary>Suggestions for skills below threshold</summary>\n")
+            for r in below:
+                lines.append(f"**{r['skill']}** ({r['overall_score']}/100): {r['summary']}")
+                for s in r.get("suggestions", []):
+                    lines.append(f"- {s}")
+                lines.append("")
+            lines.append("</details>")
+    elif not errors:
+        lines.append("_No skills to review._")
 
     path.write_text("\n".join(lines))
 

--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -108,42 +108,57 @@ jobs:
           SKILLFORGE_OUTCOME: ${{ steps.skillforge.outcome }}
           JUDGE_OUTCOME: ${{ steps.judge.outcome }}
           AUTH_AVAILABLE: ${{ steps.auth.outputs.available }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           MARKER="<!-- skill-review-bot -->"
 
           BODY="$MARKER
           ## Skill Quality Review
+          "
 
+          BODY="$BODY
           ### SkillForge (lint + security)
           "
-
           if [ -f /tmp/skillforge-report.md ]; then
-            BODY="$BODY$(cat /tmp/skillforge-report.md)
+            BODY="$BODY
+          $(cat /tmp/skillforge-report.md)
+          "
+          elif [ "$SKILLFORGE_OUTCOME" = "failure" ]; then
+            BODY="$BODY
+          :x: **Failed** — see [workflow logs]($RUN_URL)
           "
           elif [ "$SKILLFORGE_OUTCOME" = "skipped" ]; then
-            BODY="$BODY:grey_question: Did not run
+            BODY="$BODY
+          :grey_question: Did not run
+          "
+          else
+            BODY="$BODY
+          :grey_question: No results available
           "
           fi
 
+          BODY="$BODY
+          ### Claude Quality Judge
+          "
           if [ -f /tmp/skill-review-report.md ]; then
             BODY="$BODY
-          ### Claude Quality Judge
           $(cat /tmp/skill-review-report.md)
           "
           elif [ "$AUTH_AVAILABLE" = "true" ] && [ "$JUDGE_OUTCOME" = "failure" ]; then
             BODY="$BODY
-          ### Claude Quality Judge
-          :x: Failed — see [workflow logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+          :x: **Failed** — see [workflow logs]($RUN_URL)
           "
           elif [ "$AUTH_AVAILABLE" = "true" ] && [ "$JUDGE_OUTCOME" = "skipped" ]; then
             BODY="$BODY
-          ### Claude Quality Judge
-          _Skipped: blocked by earlier step failure._
+          _Skipped: no changed skills detected or blocked by earlier failure._
           "
           elif [ "$AUTH_AVAILABLE" != "true" ]; then
             BODY="$BODY
-          ### Claude Quality Judge
           _Skipped: \`ANTHROPIC_API_KEY\` not configured._
+          "
+          else
+            BODY="$BODY
+          :grey_question: No results available
           "
           fi
 


### PR DESCRIPTION
## Problem

The Claude quality judge fails silently ([run](https://github.com/scylladb/scylla-cluster-tests/actions/runs/28739522147/job/85219687605)):
- Model `claude-sonnet-4-20250514` returns 404 from the API
- Errors are emitted as `::warning::` (easy to miss) instead of `::error::`
- The PR comment shows nothing about the failure — errors are swallowed

## Fixes

1. **Model**: Default to `claude-sonnet-4-6` (configurable via `ANTHROPIC_MODEL` env var)
2. **Error visibility**: Changed from `::warning::` to `::error::` annotations in GitHub Actions
3. **PR comment**: Errors now appear in the report with ❌ and the error message
4. **Exit code**: Script exits non-zero when skills fail to evaluate, so the workflow step shows red
5. **Error tracking**: Separate errors list passed to report writer, always included in output

## Expected PR comment when errors occur

```
### Claude Quality Judge
❌ **2 skill(s) failed** to evaluate

- `code-review`: Error code: 404 - model not found
- `writing-unit-tests`: Error code: 429 - rate limited

**1 skills** reviewed | Average: **85/100** | Threshold: 70
| Skill | Description | Content | Overall | Status |
...
```