### PR TITLE
fix(skill-review): fix workflow multiline output and add debug logging

### DIFF
--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -30,7 +30,10 @@ jobs:
 
           for skill_dir in skills/*/; do
             if [ -f "$skill_dir/SKILL.md" ]; then
+              echo "::group::Checking $skill_dir"
               OUTPUT=$(aif check "$skill_dir/SKILL.md" 2>&1) || true
+              echo "$OUTPUT"
+              echo "::endgroup::"
               if echo "$OUTPUT" | grep -q "^PASS"; then
                 PASSED=$((PASSED + 1))
               elif echo "$OUTPUT" | grep -q "^FAIL"; then
@@ -38,6 +41,8 @@ jobs:
                 ISSUES=$(echo "$OUTPUT" | grep -E "^\s+\[" | sed 's/^/  /')
                 FINDINGS="$FINDINGS
           | \`$(basename "$skill_dir")\` | :x: | $(echo "$ISSUES" | head -1 | sed 's/^  //') |"
+              else
+                echo "::warning::Unexpected output for $skill_dir: $OUTPUT"
               fi
             fi
           done
@@ -79,11 +84,13 @@ jobs:
         run: |
           DIRS=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}/files" \
             --jq '[.[].filename | select(startswith("skills/")) | split("/")[0:2] | join("/")] | unique | .[]')
-          echo "skill_dirs=$DIRS" >> "$GITHUB_OUTPUT"
-          if [ -z "$DIRS" ]; then
+          # Use space-separated single line for GITHUB_OUTPUT (multiline breaks the format)
+          DIRS_ONELINE=$(echo "$DIRS" | tr '\n' ' ' | xargs)
+          echo "skill_dirs=$DIRS_ONELINE" >> "$GITHUB_OUTPUT"
+          if [ -z "$DIRS_ONELINE" ]; then
             echo "No skill directories changed"
           else
-            echo "Changed skills: $DIRS"
+            echo "Changed skills: $DIRS_ONELINE"
           fi
 
       - name: Install anthropic SDK

--- a/defaults/aws_emr_config.yaml
+++ b/defaults/aws_emr_config.yaml
@@ -11,5 +11,6 @@ emr_spark_migrator_jar_path: ''
 emr_spark_migrator_release: ''
 emr_log_uri: ''
 emr_keep_alive: true
+emr_install_spark4_via_bootstrap: false
 migrator_step_timeout_minutes: 360
 validator_step_timeout_minutes: 60

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -1956,6 +1956,18 @@ Whether EMR cluster stays alive after job completion (default: true for reuse du
 - `True`: aws
 
 
+## **emr_install_spark4_via_bootstrap** / SCT_EMR_INSTALL_SPARK4_VIA_BOOTSTRAP
+
+Legacy fallback: install Spark 4.x via an EMR bootstrap action and submit the migrator through script-runner.jar (for emr-7.x releases). Default value is false - i.e. deployment of native Spark on an `emr-spark-8.x` release label.
+
+**default:** N/A
+
+**type:** bool
+
+**backend overrides:**
+- `False`: aws
+
+
 ## **migrator_source_hosts** / SCT_MIGRATOR_SOURCE_HOSTS
 
 CQL contact-point IPs for the source Cassandra/Scylla cluster. Mutually exclusive with migrator_source_test_id.

--- a/docs/cs-to-scylla-migration.md
+++ b/docs/cs-to-scylla-migration.md
@@ -27,6 +27,21 @@ Both yamls set `db_type: mixed_cassandra` so SCT provisions BOTH a Scylla target
 cluster (`self.db_cluster`) AND a Cassandra source cluster (`self.cs_db_cluster`)
 in a single run, plus an EMR cluster (`self.emr_cluster`) sized for the migration job.
 
+## EMR Spark provisioning mode
+
+The migrator requires Spark 4.x / Scala 2.13. By default SCT provisions a **native Spark 4.0** EMR
+cluster (`emr_install_spark4_via_bootstrap: false`) on an `emr-spark-8.x` release label (e.g. `emr-spark-8.0.0`):
+the migrator and validator run as native `spark-submit` steps on the cluster own Spark, with the
+app JAR and the `--files` config read directly from S3 - no bootstrap.
+The `cs-to-scylla-small` and `cs-to-scylla-500gb` yamls use this path.
+
+The legacy fallback (`emr_install_spark4_via_bootstrap: true`) targets an `emr-7.x` release that ships
+Spark 3.x, installs Spark 4.x into `/opt/spark4` via an EMR bootstrap action, and submits jobs through
+`script-runner.jar`. It is retained for debugging and kept runnable via `spark-migrator-basic.yaml` config.
+
+The two switches must agree: the native path requires an `emr-spark-*` label, so config verification
+fails fast at load time on a `native + emr-7.x` mismatch (and warns on the redundant `legacy + emr-spark-*` combination).
+
 ## Reusing a provisioned cluster
 
 The 500GB preload takes a long time. To skip preload and rerun the migration + validation

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1290,6 +1290,11 @@ class SCTConfiguration(BaseModel):
     emr_keep_alive: Boolean = SctField(
         description="Whether EMR cluster stays alive after job completion (default: true for reuse during testing)",
     )
+    emr_install_spark4_via_bootstrap: Boolean = SctField(
+        description="Legacy fallback: install Spark 4.x via an EMR bootstrap action and submit the migrator "
+        "through script-runner.jar (for emr-7.x releases). Default value is false - i.e. deployment of native Spark "
+        "on an `emr-spark-8.x` release label.",
+    )
     # spark-migrator external-source options (for Cassandra-to-Scylla migration)
     migrator_source_hosts: StringOrList = SctField(
         description="CQL contact-point IPs for the source Cassandra/Scylla cluster. "
@@ -3810,6 +3815,7 @@ class SCTConfiguration(BaseModel):
         self._validate_perf_gradual_throttle_steps()
 
         self._verify_migrator_source_params()
+        self._verify_emr_spark_mode()
 
     def _get_normalized_arch(self, instance_type: str, region_name: str, default: str = "x86_64") -> str:
         """Detect architecture from AWS instance type and normalize to Scylla package naming.
@@ -4696,6 +4702,27 @@ class SCTConfiguration(BaseModel):
     def _verify_migrator_source_params(self):
         if self.get("migrator_source_hosts") and self.get("migrator_source_test_id"):
             raise ValueError("migrator_source_hosts and migrator_source_test_id are mutually exclusive — set only one")
+
+    def _verify_emr_spark_mode(self):
+        """Validate that EMR release label matches selected Spark provisioning mode."""
+        label = self.get("emr_release_label")
+        if not label:
+            return
+
+        native = not self.get("emr_install_spark4_via_bootstrap")
+        is_spark_release = label.startswith("emr-spark-")
+        if native and not is_spark_release:
+            raise ValueError(
+                f"emr_release_label={label!r} is not a native Spark 4.X release; the native path "
+                "(emr_install_spark4_via_bootstrap=false) requires an 'emr-spark-*' label such as "
+                "'emr-spark-8.0.0'. Set emr_install_spark4_via_bootstrap=true to use an emr-7.x release."
+            )
+        if not native and is_spark_release:
+            self.log.warning(
+                "emr_install_spark4_via_bootstrap=true installs standalone Spark 4.x via bootstrap, but "
+                "release %s already ships native Spark 4 - the bootstrap is redundant.",
+                label,
+            )
 
     def _verify_data_volume_configuration(self, backend):
         dev_num = self.get("data_volume_disk_num")

--- a/sdcm/spark_migrator.py
+++ b/sdcm/spark_migrator.py
@@ -51,6 +51,8 @@ _RUNNER_SCRIPT_S3_KEY = "scripts/run-migrator.sh"
 _VALIDATOR_SCRIPT_S3_KEY = "scripts/run-validator.sh"
 _MIGRATOR_MAIN_CLASS = "com.scylladb.migrator.Migrator"
 _VALIDATOR_MAIN_CLASS = "com.scylladb.migrator.Validator"
+_COMMAND_RUNNER_JAR = "command-runner.jar"
+_SPARK_SCYLLA_CONFIG_KEY = "spark.scylla.config"
 
 
 def _build_bootstrap_script(s3_bucket):
@@ -346,14 +348,74 @@ cd /tmp
         LOGGER.info("Runner script uploaded to %s", s3_uri)
         return s3_uri
 
-    # TODO: Spark 4.x workaround
-    def submit_migration_job(self, cluster_id, jar_s3_path, migrator_config):
-        """Submit a spark-migrator job as an EMR step.
+    def _use_bootstrap(self):
+        """True when the legacy Spark-4 bootstrap workaround is selected (emr_install_spark4_via_bootstrap)."""
+        return bool(self.emr_provisioner.params.get("emr_install_spark4_via_bootstrap"))
 
-        Uses script-runner.jar with a wrapper script that invokes the standalone
-        Spark 4.x installation. This is part of the Spark 4.x workaround — once
-        EMR bundles Spark 4.x, this can be replaced with a native spark-submit step
-        using command-runner.jar.
+    def _submit_spark_step(self, cluster_id, step_name, jar_s3_path, config_s3_path, main_class, deploy_mode):
+        """Submit a Spark EMR step using either legacy bootstrap mode or native command-runner mode.
+
+        Args:
+            cluster_id: EMR cluster ID.
+            step_name: EMR step name.
+            jar_s3_path: S3 path to the spark-migrator JAR.
+            config_s3_path: S3 path to the migrator config YAML.
+            main_class: Spark application main class (Migrator or Validator).
+            deploy_mode: Spark deploy mode ("cluster" for migration, "client" for the validator so its
+                log4j output lands in the step's stderr.gz).
+
+        Returns:
+            str: Step ID of the submitted job.
+        """
+        if self._use_bootstrap():  # Spark 4.x workaround - legacy script-runner.jar + /opt/spark4 wrapper
+            script_key = _RUNNER_SCRIPT_S3_KEY if main_class == _MIGRATOR_MAIN_CLASS else _VALIDATOR_SCRIPT_S3_KEY
+            runner_script_uri = self._upload_runner_script(
+                jar_s3_path,
+                config_s3_path,
+                main_class=main_class,
+                script_key=script_key,
+                deploy_mode=deploy_mode,
+            )
+            jar = f"s3://{self.emr_provisioner.region_name}.elasticmapreduce/libs/script-runner/script-runner.jar"
+            args = [runner_script_uri]
+            return self.emr_provisioner.add_step(cluster_id=cluster_id, step_name=step_name, jar=jar, args=args)
+
+        # native EMR Spark 4
+        jar = _COMMAND_RUNNER_JAR
+        config_basename = config_s3_path.rsplit("/", 1)[-1]
+        config_ref = config_basename
+        files_arg = config_s3_path
+
+        pre_cmd = ""
+        if deploy_mode == "client":
+            config_ref = f"/tmp/{config_basename}"
+            files_arg = config_ref
+            pre_cmd = f"aws s3 cp {config_s3_path} {config_ref} && "
+
+        spark_submit_parts = [
+            "spark-submit",
+            "--deploy-mode",
+            deploy_mode,
+            "--master",
+            "yarn",
+            "--class",
+            main_class,
+            "--conf",
+            f"{_SPARK_SCYLLA_CONFIG_KEY}={config_ref}",
+            "--files",
+            files_arg,
+            jar_s3_path,
+        ]
+
+        if pre_cmd:
+            args = ["bash", "-c", pre_cmd + " ".join(spark_submit_parts)]
+        else:
+            args = spark_submit_parts
+
+        return self.emr_provisioner.add_step(cluster_id=cluster_id, step_name=step_name, jar=jar, args=args)
+
+    def submit_migration_job(self, cluster_id, jar_s3_path, migrator_config):
+        """Submit a spark-migrator job as an EMR step (cluster deploy mode).
 
         Args:
             cluster_id: EMR cluster ID.
@@ -363,26 +425,18 @@ cd /tmp
         Returns:
             str: Step ID of the submitted job.
         """
-        runner_script_uri = self._upload_runner_script(jar_s3_path, migrator_config.config_path)
-        script_runner_jar = (
-            f"s3://{self.emr_provisioner.region_name}.elasticmapreduce/libs/script-runner/script-runner.jar"
-        )
-        step_id = self.emr_provisioner.add_step(
-            cluster_id=cluster_id,
-            step_name="spark-migrator",
-            jar=script_runner_jar,
-            args=[runner_script_uri],
+        step_id = self._submit_spark_step(
+            cluster_id, "spark-migrator", jar_s3_path, migrator_config.config_path, _MIGRATOR_MAIN_CLASS, "cluster"
         )
         LOGGER.info("Spark migrator job submitted as step %s on cluster %s", step_id, cluster_id)
         return step_id
 
-    # TODO: Spark 4.x workaround
     def submit_validator_job(self, cluster_id, jar_s3_path, migrator_config):
-        """Submit a scylla-migrator validator job as an EMR step.
+        """Submit a scylla-migrator validator job as an EMR step (client deploy mode).
 
-        Reuses the script-runner.jar wrapper pattern from submit_migration_job but invokes
-        com.scylladb.migrator.Validator instead. Validator reads the same migrator config
-        YAML - no separate config upload needed.
+        Validator reads the same migrator config YAML as the migration — no separate config upload
+        needed. Client mode keeps the driver on the master so its log4j diff summary lands in the
+        step's stderr.gz.
 
         Args:
             cluster_id: EMR cluster ID.
@@ -392,21 +446,13 @@ cd /tmp
         Returns:
             str: Step ID of the submitted validator job.
         """
-        runner_script_uri = self._upload_runner_script(
+        step_id = self._submit_spark_step(
+            cluster_id,
+            "spark-migrator-validator",
             jar_s3_path,
             migrator_config.config_path,
-            main_class=_VALIDATOR_MAIN_CLASS,
-            script_key=_VALIDATOR_SCRIPT_S3_KEY,
-            deploy_mode="client",
-        )
-        script_runner_jar = (
-            f"s3://{self.emr_provisioner.region_name}.elasticmapreduce/libs/script-runner/script-runner.jar"
-        )
-        step_id = self.emr_provisioner.add_step(
-            cluster_id=cluster_id,
-            step_name="spark-migrator-validator",
-            jar=script_runner_jar,
-            args=[runner_script_uri],
+            _VALIDATOR_MAIN_CLASS,
+            "client",
         )
         LOGGER.info("Spark migrator validator job submitted as step %s on cluster %s", step_id, cluster_id)
         return step_id

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -2408,8 +2408,9 @@ class ClusterTester(unittest.TestCase):
             if subnets:
                 subnet_id = subnets.id
 
-        # TODO: Spark 4.x workaround
-        bootstrap_actions = build_spark4_bootstrap_actions(region_name)
+        bootstrap_actions = None
+        if self.params.get("emr_install_spark4_via_bootstrap"):
+            bootstrap_actions = build_spark4_bootstrap_actions(region_name)
 
         self.emr_cluster.create_emr_cluster(
             test_id=self.test_config.test_id(),

--- a/spark_migrator_test.py
+++ b/spark_migrator_test.py
@@ -38,6 +38,9 @@ from sdcm.tester import ClusterTester
 
 _SAMPLE_SIZE = 10
 
+_VALIDATOR_LOG_FETCH_ATTEMPTS = 6
+_VALIDATOR_LOG_FETCH_DELAY_S = 20
+
 
 class SparkMigratorTest(ClusterTester):
     """Test scylla-spark-migrator on Amazon EMR clusters.
@@ -552,16 +555,33 @@ class SparkMigratorTest(ClusterTester):
                 step_id,
                 timeout_minutes=self.params.get("validator_step_timeout_minutes") or 60,
             )
-        except AssertionError:
+        except AssertionError as step_err:
+            step_log = self._fetch_validator_step_log(runner, step_id)
+            self.log.error("Validator step output:\n%s", step_log or "(no log captured)")
+            raise AssertionError(f"validator step FAILED: {step_err}") from step_err
+
+        self.log.info("Validator passed: 0 mismatches across migrated rows")
+
+    def _fetch_validator_step_log(self, runner, step_id):
+        """Fetch validator stdout/stderr from S3, retrying for EMR log-flush delay."""
+        for attempt in range(1, _VALIDATOR_LOG_FETCH_ATTEMPTS + 1):
             try:
                 step_log = runner.get_step_stdout(self.emr_cluster.cluster_id, step_id)
             except Exception as fetch_err:  # noqa: BLE001
                 self.log.warning("Could not fetch validator step log: %s", fetch_err)
-                step_log = ""
-            self.log.error("Validator step output:\n%s", step_log or "(no log captured)")
-            raise AssertionError("validator step FAILED — see stdout dump above") from None
+                return ""
 
-        self.log.info("Validator passed: 0 mismatches across migrated rows")
+            if step_log:
+                return step_log
+            if attempt < _VALIDATOR_LOG_FETCH_ATTEMPTS:
+                self.log.debug(
+                    "Validator step log not on S3 yet (attempt %d/%d); waiting %ds for EMR to flush",
+                    attempt,
+                    _VALIDATOR_LOG_FETCH_ATTEMPTS,
+                    _VALIDATOR_LOG_FETCH_DELAY_S,
+                )
+                time.sleep(_VALIDATOR_LOG_FETCH_DELAY_S)
+        return ""
 
     def test_migration_cs_to_scylla_scale(self):
         """Scale-out variant of the cs-to-scylla migration test."""

--- a/test-cases/spark-migrator/cs-to-scylla-500gb.yaml
+++ b/test-cases/spark-migrator/cs-to-scylla-500gb.yaml
@@ -19,8 +19,7 @@ instance_type_loader: 'c6i.4xlarge'
 n_monitor_nodes: 1
 instance_type_monitor: 'i4i.large'
 
-# EMR cluster
-emr_release_label: 'emr-7.12.0'
+emr_release_label: 'emr-spark-8.0.0'
 emr_instance_type_master: 'm5.xlarge'
 emr_instance_type_core: 'm5.2xlarge'
 emr_instance_count_core: 2

--- a/test-cases/spark-migrator/cs-to-scylla-small.yaml
+++ b/test-cases/spark-migrator/cs-to-scylla-small.yaml
@@ -18,8 +18,7 @@ n_loaders: 0
 n_monitor_nodes: 1
 instance_type_monitor: 't3.large'
 
-# EMR cluster (single core node is enough for a 100K-row migration)
-emr_release_label: 'emr-7.12.0'
+emr_release_label: 'emr-spark-8.0.0'
 emr_instance_type_master: 'm5.xlarge'
 emr_instance_type_core: 'm5.xlarge'
 emr_instance_count_core: 1

--- a/test-cases/spark-migrator/spark-migrator-basic.yaml
+++ b/test-cases/spark-migrator/spark-migrator-basic.yaml
@@ -8,8 +8,9 @@ instance_type_db: 'i4i.large'
 instance_type_loader: 'c6i.xlarge'
 instance_type_monitor: 't3.large'
 
-# EMR cluster configuration
+# legacy fallback: Spark 4.x installed via bootstrap on an emr-7.x release
 emr_release_label: 'emr-7.12.0'
+emr_install_spark4_via_bootstrap: true
 emr_instance_type_master: 'm5.xlarge'
 emr_instance_type_core: 'm5.xlarge'
 emr_instance_count_core: 2

--- a/unit_tests/unit/test_config.py
+++ b/unit_tests/unit/test_config.py
@@ -992,3 +992,23 @@ def test_resolved_placement_with_amis_applies_directly_and_skips_re_resolution(m
     assert conf.region_names == ["eu-west-1"]
     assert conf["availability_zone"] == "b"
     assert conf["ami_id_db_scylla"] == "ami-persisted-west"
+
+
+@pytest.mark.parametrize(
+    "release_label, expected_error",
+    [
+        ("emr-7.12.0", "not a native Spark 4.X release"),
+        ("emr-spark-8.0.0", None),
+    ],
+)
+def test_verify_emr_spark_mode_native_release_label(monkeypatch, release_label, expected_error):
+    """Native Spark mode validates emr-spark-* releases and rejects non-spark release labels."""
+    monkeypatch.setenv("SCT_CLUSTER_BACKEND", "docker")
+    monkeypatch.setenv("SCT_EMR_RELEASE_LABEL", release_label)
+
+    conf = sct_config.SCTConfiguration()
+    if expected_error is None:
+        conf.verify_configuration()
+    else:
+        with pytest.raises(ValueError, match=expected_error):
+            conf.verify_configuration()

--- a/unit_tests/unit/test_spark_migrator.py
+++ b/unit_tests/unit/test_spark_migrator.py
@@ -429,7 +429,7 @@ def test_submit_validator_job_uploads_validator_script_with_validator_main_class
     s3_client = boto3.client("s3", region_name="us-east-1")
     s3_client.create_bucket(Bucket="sct-emr-spark-migrator-us-east-1")
 
-    mock_provisioner = MagicMock(region_name="us-east-1")
+    mock_provisioner = MagicMock(region_name="us-east-1", params={"emr_install_spark4_via_bootstrap": True})
     mock_provisioner.add_step.return_value = "s-VALIDATOR123"
 
     config = MigratorConfig(source_hosts=["10.0.0.1"], target_host="10.0.0.2")
@@ -463,7 +463,7 @@ def test_submit_validator_job_uses_distinct_step_name_and_script_runner():
         CreateBucketConfiguration={"LocationConstraint": "eu-west-1"},
     )
 
-    mock_provisioner = MagicMock(region_name="eu-west-1")
+    mock_provisioner = MagicMock(region_name="eu-west-1", params={"emr_install_spark4_via_bootstrap": True})
     mock_provisioner.add_step.return_value = "s-VAL"
 
     config = MigratorConfig(source_hosts=["10.0.0.1"], target_host="10.0.0.2")
@@ -484,7 +484,9 @@ def test_submit_migration_job_still_uses_cluster_deploy_mode():
     s3_client = boto3.client("s3", region_name="us-east-1")
     s3_client.create_bucket(Bucket="sct-emr-spark-migrator-us-east-1")
 
-    mock_provisioner = MagicMock(region_name="us-east-1", **{"add_step.return_value": "s-MIG"})
+    mock_provisioner = MagicMock(
+        region_name="us-east-1", params={"emr_install_spark4_via_bootstrap": True}, **{"add_step.return_value": "s-MIG"}
+    )
 
     config = MigratorConfig(source_hosts=["10.0.0.1"], target_host="10.0.0.2")
     config.config_path = "s3://bucket/configs/test-id/config.yaml"
@@ -497,6 +499,76 @@ def test_submit_migration_job_still_uses_cluster_deploy_mode():
         .decode("utf-8")
     )
     assert "--deploy-mode cluster" in body
+
+
+def _build_native_runner_and_config(step_return_value):
+    provisioner = MagicMock(region_name="us-east-1", params={"emr_install_spark4_via_bootstrap": False})
+    provisioner.add_step.return_value = step_return_value
+
+    config = MigratorConfig(source_hosts=["10.0.0.1"], target_host="10.0.0.2")
+    config.config_path = "s3://bucket/configs/test-id/config.yaml"
+
+    return SparkMigratorRunner(provisioner), provisioner, config
+
+
+def test_submit_migration_native_uses_command_runner_with_s3_files():
+    """Native migration (cluster mode): command-runner.jar spark-submit, config read via --files from S3.
+
+    In cluster mode YARN localizes --files into the driver container CWD, so a relative
+    spark.scylla.config basename resolves — no local staging needed.
+    """
+    runner, provisioner, config = _build_native_runner_and_config("s-MIG")
+
+    with patch.object(SparkMigratorRunner, "_upload_runner_script") as mock_upload:
+        step_id = runner.submit_migration_job("j-CLUSTER", "s3://bucket/jars/x/migrator.jar", config)
+
+    assert step_id == "s-MIG"
+    mock_upload.assert_not_called()  # native path uploads no /opt/spark4 wrapper
+
+    kwargs = provisioner.add_step.call_args[1]
+    assert kwargs["step_name"] == "spark-migrator"
+    assert kwargs["jar"] == "command-runner.jar"
+    assert kwargs["args"] == [
+        "spark-submit",
+        "--deploy-mode",
+        "cluster",
+        "--master",
+        "yarn",
+        "--class",
+        "com.scylladb.migrator.Migrator",
+        "--conf",
+        "spark.scylla.config=config.yaml",
+        "--files",
+        "s3://bucket/configs/test-id/config.yaml",
+        "s3://bucket/jars/x/migrator.jar",
+    ]
+
+
+def test_submit_validator_native_stages_config_locally_for_client_mode():
+    """Native validator (client mode) must stage config to /tmp and use local spark.scylla.config path."""
+    runner, provisioner, config = _build_native_runner_and_config("s-VAL")
+    jar_s3_path = "s3://bucket/jars/x/migrator.jar"
+
+    expected_args = [
+        "bash",
+        "-c",
+        "aws s3 cp s3://bucket/configs/test-id/config.yaml /tmp/config.yaml && "
+        "spark-submit --deploy-mode client --master yarn "
+        "--class com.scylladb.migrator.Validator "
+        "--conf spark.scylla.config=/tmp/config.yaml "
+        "--files /tmp/config.yaml s3://bucket/jars/x/migrator.jar",
+    ]
+
+    with patch.object(SparkMigratorRunner, "_upload_runner_script") as mock_upload:
+        step_id = runner.submit_validator_job("j-CLUSTER", jar_s3_path, config)
+
+    assert step_id == "s-VAL"
+    mock_upload.assert_not_called()
+
+    add_step_kwargs = provisioner.add_step.call_args.kwargs
+    assert add_step_kwargs["step_name"] == "spark-migrator-validator"
+    assert add_step_kwargs["jar"] == "command-runner.jar"
+    assert add_step_kwargs["args"] == expected_args
 
 
 @mock_aws


### PR DESCRIPTION
## Summary

Fixes two bugs in the `skill-review` GitHub Action that cause failures when PRs modify multiple skills:

1. **Multiline GITHUB_OUTPUT** — `Find changed skills` step writes multiline value which breaks the format (second line becomes 'Invalid format ...' error). Fix: join directories with spaces on a single line.

2. **Silent SkillForge failures** — `aif check` output is swallowed when it doesn't match expected patterns, making failures impossible to debug. Fix: add `::group::` blocks to show full output per skill, and `::warning::` for unexpected patterns.

## Context

Discovered while reviewing PR #14818 which adds two new skills (`labeling-pipelines`, `reviewing-pipeline-docs`). The workflow fails with 'Invalid format skills/reviewing-pipeline-docs' because the output contains two lines.