### PR TITLE
fix(pipelines): add default_scylla_version to trigger matrix config

### DIFF
--- a/configurations/triggers/pgo-offline-installer.yaml
+++ b/configurations/triggers/pgo-offline-installer.yaml
@@ -12,6 +12,8 @@ jenkinsfiles:
 #
 # Triggered manually with unified_package URL from a completed PGO build.
 
+default_scylla_version: "master"
+
 defaults:
   provision_type: "on_demand"
   post_behavior_db_nodes: "destroy"

--- a/sdcm/utils/trigger_matrix.py
+++ b/sdcm/utils/trigger_matrix.py
@@ -331,6 +331,7 @@ class MatrixConfig(BaseModel):
 
     jobs: list[JobConfig]
     defaults: dict = Field(default_factory=dict)
+    default_scylla_version: str = ""
     cron_triggers: list[CronTriggerConfig] = Field(default_factory=list)
     email_recipients: list[str] = Field(default_factory=list)
 
@@ -1015,7 +1016,7 @@ def send_trigger_matrix_email(
         logger.warning("Failed to send email report: %s", exc)
 
 
-def trigger_matrix(
+def trigger_matrix(  # noqa: PLR0914
     matrix_file: str,
     scylla_version: str,
     filter_version: str | None = None,
@@ -1048,6 +1049,7 @@ def trigger_matrix(
         JenkinsTriggerError: If Jenkins credentials are missing (non-dry-run).
     """
     config = load_matrix_config(matrix_file)
+    scylla_version = scylla_version or config.default_scylla_version
     resolved_folder = determine_job_folder(filter_version or scylla_version, job_folder)
 
     skip_list = [s.strip() for s in skip_jobs.split(",") if s.strip()] if skip_jobs else []

--- a/unit_tests/trigger_matrix/test_trigger.py
+++ b/unit_tests/trigger_matrix/test_trigger.py
@@ -16,6 +16,7 @@ from unittest.mock import MagicMock, patch
 
 import jenkins as jenkins_lib
 import pytest
+import yaml
 
 from sdcm.utils.trigger_matrix import JenkinsTriggerError, trigger_jenkins_job, trigger_matrix
 
@@ -165,3 +166,30 @@ def test_unknown_skip_jobs_logs_warning(sample_matrix_yaml, caplog):
             dry_run=True,
         )
     assert any("not found in matrix" in record.message for record in caplog.records)
+
+
+def test_default_scylla_version_used_when_empty(tmp_path):
+    """When scylla_version is empty, trigger_matrix uses default_scylla_version from the YAML."""
+    data = {
+        "default_scylla_version": "master",
+        "defaults": {"provision_type": "on_demand"},
+        "jobs": [
+            {
+                "job_name": "/scylla-enterprise/perf-regression/perf-test",
+                "backend": "aws",
+                "region": "us-east-1",
+                "labels": [],
+                "exclude_versions": [],
+                "params": {"unified_package": "https://example.com/scylla-unified.tar.gz"},
+            },
+        ],
+    }
+    matrix_file = tmp_path / "pgo-matrix.yaml"
+    matrix_file.write_text(yaml.dump(data))
+
+    results = trigger_matrix(
+        matrix_file=str(matrix_file),
+        scylla_version="",
+        dry_run=True,
+    )
+    assert len(results["triggered"]) == 1


### PR DESCRIPTION
## Problem

The PGO offline installer trigger ([build #4](https://jenkins.scylladb.com/job/scylla-master/job/sct_triggers/job/performance/job/perf-simple-query-offline-installer-trigger-x86-test/4/console)) fails with:

```
Error: Cannot determine job folder: scylla_version is empty. Provide a version or explicit --job-folder.
```

This happens because the trigger is invoked with only `--unified-package` (no `--scylla-version`), and `determine_job_folder()` requires a non-empty version string.

## Solution

Add a `default_scylla_version` field to `MatrixConfig` so that trigger matrix YAML files can declare their own fallback version. The `trigger_matrix()` function uses this default when the caller does not provide `scylla_version`.

Set `default_scylla_version: "master"` in `pgo-offline-installer.yaml` since PGO perf jobs always target master.

## Changes

- `sdcm/utils/trigger_matrix.py`: Added `default_scylla_version` field to `MatrixConfig` and fallback logic in `trigger_matrix()`
- `configurations/triggers/pgo-offline-installer.yaml`: Set default to `master`
- `unit_tests/trigger_matrix/test_trigger.py`: Added test for the new behavior

## Testing

All 113 trigger_matrix unit tests pass.