### PR TITLE
ci(skill-review): fail check when any review step fails

### DIFF
--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -178,3 +178,21 @@ jobs:
           else
             gh pr comment "$PR_NUMBER" --repo "${{ github.repository }}" --body "$BODY"
           fi
+
+      - name: Fail if any review step failed
+        if: always()
+        env:
+          SKILLFORGE_OUTCOME: ${{ steps.skillforge.outcome }}
+          JUDGE_OUTCOME: ${{ steps.judge.outcome }}
+        run: |
+          FAILED=""
+          if [ "$SKILLFORGE_OUTCOME" = "failure" ]; then
+            FAILED="$FAILED SkillForge"
+          fi
+          if [ "$JUDGE_OUTCOME" = "failure" ]; then
+            FAILED="$FAILED Claude-judge"
+          fi
+          if [ -n "$FAILED" ]; then
+            echo "::error::The following review steps failed:$FAILED"
+            exit 1
+          fi


### PR DESCRIPTION
## Problem

The skill-review workflow uses `continue-on-error: true` on SkillForge and Claude quality judge steps so that subsequent steps (especially the PR comment) always run. However, this also means the **job itself always shows green** — failures are silently swallowed and only visible by digging into the logs.

Observed in: https://github.com/scylladb/scylla-cluster-tests/actions/runs/28770143394/job/85302112880?pr=14818

## Solution

Add a final gate step (`Fail if any review step failed`) that:
1. Checks `steps.skillforge.outcome` and `steps.judge.outcome`
2. If either is `failure`, emits a `::error::` annotation naming the failed steps
3. Exits non-zero to fail the overall job

This preserves:
- All steps running to completion (continue-on-error stays)
- PR comment always posted (if: always() stays)
- Clear red X on the GitHub check when something actually fails
