### PR TITLE
feature(testing): add NVMe namespace-rescan repro test for all backends

### DIFF
--- a/artifacts_test.py
+++ b/artifacts_test.py
@@ -675,8 +675,21 @@ class ArtifactsTest(ClusterTester):
                         f"{[line for line in kernel_log.splitlines() if pci_addr in line]}"
                     )
 
+        with self.logged_subtest("reconcile scylla.yaml network config clobbered by the forced setup re-run"):
+            # The repro reboot forces scylla-image-setup.service (and therefore scylla_configure)
+            # to regenerate scylla.yaml from scratch, resetting listen_address/seed_provider to
+            # their machine-image defaults (private IP). broadcast_address survives untouched
+            # (scylla_configure never sets it), since it was patched in by the node's initial
+            # config_setup() call for intra_node_comm_public - so the two diverge and scylla-server
+            # refuses to start ("Use broadcast_address for seeds list"). Re-apply the same patch
+            # to reconcile them before checking scylla-server. No-op when the two already agree.
+            self.node.config_setup(append_scylla_args=self.db_cluster.get_scylla_args())
+
         with self.logged_subtest("verify scylla-server is active after recovery"):
-            self.node.wait_db_up(timeout=600)
+            # scylla-server already tried and failed to start once, with the pre-reconciliation
+            # scylla.yaml (see previous subtest) - its unit has no Restart= directive, so it will
+            # not retry on its own. Explicitly restart it now that scylla.yaml is consistent.
+            self.node.restart_scylla_server(timeout=600)
 
         with self.logged_subtest("verify recovered disk is usable"):
             self.verify_nvme_write_cache()

--- a/artifacts_test.py
+++ b/artifacts_test.py
@@ -35,9 +35,19 @@ from sdcm.utils.decorators import retrying
 from sdcm.utils.issues import SkipPerIssues
 from sdcm.utils.perftune_validator import PerftuneOutputChecker
 from sdcm.utils.validators.iotune import IOTuneValidator
+from sdcm import wait
 from utils.scylla_doctor import ScyllaDoctor
 
 STRESS_CMD: str = "/usr/bin/cassandra-stress"
