### PR TITLE
docs(plans): add strict jinja stress templating mini-plan

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -1,5 +1,7 @@
 db_type: "scylla"
 
+effective_compression_ratio: 1.0
+
 test_duration: 60
 prepare_stress_duration: 300 # 5 hours
 stress_duration: 0

--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -1,6 +1,7 @@
 db_type: "scylla"
 
 effective_compression_ratio: 1.0
+stress_template_context: {}
 
 test_duration: 60
 prepare_stress_duration: 300 # 5 hours

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -3475,6 +3475,15 @@ cassandra-stress commands for warm-up before read workload.<br>You can specify e
 **type:** str | list[str] → list[str] (appendable)
 
 
+## **effective_compression_ratio** / SCT_EFFECTIVE_COMPRESSION_RATIO
+
+Effective compression ratio used for Jinja stress command templating. Defined as on_disk_bytes / logical_uncompressed_bytes. This estimates how much disk space Scylla uses after compression relative to the logical uncompressed dataset size. For example, 1.0 means no effective compression and 0.68 means the data is expected to occupy about 68% of its logical uncompressed size on disk. Used together with the effective_disk_size_bytes template variable to calculate row counts that fill a target fraction of available disk capacity. You can estimate this ratio from Grafana in Keyspace -> Compression metrics; a compression value of 0% corresponds to effective_compression_ratio=1.0. Must be in range (0, 1.0].
+
+**default:** 1.0
+
+**type:** float
+
+
 ## **prepare_write_cmd** / SCT_PREPARE_WRITE_CMD
 
 cassandra-stress commands. You can specify everything but the -node parameter, which is going to be provided by the test suite infrastructure. Multiple commands can be passed as a list

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -3484,6 +3484,15 @@ Effective compression ratio used for Jinja stress command templating. Defined as
 **type:** float
 
 
+## **stress_template_context** / SCT_STRESS_TEMPLATE_CONTEXT
+
+Shared runtime-only Jinja variables for stress command templating. Entries are resolved in declaration order and may reference earlier context entries as well as built-in stress template variables such as effective_disk_size_bytes and db_node_count_per_dc. These values are available to stress commands rendered by SCT, but are not evaluated during config load or validation.
+
+**default:** {}
+
+**type:** dict | YAML/JSON string → dict
+
+
 ## **prepare_write_cmd** / SCT_PREPARE_WRITE_CMD
 
 cassandra-stress commands. You can specify everything but the -node parameter, which is going to be provided by the test suite infrastructure. Multiple commands can be passed as a list

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -3530,6 +3530,15 @@ Effective compression ratio used for Jinja stress command templating. Defined as
 **type:** float
 
 
+## **stress_template_context** / SCT_STRESS_TEMPLATE_CONTEXT
+
+Shared runtime-only Jinja variables for stress command templating. Entries are resolved in declaration order and may reference earlier context entries as well as built-in stress template variables such as effective_disk_size_bytes and db_node_count_per_dc. These values are available to stress commands rendered by SCT, but are not evaluated during config load or validation.
+
+**default:** {}
+
+**type:** dict | YAML/JSON string → dict
+
+
 ## **prepare_write_cmd** / SCT_PREPARE_WRITE_CMD
 
 cassandra-stress commands. You can specify everything but the -node parameter, which is going to be provided by the test suite infrastructure. Multiple commands can be passed as a list

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -3521,6 +3521,15 @@ cassandra-stress commands for warm-up before read workload.<br>You can specify e
 **type:** str | list[str] → list[str] (appendable)
 
 
+## **effective_compression_ratio** / SCT_EFFECTIVE_COMPRESSION_RATIO
+
+Effective compression ratio used for Jinja stress command templating. Defined as on_disk_bytes / logical_uncompressed_bytes. This estimates how much disk space Scylla uses after compression relative to the logical uncompressed dataset size. For example, 1.0 means no effective compression and 0.68 means the data is expected to occupy about 68% of its logical uncompressed size on disk. Used together with the effective_disk_size_bytes template variable to calculate row counts that fill a target fraction of available disk capacity. You can estimate this ratio from Grafana in Keyspace -> Compression metrics; a compression value of 0% corresponds to effective_compression_ratio=1.0. Must be in range (0, 1.0].
+
+**default:** 1.0
+
+**type:** float
+
+
 ## **prepare_write_cmd** / SCT_PREPARE_WRITE_CMD
 
 cassandra-stress commands. You can specify everything but the -node parameter, which is going to be provided by the test suite infrastructure. Multiple commands can be passed as a list

--- a/docs/loader_usage.md
+++ b/docs/loader_usage.md
@@ -93,6 +93,38 @@ Here are common parameters for longevity and performance tests:
   - Specifically used in `longevity_test.LongevityTest.test_batch_custom_time`.
   - Defines the number of stress commands executed in a single batch.
 
+- **Templated stress commands**:
+  - Longevity stress command fields such as `prepare_write_cmd` and `stress_cmd` may use Jinja expressions.
+  - Rendering happens only at runtime, immediately before SCT dispatches the stress command.
+  - The Jinja environment is strict: unknown variables fail the test before any stress thread starts.
+  - Longevity templates currently expose `effective_disk_size_bytes` and `db_node_count_per_dc` from the test object.
+  - `db_node_count_per_dc` is the DB node count for a single DC. It uses `n_db_nodes[0]` when configured and otherwise falls back to the current number of nodes in DC 0.
+  - `effective_disk_size_bytes` is calculated as `floor(average_available_bytes_on_/var/lib/scylla / effective_compression_ratio / 1.1)`.
+  - The extra `1.1` divisor is a global 10% static overhead reserve that biases templated sizing toward undershoot to account for table/storage overhead not captured by payload-only row-size estimates.
+  - `effective_compression_ratio` is defined as `on_disk_bytes / logical_uncompressed_bytes`. You can estimate it from Grafana in `Keyspace -> Compression`; a compression value of `0%` corresponds to `effective_compression_ratio=1.0`.
+  - `stress_template_context` lets you define shared derived values once and reuse them across multiple stress commands. Entries are resolved in declaration order, so later entries may reference earlier ones.
+
+Example:
+
+```yaml
+effective_compression_ratio: 0.68
+stress_template_context:
+  fill_percent: 90
+  replication_factor: 3
+  row_size_bytes: 1000
+  total_rows: "{{ ((effective_disk_size_bytes * db_node_count_per_dc * fill_percent) // 100 // replication_factor // row_size_bytes) | int }}"
+  rows_per_cmd: "{{ total_rows // 4 }}"
+
+prepare_write_cmd:
+  - >-
+    cassandra-stress write cl=QUORUM n={{ rows_per_cmd }}
+    -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)'
+    -mode cql3 native
+    -rate threads=150
+    -col 'size=FIXED(200) n=FIXED(5)'
+    -pop seq=1..{{ rows_per_cmd }}
+```
+
 ---
 
 ## Guidelines for Crafting Effective Stress Commands

--- a/docs/plans/mini-plans/2026-07-09-strict-jinja-stress-templating.md
+++ b/docs/plans/mini-plans/2026-07-09-strict-jinja-stress-templating.md
@@ -6,58 +6,84 @@
 
 ## Problem
 
-Longevity test configs hardcode row counts in stress commands, so dataset size must be recalculated manually whenever disk size, instance type, or expected compression changes. Add runtime-only strict Jinja rendering for longevity stress commands so configs can calculate row counts from available `/var/lib/scylla` capacity through an `effective_disk_size_bytes` template variable.
+Longevity test configs hardcode row counts in stress commands, so dataset size must be recalculated manually whenever disk size, instance type, or expected compression changes. The implementation now supports runtime-only strict Jinja rendering for stress commands so configs can calculate row counts from available `/var/lib/scylla` capacity through an `effective_disk_size_bytes` template variable, while keeping config loading and validation unaware of Jinja syntax.
 
 ## Approach
 
-- Add `effective_compression_ratio` to SCT config with default `1.0` and validation `0 < value <= 1`. Treat it as `on_disk_bytes / logical_uncompressed_bytes`, so `0.68` means generated logical data is expected to occupy 68% of its uncompressed size on disk.
-- Add `effective_compression_ratio: 1.0` to defaults and regenerate config docs.
-- Do not render or validate Jinja templates during config load, `verify_configuration()`, or `check_required_files()`. Existing config validation should keep seeing the original literal strings.
-- Render only at stress execution time in `LoaderUtilsMixin`, immediately before `_run_all_stress_cmds()` inspects command prefixes or dispatches to `run_stress_thread()`.
-- Use a strict Jinja environment with `StrictUndefined`; fail fast before starting stress if a command references an unknown variable or has invalid syntax.
-- Render only commands containing Jinja delimiters: `{{`, `{%`, or `{#`. Non-templated commands must remain byte-for-byte unchanged.
-- Add a cached property for `effective_disk_size_bytes` because capacity is expected to be stable for this purpose.
-- Calculate raw available capacity from DB nodes with `df -B1` against `/var/lib/scylla`, use the average available bytes across nodes because Scylla load-balances data across nodes, then export `floor(average_available_bytes / effective_compression_ratio)`.
-- Keep RF and node count outside the exported variable. Test configs should account for RF and node count directly in the Jinja formula.
-- Document a compact example that hardcodes formula constants in the command:
+- Added `effective_compression_ratio` to SCT config with default `1.0` and validation `0 < value <= 1`. It is defined as `on_disk_bytes / logical_uncompressed_bytes`, so `0.68` means the logical dataset is expected to occupy about 68% of its uncompressed size on disk.
+- Added `effective_compression_ratio: 1.0` to defaults and updated generated config docs.
+- Added `stress_template_context` to SCT config so tests can define shared derived Jinja variables once and reuse them across multiple stress commands.
+- Kept config load, `verify_configuration()`, and `check_required_files()` free of Jinja rendering. Existing validation still sees the original literal stress command strings.
+- Implemented runtime rendering in `LoaderUtilsMixin` by rendering every stress command immediately before `_run_all_stress_cmds()` performs command-specific handling and dispatches to `run_stress_thread()`.
+- Implemented a strict Jinja environment with `StrictUndefined` in `LoaderUtilsMixin.jinja_env`, plus `MixinLazyContext` so template variables are resolved lazily from the mixin owner object only when referenced.
+- Added a `stress_template_whitelist` hook to `LoaderUtilsMixin` and overrode it in `LongevityTest`, so all longevity-derived tests automatically restrict owner-backed template variables to `effective_disk_size_bytes` and `db_node_count_per_dc`.
+- Implemented ordered `stress_template_context` evaluation in `LoaderUtilsMixin`, with YAML scalar coercion and conflict detection for context keys that shadow built-in owner-backed variables.
+- Failed fast on unknown variables by converting `UndefinedError` into a `RuntimeError` that includes the original command. Syntax errors still propagate as Jinja `TemplateSyntaxError` before any stress thread starts.
+- Did not add a delimiter pre-scan optimization. Instead, all stress commands go through `render_stress_cmd()`, and literal commands remain unchanged because rendering a template with no Jinja syntax returns the original string.
+- Kept `effective_disk_size_bytes` as a cached property on `LongevityTest`, not on `LoaderUtilsMixin`. The exported value is still `floor(average_available_bytes / effective_compression_ratio)`.
+- Calculated raw available capacity from DB nodes with `df -B1 /var/lib/scylla`, using the average available bytes across nodes because Scylla load-balances data across nodes.
+- Kept RF outside the exported variables. Test configs can use `db_node_count_per_dc` directly in the Jinja formula when all DCs are expected to have the same DB node count.
+- The implementation also normalizes rendered multi-line YAML block scalars by collapsing whitespace to a single line before dispatch.
+- Added user-facing documentation in `docs/loader_usage.md` with a compact example, runtime behavior notes, the longevity-only whitelist rule, and the shared `stress_template_context` mechanism.
+
+- Example formula supported by the implementation:
 
 ```yaml
 effective_compression_ratio: 0.68
 
+stress_template_context:
+  total_rows: "{{ ((effective_disk_size_bytes * db_node_count_per_dc) // 3 // (200 * 5)) | int }}"
+  rows_per_cmd: "{{ total_rows // 4 }}"
+
 prepare_write_cmd:
   - >-
-    {% set rows = ((effective_disk_size_bytes * 3) // 3 // (200 * 5)) | int %}
-    cassandra-stress write cl=QUORUM n={{ rows }}
+    cassandra-stress write cl=QUORUM n={{ rows_per_cmd }}
     -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)'
     -mode cql3 native
     -rate threads=150
     -col 'size=FIXED(200) n=FIXED(5)'
-    -pop seq=1..{{ rows }}
+    -pop seq=1..{{ rows_per_cmd }}
 ```
 
