### PR TITLE
feat: Change wait_not_tablet_migration to wait_tablet_balanced

### DIFF
--- a/longevity_balancer_test.py
+++ b/longevity_balancer_test.py
@@ -23,7 +23,7 @@ from sdcm.sct_events import Severity
 from sdcm.sct_events.system import InfoEvent, TestFrameworkEvent
 from sdcm.utils.adaptive_timeouts import Operations, adaptive_timeout
 from sdcm.utils.common import ParallelObject, get_node_disk_usage
-from sdcm.utils.tablets.common import wait_no_tablets_migration_running
+from sdcm.utils.tablets.common import wait_tablets_balanced
 
 # Per requirement, load balance difference should be bellow 5% for nodes in the same rack
 # https://scylladb.atlassian.net/wiki/spaces/RND/pages/5505671/Size-Based+Load+Balancing+Requirement+Document#Performance
@@ -59,11 +59,7 @@ class LongevityBalancerTest(LongevityTest):
         self.db_cluster.wait_for_nodes_up_and_normal(nodes=new_nodes)
 
     def wait_for_balance(self):
-        # run multiple times because `storage_service/quiesce_topology` only returns when
-        # the topology operations that were ongoing when the command was issued are done
-        # but new operations can start right after that
-        for _ in range(3):
-            ParallelObject(objects=self.db_cluster.data_nodes, timeout=3600).run(wait_no_tablets_migration_running)
+        wait_tablets_balanced(self.db_cluster.data_nodes[0])
 
     def check_balance(self):
         rack_usages = defaultdict(list)

--- a/longevity_oos_test.py
+++ b/longevity_oos_test.py
@@ -29,7 +29,7 @@ from sdcm.sct_events.system import TestFrameworkEvent
 from sdcm.utils.adaptive_timeouts import Operations, adaptive_timeout
 from sdcm.utils.decorators import retrying
 from sdcm.nemesis.utils.indexes import create_index, verify_query_by_index_works, wait_for_index_to_be_built
-from sdcm.utils.tablets.common import wait_no_tablets_migration_running
+from sdcm.utils.tablets.common import wait_tablets_balanced
 from threading import Thread
 
 
@@ -165,8 +165,7 @@ class LongevityOutOfSpaceTest(LongevityTest):
         self.db_cluster.set_seeds()
         self.db_cluster.update_seed_provider()
         self.db_cluster.wait_for_nodes_up_and_normal(nodes=added_nodes)
-        for node in self.db_cluster.nodes:
-            wait_no_tablets_migration_running(node, timeout=7200)
+        wait_tablets_balanced(self.db_cluster.data_nodes[0], timeout=7200)
 
     def get_compactions(self, node: BaseNode, interval: int) -> int:
         """

--- a/sdcm/nemesis/__init__.py
+++ b/sdcm/nemesis/__init__.py
@@ -158,7 +158,7 @@ from sdcm.nemesis.utils.node_allocator import NemesisNodeAllocator, NemesisNodeA
 from sdcm.utils.node import build_node_api_command
 from sdcm.utils.sstable.load_utils import SstableLoadUtils
 from sdcm.utils.sstable.sstable_utils import SstableUtils
-from sdcm.utils.tablets.common import wait_no_tablets_migration_running
+from sdcm.utils.tablets.common import wait_tablets_balanced
 from sdcm.utils.toppartition_util import NewApiTopPartitionCmd, OldApiTopPartitionCmd
 from sdcm.utils.version_utils import MethodVersionNotFound, scylla_versions, ComparableScyllaVersion
 from sdcm.utils.raft import Group0MembersNotConsistentWithTokenRingMembersException, TopologyOperations
@@ -3872,7 +3872,7 @@ class NemesisRunner:
     def add_new_nodes(self, count, rack=None, instance_type: str = None) -> list[BaseNode]:
         nodes = self._add_and_init_new_cluster_nodes(count, rack=rack, instance_type=instance_type)
         self.actions_log.info(f"New nodes added: {', '.join(node.name for node in nodes)}")
-        ParallelObject(objects=self.cluster.data_nodes, timeout=7200).run(wait_no_tablets_migration_running)
+        wait_tablets_balanced(self.cluster.data_nodes[0])
         return nodes
 
     @latency_calculator_decorator(legend="Decommission nodes: remove nodes from cluster")

--- a/sdcm/utils/replication_strategy_utils.py
+++ b/sdcm/utils/replication_strategy_utils.py
@@ -7,7 +7,7 @@ from typing import Callable, Dict, TYPE_CHECKING
 
 from sdcm.utils.cql_utils import cql_quote_if_needed
 from sdcm.utils.database_query_utils import is_system_keyspace, LOGGER
-from sdcm.utils.tablets.common import wait_no_tablets_migration_running
+from sdcm.utils.tablets.common import wait_tablets_balanced
 
 if TYPE_CHECKING:
     from sdcm.cluster import BaseNode
@@ -214,7 +214,7 @@ class DataCenterTopologyRfControl:
                     keyspace=keyspace, replication_factor=self.original_nodes_number, node=self.cluster.data_nodes[0]
                 )
         if node_to_wait_for_balance:
-            wait_no_tablets_migration_running(node_to_wait_for_balance)
+            wait_tablets_balanced(node_to_wait_for_balance)
 
     def decrease_keyspaces_rf(self):
         """

