### PR TITLE
fix(nemesis): resolve timeout and node allocation failures in parallel grow-shrink

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -6469,9 +6469,25 @@ class BaseScyllaCluster:
         target_node_ip = node.ip_address
         node_allocator = self.test_config.tester_obj().nemesis_allocator
         verification_candidates = [n for n in self.data_nodes if n != node]
-        with node_allocator.run_nemesis(
-            nemesis_label="verify decommission", node_list=verification_candidates
-        ) as verification_node:
+
+        # Retry node allocation in case all candidates are temporarily busy
+        # (e.g. during parallel decommissions where multiple verify_decommission calls compete)
+        from sdcm.nemesis.utils.node_allocator import AllNodesRunNemesisError  # noqa: PLC0415
+
+        max_attempts = 10
+        for attempt in range(max_attempts):
+            try:
+                allocator_context = node_allocator.run_nemesis(
+                    nemesis_label="verify decommission", node_list=verification_candidates
+                )
+                verification_node = allocator_context.__enter__()
+                break
+            except AllNodesRunNemesisError as err:
+                if attempt == max_attempts - 1:
+                    raise AllNodesRunNemesisError("Failed to allocate node for verify_decommission") from err
+                time.sleep(5 * (attempt + 1))
+
+        try:
             node_ip_list = get_node_ip_list(verification_node)
             missing_host_ids = verification_node.raft.search_inconsistent_host_ids()
 
@@ -6509,6 +6525,8 @@ class BaseScyllaCluster:
                 verification_node.raft.clean_group0_garbage(raise_exception=True)
                 LOGGER.error("Decommission for node %s was aborted", node)
                 raise NodeCleanedAfterDecommissionAborted(f"Decommission for node {node} was aborted")
+        finally:
+            allocator_context.__exit__(None, None, None)
 
         LOGGER.info("Decommission %s PASS", node)
         self.terminate_node(node)

--- a/sdcm/nemesis/__init__.py
+++ b/sdcm/nemesis/__init__.py
@@ -3872,7 +3872,14 @@ class NemesisRunner:
     def add_new_nodes(self, count, rack=None, instance_type: str = None) -> list[BaseNode]:
         nodes = self._add_and_init_new_cluster_nodes(count, rack=rack, instance_type=instance_type)
         self.actions_log.info(f"New nodes added: {', '.join(node.name for node in nodes)}")
-        ParallelObject(objects=self.cluster.data_nodes, timeout=7200).run(wait_no_tablets_migration_running)
+        tablet_migration_timeout = 7200
+
+        def _wait_no_tablets_migration(node):
+            wait_no_tablets_migration_running(node, timeout=tablet_migration_timeout)
+
+        ParallelObject(objects=self.cluster.data_nodes, timeout=tablet_migration_timeout + 120).run(
+            _wait_no_tablets_migration
+        )
         return nodes
 
     @latency_calculator_decorator(legend="Decommission nodes: remove nodes from cluster")


### PR DESCRIPTION
Fix two issues observed during GrowShrinkClusterNemesis on large (2.5TB) clusters with parallel decommission:
1. Tablet migration timeout: increase quiesce_topology timeout from 3600s to 7200s in add_new_nodes, matching the ParallelObject timeout. With large datasets and many new nodes, tablet rebalancing routinely exceeds one hour.
2. Node allocation conflict in verify_decommission: add retry with backoff (up to 10 attempts) when all candidate nodes are temporarily busy. During parallel decommission of 9 nodes, multiple verify_decommission calls competed for the same 3 remaining nodes, causing AllNodesRunNemesisError.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] It was tested while https://github.com/scylladb/scylla-cluster-tests/pull/14573

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
