### PR TITLE
fix(oci): properly detect the cluster backend in SnitchConfig class

### DIFF
--- a/sdcm/snitch_configuration.py
+++ b/sdcm/snitch_configuration.py
@@ -60,7 +60,7 @@ class SnitchConfig:
 
         with self._node.remote_cassandra_rackdc_properties() as properties_file:
             for key, value in properties.items():
-                if force or hasattr(self._node, "query_oci_metadata"):
+                if force or self._node.parent_cluster.cluster_backend == "oci":
                     # NOTE: OCI images have predefined properties file with real data for dc and rack.
                     #       So, set it forcibly because defaulting will not have an effect.
                     properties_file[key] = value


### PR DESCRIPTION
### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [scylla-staging/valerii/vp-longevity-100gb-4h-oci-test#50](https://argus.scylladb.com/tests/scylla-cluster-tests/ca8957c9-fed8-468b-8c90-eba996b6f44b)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