--- a/sdcm/utils/tablets/common.py
+++ b/sdcm/utils/tablets/common.py
@@ -1,5 +1,4 @@
 import logging
-import time
 from dataclasses import dataclass
 from typing import Optional
 
@@ -26,31 +25,23 @@ class TabletsConfiguration:
         return "{" + ", ".join(items) + "}"
 
 
-def wait_no_tablets_migration_running(node, timeout: int = 3600):
+def wait_tablets_balanced(node, timeout: int = 3600):
     """
-    Waiting for having no ongoing tablets topology operations using REST API.
-    !!! It does not guarantee that tablets are balanced !!!
-    Keep in mind that it is good only to find when ongoing tablets topology operations is done.
-    Very next second another topology operation can be started.
-
-    doing it several times as there's a risk of:
-    "currently a small time window after adding nodes and before load balancing starts during which
-    topology may appear as quiesced because the state machine goes through an idle state before it enters load balancing state"
-    """
+    Wait for tablets to be balanced, no more pending splits/merges and no ongoing tablets topology operations using REST API.
+    A single request is enough as it is submitted as a global topology request and completes only after fresh tablet load stats produce an empty balance plan and tablets are idle."""
     if not is_tablets_feature_enabled(node):
         LOGGER.info("Tablets are disabled, skipping wait for balance")
         return
-    time.sleep(60)  # one minute gap before checking, just to give some time to the state machine
     client = RemoteCurlClient(host="127.0.0.1:10000", endpoint="", node=node)
-    LOGGER.info("Waiting for having no ongoing tablets topology operations")
+    LOGGER.info("Waiting for tablets balancing (no pending splits/merges, no ongoing topology operations)")
     try:
         with adaptive_timeout(Operations.TABLET_MIGRATION, node, timeout=timeout) as adaptive_timeout_value:
             client.run_remoter_curl(
                 method="POST", path="storage_service/quiesce_topology", params={}, timeout=adaptive_timeout_value
             )
-        LOGGER.info("All ongoing tablets topology operations are done")
+        LOGGER.info("Tablets are balanced")
     except Exception as exc:  # noqa: BLE001
         InfoEvent(
-            f"Failed to wait for having no ongoing tablets topology operations. Exception: {exc.__repr__()}",
+            f"Failed to wait for tablets to be balanced. Exception: {exc.__repr__()}",
             severity=Severity.ERROR,
         ).publish()

--- a/vnode_to_tablet_migration_test.py
+++ b/vnode_to_tablet_migration_test.py
@@ -18,7 +18,7 @@ from enum import StrEnum
 
 from longevity_test import LongevityTest
 from sdcm.sct_events.system import InfoEvent
-from sdcm.utils.tablets.common import wait_no_tablets_migration_running
+from sdcm.utils.tablets.common import wait_tablets_balanced
 from sdcm.wait import wait_for
 
 
@@ -148,8 +148,7 @@ class VnodeToTabletMigrationTest(LongevityTest):
             coordinator_node.run_nodetool(f"migrate-to-tablets finalize {ks}")
 
         InfoEvent(message="Step 6 - Waiting for tablet migration to fully complete").publish()
-        for migration_node in self.db_cluster.data_nodes:
-            wait_no_tablets_migration_running(migration_node, timeout=7200)
+        wait_tablets_balanced(self.db_cluster.data_nodes[0], timeout=7200)
 
         InfoEvent(message="Step 7 - Verifying migrated keyspaces have tablets in system.tablets").publish()
         with self.db_cluster.cql_connection_patient(coordinator_node, connect_timeout=600) as session:


### PR DESCRIPTION
* quiesce_topology endpoint which is used has changed the behaviour since this was introduced. It now also waits for tablet balancing and doesn't need to be called on all nodes
* Remove 60sec wait
  * Confirmed to not be needed 

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] Longevity - https://argus.scylladb.com/tests/scylla-cluster-tests/164ed230-55ab-46fd-9879-25a6d94b1a8c/sct-events

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
