### PR TITLE
fix(keystore): remove dead legacy key names from sct.py sync

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -257,9 +257,8 @@ def cli(ctx):
         try_auth_with_okta()
 
         key_store = KeyStore()
-        # TODO: still leaving old keys, until we'll rebuild runner images - and reconfigure jenkins
         key_store.sync(
-            keys=["scylla-qa-ec2", "scylla-test", "scylla_test_id_ed25519"],
+            keys=["scylla_test_id_ed25519"],
             local_path=Path("~/.ssh/").expanduser(),
             permissions=0o0600,
         )


### PR DESCRIPTION
## Summary

Remove `scylla-qa-ec2` and `scylla-test` from the `key_store.sync()` call in `sct.py` CLI startup.

These keys are aliases for the same `scylla_test_id_ed25519` key — syncing them is redundant and causes `NoSuchKey` errors if the legacy S3 objects are ever removed.

## Context

Found during PR #14330 CI — the provision test failed with `PermissionError` when trying to sync these legacy keys on an OCI runner where `$HOME` pointed to the wrong directory. The legacy keys add unnecessary failure surface.

## Changes

- `sct.py`: Remove `scylla-qa-ec2` and `scylla-test` from sync keys list
- Remove the stale TODO comment about runner image rebuilds

## Testing

- Unit tests pass (no test references these specific sync keys)
- The only key actually used by all backends is `scylla_test_id_ed25519`