-- Existing delimiter scan found no Jinja delimiters in relevant SCT test/config YAML directories: `test-cases/`, `configurations/`, `defaults/`, and `unit_tests/test_configs/`. Existing repository YAML delimiter usage is unrelated GitHub Actions `${{ ... }}` and Helm/minio templates under `sdcm/k8s_configs/minio/templates/`, which are unaffected because only stress command values are rendered.
+- Existing repository YAML delimiter usage outside stress command values remains unaffected because rendering happens only when stress commands are executed.
 
 ## Files to Modify
 
-- `sdcm/sct_config.py` -- Add `effective_compression_ratio` field, type constraints, and config help text.
-- `defaults/test_default.yaml` -- Add default `effective_compression_ratio: 1.0`.
-- `sdcm/utils/loader_utils.py` -- Add cached effective disk capacity calculation and strict runtime Jinja rendering before stress command dispatch.
-- `docs/configuration_options.md` -- Regenerate config documentation after adding the new option.
-- `docs/sct-configuration.md` -- Add a short usage note and example for templated longevity stress commands.
-- `unit_tests/unit/test_sct_config_validators.py` -- Add validation tests for accepted and rejected `effective_compression_ratio` values.
-- `unit_tests/unit/test_longevity.py` -- Add runtime rendering tests for successful formulas, strict undefined failures, syntax failures, unchanged literal commands, and cached effective disk size behavior.
+- `sdcm/sct_config.py` -- Added `effective_compression_ratio` field, type constraints, and config help text.
+- `sdcm/sct_config.py` -- Added `stress_template_context` field for shared runtime stress command variables.
+- `defaults/test_default.yaml` -- Added default `effective_compression_ratio: 1.0`.
+- `defaults/test_default.yaml` -- Added default `stress_template_context: {}`.
+- `longevity_test.py` -- Added cached `effective_disk_size_bytes`, scalar `db_node_count_per_dc`, and longevity template whitelist entries on `LongevityTest`.
+- `sdcm/utils/loader_utils.py` -- Added `MixinLazyContext`, strict Jinja environment setup, shared context evaluation, runtime stress command rendering before stress dispatch, and the whitelist hook used by longevity tests.
+- `docs/configuration_options.md` -- Updated generated config documentation for the new option.
+- `docs/loader_usage.md` -- Added feature documentation and an example for templated longevity stress commands.
+- `unit_tests/unit/test_sct_config_validators.py` -- Added validation tests for accepted and rejected `effective_compression_ratio` values.
+- `unit_tests/unit/test_longevity.py` -- Added tests for `effective_disk_size_bytes` calculation, scalar `db_node_count_per_dc` behavior, longevity whitelist enforcement, and context usage from whitelisted built-ins.
+- `unit_tests/unit/test_render_stress_cmd.py` -- Added renderer tests for literal commands, successful templates, shared context evaluation, unknown variables, syntax errors, multiline command normalization, and unrestricted generic mixin behavior.
+- `unit_tests/unit/test_mixin_lazy_context.py` -- Added focused tests for lazy owner attribute resolution and whitelist behavior in the custom Jinja context.
+- `test-cases/features/elasticity/elasticity-90-percent-with-nemesis.yaml` -- Migrated the Tier 1 90%% elasticity testcase to shared `stress_template_context` variables.
 
 ## Verification
 
-- [ ] `effective_compression_ratio=1.0` exports average raw available bytes unchanged.
-- [ ] `effective_compression_ratio=0.68` exports `floor(average_available_bytes / 0.68)`.
-- [ ] Effective disk size calculation averages available capacity across DB nodes instead of using the lowest node value.
-- [ ] Ratios `0`, negative values, and values above `1` fail config validation.
-- [ ] `sct.py conf` succeeds for a config containing Jinja in stress commands without requiring DB nodes or disk capacity.
-- [ ] A command without Jinja delimiters is passed to stress dispatch unchanged.
-- [ ] A command with `{{ effective_disk_size_bytes }}` renders to a concrete command before stress dispatch.
-- [ ] A command with an unknown template variable fails before any stress thread starts.
-- [ ] Existing YAML delimiter usage outside stress command values remains unaffected.
+- [x] `effective_compression_ratio=1.0` exports average raw available bytes unchanged.
+- [x] `effective_compression_ratio=0.68` exports `floor(average_available_bytes / 0.68)`.
+- [x] Effective disk size calculation averages available capacity across DB nodes instead of using the lowest node value.
+- [x] Ratios `0`, negative values, and values above `1` fail config validation.
+- [x] A literal command passed through `render_stress_cmd()` is returned unchanged.
+- [x] A command with `{{ effective_disk_size_bytes }}` renders to a concrete command string before dispatch.
+- [x] Shared `stress_template_context` entries can reference built-in variables and earlier context entries.
+- [x] `stress_template_context` values are available to all stress commands without repeating the sizing formula in each command.
+- [x] A command with an unknown template variable fails before any stress thread starts.
+- [x] Invalid Jinja syntax fails before any stress thread starts.
+- [x] Multi-line YAML block scalar output is normalized to a single-line stress command.
+- [x] Lazy Jinja owner resolution does not evaluate expensive properties unless the template references them.
+- [x] Longevity-derived tests allow `effective_disk_size_bytes` and `db_node_count_per_dc`, and reject other owner-backed template variables.
+- [x] Context keys that shadow built-in owner-backed variables are rejected.
+- [x] Non-longevity `LoaderUtilsMixin` users remain unrestricted unless they opt into a whitelist.
+- [x] Existing YAML delimiter usage outside stress command values remains unaffected because only runtime stress command rendering uses this environment.
+- [ ] `sct.py conf` succeeds for a config containing Jinja in stress commands without requiring DB nodes or disk capacity. Needs explicit end-to-end verification.
 - [ ] Unit tests pass: `uv run sct.py unit-tests -t test_sct_config_validators.py`.
 - [ ] Unit tests pass: `uv run sct.py unit-tests -t test_longevity.py`.
+- [ ] Unit tests pass: `uv run sct.py unit-tests -t test_render_stress_cmd.py`.
+- [ ] Unit tests pass: `uv run sct.py unit-tests -t test_mixin_lazy_context.py`.
 - [ ] `uv run sct.py pre-commit` passes.

