### PR TITLE
fix(sct-runner): migrate from /etc/sysctl.conf to /etc/sysctl.d/

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,11 +94,8 @@ hydra run-test longevity_test.LongevityTest.test_custom_time --backend azure --c
 If you wish to run the tests on a local machine, ensure you have Docker installed and running.
 If necessary, set a higher value for asynchronous I/O by:
 ```bash
-sudo nano /etc/sysctl.conf
-# Edit or add the following line:
-# fs.aio-max-nr=3000000
-# Save and exit the file, then apply the changes:
-sudo sysctl -p
+echo "fs.aio-max-nr=3000000" | sudo tee /etc/sysctl.d/99-sct-aio.conf
+sudo sysctl --system
 ```
 For the purpose of debugging a simple logic of a nemesis, for example, it would be recommended to use Docker backend.
 ```bash

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -591,8 +591,8 @@ class BaseNode(AutoSshContainerMixin):
                 try:
                     self.remoter.sudo(
                         shell_script_cmd("""\
-                    echo 'kernel.perf_event_paranoid = 0' >> /etc/sysctl.conf
-                    sysctl -p
+                    echo 'kernel.perf_event_paranoid = 0' > /etc/sysctl.d/99-sct-perf.conf
+                    sysctl --system
                     """),
                         verbose=True,
                     )

--- a/sdcm/sct_runner.py
+++ b/sdcm/sct_runner.py
@@ -310,7 +310,8 @@ class SctRunner(ABC):
             # Make sure that cloud-init finished running.
             until [ -f /var/lib/cloud/instance/boot-finished ]; do sleep 1; done
 
-            echo "fs.aio-max-nr = {AIO_MAX_NR_RECOMMENDED_VALUE}" >> /etc/sysctl.conf
+            echo "fs.aio-max-nr = {AIO_MAX_NR_RECOMMENDED_VALUE}" > /etc/sysctl.d/99-sct-runner.conf
+            sysctl --system
             echo "{login_user} soft nofile 65536" >> /etc/security/limits.conf
             echo "jenkins soft nofile 65536" >> /etc/security/limits.conf
             echo "root soft nofile 65536" >> /etc/security/limits.conf

--- a/sdcm/sct_runner.py
+++ b/sdcm/sct_runner.py
@@ -859,7 +859,11 @@ class AwsSctRunner(SctRunner):
         runner_image = aws_region.resource.Image(image_id)
         runner_image.wait_until_exists()
 
-        LOGGER.info("Image '%s' exists and ready. Tagging...", image_id)
+        LOGGER.info("Waiting for image '%s' to become available...", image_id)
+        waiter = aws_region.client.get_waiter("image_available")
+        waiter.wait(ImageIds=[image_id])
+
+        LOGGER.info("Image '%s' is available. Tagging...", image_id)
         runner_image.create_tags(Tags=[{"Key": key, "Value": value} for key, value in self.image_tags.items()])
         LOGGER.info("Tagging completed.")
 

--- a/sdcm/sct_runner.py
+++ b/sdcm/sct_runner.py
@@ -180,7 +180,7 @@ class SctRunnerInfo:
 class SctRunner(ABC):
     """Provision and configure the SCT runner."""
 
-    VERSION = "1.18"  # Version of the Image
+    VERSION = "1.19"  # Version of the Image
     NODE_TYPE = "sct-runner"
     RUNNER_NAME = "SCT-Runner"
     LOGIN_USER = "ubuntu"


### PR DESCRIPTION
## Summary

Migrates all `/etc/sysctl.conf` usage to modern `/etc/sysctl.d/` drop-in files (systemd best practice), bumps runner version, and fixes a race condition in AMI creation.

### Problem
SCT was appending kernel parameters to `/etc/sysctl.conf` which:
- Can conflict with other tools also appending to the same file
- Is deprecated in favor of `/etc/sysctl.d/` on modern systemd distributions
- Creates duplicate entries on repeated runs (append vs overwrite)

Additionally, `create-runner-image` only waited for the AMI to \*exist\* (metadata visible) but not to become \*available\*, causing `InvalidAMIID.Unavailable` errors when subsequently running `create-runner-instance` or copying to other regions.

### Changes

**Commit 1** — sysctl.d migration:
- `sdcm/sct_runner.py`: `fs.aio-max-nr` → `/etc/sysctl.d/99-sct-runner.conf`
- `sdcm/cluster.py`: `kernel.perf_event_paranoid` → `/etc/sysctl.d/99-sct-perf.conf`
- `README.md`: updated local docker setup instructions
- Both now use `sysctl --system` (loads all drop-ins), matching `mini_k8s.py` pattern

**Commit 2** — runner version bump:
- Bumps `SctRunner.VERSION` from `1.18` → `1.19` to trigger image rebuild

**Commit 3** — fix AMI availability race:
- `tag_image()` now calls `get_waiter('image_available')` after `wait_until_exists()`
- Ensures the AMI is fully ready before tagging and before any subsequent copy/launch

### Verification
Confirmed on a freshly built 1.19 runner:
```
ubuntu@ip-10-4-2-115:~$ cat /etc/sysctl.d/99-sct-runner.conf
fs.aio-max-nr = 1048576
ubuntu@ip-10-4-2-115:~$ sysctl fs.aio-max-nr
fs.aio-max-nr = 1048576
```

### Rebuild Commands (post-merge)
```bash
./sct.py create-runner-image -c aws -r eu-west-2 -z a

./sct.py create-runner-image -c gce -r us-east1 -z b
SCT_GCE_PROJECT=gcp-local-ssd-latency ./sct.py create-runner-image -c gce -r us-east1 -z b

./sct.py create-runner-image -c azure -r eastus -z a

./sct.py create-runner-image -c oci -r us-ashburn-1 -z a
```

Fixes: SCT-577