### PR TITLE
fix(hydra): resolve PermissionError on OCI runners with Ubuntu 26

### DIFF
--- a/docker/env/hydra.sh
+++ b/docker/env/hydra.sh
@@ -233,6 +233,7 @@ function run_in_docker () {
            -v /var/run:/run
            -v /dev:/dev:rw
            --tmpfs "${HOME_DIR}/.local:exec,mode=1777"
+           -e HOME="${HOME_DIR}"
            -u ${USER_ID}
            )
     else
@@ -358,8 +359,12 @@ if [[ -n "$RUNNER_IP" ]]; then
 
     SCT_DIR="/home/ubuntu/scylla-cluster-tests"
     HOST_NAME="ip-${RUNNER_IP//./-}"
-    USER_ID=1000:1000
     RUNNER_CMD="ssh -o StrictHostKeyChecking=no ubuntu@${RUNNER_IP}"
+    if [ -z "$HYDRA_DRY_RUN" ]; then
+        USER_ID=$(${RUNNER_CMD} id -u):$(${RUNNER_CMD} id -g)
+    else
+        USER_ID=1000:1000
+    fi
     DOCKER_HOST="-H ssh://ubuntu@${RUNNER_IP}"
 fi
 


### PR DESCRIPTION
After switching SCT runners to Ubuntu 26 images,
OCI backend tests started failing with the PermissionError
on the 'provision resources' stage.
    
Error:
```
    Traceback (most recent call last):
      File "/home/ubuntu/scylla-cluster-tests/./sct.py", line 260, in cli
        key_store.sync(
            keys=["scylla-qa-ec2", "scylla-test", "scylla_test_id_ed25519"],
             local_path=Path("~/.ssh/").expanduser(),
            permissions=0o0600,
        )
      File "/home/ubuntu/scylla-cluster-tests/sdcm/keystore.py", line 260, in sync
        list(executor.map(lambda p: self.get_obj_if_needed(*p), args))
      File "/home/ubuntu/scylla-cluster-tests/sdcm/keystore.py", line 243, in get_obj_if_needed
        os.makedirs(os.path.dirname(path), exist_ok=True)
    PermissionError: [Errno 13] Permission denied: '/home/jenkins'
```

It was caused by the following issues:
   
- The HOME environment variable was not explicitly set in the Linux
  Docker code path, causing Python's expanduser("~") to resolve to
  a wrong directory (e.g. /home/jenkins) depending on container
  runtime behavior with bind-mounted /etc/passwd.

- USER_ID was hardcoded to 1000:1000, but on Ubuntu 26 OCI base
  images the pre-existing ubuntu user may have a different UID.
  Cloud-init's uid: 1000 directive in the cloud-config is silently
  ignored when the user already exists. The container then ran as
  the wrong UID, unable to access files owned by the actual ubuntu
  user on the runner.
    
So, fix it by setting the home dir explicitly and automatically
detecting the UID of the user.
    
Closes: #SCT-578

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