--- a/docs/plans/mini-plans/2026-07-09-strict-jinja-stress-templating.md
+++ b/docs/plans/mini-plans/2026-07-09-strict-jinja-stress-templating.md
@@ -1,0 +1,63 @@
+# Mini-Plan: Strict Jinja Stress Command Templating
+
+**Date:** 2026-07-09
+**Estimated LOC:** 250
+**Related PR:** none
+
+## Problem
+
+Longevity test configs hardcode row counts in stress commands, so dataset size must be recalculated manually whenever disk size, instance type, or expected compression changes. Add runtime-only strict Jinja rendering for longevity stress commands so configs can calculate row counts from available `/var/lib/scylla` capacity through an `effective_disk_size_bytes` template variable.
+
+## Approach
+
+- Add `effective_compression_ratio` to SCT config with default `1.0` and validation `0 < value <= 1`. Treat it as `on_disk_bytes / logical_uncompressed_bytes`, so `0.68` means generated logical data is expected to occupy 68% of its uncompressed size on disk.
+- Add `effective_compression_ratio: 1.0` to defaults and regenerate config docs.
+- Do not render or validate Jinja templates during config load, `verify_configuration()`, or `check_required_files()`. Existing config validation should keep seeing the original literal strings.
+- Render only at stress execution time in `LoaderUtilsMixin`, immediately before `_run_all_stress_cmds()` inspects command prefixes or dispatches to `run_stress_thread()`.
+- Use a strict Jinja environment with `StrictUndefined`; fail fast before starting stress if a command references an unknown variable or has invalid syntax.
+- Render only commands containing Jinja delimiters: `{{`, `{%`, or `{#`. Non-templated commands must remain byte-for-byte unchanged.
+- Add a cached property for `effective_disk_size_bytes` because capacity is expected to be stable for this purpose.
+- Calculate raw available capacity from DB nodes with `df -B1` against `/var/lib/scylla`, use the average available bytes across nodes because Scylla load-balances data across nodes, then export `floor(average_available_bytes / effective_compression_ratio)`.
+- Keep RF and node count outside the exported variable. Test configs should account for RF and node count directly in the Jinja formula.
+- Document a compact example that hardcodes formula constants in the command:
+
+```yaml
+effective_compression_ratio: 0.68
+
+prepare_write_cmd:
+  - >-
+    {% set rows = ((effective_disk_size_bytes * 3) // 3 // (200 * 5)) | int %}
+    cassandra-stress write cl=QUORUM n={{ rows }}
+    -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)'
+    -mode cql3 native
+    -rate threads=150
+    -col 'size=FIXED(200) n=FIXED(5)'
+    -pop seq=1..{{ rows }}
+```
+
+- Existing delimiter scan found no Jinja delimiters in relevant SCT test/config YAML directories: `test-cases/`, `configurations/`, `defaults/`, and `unit_tests/test_configs/`. Existing repository YAML delimiter usage is unrelated GitHub Actions `${{ ... }}` and Helm/minio templates under `sdcm/k8s_configs/minio/templates/`, which are unaffected because only stress command values are rendered.
+
+## Files to Modify
+
+- `sdcm/sct_config.py` -- Add `effective_compression_ratio` field, type constraints, and config help text.
+- `defaults/test_default.yaml` -- Add default `effective_compression_ratio: 1.0`.
+- `sdcm/utils/loader_utils.py` -- Add cached effective disk capacity calculation and strict runtime Jinja rendering before stress command dispatch.
+- `docs/configuration_options.md` -- Regenerate config documentation after adding the new option.
+- `docs/sct-configuration.md` -- Add a short usage note and example for templated longevity stress commands.
+- `unit_tests/unit/test_sct_config_validators.py` -- Add validation tests for accepted and rejected `effective_compression_ratio` values.
+- `unit_tests/unit/test_longevity.py` -- Add runtime rendering tests for successful formulas, strict undefined failures, syntax failures, unchanged literal commands, and cached effective disk size behavior.
+
+## Verification
+
+- [ ] `effective_compression_ratio=1.0` exports average raw available bytes unchanged.
+- [ ] `effective_compression_ratio=0.68` exports `floor(average_available_bytes / 0.68)`.
+- [ ] Effective disk size calculation averages available capacity across DB nodes instead of using the lowest node value.
+- [ ] Ratios `0`, negative values, and values above `1` fail config validation.
+- [ ] `sct.py conf` succeeds for a config containing Jinja in stress commands without requiring DB nodes or disk capacity.
+- [ ] A command without Jinja delimiters is passed to stress dispatch unchanged.
+- [ ] A command with `{{ effective_disk_size_bytes }}` renders to a concrete command before stress dispatch.
+- [ ] A command with an unknown template variable fails before any stress thread starts.
+- [ ] Existing YAML delimiter usage outside stress command values remains unaffected.
+- [ ] Unit tests pass: `uv run sct.py unit-tests -t test_sct_config_validators.py`.
+- [ ] Unit tests pass: `uv run sct.py unit-tests -t test_longevity.py`.
+- [ ] `uv run sct.py pre-commit` passes.

--- a/longevity_test.py
+++ b/longevity_test.py
@@ -50,14 +50,30 @@ class LongevityTest(ClusterTester, loader_utils.LoaderUtilsMixin):
     Test a Scylla cluster stability over a time period.
     """
 
+    STATIC_SIZING_OVERHEAD_RATIO = 1.1
+
+    @property
+    def stress_template_whitelist(self) -> set[str]:
+        return {"db_node_count_per_dc", "effective_disk_size_bytes"}
+
+    @property
+    def db_node_count_per_dc(self) -> int:
+        configured_n_db_nodes = self.params.get("n_db_nodes") or []
+        if isinstance(configured_n_db_nodes, int):
+            return configured_n_db_nodes
+        if configured_n_db_nodes:
+            return configured_n_db_nodes[0]
+        return len(group_nodes_by_dc_idx(self.db_cluster.nodes).get(0, []))
+
     @cached_property
     def effective_disk_size_bytes(self) -> int:
-        """Return floor(average available bytes on /var/lib/scylla / effective_compression_ratio).
+        """Return floor(average available bytes on /var/lib/scylla / effective_compression_ratio / 1.1).
 
         ``df -B1`` is run on all DB nodes in parallel; the average of the available-byte column is
         used because Scylla load-balances data across nodes.  The result is then divided by the
-        configured ``effective_compression_ratio`` so that callers can fill a predictable fraction
-        of disk regardless of the instance type or backend.
+        configured ``effective_compression_ratio`` and a global 10% static overhead factor so that
+        callers bias toward undershooting disk usage instead of overshooting when payload-based row
+        sizing misses table/storage overhead.
         """
 
         def get_available_bytes(node) -> int:
@@ -72,7 +88,7 @@ class LongevityTest(ClusterTester, loader_utils.LoaderUtilsMixin):
         available_bytes_per_node = [r.result for r in results]
         average_available = sum(available_bytes_per_node) / len(available_bytes_per_node)
         ratio = self.params.get("effective_compression_ratio") or 1.0
-        return math.floor(average_available / ratio)
+        return math.floor(average_available / ratio / self.STATIC_SIZING_OVERHEAD_RATIO)
 
     def setUp(self):
         super().setUp()

--- a/longevity_test.py
+++ b/longevity_test.py
@@ -13,12 +13,14 @@
 #
 # Copyright (c) 2016 ScyllaDB
 import json
+import math
 import os
 import re
 import string
 import tempfile
 import itertools
 import contextlib
+from functools import cached_property
 from typing import List, Dict
 
 import yaml
@@ -37,6 +39,7 @@ from sdcm.utils.common import skip_optional_stage
 from sdcm.utils.cluster_tools import group_nodes_by_dc_idx
 from sdcm.utils.decorators import optional_stage
 from sdcm.utils.operations_thread import ThreadParams
+from sdcm.utils.parallel_object import ParallelObject
 from sdcm.sct_events.system import InfoEvent, TestFrameworkEvent
 from sdcm.sct_events import Severity
 from sdcm.cluster import MAX_TIME_WAIT_FOR_NEW_NODE_UP
@@ -46,6 +49,30 @@ class LongevityTest(ClusterTester, loader_utils.LoaderUtilsMixin):
     """
     Test a Scylla cluster stability over a time period.
     """
+
+    @cached_property
+    def effective_disk_size_bytes(self) -> int:
+        """Return floor(average available bytes on /var/lib/scylla / effective_compression_ratio).
+
+        ``df -B1`` is run on all DB nodes in parallel; the average of the available-byte column is
+        used because Scylla load-balances data across nodes.  The result is then divided by the
+        configured ``effective_compression_ratio`` so that callers can fill a predictable fraction
+        of disk regardless of the instance type or backend.
+        """
+
+        def get_available_bytes(node) -> int:
+            result = node.remoter.run("df -B1 /var/lib/scylla", ignore_status=False)
+            # df output: Filesystem 1B-blocks Used Available Use% Mounted-on
+            # We want the "Available" column (index 3) from the second line.
+            lines = result.stdout.strip().splitlines()
+            return int(lines[1].split()[3])
+
+        nodes = self.db_cluster.nodes
+        results = ParallelObject(nodes, timeout=60, num_workers=len(nodes)).run(get_available_bytes)
+        available_bytes_per_node = [r.result for r in results]
+        average_available = sum(available_bytes_per_node) / len(available_bytes_per_node)
+        ratio = self.params.get("effective_compression_ratio") or 1.0
+        return math.floor(average_available / ratio)
 
     def setUp(self):
         super().setUp()

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1863,6 +1863,15 @@ class SCTConfiguration(BaseModel):
             "Must be in range (0, 1.0]."
         ),
     )
+    stress_template_context: DictOrStr = SctField(
+        description=(
+            "Shared runtime-only Jinja variables for stress command templating. "
+            "Entries are resolved in declaration order and may reference earlier context entries as well as "
+            "built-in stress template variables such as effective_disk_size_bytes and db_node_count_per_dc. "
+            "These values are available to stress commands rendered by SCT, but are not evaluated during config "
+            "load or validation."
+        ),
+    )
     prepare_write_cmd: StringOrList = SctField(
         description="cassandra-stress commands. You can specify everything but the -node parameter, which is going to be provided by the test suite infrastructure. Multiple commands can be passed as a list",
     )

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1850,6 +1850,19 @@ class SCTConfiguration(BaseModel):
             be provided by the test suite infrastructure.
             multiple commands can passed as a list""",
     )
+    effective_compression_ratio: confloat(gt=0, le=1.0) = SctField(
+        description=(
+            "Effective compression ratio used for Jinja stress command templating. "
+            "Defined as on_disk_bytes / logical_uncompressed_bytes. "
+            "This estimates how much disk space Scylla uses after compression relative to the logical "
+            "uncompressed dataset size. For example, 1.0 means no effective compression and 0.68 means the "
+            "data is expected to occupy about 68% of its logical uncompressed size on disk. Used together "
+            "with the effective_disk_size_bytes template variable to calculate row counts that fill a target "
+            "fraction of available disk capacity. You can estimate this ratio from Grafana in Keyspace -> "
+            "Compression metrics; a compression value of 0% corresponds to effective_compression_ratio=1.0. "
+            "Must be in range (0, 1.0]."
+        ),
+    )
     prepare_write_cmd: StringOrList = SctField(
         description="cassandra-stress commands. You can specify everything but the -node parameter, which is going to be provided by the test suite infrastructure. Multiple commands can be passed as a list",
     )

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1950,6 +1950,19 @@ class SCTConfiguration(BaseModel):
             be provided by the test suite infrastructure.
             multiple commands can passed as a list""",
     )
+    effective_compression_ratio: confloat(gt=0, le=1.0) = SctField(
+        description=(
+            "Effective compression ratio used for Jinja stress command templating. "
+            "Defined as on_disk_bytes / logical_uncompressed_bytes. "
+            "This estimates how much disk space Scylla uses after compression relative to the logical "
+            "uncompressed dataset size. For example, 1.0 means no effective compression and 0.68 means the "
+            "data is expected to occupy about 68% of its logical uncompressed size on disk. Used together "
+            "with the effective_disk_size_bytes template variable to calculate row counts that fill a target "
+            "fraction of available disk capacity. You can estimate this ratio from Grafana in Keyspace -> "
+            "Compression metrics; a compression value of 0% corresponds to effective_compression_ratio=1.0. "
+            "Must be in range (0, 1.0]."
+        ),
+    )
     prepare_write_cmd: StringOrList = SctField(
         description="cassandra-stress commands. You can specify everything but the -node parameter, which is going to be provided by the test suite infrastructure. Multiple commands can be passed as a list",
     )

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1963,6 +1963,15 @@ class SCTConfiguration(BaseModel):
             "Must be in range (0, 1.0]."
         ),
     )
