### PR TITLE
fix(remote): fix stress metrics not published on Ubuntu 26 / Python 3.14

### DIFF
--- a/sdcm/loader.py
+++ b/sdcm/loader.py
@@ -117,9 +117,6 @@ class StressExporter(FileFollowerThread, metaclass=ABCMeta):
                 continue
 
             for line in self.follow_file(self.stress_log_filename):
-                if self.stopped():
-                    break
-
                 if self.skip_line(line=line):
                     continue
 

--- a/sdcm/remote/base.py
+++ b/sdcm/remote/base.py
@@ -19,6 +19,7 @@ import logging
 import re
 import os
 import subprocess
+import threading
 from textwrap import dedent
 
 from invoke.watchers import StreamWatcher, Responder
@@ -266,17 +267,19 @@ class OutputWatcher(StreamWatcher):
     def __init__(self, log: logging.Logger, hostname: str):
         super().__init__()
         self.hostname = hostname
-        self.len = 0
+        self._stream_lens = {}  # per-thread position tracking
         self.log = log
 
     def submit(self, stream: str) -> list:
-        stream_buffer = stream[self.len :]
+        tid = threading.current_thread().ident
+        prev_len = self._stream_lens.get(tid, 0)
+        stream_buffer = stream[prev_len:]
 
         while "\n" in stream_buffer:
             out_buf, rest_buf = stream_buffer.split("\n", 1)
             self.log.debug("<%s>: %s", self.hostname, out_buf)
             stream_buffer = rest_buf
-        self.len = len(stream) - len(stream_buffer)
+        self._stream_lens[tid] = len(stream) - len(stream_buffer)
         return []
 
     def submit_line(self, line: str):
@@ -286,9 +289,9 @@ class OutputWatcher(StreamWatcher):
 class LogWriteWatcher(StreamWatcher):
     def __init__(self, log_file: str):
         super().__init__()
-        self.len = 0
+        self._stream_lens = {}  # per-thread position tracking
         self.log_file = log_file
-        # open fail with line buffering, so prom stats would be as accuracte as possible
+        # open file with line buffering, so prom stats would be as accurate as possible
 
         self.file_object = open(self.log_file, "a+", encoding="utf-8", buffering=1)
 
@@ -296,12 +299,14 @@ class LogWriteWatcher(StreamWatcher):
         return line
 
     def submit(self, stream: str) -> list:
-        stream_buffer = stream[self.len :]
-        lines = stream_buffer.splitlines(True)
-        formatted_lines = [self._format_line(line) for line in lines]
-        self.file_object.write("".join(formatted_lines))
-
-        self.len = len(stream)
+        tid = threading.current_thread().ident
+        prev_len = self._stream_lens.get(tid, 0)
+        stream_buffer = stream[prev_len:]
+        if stream_buffer:
+            lines = stream_buffer.splitlines(True)
+            formatted_lines = [self._format_line(line) for line in lines]
+            self.file_object.write("".join(formatted_lines))
+        self._stream_lens[tid] = len(stream)
         return []
 
     def submit_line(self, line: str):

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -24,7 +24,6 @@ import time
 import datetime
 import errno
 import threading
-import select
 import shutil
 import copy
 import string
@@ -1221,22 +1220,22 @@ class FileFollowerIterator:
     def __iter__(self):
         with open(self.filename, encoding="utf-8") as input_file:
             line = ""
-            poller = select.poll()
-            registered = False
             while not self.thread_obj.stopped():
-                if not registered:
-                    poller.register(input_file, select.POLLIN)
-                    registered = True
-                if poller.poll(100):
-                    line += input_file.readline()
+                line += input_file.readline()
                 if not line or not line.endswith("\n"):
                     time.sleep(0.1)
                     continue
-                poller.unregister(input_file)
-                registered = False
                 yield line
                 line = ""
-            yield line
+            # Drain any remaining data written to the file after stop was signaled
+            while True:
+                line += input_file.readline()
+                if not line or not line.endswith("\n"):
+                    break
+                yield line
+                line = ""
+            if line:
+                yield line
 
 
 class FileFollowerThread:

--- a/unit_tests/integration/test_latte_thread.py
+++ b/unit_tests/integration/test_latte_thread.py
@@ -13,6 +13,8 @@
 
 import pytest
 import re
+import os
+import glob
 import requests
 
 from sdcm.stress.latte_thread import LatteStressThread
@@ -78,10 +80,34 @@ def test_03_latte_run(request, docker_scylla, prom_address, params):
 
     latte_thread.run()
 
-    @timeout(timeout=60)
+    @timeout(timeout=120)
     def check_metrics():
+        # Surface any stress thread exception early instead of waiting the full timeout
+        for future in latte_thread.results_futures:
+            if future.done():
+                # _run_stress swallows exceptions internally, so check the result
+                result = future.result()
+                if result:
+                    _loader, result_dict, stress_event = result
+                    if not result_dict:
+                        raise AssertionError(
+                            f"Latte stress thread completed but returned empty result. "
+                            f"Event severity: {stress_event.severity if hasattr(stress_event, 'severity') else 'N/A'}, "
+                            f"Event errors: {stress_event.errors if hasattr(stress_event, 'errors') else 'N/A'}"
+                        )
         output = requests.get(f"http://{prom_address}/metrics").text
-        assert "sct_latte_user_gauge" in output
+        # Gather diagnostic info about log files and docker containers
+        log_files = glob.glob(os.path.join(loader_set.nodes[0].logdir, "latte-*.log"))
+        log_info = {}
+        for lf in log_files:
+            try:
+                log_info[lf] = os.path.getsize(lf)
+            except OSError:
+                log_info[lf] = "not found"
+        assert "sct_latte_user_gauge" in output, (
+            f"Metric not found. Futures done: {[f.done() for f in latte_thread.results_futures]}. "
+            f"Log files: {log_info}"
+        )
 
         regex = re.compile(r"^sct_latte_user_gauge.*?([0-9\.]*?)$", re.MULTILINE)
         matches = regex.findall(output)


### PR DESCRIPTION
Root cause: a race condition between stress command completion and the
LatteExporter (FileFollowerThread) being stopped. When latte's stdout is
pipe-buffered through docker exec, all sampling data arrives at once when
the process exits. The cmd_runner.run() returns, the `with` block exits,
and LatteExporter.__exit__() signals stop — before the file-following
thread reads the freshly-written data.

On Ubuntu 24 this race rarely triggered because either the pipe flushed
incrementally or scheduling gave the reader thread time. On Ubuntu 26
(kernel 6.14, Python 3.14), the tighter scheduling consistently loses
the race.

Three fixes applied:

1. FileFollowerIterator: remove select.poll() (unreliable on regular
   files with kernel 6.14) and add a drain loop that reads all remaining
   data after stop is signaled.

2. StressExporter.run(): remove `if self.stopped(): break` inside the
   for-loop over follow_file(). This was preventing the drain from
   working — the iterator yields remaining lines but the consumer broke
   out immediately.

3. LogWriteWatcher/OutputWatcher: replace shared self.len counter with
   per-thread position tracking. Invoke calls submit() from separate
   stdout/stderr threads with independent buffers, corrupting the shared
   counter under aggressive thread scheduling.

Closes: #SCT-583

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
