### PR TITLE
fix(oci): properly set rack and dc using `add_remove_nemesis_dc` nemesis

### DIFF
--- a/sdcm/nemesis/monkey/add_remove_dc.py
+++ b/sdcm/nemesis/monkey/add_remove_dc.py
@@ -5,6 +5,7 @@ from sdcm.cluster import BaseNode
 from sdcm.exceptions import KillNemesis, UnsupportedNemesis
 from sdcm.nemesis import NemesisBaseClass
 from sdcm.provision.scylla_yaml import SeedProvider
+from sdcm.snitch_configuration import SnitchConfig
 from sdcm.utils.decorators import retrying, skip_on_capacity_issues
 from sdcm.utils.features import is_tablets_feature_enabled
 from sdcm.utils.replication_strategy_utils import (
@@ -137,13 +138,16 @@ class AddRemoveDcNemesis(NemesisBaseClass):
             ]
 
         endpoint_snitch = self.runner.cluster.params.get("endpoint_snitch") or ""
-        if endpoint_snitch.endswith("GossipingPropertyFileSnitch"):
-            rackdc_value = {"dc": "add_remove_nemesis_dc"}
-        else:
-            rackdc_value = {"dc_suffix": "_nemesis_dc"}
+        dc_suffix = "_nemesis_dc"
+        dc_name = f"add_remove{dc_suffix}"
 
-        with node.remote_cassandra_rackdc_properties() as properties_file:
-            properties_file.update(**rackdc_value)
+        SnitchConfig(node=node, datacenters=[dc_name]).apply(force=True)
+
+        if not endpoint_snitch.endswith("GossipingPropertyFileSnitch"):
+            # Non-GPFS snitches (Ec2Snitch, GoogleCloudSnitch, etc.) derive dc from cloud metadata
+            # and only read dc_suffix from the properties file to form the final dc name.
+            with node.remote_cassandra_rackdc_properties() as properties_file:
+                properties_file["dc_suffix"] = dc_suffix
 
     def add_nodes_in_new_dc(self) -> None:
         """Add and initialize temporary nodes configured to join a new datacenter."""

--- a/sdcm/snitch_configuration.py
+++ b/sdcm/snitch_configuration.py
@@ -43,11 +43,12 @@ class SnitchConfig:
         else:
             return ""
 
-    def apply(self) -> None:
+    def apply(self, force: bool = False) -> None:
         """
         Apply snitch configuration to the node (only in cassandra-rackdc.properties, scylla.yaml must be updated separately.).
 
-        Returns `True` if require Scylla restart to make the effect.
+        Args:
+            force: If True, forcibly overwrite existing properties (used by AddRemoveDc nemesis).
         """
         properties = {
             "dc": self._datacenter,
@@ -59,7 +60,7 @@ class SnitchConfig:
 
         with self._node.remote_cassandra_rackdc_properties() as properties_file:
             for key, value in properties.items():
-                if hasattr(self._node, "query_oci_metadata"):
+                if force or hasattr(self._node, "query_oci_metadata"):
                     # NOTE: OCI images have predefined properties file with real data for dc and rack.
                     #       So, set it forcibly because defaulting will not have an effect.
                     properties_file[key] = value


### PR DESCRIPTION
Running tests on OCI backend we must forcefully update
datacenter and rack info in the `cassandra-rackdc.properties` file.
It is what gets done in the `sdcm/snitch_configuration.py` file.

And it must be done in any place where we create new DB node on OCI.

So, fix the `add_remove_nemesis_dc` (`AddRemoveDcNemesis`) by doing identical changes.

Closes: #SCT-96

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- https://jenkins.scylladb.com/job/scylla-staging/job/valerii/job/vp-longevity-100gb-4h-oci-test/44
- https://jenkins.scylladb.com/job/scylla-staging/job/valerii/job/vp-longevity-100gb-4h-test/19

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
