### PR TITLE
ci(oci): switch SCT runner back to ubuntu26

### DIFF
--- a/sdcm/sct_runner.py
+++ b/sdcm/sct_runner.py
@@ -1398,22 +1398,15 @@ class OciSctRunner(SctRunner):
     LONGTERM_TEST_INSTANCE_TYPE = "VM.Standard.E4.Flex-4-16"  # 4 vcpus, 16G
     OCI_CLI_VERSION = "3.76.2"  # Pinned version for reproducibility
 
-    # Custom Ubuntu 26.04 image created by upgrading 24.04 in-place.
-    # OCI marketplace does not have Ubuntu 26.04 yet; this image was built
-    # from the marketplace 24.04 image via do-release-upgrade -d.
-    # Switch to get_ubuntu_image_ocid(version="26.04") once Canonical publishes
-    # an official 26.04 image to the OCI marketplace.
-    BASE_IMAGE = "ocid1.image.oc1.iad.aaaaaaaa25pea47rb7sjmv7wwrap2y53nbr6iumxqxxdffil4nfjjtqqjtiq"
-
-    # TODO: use following instead of the hardcoded custom image ID when OCI gets official Ubuntu26
-    # @cached_property
-    # def BASE_IMAGE(self) -> str:
-    #     """Get the latest Ubuntu 26.04 image for the source region."""
-    #     return get_ubuntu_image_ocid(
-    #         compartment_id=self.oci_region_src.compartment_id,
-    #         region=self.SOURCE_IMAGE_REGION,
-    #         version="26.04",
-    #     )
+    @cached_property
+    def BASE_IMAGE(self) -> str:
+        """Get the latest Ubuntu 24.04 image for the source region."""
+        # TODO: switch to the Ubuntu 26.04
+        return get_ubuntu_image_ocid(
+            compartment_id=self.oci_region_src.compartment_id,
+            region=self.SOURCE_IMAGE_REGION,
+            version="24.04",
+        )
 
     def __init__(self, region_name: str, availability_zone: str, params: SCTConfiguration):
         availability_zone = availability_zone or (params.get("availability_zone") if params else "")

--- a/vars/getJenkinsLabels.groovy
+++ b/vars/getJenkinsLabels.groovy
@@ -58,9 +58,9 @@ def call(String backend, String region=null, String datacenter=null, String loca
                           'aws': 'aws-sct-builders-eu-west-1-v4-asg',
                           'azure-eastus': 'aws-sct-builders-us-east-1-v4-asg',
                           'aws-fips': 'aws-sct-builders-us-east-1-v4-fibs-CI-FIPS',
-                          'oci': 'oci-sct-builders-us-ashburn-1-v2',
-                          'oci-us-ashburn-1': 'oci-sct-builders-us-ashburn-1-v2',
-                          'oci-us-phoenix-1': 'oci-sct-builders-us-phoenix-1-v2',
+                          'oci': 'oci-sct-builders-us-ashburn-1-v1',
+                          'oci-us-ashburn-1': 'oci-sct-builders-us-ashburn-1-v1',
+                          'oci-us-phoenix-1': 'oci-sct-builders-us-phoenix-1-v1',
                           ]
 
     def cloud_provider = getCloudProviderFromBackend(backend)


### PR DESCRIPTION
Ref: #SCT-578

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
