### PR TITLE
fix(trigger-matrix): resolve {branch} template from original version, not resolved full tag

### DIFF
--- a/sdcm/utils/trigger_matrix.py
+++ b/sdcm/utils/trigger_matrix.py
@@ -656,6 +656,7 @@ def build_job_parameters(
     defaults: dict,
     scylla_version: str,
     cli_overrides: dict,
+    branch_source_version: str | None = None,
 ) -> dict:
     """Build final parameter dict for a Jenkins job.
 
@@ -664,13 +665,17 @@ def build_job_parameters(
     own backend-specific images from the version.
 
     Template variables in parameter values are resolved:
-      {branch} — extracted from scylla_version (e.g., "master" from "master:latest")
+      {branch} — extracted from branch_source_version (or scylla_version if not provided)
 
     Args:
         job: Job configuration.
         defaults: Default parameters from the matrix.
-        scylla_version: Version string to pass to the job.
+        scylla_version: Version string to pass to the job (typically the resolved full version).
         cli_overrides: CLI-provided parameter overrides.
+        branch_source_version: Original version string used for {branch} template resolution
+            (e.g., "master:latest"). When provided, branch is extracted from this instead of
+            scylla_version. This avoids resolving {branch} to "2026.3" when the original
+            input was "master:latest".
 
     Returns:
         Merged parameter dictionary.
@@ -685,8 +690,9 @@ def build_job_parameters(
     if job.region:
         params.setdefault("region", job.region)
 
-    # Resolve {branch} templates in param values
-    branch = _extract_branch_from_version(scylla_version)
+    # Resolve {branch} templates — use the original version (e.g., "master:latest")
+    # not the resolved full tag (e.g., "2026.3.0~dev-...") which yields "2026.3".
+    branch = _extract_branch_from_version(branch_source_version or scylla_version)
     if branch:
         params = {k: _resolve_templates(v, branch) for k, v in params.items()}
 
@@ -1033,6 +1039,9 @@ def trigger_matrix(  # noqa: PLR0914
     Args:
         matrix_file: Path to the YAML matrix file.
         scylla_version: Full version tag or branch:qualifier.
+        filter_version: Original version string before resolution (e.g., "master:latest").
+            Used for job folder determination and as branch_source_version for {branch}
+            template resolution. When None, scylla_version is used for both.
         job_folder: Override auto-detected job folder.
         labels_selector: Comma-separated labels to filter jobs.
         backend: Filter by backend.
@@ -1091,7 +1100,9 @@ def trigger_matrix(  # noqa: PLR0914
 
     for job in filtered:
         full_path = resolve_job_path(job.job_name, resolved_folder)
-        params = build_job_parameters(job, config.defaults, scylla_version, overrides)
+        params = build_job_parameters(
+            job, config.defaults, scylla_version, overrides, branch_source_version=filter_version
+        )
 
         if job.wait:
             try:

--- a/unit_tests/trigger_matrix/test_rolling_upgrade.py
+++ b/unit_tests/trigger_matrix/test_rolling_upgrade.py
@@ -129,3 +129,34 @@ def test_weekly_label_filter():
     config = load_matrix_config(ROLLING_UPGRADE_YAML)
     weekly_jobs = filter_jobs(config.jobs, scylla_version="master:latest", labels_selector="weekly")
     assert len(weekly_jobs) >= 9
+
+
+def test_branch_source_version_overrides_resolved_version():
+    """When trigger resolves master:latest → 2026.3.0~dev-..., {branch} should still be 'master'."""
+    job = JobConfig(
+        job_name="rolling-upgrade/test",
+        backend="gce",
+        region="us-central1",
+        params={
+            "new_scylla_repo": "http://downloads.scylladb.com.s3.amazonaws.com/unstable/scylla/{branch}/deb/unified/latest/scylladb-{branch}/scylla.list"
+        },
+    )
+    params = build_job_parameters(
+        job, {}, "2026.3.0~dev-0.20260710.9cda315bbab0", {}, branch_source_version="master:latest"
+    )
+    assert params["new_scylla_repo"] == (
+        "http://downloads.scylladb.com.s3.amazonaws.com/unstable/scylla/master/deb/unified/latest/scylladb-master/scylla.list"
+    )
+    assert params["scylla_version"] == "2026.3.0~dev-0.20260710.9cda315bbab0"
+
+
+def test_branch_source_version_none_falls_back_to_scylla_version():
+    """Without branch_source_version, {branch} is still extracted from scylla_version."""
+    job = JobConfig(
+        job_name="rolling-upgrade/test",
+        backend="gce",
+        region="us-central1",
+        params={"new_scylla_repo": "http://repo/{branch}/rpm/scylla.repo"},
+    )
+    params = build_job_parameters(job, {}, "2025.4.1-0.20250601.abc123def456-1", {}, branch_source_version=None)
+    assert params["new_scylla_repo"] == "http://repo/2025.4/rpm/scylla.repo"


### PR DESCRIPTION
## Problem

When the rolling-upgrade trigger runs from the weekly cron schedule with `scylla_version=master:latest`, the CLI resolves it to a full version tag (e.g., `2026.3.0~dev-0.20260710.9cda315bbab0`). 

`build_job_parameters` then extracted `{branch}` from this resolved version, yielding `"2026.3"` — a repo path that **does not exist yet** on downloads.scylladb.com. This caused all triggered rolling-upgrade jobs to get an invalid `new_scylla_repo` URL.

**Observed in:** [rolling-upgrade-trigger build #2](https://jenkins.scylladb.com/job/scylla-master/job/sct_triggers/job/rolling-upgrade-trigger/2/console)

Triggered jobs received:
```
new_scylla_repo=http://downloads.scylladb.com.s3.amazonaws.com/unstable/scylla/2026.3/deb/unified/latest/scylladb-2026.3/scylla.list
```
Instead of:
```
new_scylla_repo=http://downloads.scylladb.com.s3.amazonaws.com/unstable/scylla/master/deb/unified/latest/scylladb-master/scylla.list
```

## Fix

`build_job_parameters` now accepts a `branch_source_version` parameter (the original `"master:latest"`) for `{branch}` template resolution. `trigger_matrix()` passes its existing `filter_version` parameter for this purpose.

This ensures `{branch}` correctly resolves to `"master"` for scheduled weekly runs while still resolving to the numeric branch (e.g., `"2025.4"`) for release-triggered runs that only provide a full version tag.

## Changes

- `sdcm/utils/trigger_matrix.py`: Added `branch_source_version` param to `build_job_parameters`; wired `filter_version` through in `trigger_matrix()`
- `unit_tests/trigger_matrix/test_rolling_upgrade.py`: Added 2 regression tests

## No schedule params missing

The cron schedule is correct as-is (`scylla_version={branch}:latest` → Jenkins resolves to `master:latest`). The bug was purely in the Python template resolution code.