### PR TITLE
fix(integration-tests): increase timeout for test_03_latte_run

### DIFF
--- a/unit_tests/integration/test_latte_thread.py
+++ b/unit_tests/integration/test_latte_thread.py
@@ -78,7 +78,7 @@ def test_03_latte_run(request, docker_scylla, prom_address, params):
 
     latte_thread.run()
 
-    @timeout(timeout=60)
+    @timeout(timeout=120)
     def check_metrics():
         output = requests.get(f"http://{prom_address}/metrics").text
         assert "sct_latte_user_gauge" in output


### PR DESCRIPTION
After switch tot he ubuntu26 on SCT runners the 'test_03_latte_run' integration test
started failing in 0-7 seconds having a 10s duration.

So, increase the timeout it uses to get metrics.

Fixes: SCT-583

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