+
+# NVMe namespace-rescan repro test (nvme_rescan_repro) - see
+# docs/plans/testing/nvme-namespace-rescan-repro-test.md
+NVME_FAULT_INJECT_SERVICE = "sct-nvme-fault-inject.service"
+NVME_IMAGE_SETUP_SERVICE = "scylla-image-setup.service"
+NVME_MACHINE_IMAGE_CONFIGURED_MARKER = "/etc/scylla/machine_image_configured"
+# written by the remove-mode injector (see NvmeFaultInjectUserDataObject)
+NVME_FAULT_INJECT_EXPECTED_CONTROLLERS_FILE = "/var/lib/sct-nvme-fault-inject/expected_controllers"
+NVME_FAULT_INJECT_REMOVED_PCI_ADDRS_FILE = "/run/sct-nvme-fault-inject/removed"
 
 
 BACKENDS = {
@@ -539,6 +549,138 @@ class ArtifactsTest(ClusterTester):
         if backend == "docker":
             with self.logged_subtest("Check docker latest tags"):
                 self.verify_docker_latest_match_release()
+
+    def _wait_for_service_terminal_state(self, service_name: str, timeout: int) -> None:
+        def is_terminal() -> bool:
+            state = self.node.remoter.sudo(
+                f"systemctl show {service_name} --property=ActiveState --value", ignore_status=True
+            ).stdout.strip()
+            return state in ("active", "failed")
+
+        wait.wait_for(
+            is_terminal,
+            step=10,
+            timeout=timeout,
+            text=f"waiting for {service_name} to reach a terminal state",
+            throw_exc=True,
+        )
+
+    def test_nvme_namespace_rescan_repro(self):
+        """
+        Repro test for the scylla-machine-image NVMe namespace-rescan race fix
+        (see docs/plans/testing/nvme-namespace-rescan-repro-test.md). Only runs when the
+        'nvme_rescan_repro' test-case flag is set.
+
+        Reboots the node with a pre-injected fault and asserts scylla-image-setup.service
+        recovers via the fix's rescan path. The fault primitive depends on
+        'nvme_rescan_repro_mode':
+
+        - 'unbind' (default): local NVMe PCI function's driver unbound - the
+          "controller present, namespace missing" repro. Exercises only the fix's
+          PCI-bus-rescan fallback branch, and cannot work on NVMe-root SKUs (a bus
+          rescan can't rebind a still-registered pci_dev).
+        - 'remove': local NVMe PCI devices deleted outright on an NVMe-root SKU
+          (Standard_L8s_v4) - the "controller never enumerated" production incident that
+          scylla-machine-image commit 02bb3c74's unconditional PCI-bus rescan fixes.
+          Additionally asserts every removed PCI address was genuinely re-enumerated on
+          the repro boot, proving the bus rescan itself did the recovery.
+
+        See the plan's Risk Mitigation section for what each mode can and cannot prove.
+        """
+        if not self.params.get("nvme_rescan_repro"):
+            self.skipTest("nvme_rescan_repro test-case flag is not set")
+
+        with self.logged_subtest("verify the idempotency marker survived the first boot"):
+            # The marker must still be present after the first boot: it is what SCT's generic
+            # setUp() machine-image wait polls for, and the fault injector deliberately leaves it
+            # in place (see NvmeFaultInjectUserDataObject). It is removed by the fault-inject
+            # systemd unit only on the reboot triggered below, right before scylla-image-setup
+            # re-runs.
+            marker_present = self.node.remoter.sudo(
+                f"test -e {NVME_MACHINE_IMAGE_CONFIGURED_MARKER}", ignore_status=True
+            ).ok
+            assert marker_present, (
+                f"{NVME_MACHINE_IMAGE_CONFIGURED_MARKER} is missing after the first boot - "
+                f"the fault injector must leave it in place so setUp()'s machine-image wait succeeds"
+            )
+
+        pre_reboot_timestamp = int(self.node.remoter.sudo("date +%s").stdout.strip())
+
+        with self.logged_subtest("reboot node with injected NVMe fault"):
+            self.node.reboot()
+
+        with self.logged_subtest("wait for scylla-image-setup.service to reach a terminal state"):
+            self._wait_for_service_terminal_state(NVME_IMAGE_SETUP_SERVICE, timeout=1200)
+
+        with self.logged_subtest("verify machine_image_configured was refreshed by the re-run"):
+            marker_mtime = int(
+                self.node.remoter.sudo(f"stat -c %Y {NVME_MACHINE_IMAGE_CONFIGURED_MARKER}").stdout.strip()
+            )
+            assert marker_mtime > pre_reboot_timestamp, (
+                f"{NVME_MACHINE_IMAGE_CONFIGURED_MARKER} mtime is not after the reboot - "
+                "scylla-image-setup was skipped, not re-run"
+            )
+
+        with self.logged_subtest("verify the fault-injection unit actually ran"):
+            fault_inject_status = self.node.remoter.sudo(
+                f"systemctl show {NVME_FAULT_INJECT_SERVICE} --property=ExecMainStatus --value"
+            ).stdout.strip()
+            if fault_inject_status != "0":
+                journal = self.node.remoter.sudo(
+                    f"journalctl -u {NVME_FAULT_INJECT_SERVICE} -b 0 --no-pager", ignore_status=True
+                ).stdout
+                raise AssertionError(
+                    f"{NVME_FAULT_INJECT_SERVICE} did not exit 0 (ExecMainStatus={fault_inject_status}) - "
+                    f"the fault may not have been injected:\n{journal}"
+                )
+
+        with self.logged_subtest("verify scylla-image-setup recovered via the retry/rescan path"):
+            journal = self.node.remoter.sudo(f"journalctl -u {NVME_IMAGE_SETUP_SERVICE} -b 0 --no-pager").stdout
+            retry_idx = journal.find("No device names available yet, retrying...")
+            found_idx = journal.find("Found devices:")
+            assert retry_idx != -1, (
+                f"Expected retry log line not found in {NVME_IMAGE_SETUP_SERVICE} journal:\n{journal}"
+            )
+            assert found_idx != -1, (
+                f"Expected recovery log line not found in {NVME_IMAGE_SETUP_SERVICE} journal:\n{journal}"
+            )
+            assert retry_idx < found_idx, (
+                f"Recovery log line appeared before the retry log line - unexpected ordering:\n{journal}"
+            )
+
+            exec_status = self.node.remoter.sudo(
+                f"systemctl show {NVME_IMAGE_SETUP_SERVICE} --property=ExecMainStatus --value"
+            ).stdout.strip()
+            assert exec_status == "0", f"{NVME_IMAGE_SETUP_SERVICE} did not exit 0 (ExecMainStatus={exec_status})"
+
+        if self.params.get("nvme_rescan_repro_mode") == "remove":
+            with self.logged_subtest("verify every removed PCI device was genuinely re-enumerated"):
+                expected_count = int(
+                    self.node.remoter.sudo(f"cat {NVME_FAULT_INJECT_EXPECTED_CONTROLLERS_FILE}").stdout.strip()
+                )
+                removed_addrs = self.node.remoter.sudo(f"cat {NVME_FAULT_INJECT_REMOVED_PCI_ADDRS_FILE}").stdout.split()
+                assert len(removed_addrs) == expected_count, (
+                    f"injector removed {len(removed_addrs)} PCI devices but the first boot recorded "
+                    f"{expected_count} non-root NVMe controllers - partial injection voids the repro"
+                )
+                kernel_log = self.node.remoter.sudo("journalctl -k -b 0 --no-pager").stdout
+                for pci_addr in removed_addrs:
+                    enumerations = kernel_log.count(f"pci function {pci_addr}")
+                    # one from initial boot enumeration, one from the fix's PCI-bus rescan
+                    # re-discovering the removed device - a single occurrence means either
+                    # the removal or the rediscovery never happened
+                    assert enumerations >= 2, (
+                        f"PCI device {pci_addr} was enumerated {enumerations} time(s) this boot, expected >= 2 - "
+                        f"recovery did not happen via genuine PCI re-enumeration:\n"
+                        f"{[line for line in kernel_log.splitlines() if pci_addr in line]}"
+                    )
+
+        with self.logged_subtest("verify scylla-server is active after recovery"):
+            self.node.wait_db_up(timeout=600)
+
+        with self.logged_subtest("verify recovered disk is usable"):
+            self.verify_nvme_write_cache()
+            self.verify_xfs_online_discard_enabled()
 
     def run_scylla_doctor(self):
         if self.params.get("client_encrypt") and SkipPerIssues(

--- a/artifacts_test.py
+++ b/artifacts_test.py
@@ -576,9 +576,11 @@ class ArtifactsTest(ClusterTester):
         'nvme_rescan_repro_mode':
 
         - 'unbind' (default): local NVMe PCI function's driver unbound - the
-          "controller present, namespace missing" repro. Exercises only the fix's
-          PCI-bus-rescan fallback branch, and cannot work on NVMe-root SKUs (a bus
-          rescan can't rebind a still-registered pci_dev).
+          "controller present, namespace missing" repro. A plain PCI-bus rescan can't
+          rebind a still-registered pci_dev, so this now exercises the fix's dedicated
+          drivers_probe branch (_unbound_nvme_pci_addresses()), added specifically to
+          recover this case - and, unlike the bus rescan, that branch is
+          SKU-agnostic, so this mode is valid on NVMe-root backends too.
         - 'remove': local NVMe PCI devices deleted outright on an NVMe-root SKU
           (Standard_L8s_v4) - the "controller never enumerated" production incident that
           scylla-machine-image commit 02bb3c74's unconditional PCI-bus rescan fixes.

--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -221,6 +221,9 @@ scylla_apt_keys:
 
 raid_level: 0
 
+nvme_rescan_repro: false
+nvme_rescan_repro_mode: 'unbind'
+
 bare_loaders: false
 
 aws_fallback_to_next_availability_zone: false

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -4459,6 +4459,24 @@ Number of of raid level: 0 - RAID0, 5 - RAID5
 **type:** int
 
 
+## **nvme_rescan_repro** / SCT_NVME_RESCAN_REPRO
+
+Inject a fault that unbinds the local/ephemeral NVMe device's PCI function before<br>scylla-image-setup.service on the next boot, reproducing the "NVMe controller present, namespace<br>missing" boot race that scylla-machine-image's rescan_nvme_controllers() fix recovers from. See<br>docs/plans/testing/nvme-namespace-rescan-repro-test.md. Only for db nodes; test-case only.
+
+**default:** False
+
+**type:** bool
+
+
+## **nvme_rescan_repro_mode** / SCT_NVME_RESCAN_REPRO_MODE
+
+Fault primitive for the NVMe namespace-rescan repro test (needs nvme_rescan_repro).<br>'unbind' (default) unbinds the local NVMe PCI function's driver - the "controller present, namespace<br>missing" repro. 'remove' deletes the PCI device entirely - the NVMe-root repro where the local<br>controller is absent from PCI enumeration and only an unconditional PCI-bus rescan can rediscover it<br>(validated on Azure Standard_L8s_v4/Hyper-V vPCI only). See<br>docs/plans/testing/nvme-namespace-rescan-repro-test.md.
+
+**default:** unbind
+
+**type:** str (appendable)
+
+
 ## **bare_loaders** / SCT_BARE_LOADERS
 
 Don't install anything but node_exporter to the loaders during cluster setup

--- a/docs/plans/MASTER.md
+++ b/docs/plans/MASTER.md
@@ -97,6 +97,7 @@ For plan writing guidelines, see [INSTRUCTIONS.md](INSTRUCTIONS.md).
 |------|--------|-----------|
 | MiniCloud Local Testing | `pending_pr` | [#14009](https://github.com/scylladb/scylla-cluster-tests/pull/14009) |
 | Unit/Integration Test Separation | `complete` | [unit-integration-test-separation.md](testing/unit-integration-test-separation.md), [#14172](https://github.com/scylladb/scylla-cluster-tests/pull/14172) |
+| NVMe Namespace-Rescan Repro Test (AWS, Azure, GCE, OCI) | `draft` | [nvme-namespace-rescan-repro-test.md](testing/nvme-namespace-rescan-repro-test.md) |
 
 ## Cross-Plan Dependencies
 

--- a/docs/plans/assets/progress-roadmap.svg
+++ b/docs/plans/assets/progress-roadmap.svg
@@ -1,10 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="840" height="968" viewBox="0 0 840 968">
-<rect width="840" height="968" fill="#0D1B2A" rx="8"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="840" height="996" viewBox="0 0 840 996">
+<rect width="840" height="996" fill="#0D1B2A" rx="8"/>
 <text x="420" y="60" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="22" font-weight="bold" fill="#00BCD4">SCT Implementation Plans</text>
-<text x="420" y="84" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="13" fill="#8899AA">31 plans across 9 domains</text>
+<text x="420" y="84" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="13" fill="#8899AA">32 plans across 9 domains</text>
 <rect x="30" y="120" width="780" height="50" rx="6" fill="#1B2A4A" stroke="#2A3F5F" stroke-width="1"/>
 <circle cx="50" cy="148" r="5" fill="#607D8B"/>
-<text x="60" y="152" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#E0E6ED">Draft: 11</text>
+<text x="60" y="152" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#E0E6ED">Draft: 12</text>
 <circle cx="180" cy="148" r="5" fill="#FFC107"/>
 <text x="190" y="152" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#E0E6ED">In Progress: 2</text>
 <circle cx="310" cy="148" r="5" fill="#2196F3"/>
@@ -16,14 +16,14 @@
 <circle cx="700" cy="148" r="5" fill="#9E9E9E"/>
 <text x="710" y="152" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#E0E6ED">Pending PR: 13</text>
 <rect x="40" y="175" width="760" height="20" rx="10" fill="#1B2A4A" stroke="#2A3F5F" stroke-width="1"/>
-<rect x="40" y="175" width="122.58064516129032" height="20" rx="10" fill="#4CAF50"/>
-<text x="101.29032258064515" y="189" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="bold" fill="#0D1B2A">5</text>
-<rect x="162.5806451612903" y="175" width="49.03225806451613" height="20" rx="0" fill="#FFC107"/>
-<text x="187.09677419354836" y="189" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="bold" fill="#0D1B2A">2</text>
-<rect x="211.61290322580643" y="175" width="269.6774193548387" height="20" rx="0" fill="#607D8B"/>
-<text x="346.4516129032258" y="189" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="bold" fill="#0D1B2A">11</text>
-<rect x="481.2903225806451" y="175" width="318.7096774193549" height="20" rx="0" fill="#9E9E9E"/>
-<text x="640.6451612903226" y="189" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="bold" fill="#0D1B2A">13</text>
+<rect x="40" y="175" width="118.75" height="20" rx="10" fill="#4CAF50"/>
+<text x="99.375" y="189" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="bold" fill="#0D1B2A">5</text>
+<rect x="158.75" y="175" width="47.5" height="20" rx="0" fill="#FFC107"/>
+<text x="182.5" y="189" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="bold" fill="#0D1B2A">2</text>
+<rect x="206.25" y="175" width="285.0" height="20" rx="0" fill="#607D8B"/>
+<text x="348.75" y="189" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="bold" fill="#0D1B2A">12</text>
+<rect x="491.25" y="175" width="308.75" height="20" rx="0" fill="#9E9E9E"/>
+<text x="645.625" y="189" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="bold" fill="#0D1B2A">13</text>
 <rect x="30" y="220" width="380" height="32" rx="4" fill="#1B2A4A" stroke="#00BCD4" stroke-width="1"/>
 <text x="42" y="241" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="bold" fill="#00BCD4">cluster</text>
 <text x="398" y="241" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#8899AA">4 plans</text>
@@ -137,12 +137,15 @@
 <text x="798" y="778" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#4CAF50">Complete</text>
 <rect x="430" y="804" width="380" height="32" rx="4" fill="#1B2A4A" stroke="#00BCD4" stroke-width="1"/>
 <text x="442" y="825" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="bold" fill="#00BCD4">testing</text>
-<text x="798" y="825" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#8899AA">2 plans</text>
-<circle cx="444" cy="850" r="4" fill="#9E9E9E"/>
-<text x="456" y="854" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">MiniCloud Local Testing</text>
-<text x="798" y="854" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#9E9E9E">Pending PR</text>
-<circle cx="444" cy="878" r="4" fill="#4CAF50"/>
-<text x="456" y="882" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">Unit/Integration Test Separation</text>
-<text x="798" y="882" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#4CAF50">Complete</text>
-<text x="420" y="933" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#8899AA">Generated from docs/plans/progress.json</text>
+<text x="798" y="825" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#8899AA">3 plans</text>
+<circle cx="444" cy="850" r="4" fill="#607D8B"/>
+<text x="456" y="854" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">NVMe Namespace-Rescan Repro Test (AWS...</text>
+<text x="798" y="854" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#607D8B">Draft</text>
+<circle cx="444" cy="878" r="4" fill="#9E9E9E"/>
+<text x="456" y="882" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">MiniCloud Local Testing</text>
+<text x="798" y="882" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#9E9E9E">Pending PR</text>
+<circle cx="444" cy="906" r="4" fill="#4CAF50"/>
+<text x="456" y="910" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">Unit/Integration Test Separation</text>
+<text x="798" y="910" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#4CAF50">Complete</text>
+<text x="420" y="961" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#8899AA">Generated from docs/plans/progress.json</text>
 </svg>

--- a/docs/plans/progress.json
+++ b/docs/plans/progress.json
@@ -2,6 +2,16 @@
   "generated": "2026-05-14",
   "plans": [
     {
+      "id": "nvme-namespace-rescan-repro-test",
+      "title": "NVMe Namespace-Rescan Repro Test (AWS, Azure, GCE, OCI)",
+      "file": "testing/nvme-namespace-rescan-repro-test.md",
+      "domain": "testing",
+      "status": "draft",
+      "created": "2026-07-09",
+      "phases_total": 6,
+      "phases_done": 0
+    },
+    {
       "id": "ai-skills-framework",
       "title": "AI Skills Framework",
       "file": "ai-tooling/ai-skills-framework.md",

--- a/docs/plans/testing/nvme-namespace-rescan-repro-test.md
+++ b/docs/plans/testing/nvme-namespace-rescan-repro-test.md
@@ -1,0 +1,437 @@
+---
+status: draft
+domain: testing
+created: 2026-07-09
+last_updated: 2026-07-10
+owner: null
+---
+
+# NVMe Namespace-Rescan Repro Test (AWS, Azure, GCE, OCI)
+
+## 1. Problem Statement
+
+scylla-machine-image commit `8f8031d` (branch `fix/nvme-namespace-rescan`) fixes a cloud
+race where an NVMe controller enumerates on boot but its namespace block device
+(`/dev/nvme*n1`) does not appear in time, causing `scylla_create_devices` to abort with
+`NoDiskFoundError` and `scylla-image-setup.service` to fail — which blocks
+`scylla-server.service` (`RequiredBy=scylla-server.service`) and leaves the node
+permanently unusable. The fix adds a retry loop with an explicit NVMe rescan
+(`rescan_nvme_controllers()` in `common/scylla_create_devices`) between attempts.
+
+Neither the fix's author nor its reviewer can trigger the underlying cloud race on
+demand — it depends on cloud-provider boot timing that isn't reproducible locally. The
+fix currently has only mocked unit tests (`tests/test_scylla_create_devices.py`), which
+prove the retry/rescan control flow in isolation but never exercise it against a real
+kernel, real NVMe driver, and real `scylla-image-setup.service` boot sequence. This plan
+adds a deterministic, real-hardware repro test in scylla-cluster-tests (SCT) that fakes
+the "disk missing at boot" condition and asserts the node still comes up via the fix's
+recovery path — turning an untestable production race into a CI-checkable scenario.
+
+The bug itself is not Azure-specific — the fix's commit message references both
+OCI (SCT-447) and Azure (SCT-297) hitting the same race, and `wait_for_devices()`/
+`rescan_nvme_controllers()` sit in the code path used by every backend
+(`common/scylla_create_devices` — `get_default_devices()` for GCE/Azure/OCI,
+`get_disk_devices()`'s `instance_store` branch for AWS/EC2). The repro mechanism
+designed below is likewise generic cloud-init/systemd infrastructure with no
+Azure-specific dependency (see Current State), so this plan targets all four
+backends SCT provisions on: AWS, Azure, GCE, OCI.
+
+Production incidents split into two distinct failure modes, and Phases 1–4's
+unbind-based test covers neither of them exactly:
+
+- **Controller bound, namespace missing** (OCI incident
+  `long-100gb-4h-oci-master-db-node-86f82825`): root disk is SCSI (`8:1`), the single
+  NVMe controller enumerates and binds (`nvme nvme0: 16/0/0 default/read/poll queues`)
+  but no `nvme0n1` ever appears. This is the fix's *primary* branch scenario (write `1`
+  to `nvme0/rescan_controller`). No real-hardware repro exists for it — see the
+  "Scope limitation" risk entry.
+- **Controller never enumerated on the PCI bus at all** (Azure incident
+  `longevity-10gb-3h-master-db-node-87adee8c`, `Standard_L8s_v4`): the root disk itself
+  is NVMe (`nvme0n1p1` mounted at `/`, device `259:1`), and the VM's separate
+  local-disk NVMe controller(s) never appear anywhere in dmesg for the whole boot. On
+  the pre-`02bb3c74` code, `rescan_nvme_controllers()` found the healthy *root*
+  controller's `rescan_controller`, wrote to it successfully, and that success alone
+  skipped the PCI-bus rescan entirely — even though a *different*, still-missing
+  controller was the actual problem. scylla-machine-image commit `02bb3c74` fixes this
+  by always issuing the PCI-bus rescan unconditionally. Phases 5–6 below add a test
+  variant that deterministically resurfaces this NVMe-root failure mode (fails against
+  pre-`02bb3c74` code, passes with it).
+
+## 2. Current State
+
+- **The fix**: `common/scylla_create_devices` (scylla-machine-image) — `wait_for_devices()`
+  retries `_get_fresh_local_disks()` for `device_wait_seconds`, calling
+  `rescan_nvme_controllers()` between attempts. That function writes `1` to each
+  `/sys/class/nvme/nvme*/rescan_controller` if present, else falls back to
+  `echo 1 > /sys/bus/pci/rescan`. On success it prints `"Found devices: [...]"`; while
+  waiting it prints `"No device names available yet, retrying..."`. If `wait_seconds` is
+  falsy, the function returns immediately without retrying (`common/scylla_create_devices`,
+  `wait_for_devices`).
+- **`device_wait_seconds` is not test-specific** — it is not set anywhere in
+  scylla-machine-image by default (`lib/user_data.py:55-56` defaults to `0`, i.e.
+  disabled). In SCT, `ScyllaUserDataObject.scylla_machine_image_json`
+  (`sdcm/sct_provision/user_data_objects/scylla.py:41`) unconditionally sets
+  `device_wait_seconds: 60` for every node, every backend — so the retry/rescan loop is
+  already live on all SCT-provisioned nodes today. This plan does not need to add or
+  override this value.
+- **Idempotency marker**: `scylla_image_setup` (scylla-machine-image,
+  `common/scylla_image_setup`) checks `/etc/scylla/machine_image_configured`; if it
+  exists, setup is skipped entirely on that boot. Removing this file is required to force
+  a real re-run of device detection on a later boot.
+- **User-data delivery is the same cloud-init pattern on all four backends**, only the
+  channel each provider API uses to hand it to the VM differs:
+  - Azure: `AzureVirtualMachineProvider.provision_vm`
+    (`sdcm/provision/azure/virtual_machine_provider.py:134-155`) sets
+    `osProfile.customData` from `UserDataBuilder.build_user_data_yaml()`
+    (`sdcm/provision/user_data.py`), plus top-level `properties.userData` (base64
+    `scylla_machine_image.json`, the `device_wait_seconds` channel).
+  - AWS: `sdcm/sct_provision/aws/user_data.py` builds the equivalent payload.
+  - GCE: `sdcm/provision/gce/instance_provider.py:265-268` sets instance
+    metadata `user-data` (cloud-init) and separately supports raw `startup-script`
+    metadata — this plan uses the `user-data`/cloud-init channel, consistent with the
+    other three backends.
+  - OCI: `sdcm/provision/oci/virtual_machine_provider.py:288-291` builds user data via
+    the same `UserDataBuilder`, base64-encoded into instance `metadata["user_data"]`.
+  - All four assemble the cloud-init YAML from the same `UserDataObject` list
+    (`sdcm/sct_provision/user_data_objects/*.py`, one `*_region_definition_builder.py`
+    per backend under `sdcm/sct_provision/<backend>/`). Each object's `script_to_run`
+    becomes a `write_files` entry plus a sequential `runcmd` invocation
+    (`sdcm/provision/user_data.py:92-114`) — this part of the plan (Phase 1) is written
+    once and applies unchanged to all four.
+- **No existing ordering hook**: cloud-init's `runcmd` stage has no guaranteed ordering
+  relative to `scylla-image-setup.service`, which only requires `network.target`
+  (`common/scylla-image-setup.service:4`). A `runcmd`-fired script could run before,
+  during, or after the service, on any backend. Systemd unit ordering (`Before=`/`After=`)
+  is reliable, but a newly-installed unit only takes effect starting the *next* boot.
+- **No existing fault-injection or NVMe-aware mechanism in SCT** — confirmed by search:
+  no references to `scylla-image-setup.service`, `machine_image_configured`, or
+  `scylla_create_devices` anywhere in scylla-cluster-tests. Each backend already has an
+  equivalent local-NVMe artifact test-case to use as a template: `test-cases/artifacts/
+  ami.yaml` (AWS, `i4i.large`), `azure-image.yaml` (Azure, `Standard_L8s_v3`/Lsv3),
+  `gce-image.yaml` (GCE), `oci-image.yaml` (OCI, `VM.DenseIO.E5.Flex:8`, a DenseIO
+  local-NVMe shape) — each run via its own `jenkins-pipelines/oss/artifacts/
+  artifacts-<backend>-image.jenkinsfile` through the shared `ArtifactsTest` class
+  (`artifacts_test.py:52`, already handles all four backends via its `BACKENDS` dict).
+  `ArtifactsTest`'s test methods run only after the node is already fully provisioned and
+  Scylla-ready — the fault must be injected before that point (i.e. from
+  provisioning-time user-data), not from within a test method, on any backend.
+- **Local-disk detection is NVMe-based on all four clouds**: `lib/scylla_cloud.py`
+  (scylla-machine-image) has `AwsInstance`, `GcpInstance`, `AzureInstance`, and
+  `OciInstance`, each computing ephemeral disks from real `/dev/nvme*` devices via the
+  same `nvmes_present`/root-device-exclusion pattern — so the injector's "find the
+  non-root NVMe PCI device" logic (Phase 1) is mount-point-based, not cloud-specific,
+  and is portable unchanged. Some shapes (e.g. OCI DenseIO, AWS instance-store) expose
+  more than one local NVMe namespace, so the injector must unbind *any* non-root NVMe
+  device, not assume exactly one — matching how the fix's own code already handles a
+  list of local disks.
+- **Reboot support already exists and is backend-agnostic**: `node.reboot()`
+  (`sdcm/cluster.py:1534`).
+- **Real-hardware scouting for the NVMe-root variant (done, 2026-07-10, on a live
+  `Standard_L8s_v4` in eastus)** — both prerequisites for Phases 5–6 verified:
+  - *Topology*: root is `nvme0` ("MSFT NVMe Accelerator v1.0", PCI `c05b:00:00.0` —
+    same model and address pattern as the production incident node); local disks are
+    four separate "Microsoft NVMe Direct Disk v2" controllers (`nvme1`–`nvme4`), one
+    namespace each, each in its own Hyper-V vPCI PCI domain. Matches the Lsv4 docs
+    (NVMe-only local temp disks, NVMe-capable OS image required — i.e. NVMe root).
+  - *Fault primitive*: `echo 1 > /sys/bus/pci/devices/<addr>/remove` fully deletes the
+    `pci_dev` on Hyper-V vPCI; the device does **not** come back spontaneously (held
+    for 10s+, repeated 3/3 iterations). Writing `1` to the surviving root controller's
+    `rescan_controller` — exactly what the pre-`02bb3c74` code did before
+    short-circuiting — brings back **0/4** removed devices. A single
+    `echo 1 > /sys/bus/pci/rescan` re-enumerates **4/4** removed controllers with
+    their namespaces within seconds, logging genuine re-enumeration lines
+    (`pci <addr>: [1414:b111] type 00 class 0x010802 PCIe Endpoint`,
+    `nvme nvmeX: pci function <addr>`) usable as test assertions.
+  - *Why `unbind` cannot cover this*: `driver/unbind` leaves the `pci_dev` registered
+    (just driverless); a PCI-bus rescan skips slots that already have a `pci_dev`
+    (verified in run `db-cluster-b0fd0433`, ~144 retry attempts over 20 minutes with
+    zero effect). Only `remove` reproduces the incident's "never enumerated on the
+    bus" state that a bus rescan can actually discover.
+  - *Disk-classification mechanics*: `AzureInstance._non_root_nvmes()`
+    (scylla-machine-image `lib/scylla_cloud.py:492`) computes EPHEMERAL as every
+    `/dev/nvme\d+n\d+` not backing `/`. With all four local controllers removed, only
+    root `nvme0n1` remains, so `get_local_disks()` returns empty and
+    `wait_for_devices()`'s retry loop genuinely fires. **Removing fewer than all
+    non-root controllers must be treated as injection failure**: the survivors keep
+    `get_local_disks()` non-empty, the first pass succeeds immediately, no rescan is
+    attempted, and RAID silently builds on the surviving subset.
+  - *Enumeration race on the repro boot*: local controllers enumerate at ~2.2s, the
+    injector unit starts at ~3s (`DefaultDependencies=no`). A controller that
+    enumerates *after* the injector ran would survive injection and void the test (see
+    previous bullet), so the remove-mode injector must know how many non-root
+    controllers to expect (recorded on the settled first boot) and wait for all of
+    them before removing anything.
+
+## 3. Goals
+
+- Deterministically reproduce, on a real VM on each of AWS, Azure, GCE, and OCI, the
+  "NVMe controller present initially, local disk not detected on first pass" condition
+  that the fix handles, without relying on actual cloud boot-timing luck.
+- Assert `scylla-image-setup.service` still completes successfully via the fix's recovery
+  path (PCI-bus-rescan fallback branch — see Risk Mitigation for why the primary
+  `rescan_controller` branch is out of scope here) and that Scylla ends up running on the
+  recovered disk, on all four backends.
+- Share one fault-injection mechanism and one test-assertion method across all four
+  backends (Phases 1 and 3) — only the per-backend test-case config and Jenkinsfile
+  (Phases 2 and 4) are backend-specific.
+- Make this runnable as a normal SCT test-case, on demand and eventually as part of each
+  backend's artifact-validation flow, not as a one-off manual script.
+- Do not touch the currently-hardcoded `device_wait_seconds: 60` (per decision — accepted
+  as sufficient for this test rather than adding a config override).
+- Deterministically reproduce, on a real Azure NVMe-root VM (`Standard_L8s_v4`), the
+  "local NVMe controller absent from PCI enumeration while the root NVMe controller is
+  healthy" incident mode, such that the test fails against pre-`02bb3c74`
+  scylla-machine-image code and passes with it — proving the unconditional PCI-bus
+  rescan specifically (via re-enumeration evidence in the kernel log, not just
+  "Found devices") did the recovery (Phases 5–6).
+
+## 4. Implementation Phases
+
+### Phase 1 — Fault-injection `UserDataObject`
+
+**Files**: new `sdcm/sct_provision/user_data_objects/nvme_fault_inject.py`.
+
+- Subclass the existing `UserDataObject` base (`sdcm/provision/common/user_data.py`).
+  `is_applicable` gated on `node_type == "scylla-db"` and a new params flag (e.g.
+  `nvme_rescan_repro: true`, read via `self.params.get(...)`, defaulting to `False` so no
+  other test-case is affected).
+- Via `write_files` (not `script_to_run`/`runcmd`, since ordering there is not
+  guaranteed — see Current State):
+  - `/etc/systemd/system/sct-nvme-fault-inject.service` — `Type=oneshot`,
+    `DefaultDependencies=no`, `Before=local-fs-pre.target scylla-image-setup.service`
+    (not just `Before=scylla-image-setup.service` — see Risk Mitigation's "busy-mount
+    race" entry for why `local-fs-pre.target` ordering is required). `ExecStart` runs a
+    script that:
+    1. Identifies the ephemeral/local-disk NVMe controller, excluding whichever backs the
+       root filesystem (mirror the exclusion logic scylla-machine-image already applies —
+       see `lib/scylla_cloud.py`'s local-disk/root-dev filtering — by checking mount
+       points, not by assuming a fixed controller index).
+    2. Safety guard: abort (non-zero exit, logged) if the identified device is mounted at
+       `/` — belt-and-suspenders even though these test configs always provision a
+       separate ephemeral/fast disk alongside the root disk.
+    3. Unbinds that device's PCI function: `echo <pci-addr> > /sys/bus/pci/devices/<pci-addr>/driver/unbind`.
+  - `/etc/systemd/system/scylla-image-setup.service.d/override.conf` —
+    `After=sct-nvme-fault-inject.service`.
+- A `runcmd` entry (ordering-insensitive, since it only needs to happen before the
+  *reboot*, not before any particular service) that:
+  1. `systemctl daemon-reload`
+  2. `systemctl enable sct-nvme-fault-inject.service`
+  3. Removes `/etc/scylla/machine_image_configured`.
+  4. Resets whatever RAID/mount/fstab state the successful first boot already created, so
+     `scylla_create_devices`/`scylla_configure` do a genuine, full re-run on the next boot:
+     remove the `machine_image_configured` marker, `mdadm --stop`/`--zero-superblock` any
+     leftover RAID array, and remove the `var-lib-scylla.mount` unit and its `/etc/fstab`
+     line. Deliberately does **not** `umount /var/lib/scylla` — since the injector unit
+     runs `Before=local-fs-pre.target`, the mount is never (re)activated on this boot in
+     the first place, so there's nothing live to unmount (see Risk Mitigation).
+  5. Triggers a reboot (or lets Phase 3's test code call `node.reboot()` explicitly instead
+     of self-rebooting from cloud-init — **Needs Investigation**, whichever is more
+     reliable to sequence from the SCT test side).
+
+**DoD**: unit test for the new `UserDataObject` (`is_applicable` gating, generated
+`write_files`/`runcmd` content) alongside existing tests for sibling objects (e.g.
+`sdcm/sct_provision/user_data_objects/docker_service.py`'s pattern).
+
+### Phase 2 — Test-case configs (one per backend)
+
+**Files**: new `test-cases/artifacts/<backend>-image-nvme-rescan.yaml` for each of:
+
+- `azure-image-nvme-rescan.yaml` — copy of `azure-image.yaml` (Standard_L8s_v3, spot).
+- `ami-nvme-rescan.yaml` — copy of `ami.yaml` (AWS, `i4i.large`).
+- `gce-image-nvme-rescan.yaml` — copy of `gce-image.yaml`.
+- `oci-image-nvme-rescan.yaml` — copy of `oci-image.yaml` (`VM.DenseIO.E5.Flex:8`).
+
+Each copy keeps its backend's existing instance type, region, and
+`nemesis_class_name: NoOpMonkey`/`n_db_nodes: 1` shape, plus adds `nvme_rescan_repro:
+true`.
+
+**DoD**: all four configs validate against SCT's config schema/validator. Land AWS or
+Azure first (whichever backend is easiest to iterate on) and use it to validate Phase 1's
+`UserDataObject` end-to-end before copying to the remaining three — the four configs
+should not require separate Phase-1 code paths, only separate yaml files.
+
+### Phase 3 — Test assertions
+
+**Files**: `artifacts_test.py` — new test method on `ArtifactsTest` (or a small subclass
+used only by this test-case), gated on the same params flag.
+
+- After node setup completes (which now spans the extra reboot from Phase 1), SSH in and
+  assert, in order:
+  1. `/etc/scylla/machine_image_configured` exists and its mtime is after the reboot
+     timestamp (proves setup actually re-ran, not skipped).
+  2. `journalctl -u sct-nvme-fault-inject.service` exited `0` (proves the fault was
+     actually injected — guards against the injector silently no-op'ing, e.g. picking the
+     wrong PCI address).
+  3. `journalctl -u scylla-image-setup.service` contains, in order, `"No device names
+     available yet, retrying..."` then `"Found devices:"`, and the unit itself exited `0`
+     (not failed, not hit the `TimeoutStartSec=900` ceiling).
+  4. `systemctl is-active scylla-server` = `active`.
+  5. Existing `ArtifactsTest` disk/RAID checks pass (recovered disk is actually usable, not
+     just detected).
+
+**DoD**: test fails clearly (not a generic timeout) if the fix regresses — a regression
+makes `scylla_create_devices` raise `NoDiskFoundError`, `scylla-image-setup.service`
+fails, `scylla-server.service` never starts (blocked by its `RequiredBy`), and the node
+never reaches Scylla-ready — this already surfaces as a normal SCT provisioning-failure
+path (e.g. `_wait_for_preinstalled_scylla` timeout), no special-casing needed.
+
+### Phase 4 — CI wiring (one per backend)
+
+**Files**: new `jenkins-pipelines/oss/artifacts/artifacts-<backend>-image-nvme-rescan.jenkinsfile`
+for each of AWS, Azure, GCE, OCI — same `artifactsPipeline(...)` shape as each backend's
+existing `artifacts-<backend>-image.jenkinsfile`, pointing at the matching new test-case
+yaml from Phase 2. Run on-demand initially; fold into each backend's nightly
+artifact-validation flow once proven stable (not part of this plan's DoD).
+
+### Phase 5 — Remove-mode fault injection (Azure NVMe-root variant)
+
+**Files**: `sdcm/sct_provision/user_data_objects/nvme_fault_inject.py`,
+`sdcm/sct_config.py`, `defaults/test_default.yaml`,
+`unit_tests/unit/provisioner/test_nvme_fault_inject.py`.
+
+- New config option `nvme_rescan_repro_mode: unbind|remove` (string, default `unbind`
+  in `defaults/test_default.yaml` per the config standard — no code default). `unbind`
+  keeps Phases 1–4's behavior byte-for-byte (existing unit tests and the four existing
+  test-case yamls stay untouched); `remove` selects the NVMe-root variant.
+- In `remove` mode, `NvmeFaultInjectUserDataObject.script_to_run` changes only the
+  fault step; the service unit, ordering (`DefaultDependencies=no`,
+  `After=systemd-remount-fs.service`, `Before=local-fs-pre.target
+  scylla-image-setup.service`), idempotency-marker/RAID/fstab teardown, and
+  enable/daemon-reload scaffolding carry over unchanged:
+  - **First boot (cloud-init)**: additionally record the number of non-root NVMe
+    controllers (counted on the fully settled system) to
+    `/var/lib/sct-nvme-fault-inject/expected_controllers`.
+  - **Repro boot (injector unit)**: wait (up to 60s) until that many non-root NVMe
+    controllers are enumerated — closing the ~2.2s-enumeration vs ~3s-unit-start race
+    (see Current State); then `echo 1 > /sys/bus/pci/devices/<addr>/remove` each one.
+    Fail the unit (exit non-zero) if the expected count never shows up or any removal
+    leaves the device present — partial injection must fail loudly, not silently pass
+    (see Current State's "removing fewer than all" bullet). Write the removed PCI
+    addresses to `/run/sct-nvme-fault-inject/removed` for the test's re-enumeration
+    assertions.
+
+**DoD**: unit tests cover the mode gating (default `unbind` output unchanged — existing
+tests pass unmodified), the remove-mode script content (expected-count recording, wait
+loop, `remove` writes, removed-addresses state file, no `unbind` write), and
+`is_applicable` unaffected by mode. ≤200 LOC including tests.
+
+### Phase 6 — NVMe-root test-case, assertions, CI wiring
+
+**Files**: new `test-cases/artifacts/azure-image-nvme-rescan-root.yaml`, new
+`jenkins-pipelines/oss/artifacts/artifacts-azure-image-nvme-rescan-root.jenkinsfile`,
+`artifacts_test.py`.
+
+- Test-case yaml: copy of `azure-image-nvme-rescan.yaml` with
+  `azure_instance_type_db: 'Standard_L8s_v4'` (the scouted, incident-matching
+  NVMe-root SKU) and `nvme_rescan_repro_mode: 'remove'`.
+- `test_nvme_namespace_rescan_repro` gains remove-mode-only assertions (gated on the
+  new option, so the four existing unbind test-cases are unaffected):
+  1. `/run/sct-nvme-fault-inject/removed` is non-empty and its count equals the
+     recorded `/var/lib/sct-nvme-fault-inject/expected_controllers` — all local
+     controllers were injected.
+  2. For every removed PCI address, the current boot's kernel log contains
+     `nvme nvmeX: pci function <addr>` at least twice — once from initial boot
+     enumeration, once from the fix's PCI-bus rescan re-enumerating it. This proves
+     recovery happened via genuine re-enumeration of that address, not a side effect
+     (a single occurrence means either the removal or the rediscovery never happened).
+  - The existing assertions (marker refresh, injector exit 0, "retrying..." →
+    "Found devices:" ordering, image-setup exit 0, scylla up, disk checks) apply as-is.
+- Jenkinsfile: same `artifactsPipeline(...)` shape as
+  `artifacts-azure-image-nvme-rescan.jenkinsfile`, pointing at the new yaml.
+
+**DoD**: config validates; running the new test-case against a scylla-machine-image
+build with `02bb3c74` passes; against a build without it (e.g. `d86a9ae`) fails on the
+"retrying → Found devices" assertion (device never returns). ≤200 LOC.
+
+## 5. Testing Requirements
+
+- Unit test for the new `UserDataObject` (Phase 1 DoD above) — runs in SCT's existing unit
+  test suite, no cloud resources needed.
+- The repro test itself *is* the integration/manual test — it requires a real VM with a
+  local-NVMe instance type on the target backend and is not expected to run in a fast
+  unit-test loop. Run manually via the new Jenkinsfile/test-case (start with one backend,
+  then the rest) before merging the scylla-machine-image fix, then periodically
+  thereafter as a regression guard on each backend.
+- The NVMe-root variant (Phase 6 DoD) must additionally be validated in both directions
+  before it counts as a regression guard: one run against a scylla-machine-image build
+  with `02bb3c74` (must pass) and one against its parent `d86a9ae` (must fail on the
+  recovery assertion).
+- No changes needed to scylla-machine-image's own test suite
+  (`tests/test_scylla_create_devices.py` already covers the mocked control flow).
+
+## 6. Success Criteria
+
+- On each of AWS, Azure, GCE, and OCI: running the new test-case against a
+  scylla-machine-image build **without** the `fix/nvme-namespace-rescan` fix fails
+  deterministically (disk never reappears, service fails/times out).
+- On each of AWS, Azure, GCE, and OCI: running it against a build **with** the fix passes
+  deterministically (disk reappears via PCI-bus rescan, service completes, Scylla
+  starts).
+- The NVMe-root variant (Phases 5–6) fails against pre-`02bb3c74` scylla-machine-image
+  code and passes with it, with kernel-log evidence that every removed controller was
+  re-enumerated by the PCI-bus rescan on the repro boot.
+- No flakiness attributable to the injected fault itself on any backend (only to normal
+  per-backend provisioning flakiness, which is out of scope here).
+
+## 7. Risk Mitigation
+
+- **Scope limitation (accepted)**: unbinding a PCI device removes both the NVMe
+  controller and its namespace — there is no userspace-reachable way to remove only the
+  namespace while leaving the controller present. This test therefore exercises the fix's
+  **PCI-bus-rescan fallback branch** (`rescan_nvme_controllers()`'s `else` path in
+  `common/scylla_create_devices`), not its primary `rescan_controller`-write branch. The
+  primary branch remains covered only by the existing mocked unit tests. Document this
+  explicitly in the new test's docstring so it isn't mistaken for full coverage of the fix.
+  A racy unbind/rebind variant that targets the primary branch was considered and
+  rejected for CI: the kernel's own async namespace scan on driver bind races with the
+  test's injected rescan, so such a test could pass regardless of whether the fix's
+  explicit rescan call did anything.
+  Consider revisiting this and asking the scylla-machine-image maintainers if there's a way to enforce this from the driver's perspective, or reach out to the kernel/cloud-provider teams for a more controlled test harness — a way to reliably reproduce "controller present, namespace missing" without full PCI unbind.
+- **PCI-bus rescan on NVMe-root backends (validated on real hardware, 2026-07-10;
+  covered by Phases 5–6 on Azure)**: the originally-flagged risk — a healthy NVMe root
+  controller's successful `rescan_controller` write causing `rescan_nvme_controllers()`
+  to skip the PCI-bus rescan — was real: it is exactly the production Azure
+  `Standard_L8s_v4` incident (see Problem Statement) and was confirmed live on a
+  scouted L8s_v4 node (root controller rescan brought back 0/4 removed local
+  controllers). scylla-machine-image commit `02bb3c74` removes the short-circuit (the
+  bus rescan now always runs), and the Phase 5–6 remove-mode variant on
+  `Standard_L8s_v4` exists specifically to catch a regression of it. Two honest
+  remainders: (1) coverage is Azure/Hyper-V-vPCI-only — the `remove`+`rescan` primitive
+  was verified on Hyper-V vPCI, not on AWS Nitro or OCI DenseIO NVMe-root shapes, so
+  `nvme_rescan_repro_mode: remove` must not be assumed portable to those backends
+  without the same scouting exercise; (2) the *unbind*-based Phases 1–4 test remains
+  structurally unable to exercise this scenario on any backend — a PCI-bus rescan is a
+  no-op against an unbound-but-still-registered `pci_dev` (verified in run
+  `db-cluster-b0fd0433`), which is precisely why the remove primitive was introduced.
+- **Reboot-based sequencing**: relies on cloud-init's `runcmd` stage running at some point
+  before the *second* boot's fault-inject unit needs to be active — not before the
+  service, only before the reboot, so no strict ordering dependency exists here. This
+  holds identically on all four backends since it's plain systemd/cloud-init behavior,
+  not backend-specific.
+- **Per-backend PCI-device identification (Needs Investigation)**: the injector's
+  "find the non-root NVMe device" step is designed to be mount-point-based and portable,
+  but must be validated against each backend's actual local-NVMe layout during
+  implementation — in particular OCI DenseIO shapes and some AWS instance-store types
+  can expose multiple local NVMe namespaces (see Current State), so the injector must
+  iterate all non-root NVMe PCI devices, not assume a single one, and the test assertions
+  (Phase 3) must tolerate multiple `sct-nvme-fault-inject`-unbound devices being recovered
+  together.
+- **State-reset correctness (Needs Investigation)**: if Phase 1's cleanup of
+  `machine_image_configured` and RAID/mount state is incomplete, `scylla_create_devices`
+  could behave unexpectedly on re-run (e.g. finding a stale RAID array). Confirm exact
+  cleanup steps against `common/scylla_configure.py` during implementation, ideally by
+  diffing on-disk state before/after a real first boot.
+- **Remove primitive is hypervisor-mediated (low likelihood, test-breaking impact)**:
+  `/sys/bus/pci/devices/<addr>/remove` + `/sys/bus/pci/rescan` on Azure goes through
+  Hyper-V vPCI, not bare-metal PCIe hotplug. It behaved exactly like physical hotplug
+  in scouting (3/3 single-device iterations plus a remove-all-4/rescan-once round), but
+  a future Azure host-side change could alter that. The test's assertions fail loudly
+  (injector unit exits non-zero, or re-enumeration lines missing) rather than
+  silently passing, so drift is detectable. Mitigation: keep the scouted behavior
+  documented here; re-scout before porting remove mode to another backend.
+- **Cross-repo coupling**: this test asserts against specific log strings
+  (`"No device names available yet, retrying..."`, `"Found devices:"`) and file paths
+  (`/etc/scylla/machine_image_configured`) owned by scylla-machine-image. If that repo
+  changes wording or paths, this test breaks silently until run. No automated
+  cross-repo contract check exists; rely on scylla-machine-image PR review to flag this
+  test as a consumer of those strings/paths.

--- a/docs/plans/testing/nvme-namespace-rescan-repro-test.md
+++ b/docs/plans/testing/nvme-namespace-rescan-repro-test.md
@@ -2,7 +2,7 @@
 status: draft
 domain: testing
 created: 2026-07-09
-last_updated: 2026-07-10
+last_updated: 2026-07-13
 owner: null
 ---
 
@@ -36,8 +36,8 @@ designed below is likewise generic cloud-init/systemd infrastructure with no
 Azure-specific dependency (see Current State), so this plan targets all four
 backends SCT provisions on: AWS, Azure, GCE, OCI.
 
-Production incidents split into two distinct failure modes, and Phases 1–4's
-unbind-based test covers neither of them exactly:
+Production incidents split into two distinct failure modes, plus a gap this plan's own
+scouting for Phases 1–4 surfaced and which scylla-machine-image has since closed:
 
 - **Controller bound, namespace missing** (OCI incident
   `long-100gb-4h-oci-master-db-node-86f82825`): root disk is SCSI (`8:1`), the single
@@ -56,16 +56,29 @@ unbind-based test covers neither of them exactly:
   by always issuing the PCI-bus rescan unconditionally. Phases 5–6 below add a test
   variant that deterministically resurfaces this NVMe-root failure mode (fails against
   pre-`02bb3c74` code, passes with it).
+- **Controller present on the PCI bus but its driver never (re)bound** (surfaced by
+  this plan's own Phases 1–4 scouting, not an independently-reported production
+  incident): the `unbind`-mode injector's fault - a driverless-but-still-registered
+  `pci_dev` - was originally believed unrecoverable by either of the two branches
+  above (a bus rescan skips slots the kernel already knows, see the "Scope
+  limitation" risk entry's real-hardware verification). scylla-machine-image has since
+  added a third branch, `_unbound_nvme_pci_addresses()` + a `drivers_probe` write,
+  specifically to recover this case. The `unbind`-mode test (Phases 1–4) now serves as
+  the repro/regression test for this branch on all four backends.
 
 ## 2. Current State
 
 - **The fix**: `common/scylla_create_devices` (scylla-machine-image) — `wait_for_devices()`
   retries `_get_fresh_local_disks()` for `device_wait_seconds`, calling
-  `rescan_nvme_controllers()` between attempts. That function writes `1` to each
-  `/sys/class/nvme/nvme*/rescan_controller` if present, else falls back to
-  `echo 1 > /sys/bus/pci/rescan`. On success it prints `"Found devices: [...]"`; while
-  waiting it prints `"No device names available yet, retrying..."`. If `wait_seconds` is
-  falsy, the function returns immediately without retrying (`common/scylla_create_devices`,
+  `rescan_nvme_controllers()` between attempts. That function unconditionally attempts
+  all three of: writing `1` to each `/sys/class/nvme/nvme*/rescan_controller` (bound
+  controllers only); writing each address returned by `_unbound_nvme_pci_addresses()`
+  (NVMe-class PCI functions with no `driver` symlink) to `/sys/bus/pci/drivers_probe`;
+  and `echo 1 > /sys/bus/pci/rescan` (added in commit `02bb3c74`, previously gated
+  behind the other steps' success). On success it prints `"Found devices: [...]"`;
+  while waiting it prints `"No device names available yet, retrying..."`. If
+  `wait_seconds` is falsy, the function returns immediately without retrying
+  (`common/scylla_create_devices`,
   `wait_for_devices`).
 - **`device_wait_seconds` is not test-specific** — it is not set anywhere in
   scylla-machine-image by default (`lib/user_data.py:55-56` defaults to `0`, i.e.
@@ -168,9 +181,10 @@ unbind-based test covers neither of them exactly:
   "NVMe controller present initially, local disk not detected on first pass" condition
   that the fix handles, without relying on actual cloud boot-timing luck.
 - Assert `scylla-image-setup.service` still completes successfully via the fix's recovery
-  path (PCI-bus-rescan fallback branch — see Risk Mitigation for why the primary
-  `rescan_controller` branch is out of scope here) and that Scylla ends up running on the
-  recovered disk, on all four backends.
+  path (the `drivers_probe` branch added to close the unbind-mode gap this plan's
+  scouting surfaced — see Risk Mitigation for why the primary `rescan_controller`
+  branch is out of scope here) and that Scylla ends up running on the recovered disk,
+  on all four backends.
 - Share one fault-injection mechanism and one test-assertion method across all four
   backends (Phases 1 and 3) — only the per-backend test-case config and Jenkinsfile
   (Phases 2 and 4) are backend-specific.
@@ -375,18 +389,26 @@ build with `02bb3c74` passes; against a build without it (e.g. `d86a9ae`) fails 
 
 ## 7. Risk Mitigation
 
-- **Scope limitation (accepted)**: unbinding a PCI device removes both the NVMe
-  controller and its namespace — there is no userspace-reachable way to remove only the
-  namespace while leaving the controller present. This test therefore exercises the fix's
-  **PCI-bus-rescan fallback branch** (`rescan_nvme_controllers()`'s `else` path in
-  `common/scylla_create_devices`), not its primary `rescan_controller`-write branch. The
-  primary branch remains covered only by the existing mocked unit tests. Document this
-  explicitly in the new test's docstring so it isn't mistaken for full coverage of the fix.
-  A racy unbind/rebind variant that targets the primary branch was considered and
-  rejected for CI: the kernel's own async namespace scan on driver bind races with the
-  test's injected rescan, so such a test could pass regardless of whether the fix's
-  explicit rescan call did anything.
-  Consider revisiting this and asking the scylla-machine-image maintainers if there's a way to enforce this from the driver's perspective, or reach out to the kernel/cloud-provider teams for a more controlled test harness — a way to reliably reproduce "controller present, namespace missing" without full PCI unbind.
+- **Scope limitation (accepted, narrowed 2026-07-13)**: unbinding a PCI device removes
+  both the NVMe controller and its namespace — there is no userspace-reachable way to
+  remove only the namespace while leaving the controller present. This test therefore
+  cannot exercise the fix's primary `rescan_controller`-write branch (the "controller
+  bound, namespace missing" scenario) — that branch remains covered only by the
+  existing mocked unit tests. A racy unbind/rebind variant that targets it was
+  considered and rejected for CI: the kernel's own async namespace scan on driver bind
+  races with the test's injected rescan, so such a test could pass regardless of
+  whether the fix's explicit rescan call did anything.
+  What unbinding *does* exercise changed after this plan's original scouting: at the
+  time (run `db-cluster-b0fd0433`), a PCI-bus rescan was confirmed to be a no-op
+  against an unbound-but-still-registered `pci_dev`, so this test was believed to only
+  reach the bus-rescan fallback branch, and to be structurally unable to prove
+  recovery from `unbind` at all. scylla-machine-image subsequently added a dedicated
+  branch closing exactly this gap — `_unbound_nvme_pci_addresses()` walks
+  `/sys/bus/pci/devices/*/class` for NVMe-class PCI functions with no `driver` symlink
+  and writes each address to `/sys/bus/pci/drivers_probe`, asking the driver core to
+  (re)bind it directly. The `unbind`-mode test (Phases 1–4) now exercises that branch
+  specifically, on every backend — it was the real-world gap this plan's scouting
+  surfaced, not a reimplementation of the bus-rescan-fallback scenario.
 - **PCI-bus rescan on NVMe-root backends (validated on real hardware, 2026-07-10;
   covered by Phases 5–6 on Azure)**: the originally-flagged risk — a healthy NVMe root
   controller's successful `rescan_controller` write causing `rescan_nvme_controllers()`
@@ -399,10 +421,12 @@ build with `02bb3c74` passes; against a build without it (e.g. `d86a9ae`) fails 
   remainders: (1) coverage is Azure/Hyper-V-vPCI-only — the `remove`+`rescan` primitive
   was verified on Hyper-V vPCI, not on AWS Nitro or OCI DenseIO NVMe-root shapes, so
   `nvme_rescan_repro_mode: remove` must not be assumed portable to those backends
-  without the same scouting exercise; (2) the *unbind*-based Phases 1–4 test remains
-  structurally unable to exercise this scenario on any backend — a PCI-bus rescan is a
-  no-op against an unbound-but-still-registered `pci_dev` (verified in run
-  `db-cluster-b0fd0433`), which is precisely why the remove primitive was introduced.
+  without the same scouting exercise; (2) `remove` is still the only mode that can
+  exercise the unconditional-bus-rescan branch specifically — a fully-removed
+  `pci_dev` has no sysfs node left for `drivers_probe` to target, so only a real bus
+  rescan can rediscover it. The `unbind`-based Phases 1–4 test now covers a different,
+  previously unfixed branch instead (see the Scope limitation entry above), not this
+  one.
 - **Reboot-based sequencing**: relies on cloud-init's `runcmd` stage running at some point
   before the *second* boot's fault-inject unit needs to be active — not before the
   service, only before the reboot, so no strict ordering dependency exists here. This

--- a/docs/plans/testing/nvme-namespace-rescan-repro-test.md
+++ b/docs/plans/testing/nvme-namespace-rescan-repro-test.md
@@ -429,6 +429,30 @@ build with `02bb3c74` passes; against a build without it (e.g. `d86a9ae`) fails 
   (injector unit exits non-zero, or re-enumeration lines missing) rather than
   silently passing, so drift is detectable. Mitigation: keep the scouted behavior
   documented here; re-scout before porting remove mode to another backend.
+- **Forced scylla-image-setup re-run clobbers `intra_node_comm_public`'s scylla.yaml patch
+  (found and fixed via a real run, 2026-07-11, on `db-cluster-1eb7c0f6`)**: the repro
+  reboot forces `scylla-image-setup.service` — and therefore scylla-machine-image's
+  `scylla_configure` — to genuinely re-run. `scylla_configure` regenerates
+  `listen_address`/`seed_provider` from its own machine-image defaults (private IP),
+  but never touches `broadcast_address`. Since Azure's two nvme-rescan test-cases set
+  `intra_node_comm_public: true` (the SCT runner runs in AWS and needs a public address
+  to reach the Azure node), the node's *initial* `config_setup()` call had already
+  patched `broadcast_address` to the public IP — a patch that lives only in the running
+  `/etc/scylla/scylla.yaml`, not in anything `scylla_configure` re-derives. The re-run
+  therefore leaves `broadcast_address` (public IP) and `seed_provider`/`listen_address`
+  (private IP, freshly regenerated) disagreeing, and Scylla's own startup validation
+  refuses to start: `Startup failed: std::runtime_error (Use broadcast_address for seeds
+  list)`. Confirmed live: `scylla-image-setup.service` itself succeeded (`exited,
+  status=0/SUCCESS`, all 4 removed controllers recovered and RAID0 rebuilt) — the NVMe
+  fix validation worked correctly — but `scylla-server.service` then failed on this
+  unrelated config mismatch, with no `Restart=` on its unit to retry automatically.
+  Fixed in `test_nvme_namespace_rescan_repro` by re-applying `node.config_setup(...)`
+  (the same patch normal node provisioning applies once) immediately before starting
+  scylla-server, then explicitly calling `node.restart_scylla_server(...)` instead of a
+  passive `wait_db_up()` (which never starts a stopped service). This is a test-design
+  gap specific to combining a forced mid-test `scylla-image-setup` re-run with
+  `intra_node_comm_public` — not a bug in scylla-machine-image's fix, and not backend-
+  general (AWS/GCE/OCI's nvme-rescan test-cases don't set `intra_node_comm_public`).
 - **Cross-repo coupling**: this test asserts against specific log strings
   (`"No device names available yet, retrying..."`, `"Found devices:"`) and file paths
   (`/etc/scylla/machine_image_configured`) owned by scylla-machine-image. If that repo

--- a/jenkins-pipelines/oss/artifacts/artifacts-ami-nvme-rescan.jenkinsfile
+++ b/jenkins-pipelines/oss/artifacts/artifacts-ami-nvme-rescan.jenkinsfile
@@ -1,0 +1,14 @@
+#! groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+artifactsPipeline(
+    test_config: 'test-cases/artifacts/ami-nvme-rescan.yaml',
+    backend: 'aws',
+    provision_type: 'spot',
+
+    timeout: [time: 60, unit: 'MINUTES'],
+    post_behavior_db_nodes: 'destroy',
+    builds_to_keep: '100'
+)

--- a/jenkins-pipelines/oss/artifacts/artifacts-azure-image-nvme-rescan-root.jenkinsfile
+++ b/jenkins-pipelines/oss/artifacts/artifacts-azure-image-nvme-rescan-root.jenkinsfile
@@ -1,0 +1,18 @@
+#! groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+artifactsPipeline(
+    params: params,
+
+    test_config: 'test-cases/artifacts/azure-image-nvme-rescan-root.yaml',
+    backend: 'azure',
+    provision_type: 'spot',
+    availability_zone: 'b', // since on release we have some families which are more available on that zone
+
+    timeout: [time: 160, unit: 'MINUTES'],
+    post_behavior_db_nodes: 'destroy',
+    builds_to_keep: '30',
+    ip_ssh_connections: 'public'
+)

--- a/jenkins-pipelines/oss/artifacts/artifacts-azure-image-nvme-rescan.jenkinsfile
+++ b/jenkins-pipelines/oss/artifacts/artifacts-azure-image-nvme-rescan.jenkinsfile
@@ -1,0 +1,18 @@
+#! groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+artifactsPipeline(
+    params: params,
+
+    test_config: 'test-cases/artifacts/azure-image-nvme-rescan.yaml',
+    backend: 'azure',
+    provision_type: 'spot',
+    availability_zone: 'b', // since on release we have some families which are more available on that zone
+
+    timeout: [time: 160, unit: 'MINUTES'],
+    post_behavior_db_nodes: 'destroy',
+    builds_to_keep: '30',
+    ip_ssh_connections: 'public'
+)

--- a/jenkins-pipelines/oss/artifacts/artifacts-gce-image-nvme-rescan.jenkinsfile
+++ b/jenkins-pipelines/oss/artifacts/artifacts-gce-image-nvme-rescan.jenkinsfile
@@ -1,0 +1,17 @@
+#! groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+artifactsPipeline(
+    params: params,
+
+    test_config: 'test-cases/artifacts/gce-image-nvme-rescan.yaml',
+    backend: 'gce',
+    provision_type: 'spot',
+    gce_datacenter: 'us-central1',
+
+    timeout: [time: 60, unit: 'MINUTES'],
+    post_behavior_db_nodes: 'destroy',
+    builds_to_keep: '30'
+)

--- a/jenkins-pipelines/oss/artifacts/artifacts-oci-image-nvme-rescan.jenkinsfile
+++ b/jenkins-pipelines/oss/artifacts/artifacts-oci-image-nvme-rescan.jenkinsfile
@@ -1,0 +1,15 @@
+#! groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+artifactsPipeline(
+    params: params,
+    test_config: 'test-cases/artifacts/oci-image-nvme-rescan.yaml',
+    backend: 'oci',
+    // NOTE: DenseIO instance shapes are not allowed to be "spot"
+    provision_type: 'on_demand',
+    timeout: [time: 160, unit: 'MINUTES'],
+    post_behavior_db_nodes: 'destroy',
+    builds_to_keep: '30',
+)

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -2250,6 +2250,20 @@ class SCTConfiguration(BaseModel):
     raid_level: int = SctField(
         description="Number of of raid level: 0 - RAID0, 5 - RAID5",
     )
+    nvme_rescan_repro: Boolean = SctField(
+        description="""Inject a fault that unbinds the local/ephemeral NVMe device's PCI function before
+        scylla-image-setup.service on the next boot, reproducing the "NVMe controller present, namespace
+        missing" boot race that scylla-machine-image's rescan_nvme_controllers() fix recovers from. See
+        docs/plans/testing/nvme-namespace-rescan-repro-test.md. Only for db nodes; test-case only.""",
+    )
+    nvme_rescan_repro_mode: String = SctField(
+        description="""Fault primitive for the NVMe namespace-rescan repro test (needs nvme_rescan_repro).
+        'unbind' (default) unbinds the local NVMe PCI function's driver - the "controller present, namespace
+        missing" repro. 'remove' deletes the PCI device entirely - the NVMe-root repro where the local
+        controller is absent from PCI enumeration and only an unconditional PCI-bus rescan can rediscover it
+        (validated on Azure Standard_L8s_v4/Hyper-V vPCI only). See
+        docs/plans/testing/nvme-namespace-rescan-repro-test.md.""",
+    )
     bare_loaders: Boolean = SctField(
         description="Don't install anything but node_exporter to the loaders during cluster setup",
     )

--- a/sdcm/sct_events/events_processes.py
+++ b/sdcm/sct_events/events_processes.py
@@ -184,6 +184,23 @@ def create_default_events_process_registry(log_dir: Union[str, Path]):
     raise RuntimeError("Try to create default EventsProcessRegistry second time")
 
 
+def destroy_default_events_process_registry(_registry: Optional[EventsProcessesRegistry] = None) -> None:
+    """Allow create_default_events_process_registry() to create a fresh default registry again.
+
+    Needed when more than one test runs in the same pytest process (e.g. two ArtifactsTest
+    methods collected into one session) - each test's teardown stops its registry's processes
+    but, without this, the module-level default stays set and the next test's setup hits
+    "Try to create default EventsProcessRegistry second time". Only resets the global if
+    `_registry` actually is the tracked default instance, so tearing down a non-default
+    (e.g. multi-tenant) registry never touches it.
+    """
+    global _EVENTS_PROCESSES  # noqa: PLW0603
+
+    with _EVENTS_PROCESSES_LOCK:
+        if _registry is None or _registry is _EVENTS_PROCESSES:
+            _EVENTS_PROCESSES = None
+
+
 def get_default_events_process_registry(_registry: Optional[EventsProcessesRegistry] = None) -> EventsProcessesRegistry:
     if _registry is not None:
         return _registry
@@ -230,6 +247,7 @@ __all__ = (
     "EventsProcessPipe",
     "EventsProcessesRegistry",
     "create_default_events_process_registry",
+    "destroy_default_events_process_registry",
     "start_events_process",
     "get_events_process",
     "verbose_suppress",

--- a/sdcm/sct_events/setup.py
+++ b/sdcm/sct_events/setup.py
@@ -41,6 +41,7 @@ from sdcm.sct_events.events_processes import (
     EVENTS_GRAFANA_POSTMAN_ID,
     EventsProcessesRegistry,
     create_default_events_process_registry,
+    destroy_default_events_process_registry,
     get_events_process,
     EVENTS_HANDLER_ID,
     EVENTS_COUNTER_ID,
@@ -102,6 +103,10 @@ def stop_events_device(_registry: Optional[EventsProcessesRegistry] = None) -> N
 
     if events_stat:
         LOGGER.info("Statistics of sent/received events (by device): %s", json.dumps(events_stat, indent=4))
+
+    # Let a later test in the same pytest process create a fresh default registry - a no-op
+    # when `_registry` isn't the tracked default (e.g. a multi-tenant registry).
+    destroy_default_events_process_registry(_registry=_registry)
 
 
 def enable_default_filters(sct_config: SCTConfiguration):

--- a/sdcm/sct_provision/region_definition_builder.py
+++ b/sdcm/sct_provision/region_definition_builder.py
@@ -24,6 +24,7 @@ from sdcm.sct_provision.common.types import NodeTypeType
 
 from sdcm.sct_provision.user_data_objects import SctUserDataObject
 from sdcm.sct_provision.user_data_objects.apt_daily_triggers import DisableAptTriggersUserDataObject
+from sdcm.sct_provision.user_data_objects.nvme_fault_inject import NvmeFaultInjectUserDataObject
 from sdcm.sct_provision.user_data_objects.scylla import ScyllaUserDataObject
 from sdcm.sct_provision.user_data_objects.sshd import SshdUserDataObject
 from sdcm.sct_provision.user_data_objects.syslog_ng import SyslogNgUserDataObject, SyslogNgExporterUserDataObject
@@ -233,6 +234,7 @@ class DefinitionBuilder(abc.ABC):
             SshdUserDataObject,
             EnableWaLinuxAgent,
             ScyllaUserDataObject,
+            NvmeFaultInjectUserDataObject,
             DockerUserDataObject,
             SctAgentUserDataObject,
         ]

--- a/sdcm/sct_provision/user_data_objects/nvme_fault_inject.py
+++ b/sdcm/sct_provision/user_data_objects/nvme_fault_inject.py
@@ -38,27 +38,34 @@ class NvmeFaultInjectUserDataObject(SctUserDataObject):
     - 'unbind' (default): unbinds the PCI function's driver, leaving the pci_dev
       registered - simulating the "controller present, namespace missing" boot race.
       Unbinding removes both the NVMe controller and its namespace - there is no
-      userspace-reachable way to remove only the namespace - so this only exercises
-      the fix's PCI-bus-rescan fallback branch, not its primary 'rescan_controller'
-      write branch. NOTE: a PCI-bus rescan cannot rebind an unbound-but-registered
-      pci_dev (pci_scan_slot() skips occupied slots), so on NVMe-root SKUs this mode
-      cannot validate the bus-rescan path at all - use 'remove' there.
+      userspace-reachable way to remove only the namespace. A plain PCI-bus rescan
+      cannot rebind an unbound-but-registered pci_dev (pci_scan_slot() skips occupied
+      slots) - this mode was originally believed structurally unfixable for exactly
+      that reason (verified live, run db-cluster-b0fd0433: 144 retries, zero effect).
+      scylla-machine-image subsequently closed that gap with a dedicated branch,
+      _unbound_nvme_pci_addresses() + a write to /sys/bus/pci/drivers_probe, which
+      explicitly asks the driver core to (re)bind a still-registered-but-driverless
+      PCI function - this mode now exercises exactly that branch. Unlike the bus
+      rescan, drivers_probe operates per-PCI-address and doesn't care whether the SKU
+      is NVMe-root, so this mode is valid on any backend, not just non-NVMe-root ones.
 
     - 'remove': deletes the pci_dev entirely (echo 1 > .../remove) - reproducing the
       Azure Standard_L8s_v4 production incident where the local-disk controller was
       absent from PCI enumeration for the whole boot while the *root* disk's own
       healthy NVMe controller answered rescan_controller writes. Pre-02bb3c74
       scylla-machine-image code short-circuited on that success and never reached the
-      PCI-bus rescan; only the unconditional bus rescan (scylla-machine-image commit
-      02bb3c74) can re-enumerate a removed device. ALL non-root controllers are
-      removed: leaving any survivor keeps get_local_disks() non-empty, so
-      wait_for_devices() succeeds on its first pass, no rescan ever runs, and RAID
-      silently builds on the surviving subset - partial injection is therefore treated
-      as failure. Because the injector unit starts ~3s into boot while controllers
-      enumerate at ~2.2s, the first boot records how many non-root controllers to
-      expect and the injector waits for all of them before removing anything.
-      Verified on Azure Standard_L8s_v4 (Hyper-V vPCI) only - re-scout before using
-      this mode on another backend.
+      PCI-bus rescan. A fully-removed pci_dev has no sysfs node left for
+      drivers_probe to target either - only the unconditional bus rescan
+      (scylla-machine-image commit 02bb3c74) can re-enumerate it, so this mode is
+      still the only way to exercise that third branch specifically. ALL non-root
+      controllers are removed: leaving any survivor keeps get_local_disks()
+      non-empty, so wait_for_devices() succeeds on its first pass, no rescan ever
+      runs, and RAID silently builds on the surviving subset - partial injection is
+      therefore treated as failure. Because the injector unit starts ~3s into boot
+      while controllers enumerate at ~2.2s, the first boot records how many non-root
+      controllers to expect and the injector waits for all of them before removing
+      anything. Verified on Azure Standard_L8s_v4 (Hyper-V vPCI) only - re-scout
+      before using this mode on another backend.
 
     This script runs during the first boot's cloud-init runcmd stage, i.e. after
     scylla-image-setup.service has already completed successfully on that same boot.

--- a/sdcm/sct_provision/user_data_objects/nvme_fault_inject.py
+++ b/sdcm/sct_provision/user_data_objects/nvme_fault_inject.py
@@ -1,0 +1,395 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2026 ScyllaDB
+from dataclasses import dataclass
+
+from sdcm.sct_provision.user_data_objects import SctUserDataObject
+
+
+NVME_FAULT_INJECT_SERVICE = "sct-nvme-fault-inject.service"
+NVME_FAULT_INJECT_SCRIPT = "/usr/local/sbin/sct-nvme-fault-inject.sh"
+NVME_MACHINE_IMAGE_CONFIGURED_MARKER = "/etc/scylla/machine_image_configured"
+# remove mode only: expected non-root controller count, recorded on the settled first
+# boot, read by the injector on the repro boot (see _remove_mode_script).
+NVME_FAULT_INJECT_EXPECTED_CONTROLLERS_FILE = "/var/lib/sct-nvme-fault-inject/expected_controllers"
+# remove mode only: PCI addresses the injector removed on the repro boot, one per line,
+# read by the test's re-enumeration assertions. /run is per-boot by design.
+NVME_FAULT_INJECT_REMOVED_PCI_ADDRS_FILE = "/run/sct-nvme-fault-inject/removed"
+
+
+@dataclass
+class NvmeFaultInjectUserDataObject(SctUserDataObject):
+    """Fault injection for the NVMe namespace-rescan repro test.
+
+    See docs/plans/testing/nvme-namespace-rescan-repro-test.md. Installs a oneshot
+    systemd unit, ordered before scylla-image-setup.service, that breaks the node's
+    local/ephemeral NVMe disk(s) in one of two ways, selected by the
+    'nvme_rescan_repro_mode' test-case option:
+
+    - 'unbind' (default): unbinds the PCI function's driver, leaving the pci_dev
+      registered - simulating the "controller present, namespace missing" boot race.
+      Unbinding removes both the NVMe controller and its namespace - there is no
+      userspace-reachable way to remove only the namespace - so this only exercises
+      the fix's PCI-bus-rescan fallback branch, not its primary 'rescan_controller'
+      write branch. NOTE: a PCI-bus rescan cannot rebind an unbound-but-registered
+      pci_dev (pci_scan_slot() skips occupied slots), so on NVMe-root SKUs this mode
+      cannot validate the bus-rescan path at all - use 'remove' there.
+
+    - 'remove': deletes the pci_dev entirely (echo 1 > .../remove) - reproducing the
+      Azure Standard_L8s_v4 production incident where the local-disk controller was
+      absent from PCI enumeration for the whole boot while the *root* disk's own
+      healthy NVMe controller answered rescan_controller writes. Pre-02bb3c74
+      scylla-machine-image code short-circuited on that success and never reached the
+      PCI-bus rescan; only the unconditional bus rescan (scylla-machine-image commit
+      02bb3c74) can re-enumerate a removed device. ALL non-root controllers are
+      removed: leaving any survivor keeps get_local_disks() non-empty, so
+      wait_for_devices() succeeds on its first pass, no rescan ever runs, and RAID
+      silently builds on the surviving subset - partial injection is therefore treated
+      as failure. Because the injector unit starts ~3s into boot while controllers
+      enumerate at ~2.2s, the first boot records how many non-root controllers to
+      expect and the injector waits for all of them before removing anything.
+      Verified on Azure Standard_L8s_v4 (Hyper-V vPCI) only - re-scout before using
+      this mode on another backend.
+
+    This script runs during the first boot's cloud-init runcmd stage, i.e. after
+    scylla-image-setup.service has already completed successfully on that same boot.
+    It only enables the fault for the *next* boot; it does not reboot the node
+    itself. The test triggers that reboot explicitly so it can observe the recovery
+    deterministically.
+
+    IMPORTANT (ordering): the first-boot cloud-init script must NOT delete the
+    idempotency marker (/etc/scylla/machine_image_configured) or tear down the
+    /var/lib/scylla mount. SCT's generic node-provisioning wait
+    (Node.wait_for_machine_image_configured(), used by every artifacts test's
+    setUp()) only starts polling for that marker *after* cloud-init returns - which
+    is exactly when this first-boot script has already finished. If the marker were
+    removed here it would never reappear before the test body's reboot, so setUp()
+    would time out and fail deterministically before the test method ever runs.
+
+    Instead, the destructive teardown (marker removal, mount/md0 teardown) is
+    performed by the fault-inject systemd unit itself on the *next* boot, ordered
+    Before=local-fs-pre.target (see below) and Before=scylla-image-setup.service.
+    That forces a genuine re-run of scylla-image-setup on that boot while keeping
+    the first boot's node setup intact.
+
+    ORDERING (why Before=local-fs-pre.target, not just Before=scylla-image-setup.service):
+    on the re-run boot, /var/lib/scylla (created by the first boot's successful setup)
+    is mounted by local-fs.target - which completes, by default systemd dependency
+    ordering, before scylla-image-setup.service ever starts (a plain .service unit
+    without DefaultDependencies=no is implicitly ordered After=sysinit.target, which
+    requires local-fs.target). Trying to fault-inject only Before=scylla-image-setup.service
+    therefore means /var/lib/scylla is already actively mounted by the time the
+    injector runs, forcing it to lazily unmount (`umount -l`) a live, busy mount and
+    race scylla_raid_setup's own mount check on the same boot - this raced in practice
+    (device still reported busy) and is why an earlier version of this injector, despite
+    tearing down the mount before its own root-device scan, still misidentified the data
+    device as "root" (it was still visible via findmnt) and still hit "device is busy"
+    when scylla_raid_setup tried to reformat it. Ordering the injector
+    Before=local-fs-pre.target instead runs it before local-fs.target ever attempts
+    the mount in the first place (local-fs-pre.target is systemd's documented hook for
+    "run this before any local filesystem is mounted", see systemd.special(7)) - so
+    there is no live mount to race against at all: the injector deletes the stale
+    mount unit/fstab line and unbinds the device before local-fs.target looks for
+    either. The explicit Before=scylla-image-setup.service ordering is also kept
+    as a second, redundant guarantee independent of this default-dependency chain.
+
+    After=systemd-remount-fs.service is required for the same DefaultDependencies=no
+    reason: without it, this unit can start concurrently with the remount of root
+    from its initial read-only boot state, and its own `rm` of the idempotency marker
+    races that remount. Observed in practice: the unit started at boot+3.15s, root
+    remounted r/w at boot+3.36s, and the unit's `rm` failed with "Read-only file
+    system" and (via set -e) aborted before ever reaching the NVMe unbind loop -
+    silently defeating the whole fault injection.
+    """
+
+    @property
+    def is_applicable(self) -> bool:
+        return self.node_type == "scylla-db" and bool(self.params.get("nvme_rescan_repro"))
+
+    @property
+    def script_to_run(self) -> str:
+        mode = self.params.get("nvme_rescan_repro_mode") or "unbind"
+        if mode == "unbind":
+            return self._unbind_mode_script
+        if mode == "remove":
+            return self._remove_mode_script
+        raise ValueError(f"unsupported nvme_rescan_repro_mode: {mode!r} (expected 'unbind' or 'remove')")
+
+    def _service_install_script(self, fault_verb: str) -> str:
+        return f"""
+cat > /etc/systemd/system/{NVME_FAULT_INJECT_SERVICE} <<'SERVICE_EOF'
+[Unit]
+Description=SCT: {fault_verb} local NVMe device before local mounts and scylla-image-setup (fault injection)
+DefaultDependencies=no
+After=systemd-remount-fs.service
+Before=local-fs-pre.target scylla-image-setup.service
+
+[Service]
+Type=oneshot
+ExecStart={NVME_FAULT_INJECT_SCRIPT}
+RemainAfterExit=yes
+
+[Install]
+WantedBy=sysinit.target
+SERVICE_EOF
+
+cat > /etc/systemd/system/scylla-image-setup.service.d/override.conf <<'OVERRIDE_EOF'
+[Unit]
+After={NVME_FAULT_INJECT_SERVICE}
+OVERRIDE_EOF
+
+systemctl daemon-reload
+systemctl enable {NVME_FAULT_INJECT_SERVICE}
+
+# Deliberately DO NOT remove the idempotency marker or tear down /var/lib/scylla
+# here. This first-boot setup completed successfully and must stay intact so SCT's
+# generic setUp() machine-image wait (which starts polling only after cloud-init
+# returns) succeeds. The marker removal and mount teardown happen in
+# {NVME_FAULT_INJECT_SERVICE} on the next boot, right before scylla-image-setup
+# re-runs - see {NVME_FAULT_INJECT_SCRIPT}.
+"""
+
+    @property
+    def _unbind_mode_script(self) -> str:
+        return f"""
+install -d -m 0755 /etc/systemd/system/scylla-image-setup.service.d
+
+cat > {NVME_FAULT_INJECT_SCRIPT} <<'INJECTOR_EOF'
+#!/bin/bash
+# Runs on the *next* boot, ordered Before=local-fs-pre.target (i.e. before any local
+# filesystem, including a leftover /var/lib/scylla from a prior successful boot, is
+# mounted) and Before=scylla-image-setup.service. Removes the idempotency marker and
+# any leftover mount-unit/fstab/RAID state for /var/lib/scylla so scylla-image-setup
+# genuinely re-runs and local-fs.target never (re)mounts it on this boot, then unbinds
+# the PCI function backing any non-root local NVMe namespace. Iterates every NVMe
+# controller, not just the first, since some shapes (OCI DenseIO, AWS instance-store)
+# expose more than one local NVMe namespace.
+#
+# Deliberately does NOT umount /var/lib/scylla: because this unit runs before
+# local-fs-pre.target, the mount never gets (re)activated on this boot in the first
+# place, so there's nothing live to unmount or race against.
+set -euo pipefail
+
+# Force a genuine re-run of scylla_create_devices/scylla-image-setup on this boot -
+# the previous boot's setup completed successfully and must not be skipped via the
+# idempotency marker. Done here (not in first-boot cloud-init) so the marker stays
+# present until this reboot; otherwise SCT's generic setUp() machine-image wait,
+# which only starts polling after cloud-init returns, would time out before the
+# test body ever reboots the node.
+md0_members=$(awk '$1 == "md0" {{for (i=5; i<=NF; i++) {{ sub(/\\[.*/, "", $i); print $i }} }}' /proc/mdstat 2>/dev/null || true)
+
+rm -f {NVME_MACHINE_IMAGE_CONFIGURED_MARKER}
+mdadm --stop /dev/md0 2>/dev/null || true
+for member in $md0_members; do
+    mdadm --zero-superblock "/dev/$member" 2>/dev/null || true
+done
+rm -f /etc/systemd/system/var-lib-scylla.mount
+sed -i '\\#/var/lib/scylla#d' /etc/fstab || true
+systemctl daemon-reload
+
+root_devs=$(findmnt -n -o SOURCE --list | grep -E '^/dev/nvme' || true)
+found=0
+
+for ctrl_path in /sys/class/nvme/nvme*; do
+    [ -e "$ctrl_path" ] || continue
+    ctrl_name=$(basename "$ctrl_path")
+    for ns_path in "$ctrl_path"/nvme*n*; do
+        [ -e "$ns_path" ] || continue
+        ns_name=$(basename "$ns_path")
+        dev="/dev/$ns_name"
+        [ -e "$dev" ] || continue
+
+        is_root=0
+        for root_dev in $root_devs; do
+            case "$root_dev" in
+                "$dev"*) is_root=1 ;;
+            esac
+        done
+        if mount | grep -q "^$dev on / "; then
+            is_root=1
+        fi
+        if [ "$is_root" -eq 1 ]; then
+            echo "sct-nvme-fault-inject: skipping root device $dev"
+            continue
+        fi
+
+        pci_addr=$(basename "$(readlink -f "/sys/class/nvme/$ctrl_name/device")")
+        if [ ! -e "/sys/bus/pci/devices/$pci_addr/driver/unbind" ]; then
+            echo "sct-nvme-fault-inject: no driver bound for $pci_addr, skipping" >&2
+            continue
+        fi
+        echo "sct-nvme-fault-inject: unbinding $ctrl_name (PCI $pci_addr), backs $dev"
+        echo "$pci_addr" > "/sys/bus/pci/devices/$pci_addr/driver/unbind"
+        found=1
+    done
+done
+
+if [ "$found" -eq 0 ]; then
+    echo "sct-nvme-fault-inject: no non-root NVMe device found to unbind" >&2
+    exit 1
+fi
+INJECTOR_EOF
+chmod 0755 {NVME_FAULT_INJECT_SCRIPT}
+{self._service_install_script(fault_verb="unbind")}"""
+
+    @property
+    def _remove_mode_script(self) -> str:
+        return f"""
+install -d -m 0755 /etc/systemd/system/scylla-image-setup.service.d
+
+cat > {NVME_FAULT_INJECT_SCRIPT} <<'INJECTOR_EOF'
+#!/bin/bash
+# Runs on the *next* boot, ordered Before=local-fs-pre.target and
+# Before=scylla-image-setup.service (same teardown rationale as unbind mode - see
+# NvmeFaultInjectUserDataObject). Then, instead of unbinding drivers, fully DELETES
+# the PCI device of every non-root NVMe controller (echo 1 > .../remove) - after
+# which only an unconditional PCI-bus rescan can re-discover them, exactly like the
+# production "controller never enumerated" incident on NVMe-root SKUs.
+#
+# ALL non-root controllers must be removed: any survivor keeps get_local_disks()
+# non-empty, wait_for_devices() succeeds on its first pass without rescanning, and
+# RAID silently builds on the surviving subset - so partial injection exits non-zero.
+# Controllers enumerate at ~2.2s while this unit starts at ~3s, so wait for the
+# non-root controller count recorded on the settled first boot before removing.
+set -euo pipefail
+
+rm -f {NVME_MACHINE_IMAGE_CONFIGURED_MARKER}
+mdadm --stop /dev/md0 2>/dev/null || true
+rm -f /etc/systemd/system/var-lib-scylla.mount
+sed -i '\\#/var/lib/scylla#d' /etc/fstab || true
+systemctl daemon-reload
+
+if [ ! -s {NVME_FAULT_INJECT_EXPECTED_CONTROLLERS_FILE} ]; then
+    echo "sct-nvme-fault-inject: {NVME_FAULT_INJECT_EXPECTED_CONTROLLERS_FILE} missing or empty - first boot never recorded it" >&2
+    exit 1
+fi
+expected=$(cat {NVME_FAULT_INJECT_EXPECTED_CONTROLLERS_FILE})
+if [ "$expected" -le 0 ]; then
+    echo "sct-nvme-fault-inject: first boot recorded $expected non-root NVMe controllers - nothing to inject" >&2
+    exit 1
+fi
+
+root_devs=$(findmnt -n -o SOURCE --list | grep -E '^/dev/nvme' || true)
+
+list_nonroot_nvme() {{
+    # one "pci_addr /dev/nvmeXnY" line per non-root NVMe namespace
+    for ctrl_path in /sys/class/nvme/nvme*; do
+        [ -e "$ctrl_path" ] || continue
+        for ns_path in "$ctrl_path"/nvme*n*; do
+            [ -e "$ns_path" ] || continue
+            dev="/dev/$(basename "$ns_path")"
+            [ -e "$dev" ] || continue
+            is_root=0
+            for root_dev in $root_devs; do
+                case "$root_dev" in
+                    "$dev"*) is_root=1 ;;
+                esac
+            done
+            if mount | grep -q "^$dev on / "; then
+                is_root=1
+            fi
+            if [ "$is_root" -eq 1 ]; then
+                echo "sct-nvme-fault-inject: skipping root device $dev" >&2
+                continue
+            fi
+            echo "$(basename "$(readlink -f "$ctrl_path/device")") $dev"
+        done
+    done
+}}
+
+echo "sct-nvme-fault-inject: waiting for $expected non-root NVMe controllers to enumerate"
+found_count=0
+for _ in $(seq 1 60); do
+    found_count=$(list_nonroot_nvme | awk '{{print $1}}' | sort -u | wc -l)
+    if [ "$found_count" -ge "$expected" ]; then
+        break
+    fi
+    sleep 1
+done
+if [ "$found_count" -lt "$expected" ]; then
+    echo "sct-nvme-fault-inject: only $found_count of $expected non-root NVMe controllers enumerated - partial injection would silently void the repro" >&2
+    exit 1
+fi
+
+# udev's incremental assembly may have re-assembled md0 from members that enumerated
+# after the teardown above; stop it again so the superblocks can be zeroed.
+mdadm --stop /dev/md0 2>/dev/null || true
+list_nonroot_nvme | while read -r pci_addr dev; do
+    mdadm --zero-superblock "$dev" 2>/dev/null || true
+done
+
+target_pci_addrs=$(list_nonroot_nvme | awk '{{print $1}}' | sort -u)
+for pci_addr in $target_pci_addrs; do
+    echo "sct-nvme-fault-inject: removing PCI device $pci_addr"
+    echo 1 > "/sys/bus/pci/devices/$pci_addr/remove"
+done
+
+remaining=1
+for _ in $(seq 1 10); do
+    remaining=0
+    for pci_addr in $target_pci_addrs; do
+        if [ -e "/sys/bus/pci/devices/$pci_addr" ]; then
+            remaining=$((remaining + 1))
+        fi
+    done
+    if [ "$remaining" -eq 0 ]; then
+        break
+    fi
+    sleep 1
+done
+if [ "$remaining" -ne 0 ]; then
+    echo "sct-nvme-fault-inject: $remaining PCI devices still present after remove" >&2
+    exit 1
+fi
+
+install -d -m 0755 $(dirname {NVME_FAULT_INJECT_REMOVED_PCI_ADDRS_FILE})
+printf '%s\\n' $target_pci_addrs > {NVME_FAULT_INJECT_REMOVED_PCI_ADDRS_FILE}
+echo "sct-nvme-fault-inject: removed PCI devices:" $target_pci_addrs
+INJECTOR_EOF
+chmod 0755 {NVME_FAULT_INJECT_SCRIPT}
+{self._service_install_script(fault_verb="remove")}
+# Record how many non-root NVMe controllers the injector must wait for on the repro
+# boot. Counted here, on the fully settled first boot, because on the repro boot the
+# injector starts before late-enumerating controllers appear and has no other way to
+# know it is seeing all of them.
+install -d -m 0755 $(dirname {NVME_FAULT_INJECT_EXPECTED_CONTROLLERS_FILE})
+root_devs=$(findmnt -n -o SOURCE --list | grep -E '^/dev/nvme' || true)
+expected=0
+seen_pci_addrs=""
+for ctrl_path in /sys/class/nvme/nvme*; do
+    [ -e "$ctrl_path" ] || continue
+    for ns_path in "$ctrl_path"/nvme*n*; do
+        [ -e "$ns_path" ] || continue
+        dev="/dev/$(basename "$ns_path")"
+        [ -e "$dev" ] || continue
+        is_root=0
+        for root_dev in $root_devs; do
+            case "$root_dev" in
+                "$dev"*) is_root=1 ;;
+            esac
+        done
+        if [ "$is_root" -eq 1 ]; then
+            continue
+        fi
+        pci_addr=$(basename "$(readlink -f "$ctrl_path/device")")
+        case " $seen_pci_addrs " in
+            *" $pci_addr "*) ;;
+            *)
+                seen_pci_addrs="$seen_pci_addrs $pci_addr"
+                expected=$((expected + 1))
+                ;;
+        esac
+    done
+done
+echo "$expected" > {NVME_FAULT_INJECT_EXPECTED_CONTROLLERS_FILE}
+echo "sct-nvme-fault-inject: recorded $expected non-root NVMe controllers for the repro boot"
+"""

--- a/test-cases/artifacts/ami-nvme-rescan.yaml
+++ b/test-cases/artifacts/ami-nvme-rescan.yaml
@@ -1,0 +1,16 @@
+root_disk_size_db: 50
+backtrace_decoding: false
+cluster_backend: 'aws'
+instance_type_db: 'i4i.large'
+instance_provision: "spot"
+instance_provision_fallback_on_demand: true
+n_db_nodes: 1
+n_loaders: 0
+n_monitor_nodes: 0
+nemesis_class_name: 'NoOpMonkey'
+region_name: 'us-east-1'
+scylla_linux_distro: 'centos'
+test_duration: 60
+user_prefix: 'artifacts-ami-nvme-rescan'
+fallback_to_next_availability_zone: true
+nvme_rescan_repro: true

--- a/test-cases/artifacts/azure-image-nvme-rescan-root.yaml
+++ b/test-cases/artifacts/azure-image-nvme-rescan-root.yaml
@@ -1,0 +1,22 @@
+cluster_backend: 'azure'
+azure_region_name: "eastus"
+use_preinstalled_scylla: true
+backtrace_decoding: false
+# NVMe-root SKU (root disk on its own NVMe controller + four separate local-disk NVMe
+# controllers) - required by nvme_rescan_repro_mode 'remove', which reproduces the
+# Standard_L8s_v4 production incident where only an unconditional PCI-bus rescan can
+# rediscover the local controllers. See docs/plans/testing/nvme-namespace-rescan-repro-test.md.
+azure_instance_type_db: 'Standard_L8s_v4'
+instance_provision: "spot"
+instance_provision_fallback_on_demand: false  # todo lukasz: add support for fallback on demand for azure
+n_db_nodes: 1
+n_loaders: 0
+n_monitor_nodes: 0
+nemesis_class_name: 'NoOpMonkey'
+test_duration: 60
+user_prefix: 'artifacts-azure-image-nvme-rescan-root'
+
+# since running from runner in AWS, we need the address to be publicly available
+intra_node_comm_public: true
+nvme_rescan_repro: true
+nvme_rescan_repro_mode: 'remove'

--- a/test-cases/artifacts/azure-image-nvme-rescan.yaml
+++ b/test-cases/artifacts/azure-image-nvme-rescan.yaml
@@ -1,0 +1,18 @@
+cluster_backend: 'azure'
+azure_region_name: "eastus"
+use_preinstalled_scylla: true
+backtrace_decoding: false
+azure_instance_type_db: 'Standard_L8s_v3'
+#root_disk_size_db: 50
+instance_provision: "spot"
+instance_provision_fallback_on_demand: false  # todo lukasz: add support for fallback on demand for azure
+n_db_nodes: 1
+n_loaders: 0
+n_monitor_nodes: 0
+nemesis_class_name: 'NoOpMonkey'
+test_duration: 60
+user_prefix: 'artifacts-azure-image-nvme-rescan'
+
+# since running from runner in AWS, we need the address to be publicly available
+intra_node_comm_public: true
+nvme_rescan_repro: true

--- a/test-cases/artifacts/gce-image-nvme-rescan.yaml
+++ b/test-cases/artifacts/gce-image-nvme-rescan.yaml
@@ -1,0 +1,17 @@
+cluster_backend: 'gce'
+backtrace_decoding: false
+gce_instance_type_db: 'n2-standard-2'
+gce_root_disk_type_db: 'pd-ssd'
+root_disk_size_db: 50
+gce_n_local_ssd_disk_db: 8
+instance_provision: "spot"
+instance_provision_fallback_on_demand: true
+n_db_nodes: 1
+n_loaders: 0
+n_monitor_nodes: 0
+nemesis_class_name: 'NoOpMonkey'
+scylla_linux_distro: 'centos'
+test_duration: 60
+user_prefix: 'artifacts-gce-image-nvme-rescan'
+fallback_to_next_availability_zone: true
+nvme_rescan_repro: true

--- a/test-cases/artifacts/oci-image-nvme-rescan.yaml
+++ b/test-cases/artifacts/oci-image-nvme-rescan.yaml
@@ -1,0 +1,18 @@
+cluster_backend: "oci"
+oci_region_name: "us-ashburn-1"
+use_preinstalled_scylla: true
+backtrace_decoding: false
+
+oci_instance_type_db: "VM.DenseIO.E5.Flex:8"
+
+# NOTE: DenseIO instance shapes are not allowed to be "spot"
+instance_provision: "on_demand"
+
+instance_provision_fallback_on_demand: true
+n_db_nodes: 1
+n_loaders: 0
+n_monitor_nodes: 0
+nemesis_class_name: 'NoOpMonkey'
+test_duration: 60
+user_prefix: 'artifacts-oci-image-nvme-rescan'
+nvme_rescan_repro: true

--- a/unit_tests/unit/provisioner/test_nvme_fault_inject.py
+++ b/unit_tests/unit/provisioner/test_nvme_fault_inject.py
@@ -1,0 +1,197 @@
+import subprocess
+
+import pytest
+
+from sdcm.sct_provision.user_data_objects.nvme_fault_inject import (
+    NVME_FAULT_INJECT_EXPECTED_CONTROLLERS_FILE,
+    NVME_FAULT_INJECT_REMOVED_PCI_ADDRS_FILE,
+    NVME_FAULT_INJECT_SCRIPT,
+    NVME_FAULT_INJECT_SERVICE,
+    NvmeFaultInjectUserDataObject,
+)
+from sdcm.test_config import TestConfig
+
+
+def _make_object(node_type="scylla-db", nvme_rescan_repro=True, mode=None):
+    params = {"nvme_rescan_repro": nvme_rescan_repro}
+    if mode is not None:
+        params["nvme_rescan_repro_mode"] = mode
+    return NvmeFaultInjectUserDataObject(
+        test_config=TestConfig(),
+        params=params,
+        instance_name="test-instance",
+        node_type=node_type,
+    )
+
+
+def _injector_body(script):
+    start = script.find("INJECTOR_EOF")
+    end = script.find("INJECTOR_EOF", start + 1)
+    assert start != -1 and end != -1
+    return script[start:end]
+
+
+def test_is_applicable_only_for_db_node_with_flag_enabled():
+    assert _make_object(node_type="scylla-db", nvme_rescan_repro=True).is_applicable is True
+
+
+def test_is_not_applicable_when_flag_disabled():
+    assert _make_object(node_type="scylla-db", nvme_rescan_repro=False).is_applicable is False
+
+
+def test_is_not_applicable_when_flag_missing():
+    sud = NvmeFaultInjectUserDataObject(
+        test_config=TestConfig(), params={}, instance_name="test-instance", node_type="scylla-db"
+    )
+    assert sud.is_applicable is False
+
+
+def test_is_not_applicable_for_non_db_node_types():
+    for node_type in ("loader", "monitor"):
+        assert _make_object(node_type=node_type, nvme_rescan_repro=True).is_applicable is False
+
+
+def test_script_installs_and_enables_fault_inject_unit_before_local_mounts_and_image_setup():
+    script = _make_object().script_to_run
+
+    assert f"cat > /etc/systemd/system/{NVME_FAULT_INJECT_SERVICE}" in script
+    # DefaultDependencies=no + Before=local-fs-pre.target is required so this unit runs
+    # before local-fs.target (re)mounts a leftover /var/lib/scylla from a prior boot -
+    # otherwise the injector would have to unmount a live, busy mount and race
+    # scylla_raid_setup's own mount check on the same boot (see docstring/plan doc).
+    assert "DefaultDependencies=no" in script
+    assert "Before=local-fs-pre.target scylla-image-setup.service" in script
+    assert f"ExecStart={NVME_FAULT_INJECT_SCRIPT}" in script
+    assert "WantedBy=sysinit.target" in script
+    assert "cat > /etc/systemd/system/scylla-image-setup.service.d/override.conf" in script
+    assert f"After={NVME_FAULT_INJECT_SERVICE}" in script
+    assert f"systemctl enable {NVME_FAULT_INJECT_SERVICE}" in script
+
+
+def test_marker_teardown_deferred_to_injector_unit_not_first_boot():
+    """The destructive teardown must live inside the fault-inject unit script (which runs
+    on the next boot, before scylla-image-setup), NOT in the first-boot cloud-init script.
+
+    If the marker were removed on the first boot, SCT's generic setUp() machine-image wait
+    (which only starts polling after cloud-init returns) would time out before the test body
+    ever reboots the node. See NvmeFaultInjectUserDataObject docstring.
+    """
+    script = _make_object().script_to_run
+
+    injector_start = script.find("INJECTOR_EOF")
+    injector_end = script.find("INJECTOR_EOF", injector_start + 1)
+    assert injector_start != -1 and injector_end != -1
+    injector_body = script[injector_start:injector_end]
+
+    # teardown lives inside the injector heredoc (next boot)
+    assert "rm -f /etc/scylla/machine_image_configured" in injector_body
+    assert "rm -f /etc/systemd/system/var-lib-scylla.mount" in injector_body
+    assert "mdadm --stop /dev/md0" in injector_body
+    assert "mdadm --zero-superblock" in injector_body
+
+    # no live-mount teardown: the unit runs Before=local-fs-pre.target, so
+    # /var/lib/scylla is never (re)mounted on this boot in the first place - there is
+    # nothing to unmount, so no umount command must appear anywhere in the script.
+    assert "umount -l" not in script
+
+    # ...and NOT in the first-boot cloud-init part (after the injector heredoc closes)
+    first_boot_tail = script[injector_end:]
+    assert "rm -f /etc/scylla/machine_image_configured" not in first_boot_tail
+
+    # the script must never issue a reboot/shutdown itself - the test triggers the reboot
+    assert "systemctl reboot" not in script
+    assert "\nreboot" not in script
+    assert "shutdown" not in script
+
+
+def test_script_captures_raid_members_before_stopping_the_array():
+    script = _make_object().script_to_run
+
+    members_idx = script.find("md0_members=")
+    stop_idx = script.find("mdadm --stop /dev/md0")
+    assert members_idx != -1 and stop_idx != -1
+    assert members_idx < stop_idx, "RAID members must be captured from /proc/mdstat before the array is stopped"
+
+
+def test_injector_script_iterates_all_nvme_controllers_and_skips_root():
+    script = _make_object().script_to_run
+
+    assert "for ctrl_path in /sys/class/nvme/nvme*" in script
+    assert "skipping root device" in script
+    assert "no non-root NVMe device found to unbind" in script
+
+
+def test_default_mode_is_unbind():
+    assert _make_object().script_to_run == _make_object(mode="unbind").script_to_run
+
+
+def test_unknown_mode_raises():
+    with pytest.raises(ValueError, match="nvme_rescan_repro_mode"):
+        _make_object(mode="detach").script_to_run  # noqa: B018
+
+
+def test_remove_mode_script_removes_pci_devices_instead_of_unbinding():
+    injector = _injector_body(_make_object(mode="remove").script_to_run)
+
+    assert '> "/sys/bus/pci/devices/$pci_addr/remove"' in injector
+    assert "driver/unbind" not in injector
+    assert "skipping root device" in injector
+
+
+def test_remove_mode_waits_for_expected_controller_count_and_fails_on_partial_injection():
+    """Removing fewer than all non-root controllers must fail the unit: any survivor keeps
+    get_local_disks() non-empty, so wait_for_devices() succeeds on its first pass without
+    ever rescanning and the repro is silently voided (see plan doc, Current State)."""
+    injector = _injector_body(_make_object(mode="remove").script_to_run)
+
+    assert NVME_FAULT_INJECT_EXPECTED_CONTROLLERS_FILE in injector
+    wait_idx = injector.find("waiting for $expected non-root NVMe controllers")
+    remove_idx = injector.find('> "/sys/bus/pci/devices/$pci_addr/remove"')
+    assert wait_idx != -1 and remove_idx != -1
+    assert wait_idx < remove_idx, "the enumeration wait must happen before any removal"
+    assert "partial injection would silently void the repro" in injector
+    assert "PCI devices still present after remove" in injector
+
+
+def test_remove_mode_records_removed_pci_addresses_for_test_assertions():
+    injector = _injector_body(_make_object(mode="remove").script_to_run)
+
+    assert f"> {NVME_FAULT_INJECT_REMOVED_PCI_ADDRS_FILE}" in injector
+
+
+def test_remove_mode_records_expected_count_on_first_boot_only():
+    script = _make_object(mode="remove").script_to_run
+    first_boot_tail = script[script.find("INJECTOR_EOF", script.find("INJECTOR_EOF") + 1) :]
+
+    assert f'echo "$expected" > {NVME_FAULT_INJECT_EXPECTED_CONTROLLERS_FILE}' in first_boot_tail
+    # same first-boot invariants as unbind mode: marker/mount teardown stays deferred
+    # to the injector unit, and nothing reboots the node
+    assert "rm -f /etc/scylla/machine_image_configured" not in first_boot_tail
+    assert "shutdown" not in script
+    assert "systemctl reboot" not in script
+
+
+def test_remove_mode_keeps_unbind_service_scaffolding():
+    script = _make_object(mode="remove").script_to_run
+
+    assert "DefaultDependencies=no" in script
+    assert "After=systemd-remount-fs.service" in script
+    assert "Before=local-fs-pre.target scylla-image-setup.service" in script
+    assert f"systemctl enable {NVME_FAULT_INJECT_SERVICE}" in script
+    assert "cat > /etc/systemd/system/scylla-image-setup.service.d/override.conf" in script
+
+
+@pytest.mark.parametrize("mode", ["unbind", "remove"], ids=["unbind", "remove"])
+def test_generated_scripts_are_valid_bash(mode, tmp_path):
+    """Both the first-boot cloud-init script (run via `bash -eux`) and the embedded
+    injector heredoc (run via its own #!/bin/bash shebang) must parse."""
+    script = _make_object(mode=mode).script_to_run
+
+    first_boot = tmp_path / "first_boot.sh"
+    first_boot.write_text(script)
+    subprocess.run(["bash", "-n", str(first_boot)], check=True)
+
+    injector = _injector_body(script)
+    injector_file = tmp_path / "injector.sh"
+    injector_file.write_text(injector[injector.find("\n") + 1 :])
+    subprocess.run(["bash", "-n", str(injector_file)], check=True)

--- a/unit_tests/unit/test_sct_events_events_processes.py
+++ b/unit_tests/unit/test_sct_events_events_processes.py
@@ -19,6 +19,7 @@ import pytest
 from sdcm.sct_events.events_processes import (
     EventsProcessesRegistry,
     create_default_events_process_registry,
+    destroy_default_events_process_registry,
     get_default_events_process_registry,
 )
 
@@ -75,3 +76,39 @@ def test_create_default_registry():
     assert registry.log_dir == Path("some_path")
     assert registry.default is True
     assert get_default_events_process_registry() is registry
+
+
+@patch("sdcm.sct_events.events_processes._EVENTS_PROCESSES", None)
+def test_destroy_default_registry_allows_recreation():
+    """Simulates two tests sharing one pytest process: the second test's setup must not hit
+    "Try to create default EventsProcessRegistry second time" once the first test's teardown
+    has destroyed its registry."""
+    first = create_default_events_process_registry(log_dir="some_path")
+
+    destroy_default_events_process_registry(_registry=first)
+
+    second = create_default_events_process_registry(log_dir="some_path")
+    assert second is not first
+    assert get_default_events_process_registry() is second
+
+
+@patch("sdcm.sct_events.events_processes._EVENTS_PROCESSES", None)
+def test_destroy_default_registry_with_none_resets_unconditionally():
+    create_default_events_process_registry(log_dir="some_path")
+
+    destroy_default_events_process_registry(_registry=None)
+
+    with pytest.raises(RuntimeError):
+        get_default_events_process_registry()
+
+
+@patch("sdcm.sct_events.events_processes._EVENTS_PROCESSES", None)
+def test_destroy_default_registry_ignores_non_default_registry():
+    """A multi-tenant (non-default) registry being torn down must never clobber the default
+    one that a different, concurrently-running test still owns."""
+    default_registry = create_default_events_process_registry(log_dir="some_path")
+    other_registry = EventsProcessesRegistry("other_path")
+
+    destroy_default_events_process_registry(_registry=other_registry)
+
+    assert get_default_events_process_registry() is default_registry


### PR DESCRIPTION
## Summary
- Adds a real-hardware repro test (AWS/Azure/GCE/OCI) for scylla-machine-image's `fix/nvme-namespace-rescan` fix, which currently has only mocked unit tests.
- New `NvmeFaultInjectUserDataObject` (gated by a `nvme_rescan_repro` config flag, default off) installs a oneshot systemd unit that unbinds the node's local NVMe PCI function before `scylla-image-setup.service` runs on the *next* boot, simulating the "controller present, namespace missing" boot race.
- New `test_nvme_namespace_rescan_repro` in `artifacts_test.py` reboots the node and asserts recovery via the fix's retry/rescan path (journalctl content, service exit status, disk usability).
- New per-backend test-case yamls and Jenkinsfiles for AWS, Azure, GCE, OCI.
- Design doc: `docs/plans/testing/nvme-namespace-rescan-repro-test.md`.

## Known limitation (flagged for real-hardware validation)
Unbinding a PCI function removes the whole NVMe controller, so this only exercises the fix's PCI-bus-rescan **fallback** branch, not its primary `rescan_controller`-write branch (see plan's Risk Mitigation). There's also an open, unverified risk that on NVMe-root backends (e.g. Nitro-based AWS, possibly OCI) the fallback path might not even be reached, since `rescan_nvme_controllers()` only falls back to a PCI-bus rescan if no *currently present* controller's `rescan_controller` write succeeds — the root controller could satisfy that check first. Recommend landing/validating on AWS or Azure first per the plan's Phase 2 guidance before trusting OCI/AWS results.

## Test plan
- [x] Unit tests for the new `UserDataObject` pass (`unit_tests/unit/provisioner/test_nvme_fault_inject.py`)
- [x] `ruff` / `pre-commit` clean
- [x] All 4 new test-case yamls validate against the config schema
- [ ] Run each Jenkinsfile against a scylla-machine-image build with and without the fix, on all 4 backends, to confirm deterministic fail/pass (not yet done - requires real cloud VMs)