+    stress_template_context: DictOrStr = SctField(
+        description=(
+            "Shared runtime-only Jinja variables for stress command templating. "
+            "Entries are resolved in declaration order and may reference earlier context entries as well as "
+            "built-in stress template variables such as effective_disk_size_bytes and db_node_count_per_dc. "
+            "These values are available to stress commands rendered by SCT, but are not evaluated during config "
+            "load or validation."
+        ),
+    )
     prepare_write_cmd: StringOrList = SctField(
         description="cassandra-stress commands. You can specify everything but the -node parameter, which is going to be provided by the test suite infrastructure. Multiple commands can be passed as a list",
     )

--- a/sdcm/utils/loader_utils.py
+++ b/sdcm/utils/loader_utils.py
@@ -17,6 +17,7 @@ import re
 import time
 from functools import cached_property
 
+import yaml
 from jinja2 import Environment, StrictUndefined, UndefinedError
 from jinja2.runtime import Context
 from jinja2.runtime import missing as jinja_missing
@@ -63,6 +64,15 @@ class MixinLazyContext(Context):
 
 class LoaderUtilsMixin:
     """This mixin can be added to any class that inherits the 'ClusterTester' one"""
+
+    @property
+    def stress_template_whitelist(self) -> set[str] | None:
+        """Return the allowed owner-backed Jinja variables for stress command rendering.
+
+        ``None`` means owner attributes are not restricted. Callers that want a strict
+        template surface can override this property and return a concrete set.
+        """
+        return None
 
     def _create_counter_table(self):
         """
@@ -131,7 +141,39 @@ class LoaderUtilsMixin:
         env = Environment(undefined=StrictUndefined)
         env.context_class = MixinLazyContext
         env.owner = self
+        if self.stress_template_whitelist is not None:
+            env.whitelist = self.stress_template_whitelist
         return env
+
+    def build_stress_template_context(self) -> dict:
+        """Resolve shared Jinja variables for stress command rendering.
+
+        Context entries are resolved in declaration order, so later entries may refer
+        to earlier ones. Owner-backed template variables remain subject to the mixin's
+        whitelist, while explicit context entries are passed as render locals.
+        """
+        raw_context = self.params.get("stress_template_context") or {}
+        resolved_context = {}
+
+        for key, value in raw_context.items():
+            if self.stress_template_whitelist is not None and key in self.stress_template_whitelist:
+                raise RuntimeError(
+                    f"stress_template_context key '{key}' conflicts with a built-in stress template variable"
+                )
+
+            if isinstance(value, str):
+                try:
+                    rendered_value = self.jinja_env.from_string(value).render(**resolved_context)
+                except UndefinedError as exc:
+                    raise RuntimeError(
+                        f"stress_template_context entry '{key}' references an unknown Jinja variable: {exc}\n\n"
+                        f"Value: {value}"
+                    ) from exc
+                resolved_context[key] = yaml.safe_load(rendered_value)
+            else:
+                resolved_context[key] = value
+
+        return resolved_context
 
     def render_stress_cmd(self, stress_cmd: str) -> str:
         """Render *stress_cmd* through a strict Jinja environment.
@@ -146,8 +188,9 @@ class LoaderUtilsMixin:
         contains invalid Jinja syntax, failing fast before any stress thread starts.
         Collapses whitespace introduced by multi-line YAML block scalars.
         """
+        stress_template_context = self.build_stress_template_context()
         try:
-            rendered = self.jinja_env.from_string(stress_cmd).render()
+            rendered = self.jinja_env.from_string(stress_cmd).render(**stress_template_context)
         except UndefinedError as exc:
             raise RuntimeError(
                 f"Stress command references an unknown Jinja variable: {exc}\n\nCommand: {stress_cmd}"

--- a/sdcm/utils/loader_utils.py
+++ b/sdcm/utils/loader_utils.py
@@ -17,6 +17,10 @@ import re
 import time
 from functools import cached_property
 
+from jinja2 import Environment, StrictUndefined, UndefinedError
+from jinja2.runtime import Context
+from jinja2.runtime import missing as jinja_missing
+
 from sdcm.sct_events import Severity
 from sdcm.sct_events.system import TestFrameworkEvent
 from sdcm.utils.common import skip_optional_stage
@@ -29,6 +33,32 @@ DEFAULT_USER_PASSWORD = "cassandra"
 STRESS_ROLE_NAME_TEMPLATE = "role%s_%s"
 STRESS_ROLE_PASSWORD_TEMPLATE = "rolep%s"
 SERVICE_LEVEL_NAME_TEMPLATE = "sl%s_%s"
+
+
+class MixinLazyContext(Context):
+    """Jinja2 ``Context`` subclass that resolves template variables from an *owner* object on demand.
+
+    Set ``env.owner`` and optionally ``env.whitelist`` on the ``Environment`` before rendering.
+    Attribute lookups on *owner* are deferred until Jinja actually references the variable name, so
+    expensive ``cached_property`` values (e.g. ones that SSH into nodes) are only evaluated when a
+    template uses them.
+
+    ``env.whitelist``: if set to a ``set[str]``, only keys in the set may be resolved from *owner*.
+    Any other key is treated as undefined (``UndefinedError`` with ``StrictUndefined``). Variables
+    already present in the render context (e.g. from ``{% set ... %}``) are always accessible.
+    """
+
+    def resolve_or_missing(self, key: str):
+        result = super().resolve_or_missing(key)
+        if result is not jinja_missing:
+            return result
+        whitelist = getattr(self.environment, "whitelist", None)
+        if whitelist is not None and key not in whitelist:
+            return jinja_missing
+        try:
+            return getattr(self.environment.owner, key)
+        except AttributeError:
+            return jinja_missing
 
 
 class LoaderUtilsMixin:
@@ -96,6 +126,35 @@ class LoaderUtilsMixin:
         # is tablets feature enabled in Scylla configuration.
         return is_tablets_feature_enabled(self.db_cluster.nodes[0])
 
+    @cached_property
+    def jinja_env(self) -> Environment:
+        env = Environment(undefined=StrictUndefined)
+        env.context_class = MixinLazyContext
+        env.owner = self
+        return env
+
+    def render_stress_cmd(self, stress_cmd: str) -> str:
+        """Render *stress_cmd* through a strict Jinja environment.
+
+        Any attribute accessible on this mixin instance (including ``cached_property``
+        values) is available as a template variable via :class:`MixinLazyContext`.
+        Variables are resolved only when Jinja actually references them, so expensive
+        properties (e.g. ones that SSH into nodes) are not evaluated for commands that
+        don't use them.
+
+        Raises ``RuntimeError`` if the command references an unknown variable or
+        contains invalid Jinja syntax, failing fast before any stress thread starts.
+        Collapses whitespace introduced by multi-line YAML block scalars.
+        """
+        try:
+            rendered = self.jinja_env.from_string(stress_cmd).render()
+        except UndefinedError as exc:
+            raise RuntimeError(
+                f"Stress command references an unknown Jinja variable: {exc}\n\nCommand: {stress_cmd}"
+            ) from exc
+        # Collapse any whitespace introduced by multi-line YAML block scalars.
+        return " ".join(rendered.split())
+
     def _run_all_stress_cmds(self, stress_queue, params):
         stress_cmds = params["stress_cmd"]
         # In some cases we want the same stress_cmd to run several times (can be used with round_robin or not).
@@ -104,28 +163,29 @@ class LoaderUtilsMixin:
             stress_cmds *= stress_multiplier
 
         for stress_cmd in stress_cmds:
+            rendered_cmd = self.render_stress_cmd(stress_cmd)
             stress_params = dict(params)
-            stress_params.update({"stress_cmd": stress_cmd})
+            stress_params.update({"stress_cmd": rendered_cmd})
 
             # Due to an issue with scylla & cassandra-stress - we need to create the counter table manually
             # also tablets doesn't yet support counters, so we skip the command and error about it
-            if "counter_" in stress_cmd:
+            if "counter_" in rendered_cmd:
                 if self.tablets_enabled and SkipPerIssues("scylladb/scylladb#18180", params=self.params):
                     TestFrameworkEvent(
                         severity=Severity.ERROR,
                         source=self.__class__.__name__,
                         source_method="_run_all_stress_cmds",
-                        message=f"Tablets feature is enabled, skipping counter stress:\n\n{stress_cmd}",
+                        message=f"Tablets feature is enabled, skipping counter stress:\n\n{rendered_cmd}",
                     ).publish()
                 else:
                     self._create_counter_table()
 
             # Run all stress commands
-            self.log.debug(f"stress cmd: {stress_cmd}")
-            if stress_cmd.startswith("scylla-bench"):
+            self.log.debug(f"stress cmd: {rendered_cmd}")
+            if rendered_cmd.startswith("scylla-bench"):
                 stress_queue.append(
                     self.run_stress_thread(
-                        stress_cmd=stress_cmd, stats_aggregate_cmds=False, round_robin=self.params.get("round_robin")
+                        stress_cmd=rendered_cmd, stats_aggregate_cmds=False, round_robin=self.params.get("round_robin")
                     )
                 )
             else:

--- a/sdcm/utils/loader_utils.py
+++ b/sdcm/utils/loader_utils.py
@@ -17,6 +17,7 @@ import re
 import time
 from functools import cached_property
 
+import yaml
 from jinja2 import Environment, StrictUndefined, UndefinedError
 from jinja2.runtime import Context
 from jinja2.runtime import missing as jinja_missing
@@ -63,6 +64,15 @@ class MixinLazyContext(Context):
 
 class LoaderUtilsMixin:
     """This mixin can be added to any class that inherits the 'ClusterTester' one"""
+
+    @property
+    def stress_template_whitelist(self) -> set[str] | None:
+        """Return the allowed owner-backed Jinja variables for stress command rendering.
+
+        ``None`` means owner attributes are not restricted. Callers that want a strict
+        template surface can override this property and return a concrete set.
+        """
+        return None
 
     def _create_counter_table(self):
         """
@@ -131,7 +141,39 @@ class LoaderUtilsMixin:
         env = Environment(undefined=StrictUndefined)
         env.context_class = MixinLazyContext
         env.owner = self
+        if self.stress_template_whitelist is not None:
+            env.whitelist = self.stress_template_whitelist
         return env
