### PR TITLE
fix(network): resolve NIC creation race condition by utilizing poller results

### DIFF
--- a/sdcm/provision/azure/network_interface_provider.py
+++ b/sdcm/provision/azure/network_interface_provider.py
@@ -81,8 +81,7 @@ class NetworkInterfaceProvider:
             )
             pollers.append((nic_name, poller))
         for nic_name, poller in pollers:
-            poller.wait()
-            nic = self._azure_service.network.network_interfaces.get(self._resource_group_name, nic_name)
+            nic = poller.result()
             LOGGER.info("Provisioned nic %s in the %s resource group", nic.name, self._resource_group_name)
             self._cache[nic_name] = nic
             nics.append(nic)

--- a/unit_tests/unit/provisioner/fake_azure_service.py
+++ b/unit_tests/unit/provisioner/fake_azure_service.py
@@ -41,8 +41,9 @@ def dict_keys_to_camel_case(dct):
 
 
 class WaitableObject:
-    def __init__(self, error: AzureError = None):
+    def __init__(self, error: AzureError = None, value: Any = None):
         self.error = error
+        self.value = value
 
     def wait(self, timeout=None):
         if self.error:
@@ -50,6 +51,11 @@ class WaitableObject:
 
     def done(self) -> bool:
         return True
+
+    def result(self, timeout=None):
+        if self.error:
+            raise self.error
+        return self.value
 
 
 class ResultableObject:
@@ -434,7 +440,7 @@ class FakeNetworkInterface:
             self.path / resource_group_name / f"nic-{network_interface_name}.json", "w", encoding="utf-8"
         ) as file:
             json.dump(base, fp=file, indent=2)
-        return WaitableObject()
+        return WaitableObject(value=NetworkInterface.from_dict(base))
 
     def get(self, resource_group_name: str, network_interface_name: str) -> NetworkInterface:
         try:


### PR DESCRIPTION
Fixed a ResourceNotFoundError caused by an immediate read-after-write GET request to Azure ARM before global propagation finished.

Replaced `poller.wait()` followed by a explicit `.get()` fetch with `poller.result()`, which safely extracts the provisioned NetworkInterface directly from the creation response payload. Removed the redundant API call.

fixes: https://scylladb.atlassian.net/browse/SCT-544

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
