### PR TITLE
fix(hydra): set HOME in Docker container and clean cloud-init on image bake

### DIFF
--- a/docker/env/hydra.sh
+++ b/docker/env/hydra.sh
@@ -234,6 +234,7 @@ function run_in_docker () {
            -v /dev:/dev:rw
            --tmpfs "${HOME_DIR}/.local:exec,mode=1777"
            -u ${USER_ID}
+           -e HOME="${HOME_DIR}"
            )
     else
         PODMAN_PORT=$(EPHEMERAL_PORT)

--- a/sct.py
+++ b/sct.py
@@ -257,7 +257,6 @@ def cli(ctx):
         try_auth_with_okta()
 
         key_store = KeyStore()
-        # TODO: still leaving old keys, until we'll rebuild runner images - and reconfigure jenkins
         key_store.sync(
             keys=["scylla-qa-ec2", "scylla-test", "scylla_test_id_ed25519"],
             local_path=Path("~/.ssh/").expanduser(),

--- a/sdcm/keystore.py
+++ b/sdcm/keystore.py
@@ -248,6 +248,8 @@ class KeyStore:
                     dl_flag = False
         except FileNotFoundError:
             pass
+        except PermissionError:
+            os.unlink(path)
 
         if dl_flag:
             self.download_file(filename=key, dest_filename=path)

--- a/sdcm/sct_runner.py
+++ b/sdcm/sct_runner.py
@@ -180,7 +180,7 @@ class SctRunnerInfo:
 class SctRunner(ABC):
     """Provision and configure the SCT runner."""
 
-    VERSION = "1.19"  # Version of the Image
+    VERSION = "1.20"  # Version of the Image
     NODE_TYPE = "sct-runner"
     RUNNER_NAME = "SCT-Runner"
     LOGIN_USER = "ubuntu"
@@ -401,6 +401,8 @@ class SctRunner(ABC):
 
         node_exporter_setup = NodeExporterSetup()
         node_exporter_setup.install(remoter=remoter)
+
+        remoter.sudo("cloud-init clean --logs")
 
         remoter.stop()
         if result.ok:


### PR DESCRIPTION
## Summary

Fix PermissionError on OCI (and potentially all) SCT runners by addressing three layered issues in the Docker/runner environment.

## Problems

### 1. HOME=/home/jenkins inside Docker container
The hydra Docker image has `HOME=/home/jenkins` baked in. On Linux, Docker does NOT override image `ENV` vars when using `-u UID:GID` — it only changes the running UID. macOS already passes `-e HOME="${HOME_DIR}"` but Linux did not.

### 2. cloud-init not re-running on new instances
After 91e16755fc switched OCI to a custom Ubuntu 26.04 image (in-place upgrade from 24.04), runner images baked without `cloud-init clean` retain stale state. Cloud-init sees `/var/lib/cloud/instance/boot-finished` and skips re-running — the cloud-config that fixes user/permissions setup is silently ignored.

### 3. Stale root-owned SSH key files from image bake
During image baking, SSH keys are downloaded as root. Without cloud-init re-running `chown -R ubuntu:ubuntu /home/ubuntu`, these files remain root:root with 0600, unreadable by the container UID 1000.

## Fixes

| File | Change |
|------|--------|
| `docker/env/hydra.sh` | Add `-e HOME="${HOME_DIR}"` to Linux Docker args (matching macOS) |
| `sdcm/keystore.py` | Handle `PermissionError` on existing key files by unlinking and re-downloading |
| `sdcm/sct_runner.py` | Run `cloud-init clean --logs` before image capture; bump VERSION to 1.20 |
| `sct.py` | Remove stale TODO comment |

## Testing

After merging, OCI runner image needs to be rebuilt (`hydra create-runner-image --cloud-provider oci`) to pick up the cloud-init fix.