+
+    def build_stress_template_context(self) -> dict:
+        """Resolve shared Jinja variables for stress command rendering.
+
+        Context entries are resolved in declaration order, so later entries may refer
+        to earlier ones. Owner-backed template variables remain subject to the mixin's
+        whitelist, while explicit context entries are passed as render locals.
+        """
+        raw_context = self.params.get("stress_template_context") or {}
+        resolved_context = {}
+
+        for key, value in raw_context.items():
+            if self.stress_template_whitelist is not None and key in self.stress_template_whitelist:
+                raise RuntimeError(
+                    f"stress_template_context key '{key}' conflicts with a built-in stress template variable"
+                )
+
+            if isinstance(value, str) and ("{{" in value or "{%" in value or "{#" in value):
+                try:
+                    rendered_value = self.jinja_env.from_string(value).render(**resolved_context)
+                except UndefinedError as exc:
+                    raise RuntimeError(
+                        f"stress_template_context entry '{key}' references an unknown Jinja variable: {exc}\n\n"
+                        f"Value: {value}"
+                    ) from exc
+                resolved_context[key] = yaml.safe_load(rendered_value)
+            else:
+                resolved_context[key] = value
+
+        return resolved_context
 
     def render_stress_cmd(self, stress_cmd: str) -> str:
         """Render *stress_cmd* through a strict Jinja environment.
@@ -146,14 +188,17 @@ class LoaderUtilsMixin:
         contains invalid Jinja syntax, failing fast before any stress thread starts.
         Collapses whitespace introduced by multi-line YAML block scalars.
         """
+        stress_template_context = self.build_stress_template_context()
         try:
-            rendered = self.jinja_env.from_string(stress_cmd).render()
+            rendered = self.jinja_env.from_string(stress_cmd).render(**stress_template_context)
         except UndefinedError as exc:
             raise RuntimeError(
                 f"Stress command references an unknown Jinja variable: {exc}\n\nCommand: {stress_cmd}"
             ) from exc
         # Collapse any whitespace introduced by multi-line YAML block scalars.
-        return " ".join(rendered.split())
+        if "\n" not in rendered and "\r" not in rendered:
+            return rendered
+        return " ".join(line.strip() for line in rendered.splitlines() if line.strip())
 
     def _run_all_stress_cmds(self, stress_queue, params):
         stress_cmds = params["stress_cmd"]

--- a/test-cases/features/elasticity/elasticity-90-percent-with-nemesis.yaml
+++ b/test-cases/features/elasticity/elasticity-90-percent-with-nemesis.yaml
@@ -2,15 +2,23 @@
 test_duration: 3000
 prepare_stress_duration: 720
 
+stress_template_context:
+  fill_percent: 90
+  replication_factor: 3
+  row_size_bytes: 1034
+  total_rows: "{{ ((effective_disk_size_bytes * db_node_count_per_dc * fill_percent) // 100 // replication_factor // row_size_bytes) | int }}"
+  rows_per_cmd: "{{ total_rows // 4 }}"
+  hotset_rows: "{{ total_rows // 2 }}"
+
 prepare_write_cmd:
-  - "cassandra-stress write no-warmup cl=ALL n=180000000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate 'threads=100 fixed=6000/s' -col 'size=FIXED(128) n=FIXED(8)' -pop seq=1..180000000"
-  - "cassandra-stress write no-warmup cl=ALL n=180000000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate 'threads=100 fixed=6000/s' -col 'size=FIXED(128) n=FIXED(8)' -pop seq=180000001..360000000"
-  - "cassandra-stress write no-warmup cl=ALL n=180000000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate 'threads=100 fixed=6000/s' -col 'size=FIXED(128) n=FIXED(8)' -pop seq=360000001..540000000"
-  - "cassandra-stress write no-warmup cl=ALL n=180000000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate 'threads=100 fixed=6000/s' -col 'size=FIXED(128) n=FIXED(8)' -pop seq=540000001..720000000"
+  - "cassandra-stress write no-warmup cl=ALL n={{ rows_per_cmd }} -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate 'threads=100 fixed=6000/s' -col 'size=FIXED(128) n=FIXED(8)' -pop seq=1..{{ rows_per_cmd }}"
+  - "cassandra-stress write no-warmup cl=ALL n={{ rows_per_cmd }} -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate 'threads=100 fixed=6000/s' -col 'size=FIXED(128) n=FIXED(8)' -pop seq={{ rows_per_cmd + 1 }}..{{ rows_per_cmd * 2 }}"
+  - "cassandra-stress write no-warmup cl=ALL n={{ rows_per_cmd }} -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate 'threads=100 fixed=6000/s' -col 'size=FIXED(128) n=FIXED(8)' -pop seq={{ (rows_per_cmd * 2) + 1 }}..{{ rows_per_cmd * 3 }}"
+  - "cassandra-stress write no-warmup cl=ALL n={{ rows_per_cmd }} -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate 'threads=100 fixed=6000/s' -col 'size=FIXED(128) n=FIXED(8)' -pop seq={{ (rows_per_cmd * 3) + 1 }}..{{ rows_per_cmd * 4 }}"
 
 stress_cmd:
-  - "cassandra-stress read no-warmup cl=QUORUM duration=2400m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate 'threads=200 fixed=3000/s' -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..360000000,180000000,3600000)'"
-  - "cassandra-stress write no-warmup cl=ONE duration=2400m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate 'threads=1 fixed=10/s' -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..360000000,180000000,3600000)'"
+  - "cassandra-stress read no-warmup cl=QUORUM duration=2400m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate 'threads=200 fixed=3000/s' -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..{{ hotset_rows }},{{ hotset_rows // 2 }},{{ hotset_rows // 100 }})'"
+  - "cassandra-stress write no-warmup cl=ONE duration=2400m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate 'threads=1 fixed=10/s' -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..{{ hotset_rows }},{{ hotset_rows // 2 }},{{ hotset_rows // 100 }})'"
 
 pre_create_keyspace: "CREATE KEYSPACE IF NOT EXISTS keyspace1 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3} AND tablets = {'initial': 64};"
 

--- a/unit_tests/unit/test_longevity.py
+++ b/unit_tests/unit/test_longevity.py
@@ -1,4 +1,3 @@
-import math
 import threading
 import unittest
 from unittest.mock import MagicMock, patch
@@ -112,7 +111,13 @@ class DummyLongevityTest(LongevityTest):
 # ---------------------------------------------------------------------------
 
 
-def make_longevity_test_with_df_output(monkeypatch, df_available_per_node, effective_compression_ratio=1.0):
+def make_longevity_test_with_df_output(
+    monkeypatch,
+    df_available_per_node,
+    effective_compression_ratio=1.0,
+    dc_indices=None,
+    configured_n_db_nodes=None,
+):
     """Return a LongevityTest instance whose nodes return controlled df output."""
 
     class FakeLongevityTest(LongevityTest):
