### PR TITLE
fix(error filtering): broaden raft topology closed connection filter

### DIFF
--- a/sdcm/sct_events/group_common_events.py
+++ b/sdcm/sct_events/group_common_events.py
@@ -486,7 +486,10 @@ def ignore_raft_topology_cmd_failing():
             EventsSeverityChangerFilter(
                 new_severity=Severity.WARNING,
                 event_class=DatabaseLogEvent,
-                regex=r".*raft_topology - topology change coordinator fiber got error std::runtime_error.*connection is closed",
+                regex=(
+                    r".*raft_topology - topology change coordinator fiber got error "
+                    r".*connection is closed"
+                ),
                 extra_time_to_expiration=30,
             )
         )


### PR DESCRIPTION
The topology change coordinator may report a closed connection either as std::runtime_error or directly as seastar::rpc::closed_error.

Broaden the existing filter to cover both variants while keeping it limited to topology change coordinator errors caused by a closed connection.

### Testing
Local regexp testing

Fixes: https://scylladb.atlassian.net/browse/SCT-467

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
