### PR TITLE
fix(log-archive): use /var/tmp for chunk splitting to avoid tmpfs quota

### DIFF
--- a/sdcm/log_archive.sh
+++ b/sdcm/log_archive.sh
@@ -11,7 +11,7 @@ FILE="$1"
 CHUNK_SIZE="$2"
 ARCHIVE_NAME="$3"
 
-WORK_DIR=$(mktemp -d)
+WORK_DIR=$(mktemp -d --tmpdir=/var/tmp)
 trap 'rm -rf "$WORK_DIR"' EXIT
 
 split --line-bytes="$CHUNK_SIZE" --numeric-suffixes=1 --additional-suffix=".part" "$FILE" "$WORK_DIR/chunk_"


### PR DESCRIPTION
Ubuntu 26.04 enables tmp.mount by default, mounting /tmp
as tmpfs limited to 50% of RAM (~4GB on SCT runner instances).
Long longevity tests produce log files exceeding this limit,
causing "Disk quota exceeded" errors during log archival.

So, fix it by using /var/tmp dir instead of the /tmp for those cases.

Closes: #SCT-609

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