@@ -121,10 +126,16 @@ def make_longevity_test_with_df_output(monkeypatch, df_available_per_node, effec
 
     instance = FakeLongevityTest()
     instance.params = {"effective_compression_ratio": effective_compression_ratio}
+    if configured_n_db_nodes is not None:
+        instance.params["n_db_nodes"] = configured_n_db_nodes
+
+    if dc_indices is None:
+        dc_indices = [0] * len(df_available_per_node)
 
     nodes = []
-    for available_bytes in df_available_per_node:
+    for available_bytes, dc_idx in zip(df_available_per_node, dc_indices):
         node = MagicMock()
+        node.dc_idx = dc_idx
         node.remoter.run.return_value.stdout = (
             f"Filesystem        1B-blocks       Used  Available Use% Mounted on\n"
             f"/dev/nvme0n1p1  1000000000  100000000  {available_bytes}  10% /var/lib/scylla\n"
@@ -139,11 +150,11 @@ def make_longevity_test_with_df_output(monkeypatch, df_available_per_node, effec
 @pytest.mark.parametrize(
     "df_available_per_node, compression_ratio, expected",
     [
-        ([1_000_000_000], 1.0, 1_000_000_000),
-        ([1_000_000_000], 0.5, 2_000_000_000),
-        ([1_000_000_000], 0.68, math.floor(1_000_000_000 / 0.68)),
-        ([600_000_000, 1_000_000_000, 800_000_000], 1.0, 800_000_000),  # average of three nodes
-        ([600_000_000, 1_000_000_000, 800_000_000], 0.5, 1_600_000_000),
+        ([111], 1.0, 100),
+        ([56], 0.5, 101),
+        ([748_001], 0.68, 1_000_001),
+        ([67, 111, 89], 1.0, 80),  # average of three nodes
+        ([660_001, 1_100_001, 880_001], 0.5, 1_600_001),
     ],
 )
 def test_effective_disk_size_bytes(monkeypatch, df_available_per_node, compression_ratio, expected):
@@ -151,3 +162,63 @@ def test_effective_disk_size_bytes(monkeypatch, df_available_per_node, compressi
     with patch("longevity_test.ParallelObject") as mock_parallel:
         mock_parallel.return_value.run.return_value = [MagicMock(result=b) for b in df_available_per_node]
         assert instance.effective_disk_size_bytes == expected
+
+
+def test_longevity_whitelist_allows_effective_disk_size_bytes(monkeypatch):
+    instance = make_longevity_test_with_df_output(monkeypatch, [111])
+    with patch("longevity_test.ParallelObject") as mock_parallel:
+        mock_parallel.return_value.run.return_value = [MagicMock(result=111)]
+        rendered = instance.render_stress_cmd("cassandra-stress write n={{ effective_disk_size_bytes }}")
+    assert rendered == "cassandra-stress write n=100"
+
+
+def test_longevity_whitelist_allows_db_node_count_per_dc(monkeypatch):
+    instance = make_longevity_test_with_df_output(
+        monkeypatch,
+        [600_000_000, 1_000_000_000, 800_000_000],
+        dc_indices=[0, 0, 2],
+        configured_n_db_nodes=[2, 0, 1],
+    )
+    rendered = instance.render_stress_cmd("cassandra-stress write n={{ db_node_count_per_dc }}")
+    assert instance.db_node_count_per_dc == 2
+    assert rendered == "cassandra-stress write n=2"
+
+
+def test_db_node_count_per_dc_falls_back_to_runtime_nodes_when_config_missing(monkeypatch):
+    instance = make_longevity_test_with_df_output(
+        monkeypatch,
+        [600_000_000, 1_000_000_000, 800_000_000],
+        dc_indices=[0, 0, 2],
+    )
+    assert instance.db_node_count_per_dc == 2
+
+
+def test_longevity_stress_template_context_can_use_whitelisted_builtins(monkeypatch):
+    instance = make_longevity_test_with_df_output(
+        monkeypatch,
+        [660_001, 1_100_001],
+        dc_indices=[0, 0],
+        configured_n_db_nodes=[2],
+    )
+    instance.params["stress_template_context"] = {
+        "rows_total": "{{ ((effective_disk_size_bytes * db_node_count_per_dc) // 1000) | int }}",
+        "rows_per_cmd": "{{ rows_total // 4 }}",
+    }
+    with patch("longevity_test.ParallelObject") as mock_parallel:
+        mock_parallel.return_value.run.return_value = [MagicMock(result=660_001), MagicMock(result=1_100_001)]
+        rendered = instance.render_stress_cmd("cassandra-stress write n={{ rows_per_cmd }}")
+    assert rendered == "cassandra-stress write n=400"
+
+
+def test_longevity_rejects_context_key_conflicting_with_builtin(monkeypatch):
+    instance = make_longevity_test_with_df_output(monkeypatch, [1_000_000_000], configured_n_db_nodes=[1])
+    instance.params["stress_template_context"] = {"db_node_count_per_dc": 99}
+    with pytest.raises(RuntimeError, match="conflicts with a built-in stress template variable"):
+        instance.render_stress_cmd("cassandra-stress write n={{ db_node_count_per_dc }}")
+
+
+def test_longevity_whitelist_blocks_other_owner_attributes(monkeypatch):
+    instance = make_longevity_test_with_df_output(monkeypatch, [1_000_000_000])
+    instance.some_other_template_value = 17
+    with pytest.raises(RuntimeError, match="unknown Jinja variable"):
+        instance.render_stress_cmd("cassandra-stress write n={{ some_other_template_value }}")

--- a/unit_tests/unit/test_longevity.py
+++ b/unit_tests/unit/test_longevity.py
@@ -1,6 +1,7 @@
+import math
 import threading
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -104,3 +105,49 @@ class DummyLongevityTest(LongevityTest):
             m = MagicMock()
             m.parse_results.return_value = ([], {})
             stress_queue.append(m)
+
+
+# ---------------------------------------------------------------------------
+# effective_disk_size_bytes tests
+# ---------------------------------------------------------------------------
+
+
+def make_longevity_test_with_df_output(monkeypatch, df_available_per_node, effective_compression_ratio=1.0):
+    """Return a LongevityTest instance whose nodes return controlled df output."""
+
+    class FakeLongevityTest(LongevityTest):
+        def __init__(self):
+            pass  # skip full ClusterTester.__init__
+
+    instance = FakeLongevityTest()
+    instance.params = {"effective_compression_ratio": effective_compression_ratio}
+
+    nodes = []
+    for available_bytes in df_available_per_node:
+        node = MagicMock()
+        node.remoter.run.return_value.stdout = (
+            f"Filesystem        1B-blocks       Used  Available Use% Mounted on\n"
+            f"/dev/nvme0n1p1  1000000000  100000000  {available_bytes}  10% /var/lib/scylla\n"
+        )
+        nodes.append(node)
+
+    instance.db_cluster = MagicMock()
+    instance.db_cluster.nodes = nodes
+    return instance
+
+
+@pytest.mark.parametrize(
+    "df_available_per_node, compression_ratio, expected",
+    [
+        ([1_000_000_000], 1.0, 1_000_000_000),
+        ([1_000_000_000], 0.5, 2_000_000_000),
+        ([1_000_000_000], 0.68, math.floor(1_000_000_000 / 0.68)),
+        ([600_000_000, 1_000_000_000, 800_000_000], 1.0, 800_000_000),  # average of three nodes
+        ([600_000_000, 1_000_000_000, 800_000_000], 0.5, 1_600_000_000),
+    ],
+)
+def test_effective_disk_size_bytes(monkeypatch, df_available_per_node, compression_ratio, expected):
+    instance = make_longevity_test_with_df_output(monkeypatch, df_available_per_node, compression_ratio)
+    with patch("longevity_test.ParallelObject") as mock_parallel:
+        mock_parallel.return_value.run.return_value = [MagicMock(result=b) for b in df_available_per_node]
+        assert instance.effective_disk_size_bytes == expected

--- a/unit_tests/unit/test_longevity.py
+++ b/unit_tests/unit/test_longevity.py
@@ -1,6 +1,7 @@
+import math
 import threading
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -109,3 +110,49 @@ class DummyLongevityTest(LongevityTest):
             m = MagicMock()
             m.parse_results.return_value = ([], {})
             stress_queue.append(m)
+
+
+# ---------------------------------------------------------------------------
+# effective_disk_size_bytes tests
+# ---------------------------------------------------------------------------
+
+
+def make_longevity_test_with_df_output(monkeypatch, df_available_per_node, effective_compression_ratio=1.0):
+    """Return a LongevityTest instance whose nodes return controlled df output."""
+
+    class FakeLongevityTest(LongevityTest):
+        def __init__(self):
+            pass  # skip full ClusterTester.__init__
+
+    instance = FakeLongevityTest()
+    instance.params = {"effective_compression_ratio": effective_compression_ratio}
+
+    nodes = []
+    for available_bytes in df_available_per_node:
+        node = MagicMock()
+        node.remoter.run.return_value.stdout = (
+            f"Filesystem        1B-blocks       Used  Available Use% Mounted on\n"
+            f"/dev/nvme0n1p1  1000000000  100000000  {available_bytes}  10% /var/lib/scylla\n"
+        )
+        nodes.append(node)
+
+    instance.db_cluster = MagicMock()
+    instance.db_cluster.nodes = nodes
+    return instance
+
+
+@pytest.mark.parametrize(
+    "df_available_per_node, compression_ratio, expected",
+    [
+        ([1_000_000_000], 1.0, 1_000_000_000),
+        ([1_000_000_000], 0.5, 2_000_000_000),
+        ([1_000_000_000], 0.68, math.floor(1_000_000_000 / 0.68)),
+        ([600_000_000, 1_000_000_000, 800_000_000], 1.0, 800_000_000),  # average of three nodes
+        ([600_000_000, 1_000_000_000, 800_000_000], 0.5, 1_600_000_000),
+    ],
+)
+def test_effective_disk_size_bytes(monkeypatch, df_available_per_node, compression_ratio, expected):
+    instance = make_longevity_test_with_df_output(monkeypatch, df_available_per_node, compression_ratio)
+    with patch("longevity_test.ParallelObject") as mock_parallel:
+        mock_parallel.return_value.run.return_value = [MagicMock(result=b) for b in df_available_per_node]
+        assert instance.effective_disk_size_bytes == expected

--- a/unit_tests/unit/test_longevity.py
+++ b/unit_tests/unit/test_longevity.py
@@ -1,4 +1,3 @@
-import math
 import threading
 import unittest
 from unittest.mock import MagicMock, patch
@@ -117,7 +116,13 @@ class DummyLongevityTest(LongevityTest):
 # ---------------------------------------------------------------------------
 
 
-def make_longevity_test_with_df_output(monkeypatch, df_available_per_node, effective_compression_ratio=1.0):
+def make_longevity_test_with_df_output(
+    monkeypatch,
+    df_available_per_node,
+    effective_compression_ratio=1.0,
+    dc_indices=None,
+    configured_n_db_nodes=None,
+):
     """Return a LongevityTest instance whose nodes return controlled df output."""
 
     class FakeLongevityTest(LongevityTest):
@@ -126,10 +131,16 @@ def make_longevity_test_with_df_output(monkeypatch, df_available_per_node, effec
 
     instance = FakeLongevityTest()
     instance.params = {"effective_compression_ratio": effective_compression_ratio}
+    if configured_n_db_nodes is not None:
+        instance.params["n_db_nodes"] = configured_n_db_nodes
+
+    if dc_indices is None:
+        dc_indices = [0] * len(df_available_per_node)
 
     nodes = []
-    for available_bytes in df_available_per_node:
+    for available_bytes, dc_idx in zip(df_available_per_node, dc_indices):
         node = MagicMock()
+        node.dc_idx = dc_idx
         node.remoter.run.return_value.stdout = (
             f"Filesystem        1B-blocks       Used  Available Use% Mounted on\n"
             f"/dev/nvme0n1p1  1000000000  100000000  {available_bytes}  10% /var/lib/scylla\n"
@@ -144,11 +155,11 @@ def make_longevity_test_with_df_output(monkeypatch, df_available_per_node, effec
 @pytest.mark.parametrize(
     "df_available_per_node, compression_ratio, expected",
     [
-        ([1_000_000_000], 1.0, 1_000_000_000),
-        ([1_000_000_000], 0.5, 2_000_000_000),
-        ([1_000_000_000], 0.68, math.floor(1_000_000_000 / 0.68)),
-        ([600_000_000, 1_000_000_000, 800_000_000], 1.0, 800_000_000),  # average of three nodes
-        ([600_000_000, 1_000_000_000, 800_000_000], 0.5, 1_600_000_000),
+        ([111], 1.0, 100),
+        ([56], 0.5, 101),
+        ([748_001], 0.68, 1_000_001),
+        ([67, 111, 89], 1.0, 80),  # average of three nodes
+        ([660_001, 1_100_001, 880_001], 0.5, 1_600_001),
     ],
 )
 def test_effective_disk_size_bytes(monkeypatch, df_available_per_node, compression_ratio, expected):
@@ -156,3 +167,63 @@ def test_effective_disk_size_bytes(monkeypatch, df_available_per_node, compressi
     with patch("longevity_test.ParallelObject") as mock_parallel:
         mock_parallel.return_value.run.return_value = [MagicMock(result=b) for b in df_available_per_node]
         assert instance.effective_disk_size_bytes == expected
+
+
+def test_longevity_whitelist_allows_effective_disk_size_bytes(monkeypatch):
+    instance = make_longevity_test_with_df_output(monkeypatch, [111])
+    with patch("longevity_test.ParallelObject") as mock_parallel:
+        mock_parallel.return_value.run.return_value = [MagicMock(result=111)]
+        rendered = instance.render_stress_cmd("cassandra-stress write n={{ effective_disk_size_bytes }}")
+    assert rendered == "cassandra-stress write n=100"
+
+
+def test_longevity_whitelist_allows_db_node_count_per_dc(monkeypatch):
+    instance = make_longevity_test_with_df_output(
+        monkeypatch,
+        [600_000_000, 1_000_000_000, 800_000_000],
+        dc_indices=[0, 0, 2],
+        configured_n_db_nodes=[2, 0, 1],
+    )
+    rendered = instance.render_stress_cmd("cassandra-stress write n={{ db_node_count_per_dc }}")
+    assert instance.db_node_count_per_dc == 2
+    assert rendered == "cassandra-stress write n=2"
+
+
+def test_db_node_count_per_dc_falls_back_to_runtime_nodes_when_config_missing(monkeypatch):
+    instance = make_longevity_test_with_df_output(
+        monkeypatch,
+        [600_000_000, 1_000_000_000, 800_000_000],
+        dc_indices=[0, 0, 2],
+    )
+    assert instance.db_node_count_per_dc == 2
+
+
+def test_longevity_stress_template_context_can_use_whitelisted_builtins(monkeypatch):
+    instance = make_longevity_test_with_df_output(
+        monkeypatch,
+        [660_001, 1_100_001],
+        dc_indices=[0, 0],
+        configured_n_db_nodes=[2],
+    )
+    instance.params["stress_template_context"] = {
+        "rows_total": "{{ ((effective_disk_size_bytes * db_node_count_per_dc) // 1000) | int }}",
+        "rows_per_cmd": "{{ rows_total // 4 }}",
+    }
+    with patch("longevity_test.ParallelObject") as mock_parallel:
+        mock_parallel.return_value.run.return_value = [MagicMock(result=660_001), MagicMock(result=1_100_001)]
+        rendered = instance.render_stress_cmd("cassandra-stress write n={{ rows_per_cmd }}")
+    assert rendered == "cassandra-stress write n=400"
+
+
+def test_longevity_rejects_context_key_conflicting_with_builtin(monkeypatch):
+    instance = make_longevity_test_with_df_output(monkeypatch, [1_000_000_000], configured_n_db_nodes=[1])
+    instance.params["stress_template_context"] = {"db_node_count_per_dc": 99}
+    with pytest.raises(RuntimeError, match="conflicts with a built-in stress template variable"):
+        instance.render_stress_cmd("cassandra-stress write n={{ db_node_count_per_dc }}")
+
+
+def test_longevity_whitelist_blocks_other_owner_attributes(monkeypatch):
+    instance = make_longevity_test_with_df_output(monkeypatch, [1_000_000_000])
+    instance.some_other_template_value = 17
+    with pytest.raises(RuntimeError, match="unknown Jinja variable"):
+        instance.render_stress_cmd("cassandra-stress write n={{ some_other_template_value }}")

--- a/unit_tests/unit/test_mixin_lazy_context.py
+++ b/unit_tests/unit/test_mixin_lazy_context.py
@@ -1,0 +1,87 @@
+"""Tests for MixinLazyContext — the lazy Jinja2 context that resolves variables from an owner."""
+
+import pytest
+from jinja2 import Environment, StrictUndefined, UndefinedError
+
+from sdcm.utils.loader_utils import MixinLazyContext
+
+
+class Owner:
+    """Simple owner with a plain attribute, a call-tracked property, and nothing else."""
+
+    plain = "plain_value"
+
+    def __init__(self):
+        self.call_count = 0
+
+    @property
+    def expensive(self):
+        self.call_count += 1
+        return 42
+
+
+def render(owner, template_str, whitelist=None):
+    """Render *template_str* using MixinLazyContext against *owner*."""
+    env = Environment(undefined=StrictUndefined)
+    env.context_class = MixinLazyContext
+    env.owner = owner
+    if whitelist is not None:
+        env.whitelist = whitelist
+    return env.from_string(template_str).render()
+
+
+@pytest.mark.parametrize(
+    "template_str, expected",
+    [
+        ("{{ plain }}", "plain_value"),
+        ("{{ expensive }}", "42"),
+        ("{{ plain }} {{ expensive }}", "plain_value 42"),
+    ],
+)
+def test_resolves_owner_attributes(template_str, expected):
+    assert render(Owner(), template_str) == expected
+
+
+def test_property_not_called_when_not_referenced():
+    owner = Owner()
+    render(owner, "{{ plain }}")
+    assert owner.call_count == 0
+
+
+def test_property_called_once_per_render():
+    owner = Owner()
+    render(owner, "{{ expensive }}{{ expensive }}")
+    assert owner.call_count == 1
+
+
+def test_missing_attribute_raises_undefined_error():
+    with pytest.raises(UndefinedError):
+        render(Owner(), "{{ nonexistent }}")
+
+
+@pytest.mark.parametrize(
+    "template_str, whitelist, expected",
+    [
+        ("{{ plain }}", {"plain"}, "plain_value"),
+        ("{{ plain }}", {"plain", "expensive"}, "plain_value"),
+    ],
+)
+def test_whitelist_allows_listed_keys(template_str, whitelist, expected):
+    assert render(Owner(), template_str, whitelist=whitelist) == expected
+
+
+@pytest.mark.parametrize(
+    "template_str, whitelist",
+    [
+        ("{{ expensive }}", {"plain"}),
+        ("{{ plain }}", set()),
+    ],
+)
+def test_whitelist_blocks_unlisted_keys(template_str, whitelist):
+    with pytest.raises(UndefinedError):
+        render(Owner(), template_str, whitelist=whitelist)
+
+
+def test_no_whitelist_allows_all_attributes():
+    result = render(Owner(), "{{ plain }} {{ expensive }}", whitelist=None)
+    assert result == "plain_value 42"

--- a/unit_tests/unit/test_render_stress_cmd.py
+++ b/unit_tests/unit/test_render_stress_cmd.py
@@ -19,6 +19,10 @@ class FakeLoaderMixin(LoaderUtilsMixin):
     def effective_disk_size_bytes(self) -> int:
         return self.fake_effective_disk_size
 
+    @property
+    def some_other_template_value(self) -> int:
+        return 17
+
 
 @pytest.mark.parametrize(
     "cmd",
@@ -51,6 +55,42 @@ def test_template_renders_correctly(disk_size, template, expected_substring):
 def test_unknown_variable_raises_runtime_error():
     with pytest.raises(RuntimeError, match="unknown Jinja variable"):
         FakeLoaderMixin().render_stress_cmd("cassandra-stress write n={{ unknown_variable }}")
+
+
+def test_generic_loader_mixin_has_no_owner_attribute_whitelist_by_default():
+    result = FakeLoaderMixin().render_stress_cmd("cassandra-stress write n={{ some_other_template_value }}")
+    assert result == "cassandra-stress write n=17"
+
+
+def test_stress_template_context_supports_ordered_reuse_and_scalar_coercion():
+    instance = FakeLoaderMixin(effective_disk_size=1_000)
+    instance.params["stress_template_context"] = {
+        "chunk_count": "4",
+        "rows_total": "{{ effective_disk_size_bytes // 10 }}",
+        "rows_per_cmd": "{{ rows_total // chunk_count }}",
+    }
+
+    rendered = instance.render_stress_cmd("cassandra-stress write n={{ rows_per_cmd }}")
+    assert rendered == "cassandra-stress write n=25"
+
+
+def test_stress_template_context_rejects_unknown_variable():
+    instance = FakeLoaderMixin()
+    instance.params["stress_template_context"] = {"rows_per_cmd": "{{ missing_value // 4 }}"}
+
+    with pytest.raises(RuntimeError, match="stress_template_context entry 'rows_per_cmd' references an unknown"):
+        instance.render_stress_cmd("cassandra-stress write n={{ rows_per_cmd }}")
+
+
+def test_stress_template_context_must_reference_earlier_keys_only():
+    instance = FakeLoaderMixin()
+    instance.params["stress_template_context"] = {
+        "rows_per_cmd": "{{ rows_total // 4 }}",
+        "rows_total": "{{ effective_disk_size_bytes }}",
+    }
+
+    with pytest.raises(RuntimeError, match="stress_template_context entry 'rows_per_cmd' references an unknown"):
+        instance.render_stress_cmd("cassandra-stress write n={{ rows_per_cmd }}")
 
 
 def test_syntax_error_raises_before_stress_starts():

--- a/unit_tests/unit/test_render_stress_cmd.py
+++ b/unit_tests/unit/test_render_stress_cmd.py
@@ -1,0 +1,73 @@
+"""Tests for LoaderUtilsMixin.render_stress_cmd."""
+
+import pytest
+from unittest.mock import MagicMock
+from jinja2 import TemplateSyntaxError
+
+from sdcm.utils.loader_utils import LoaderUtilsMixin
+
+
+class FakeLoaderMixin(LoaderUtilsMixin):
+    """Minimal LoaderUtilsMixin stand-in with a controllable effective_disk_size_bytes."""
+
+    def __init__(self, effective_disk_size: int = 1_000_000_000):
+        self.fake_effective_disk_size = effective_disk_size
+        self.params = {}
+        self.log = MagicMock()
+
+    @property
+    def effective_disk_size_bytes(self) -> int:
+        return self.fake_effective_disk_size
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        "cassandra-stress write cl=QUORUM n=5000000 -rate threads=80",
+        "scylla-bench -workload=sequential -mode=write -partition-count=10000",
+        "cassandra-stress write -schema 'compression={}'",
+    ],
+)
+def test_literal_command_passes_through_unchanged(cmd):
+    """Commands with no Jinja syntax are returned unchanged."""
+    assert FakeLoaderMixin().render_stress_cmd(cmd) == cmd
+
+
+@pytest.mark.parametrize(
+    "disk_size, template, expected_substring",
+    [
+        (1_073_741_824, "cassandra-stress write n={{ effective_disk_size_bytes }}", "1073741824"),
+        (500_000_000, "n={{ (effective_disk_size_bytes // 1000) | int }}", "500000"),
+        (999, "{% set rows = effective_disk_size_bytes %}n={{ rows }}", "999"),
+    ],
+)
+def test_template_renders_correctly(disk_size, template, expected_substring):
+    result = FakeLoaderMixin(effective_disk_size=disk_size).render_stress_cmd(template)
+    assert expected_substring in result
+    assert "{{" not in result
+    assert "{%" not in result
+
+
+def test_unknown_variable_raises_runtime_error():
+    with pytest.raises(RuntimeError, match="unknown Jinja variable"):
+        FakeLoaderMixin().render_stress_cmd("cassandra-stress write n={{ unknown_variable }}")
+
+
+def test_syntax_error_raises_before_stress_starts():
+    with pytest.raises(TemplateSyntaxError):
+        FakeLoaderMixin().render_stress_cmd("cassandra-stress write n={{ unclosed")
+
+
+@pytest.mark.parametrize(
+    "cmd, expected",
+    [
+        (
+            "  {% set rows = effective_disk_size_bytes %}\n  cassandra-stress write n={{ rows }}\n  -rate threads=80  ",
+            "cassandra-stress write n=1000 -rate threads=80",
+        ),
+    ],
+)
+def test_multiline_yaml_block_collapsed_to_single_line(cmd, expected):
+    result = FakeLoaderMixin(effective_disk_size=1000).render_stress_cmd(cmd)
+    assert "\n" not in result
+    assert result == expected

--- a/unit_tests/unit/test_render_stress_cmd.py
+++ b/unit_tests/unit/test_render_stress_cmd.py
@@ -19,6 +19,10 @@ class FakeLoaderMixin(LoaderUtilsMixin):
     def effective_disk_size_bytes(self) -> int:
         return self.fake_effective_disk_size
 
+    @property
+    def some_other_template_value(self) -> int:
+        return 17
+
 
 @pytest.mark.parametrize(
     "cmd",
@@ -51,6 +55,55 @@ def test_template_renders_correctly(disk_size, template, expected_substring):
 def test_unknown_variable_raises_runtime_error():
     with pytest.raises(RuntimeError, match="unknown Jinja variable"):
         FakeLoaderMixin().render_stress_cmd("cassandra-stress write n={{ unknown_variable }}")
+
+
+def test_generic_loader_mixin_has_no_owner_attribute_whitelist_by_default():
+    result = FakeLoaderMixin().render_stress_cmd("cassandra-stress write n={{ some_other_template_value }}")
+    assert result == "cassandra-stress write n=17"
+
+
+def test_stress_template_context_supports_ordered_reuse_and_scalar_coercion():
+    instance = FakeLoaderMixin(effective_disk_size=1_000)
+    instance.params["stress_template_context"] = {
+        "chunk_count": 4,
+        "rows_total": "{{ effective_disk_size_bytes // 10 }}",
+        "rows_per_cmd": "{{ rows_total // chunk_count }}",
+    }
+
+    rendered = instance.render_stress_cmd("cassandra-stress write n={{ rows_per_cmd }}")
+    assert rendered == "cassandra-stress write n=25"
+
+
+@pytest.mark.parametrize(
+    "literal_value",
+    ["4", "yes", "no", "2026-08-24", "1:30:00"],
+)
+def test_stress_template_context_leaves_non_template_strings_unparsed(literal_value):
+    """Plain strings with no Jinja syntax must not be re-typed by YAML (e.g. "yes" -> True)."""
+    instance = FakeLoaderMixin()
+    instance.params["stress_template_context"] = {"literal": literal_value}
+
+    resolved = instance.build_stress_template_context()
+    assert resolved["literal"] == literal_value
+
+
+def test_stress_template_context_rejects_unknown_variable():
+    instance = FakeLoaderMixin()
+    instance.params["stress_template_context"] = {"rows_per_cmd": "{{ missing_value // 4 }}"}
+
+    with pytest.raises(RuntimeError, match="stress_template_context entry 'rows_per_cmd' references an unknown"):
+        instance.render_stress_cmd("cassandra-stress write n={{ rows_per_cmd }}")
+
+
+def test_stress_template_context_must_reference_earlier_keys_only():
+    instance = FakeLoaderMixin()
+    instance.params["stress_template_context"] = {
+        "rows_per_cmd": "{{ rows_total // 4 }}",
+        "rows_total": "{{ effective_disk_size_bytes }}",
+    }
+
+    with pytest.raises(RuntimeError, match="stress_template_context entry 'rows_per_cmd' references an unknown"):
+        instance.render_stress_cmd("cassandra-stress write n={{ rows_per_cmd }}")
 
 
 def test_syntax_error_raises_before_stress_starts():

--- a/unit_tests/unit/test_sct_config_validators.py
+++ b/unit_tests/unit/test_sct_config_validators.py
@@ -234,3 +234,25 @@ def test_effective_compression_ratio_invalid(monkeypatch, value, expected_match)
 
     with pytest.raises(ValidationError, match=expected_match):
         SCTConfiguration()
+
+
+def test_stress_template_context_accepts_dict(monkeypatch):
+    monkeypatch.setenv("SCT_CLUSTER_BACKEND", "docker")
+    monkeypatch.setenv("SCT_USE_MGMT", "false")
+    monkeypatch.setenv("SCT_SCYLLA_VERSION", "2025.1.0")
+    monkeypatch.setenv("SCT_CONFIG_FILES", "unit_tests/test_configs/minimal_test_case.yaml")
+    monkeypatch.setenv("SCT_STRESS_TEMPLATE_CONTEXT", '{"rows_total": "{{ effective_disk_size_bytes }}"}')
+
+    conf = SCTConfiguration()
+    assert conf.stress_template_context == {"rows_total": "{{ effective_disk_size_bytes }}"}
+
+
+def test_stress_template_context_accepts_yaml_string(monkeypatch):
+    monkeypatch.setenv("SCT_CLUSTER_BACKEND", "docker")
+    monkeypatch.setenv("SCT_USE_MGMT", "false")
+    monkeypatch.setenv("SCT_SCYLLA_VERSION", "2025.1.0")
+    monkeypatch.setenv("SCT_CONFIG_FILES", "unit_tests/test_configs/minimal_test_case.yaml")
+    monkeypatch.setenv("SCT_STRESS_TEMPLATE_CONTEXT", "rows_total: '{{ effective_disk_size_bytes }}'")
+
+    conf = SCTConfiguration()
+    assert conf.stress_template_context == {"rows_total": "{{ effective_disk_size_bytes }}"}

--- a/unit_tests/unit/test_sct_config_validators.py
+++ b/unit_tests/unit/test_sct_config_validators.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from pydantic import ValidationError
 from sdcm.sct_config import (
     SCTConfiguration,
     boolean_or_space_separated_booleans,
@@ -194,3 +195,42 @@ def test_list_of_stress_tools_with_list_stress_cmd(monkeypatch):
     conf = SCTConfiguration()
     tools = conf.list_of_stress_tools
     assert "cassandra-stress" in tools
+
+
+# ---------------------------------------------------------------------------
+# effective_compression_ratio validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("value", [1.0, 0.68, 0.5, 0.01])
+def test_effective_compression_ratio_valid(monkeypatch, value):
+    """effective_compression_ratio accepts values in (0, 1.0]."""
+    monkeypatch.setenv("SCT_CLUSTER_BACKEND", "docker")
+    monkeypatch.setenv("SCT_USE_MGMT", "false")
+    monkeypatch.setenv("SCT_SCYLLA_VERSION", "2025.1.0")
+    monkeypatch.setenv("SCT_CONFIG_FILES", "unit_tests/test_configs/minimal_test_case.yaml")
+    monkeypatch.setenv("SCT_EFFECTIVE_COMPRESSION_RATIO", str(value))
+
+    conf = SCTConfiguration()
+    assert conf.effective_compression_ratio == pytest.approx(value)
+
+
+@pytest.mark.parametrize(
+    "value, expected_match",
+    [
+        (0, "greater than 0"),
+        (-0.5, "greater than 0"),
+        (1.1, "less than or equal to 1"),
+        (2.0, "less than or equal to 1"),
+    ],
+)
+def test_effective_compression_ratio_invalid(monkeypatch, value, expected_match):
+    """effective_compression_ratio rejects 0, negative values, and values above 1.0."""
+    monkeypatch.setenv("SCT_CLUSTER_BACKEND", "docker")
+    monkeypatch.setenv("SCT_USE_MGMT", "false")
+    monkeypatch.setenv("SCT_SCYLLA_VERSION", "2025.1.0")
+    monkeypatch.setenv("SCT_CONFIG_FILES", "unit_tests/test_configs/minimal_test_case.yaml")
+    monkeypatch.setenv("SCT_EFFECTIVE_COMPRESSION_RATIO", str(value))
+
+    with pytest.raises(ValidationError, match=expected_match):
+        SCTConfiguration()

--- a/unit_tests/unit/test_sct_config_validators.py
+++ b/unit_tests/unit/test_sct_config_validators.py
@@ -207,7 +207,7 @@ def test_effective_compression_ratio_valid(monkeypatch, value):
     """effective_compression_ratio accepts values in (0, 1.0]."""
     monkeypatch.setenv("SCT_CLUSTER_BACKEND", "docker")
     monkeypatch.setenv("SCT_USE_MGMT", "false")
-    monkeypatch.setenv("SCT_SCYLLA_VERSION", "2025.1.0")
+    monkeypatch.setenv("SCT_SCYLLA_VERSION", "2026.1.0")
     monkeypatch.setenv("SCT_CONFIG_FILES", "unit_tests/test_configs/minimal_test_case.yaml")
     monkeypatch.setenv("SCT_EFFECTIVE_COMPRESSION_RATIO", str(value))
 
@@ -228,9 +228,31 @@ def test_effective_compression_ratio_invalid(monkeypatch, value, expected_match)
     """effective_compression_ratio rejects 0, negative values, and values above 1.0."""
     monkeypatch.setenv("SCT_CLUSTER_BACKEND", "docker")
     monkeypatch.setenv("SCT_USE_MGMT", "false")
-    monkeypatch.setenv("SCT_SCYLLA_VERSION", "2025.1.0")
+    monkeypatch.setenv("SCT_SCYLLA_VERSION", "2026.1.0")
     monkeypatch.setenv("SCT_CONFIG_FILES", "unit_tests/test_configs/minimal_test_case.yaml")
     monkeypatch.setenv("SCT_EFFECTIVE_COMPRESSION_RATIO", str(value))
 
     with pytest.raises(ValidationError, match=expected_match):
         SCTConfiguration()
+
+
+def test_stress_template_context_accepts_dict(monkeypatch):
+    monkeypatch.setenv("SCT_CLUSTER_BACKEND", "docker")
+    monkeypatch.setenv("SCT_USE_MGMT", "false")
+    monkeypatch.setenv("SCT_SCYLLA_VERSION", "2026.1.0")
+    monkeypatch.setenv("SCT_CONFIG_FILES", "unit_tests/test_configs/minimal_test_case.yaml")
+    monkeypatch.setenv("SCT_STRESS_TEMPLATE_CONTEXT", '{"rows_total": "{{ effective_disk_size_bytes }}"}')
+
+    conf = SCTConfiguration()
+    assert conf.stress_template_context == {"rows_total": "{{ effective_disk_size_bytes }}"}
+
+
+def test_stress_template_context_accepts_yaml_string(monkeypatch):
+    monkeypatch.setenv("SCT_CLUSTER_BACKEND", "docker")
+    monkeypatch.setenv("SCT_USE_MGMT", "false")
+    monkeypatch.setenv("SCT_SCYLLA_VERSION", "2026.1.0")
+    monkeypatch.setenv("SCT_CONFIG_FILES", "unit_tests/test_configs/minimal_test_case.yaml")
+    monkeypatch.setenv("SCT_STRESS_TEMPLATE_CONTEXT", "rows_total: '{{ effective_disk_size_bytes }}'")
+
+    conf = SCTConfiguration()
+    assert conf.stress_template_context == {"rows_total": "{{ effective_disk_size_bytes }}"}


### PR DESCRIPTION
Longevity test configs hardcode row counts in stress commands, so dataset size must be recalculated manually whenever disk size, instance type, or expected compression changes. Add runtime-only strict Jinja rendering for longevity stress commands so configs can calculate row counts from available `/var/lib/scylla` capacity through an `effective_disk_size_bytes` template variable.

This will enable us to create tests with e.g. 40% of disk utilization regardless of instance and cloud.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
