### PR TITLE
improvement(log-archive): stream 1 chunk at a time

### DIFF
--- a/sdcm/log_archive.sh
+++ b/sdcm/log_archive.sh
@@ -1,31 +1,35 @@
-#!/bin/bash
-# Split a large log file into compressed chunks efficiently.
+#!/usr/bin/env bash
 # Usage: log_archive.sh <file> <chunk_size_bytes> <archive_name>
-#
-# Uses split for single-pass file splitting, then compresses chunks in parallel.
-# Disk-efficient: removes each raw chunk immediately after compression.
 
 set -euo pipefail
 
-FILE="$1"
+INPUT_FILE="$1"
 CHUNK_SIZE="$2"
 ARCHIVE_NAME="$3"
 
-WORK_DIR=$(mktemp -d --tmpdir=/var/tmp)
+WORK_DIR=${LOG_ARCHIVE_WORK_DIR:-$(mktemp -d --tmpdir=/var/tmp)}
 trap 'rm -rf "$WORK_DIR"' EXIT
 
-split --line-bytes="$CHUNK_SIZE" --numeric-suffixes=1 --additional-suffix=".part" "$FILE" "$WORK_DIR/chunk_"
+export WORK_DIR ARCHIVE_NAME
 
-seq=0
-for chunk in "$WORK_DIR"/chunk_*.part; do
-    [ -f "$chunk" ] || continue
-    seq=$((seq + 1))
-    timestamp=$(head -1 "$chunk" | awk '{print $2,$3}' | sed -e 's/t://g;s/ /__/g;s/-/_/g;s/:/_/g;s/,/_/g;')
-    if [ -z "$timestamp" ] || [ "$timestamp" = "__" ]; then
-        timestamp="part_$(printf '%04d' $seq)"
-    fi
-    out_name="${timestamp}.${ARCHIVE_NAME}.zst"
-    zstd --rm -q "$chunk" -o "$out_name" &
-done
+# Injecting 'set -eu' into the subshell ensures failures abort the split process.
+# (Note: 'pipefail' is omitted as split defaults to /bin/sh, which is 'dash' on many distros).
+split --line-bytes="$CHUNK_SIZE" --numeric-suffixes=1 --additional-suffix=".part" \
+    --filter='
+        set -eu
+        if IFS= read -r first_line; then
+            chunk_seq=$(basename "$FILE" .part)
 
-wait
+            # Extract timestamp completely in-memory
+            timestamp=$(printf "%s\n" "$first_line" | awk "{print \$2,\$3}" | sed -e "s/t://g;s/ /__/g;s/-/_/g;s/:/_/g;s/,/_/g;")
+
+            if [ -z "$timestamp" ] || [ "$timestamp" = "__" ]; then
+                out_name="${chunk_seq}.${ARCHIVE_NAME}.zst"
+            else
+                out_name="${timestamp}.${chunk_seq}.${ARCHIVE_NAME}.zst"
+            fi
+
+            # Stream the first line + the remaining stdin directly into zstd
+            { printf "%s\n" "$first_line"; cat; } | zstd -q -o "$out_name"
+        fi
+    ' "$INPUT_FILE" "$WORK_DIR/chunk_"

--- a/unit_tests/unit/test_log_archive.py
+++ b/unit_tests/unit/test_log_archive.py
@@ -14,6 +14,7 @@
 import os
 import shutil
 import subprocess
+import threading
 
 import pytest
 
@@ -229,7 +230,7 @@ def test_disk_efficiency_original_not_duplicated(tmp_path, large_log_file):
     assert len(part_files) == 0, f"Raw chunks should be removed after compression: {part_files}"
 
 
-def test_parallel_compression_produces_valid_archives(tmp_path, large_log_file):
+def test_many_chunks_produce_valid_archives(tmp_path, large_log_file):
     file_size = os.path.getsize(large_log_file)
     chunk_size = file_size // 8
 
@@ -247,3 +248,57 @@ def test_parallel_compression_produces_valid_archives(tmp_path, large_log_file):
     for zst_file in zst_files:
         result = subprocess.run(["zstd", "-t", str(zst_file)], capture_output=True, text=True, check=False)
         assert result.returncode == 0, f"Corrupt archive: {zst_file}"
+
+
+def test_peak_work_dir_size_bounded_to_single_chunk(tmp_path, large_log_file):
+    """Assert peak temp-dir size stays bounded — no raw chunks accumulate.
+
+    This is the core regression test for the streaming rewrite: the old approach
+    wrote all split chunks to WORK_DIR before compressing (peak = full file size),
+    while the new --filter approach pipes directly (peak ~ 0).
+    """
+
+    file_size = os.path.getsize(large_log_file)
+    chunk_size = file_size // 4
+
+    work_dir = tmp_path / "work"
+    work_dir.mkdir()
+
+    max_observed = [0]
+    stop_event = threading.Event()
+
+    def monitor_work_dir():
+        while not stop_event.is_set():
+            try:
+                total = sum(f.stat().st_size for f in work_dir.iterdir() if f.is_file())
+                max_observed[0] = max(max_observed[0], total)
+            except (FileNotFoundError, OSError):
+                pass
+            stop_event.wait(0.005)
+
+    monitor = threading.Thread(target=monitor_work_dir, daemon=True)
+    monitor.start()
+
+    env = os.environ.copy()
+    env["LOG_ARCHIVE_WORK_DIR"] = str(work_dir)
+
+    result = subprocess.run(
+        ["bash", LOG_ARCHIVE_SCRIPT, str(large_log_file), str(chunk_size), "sct.log"],
+        cwd=str(tmp_path),
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+
+    stop_event.set()
+    monitor.join(timeout=2)
+
+    assert result.returncode == 0, f"Script failed: {result.stderr}"
+
+    # With streaming, the work dir should never hold raw chunks.
+    # Allow a small margin for filesystem metadata / directory entries.
+    assert max_observed[0] < chunk_size, (
+        f"Peak work-dir usage was {max_observed[0]} bytes — expected < {chunk_size} (one chunk). "
+        f"Raw chunks are being written to disk instead of streamed."
+    )


### PR DESCRIPTION
Ubuntu 26.04 enables tmp.mount by default, mounting /tmp
as a tmpfs limited to 50% of RAM (~4GB on SCT runner instances).

The previous implementation wrote all split chunks to disk before compressing,
requiring disk space equal to the full log file size.
Long longevity tests produce logs exceeding the tmpfs quota,
causing "Disk quota exceeded" failures during log collection.

So, rewrite it to use 'split --filter'.
It will stream one chunk at a time.
Each chunk is written, compressed with zstd and removed before the next one begins.
Peak temporary disk usage drops from full-file-size to a single chunk.

Ref: #SCT-609

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- https://jenkins.scylladb.com/job/sct-github-PRs-scan/job/scylla-cluster-tests/job/PR-15364/3/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
