### PR TITLE
fix(latency-decorator): preserve exceptions through latency collection

### DIFF
--- a/sdcm/utils/decorators.py
+++ b/sdcm/utils/decorators.py
@@ -185,7 +185,7 @@ def _find_hdr_tags(*args):
     raise ValueError("Failed to find 'hdr_tags'")
 
 
-def latency_calculator_decorator(
+def latency_calculator_decorator(  # noqa: PLR0915
     original_function: Optional[Callable] = None,
     *,
     legend: Optional[str] = None,
@@ -208,7 +208,7 @@ def latency_calculator_decorator(
 
     def wrapper(func):
         @wraps(func)
-        def wrapped(*args, **kwargs):  # noqa: PLR0914
+        def wrapped(*args, **kwargs):  # noqa: PLR0912, PLR0914
             from sdcm.tester import ClusterTester  # noqa: PLC0415
             from sdcm.nemesis import NemesisRunner  # noqa: PLC0415
 
@@ -232,16 +232,26 @@ def latency_calculator_decorator(
             LOGGER.debug("latency_calculator_decorator cluster: %s", cluster)
             start_node_list = cluster.nodes[:]
             func_name = cycle_name or func.__name__
+            func_exception = None
             with EventCounterContextManager(
                 name=func.__name__, event_type=(DatabaseLogEvent.REACTOR_STALLED,)
             ) as counter:
-                res = func(*args, **kwargs)
+                try:
+                    res = func(*args, **kwargs)
+                except Exception as exc:  # noqa: BLE001
+                    func_exception = exc
+                    res = None
+                    LOGGER.warning(
+                        "latency_calculator_decorator: %s raised %s, will still collect latency results", func_name, exc
+                    )
                 reactor_stall_stats = counter.get_stats().copy()
             end_node_list = cluster.nodes[:]
             all_nodes_list = list(set(start_node_list + end_node_list))
             end = time.time()
             test_name = tester.__repr__().split("testMethod=")[-1].split(">")[0]
             if not monitoring_set or not monitoring_set.nodes or not tester.params.get("use_hdrhistogram"):
+                if func_exception:
+                    raise func_exception  # noqa: TRY201
                 return res
             try:
                 monitor = monitoring_set.nodes[0]
@@ -259,6 +269,8 @@ def latency_calculator_decorator(
                 elif tester.params.get("workload_name"):
                     workload = tester.params["workload_name"]
                 else:
+                    if func_exception:
+                        raise func_exception  # noqa: TRY201
                     return res
 
                 latency_results_file_path = tester.latency_results_file
@@ -341,6 +353,8 @@ def latency_calculator_decorator(
                     trace=exc.__traceback__.tb_frame,
                 ).publish_or_dump(default_logger=LOGGER)
 
+            if func_exception:
+                raise func_exception  # noqa: TRY201
             return res
 
         return wrapped


### PR DESCRIPTION
The latency_calculator_decorator now catches exceptions from the decorated function, still collects and reports latency metrics to Argus, then re-raises. Previously, any exception during the decorated operation caused the entire step's latency data to be silently dropped.

The re-raise is guarded on all exit paths (two early returns and the main path) to ensure the original exception always propagates to the caller regardless of monitoring configuration or workload detection.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->

- [x] It was tested while https://github.com/scylladb/scylla-cluster-tests/pull/14573

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
