### PR TITLE
fix(aws-provision): avoid O(cluster_size) SSH sweep during wait_for_init

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1265,12 +1265,7 @@ class BaseNode(AutoSshContainerMixin):
         raise NotImplementedError()
 
     def get_all_ip_addresses(self):
-        public_ipv4_addresses, private_ipv4_addresses = self._refresh_instance_state()
-        public_ipv4_addresses = [to_inet_ntop_format(address) for address in public_ipv4_addresses]
-        private_ipv4_addresses = [to_inet_ntop_format(address) for address in private_ipv4_addresses]
-        return list(
-            set(public_ipv4_addresses + private_ipv4_addresses + [to_inet_ntop_format(self._get_ipv6_ip_address())])
-        )
+        return [ip for ip in (self.private_ip_address, self.public_ip_address, self.ipv6_ip_address) if ip]
 
     def _wait_public_ip(self):
         public_ips, _ = self._refresh_instance_state()
@@ -3556,11 +3551,12 @@ class BaseNode(AutoSshContainerMixin):
             )
             time.sleep(CHECK_NODE_HEALTH_RETRY_DELAY)
 
-    def get_nodes_status(self) -> dict[BaseNode, dict]:
+    def get_nodes_status(self, nodes: list[BaseNode] | None = None) -> dict[BaseNode, dict]:
         nodes_status = {}
         try:
             statuses = self.parent_cluster.get_nodetool_status(verification_node=self)
-            node_ip_map = self.parent_cluster.get_ip_to_node_map()
+            node_ip_map = self.parent_cluster.get_ip_to_node_map(nodes=nodes)
+            partial = nodes is not None
             for dc, dc_status in statuses.items():
                 for node_ip, node_properties in dc_status.items():
                     if node := node_ip_map.get(node_ip):
@@ -3569,9 +3565,8 @@ class BaseNode(AutoSshContainerMixin):
                             "dc": dc,
                             "rack": node_properties["rack"],
                         }
-                    else:  # noqa: PLR5501
-                        if node_ip:
-                            LOGGER.error("Get nodes statuses. Failed to find a node in cluster by IP: %s", node_ip)
+                    elif node_ip and not partial:
+                        LOGGER.error("Get nodes statuses. Failed to find a node in cluster by IP: %s", node_ip)
 
         except Exception as error:  # noqa: BLE001
             ClusterHealthValidatorEvent.NodeStatus(
@@ -4250,9 +4245,14 @@ class BaseCluster:
     def dead_nodes_ip_address_list(self):
         return [node.ip_address for node in self.dead_nodes_list]
 
-    def get_ip_to_node_map(self) -> dict[str, BaseNode]:
-        """returns {ip: node} map for all nodes in cluster to get node by ip"""
-        return {ip: node for node in self.nodes for ip in node.get_all_ip_addresses()}
+    def get_ip_to_node_map(self, nodes: list[BaseNode] | None = None) -> dict[str, BaseNode]:
+        """Returns {ip: node} map for nodes in the cluster.
+
+        Args:
+            nodes: Subset of nodes to include. Defaults to all nodes.
+        """
+        nodes = nodes if nodes is not None else self.nodes
+        return {ip: node for node in nodes for ip in node.get_all_ip_addresses()}
 
     @retrying(n=3, sleep_time=5)
     def get_nodetool_status(
@@ -4372,7 +4372,7 @@ class BaseCluster:
 
     def get_rack_names_per_datacenter_and_rack_idx(self, db_nodes: list[BaseNode] | None = None):
         db_nodes = db_nodes if db_nodes else self.nodes
-        status = db_nodes[0].get_nodes_status()
+        status = db_nodes[0].get_nodes_status(nodes=db_nodes)
 
         # intersection of asked nodes and nodes returned by nodetool status
         # since topology might change during this command execution

--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -2093,6 +2093,13 @@ class BasePodContainer(cluster.BaseNode):
             ],
         )
 
+    def get_all_ip_addresses(self):
+        ips = super().get_all_ip_addresses()
+        if cluster_ip_service := self._cluster_ip_service:
+            if cluster_ip := cluster_ip_service.spec.cluster_ip:
+                ips.append(cluster_ip)
+        return ips
+
     @property
     def k8s_pod_uid(self) -> str:
         try:

--- a/unit_tests/lib/dummy_remote.py
+++ b/unit_tests/lib/dummy_remote.py
@@ -156,6 +156,7 @@ class LocalScyllaClusterDummy(BaseScyllaCluster, BaseCluster):
     def add_nodes(self, *args, **kwargs):
         raise NotImplementedError
 
-    def get_ip_to_node_map(self):
+    def get_ip_to_node_map(self, nodes=None):
         """returns {ip: node} map for all nodes in cluster to get node by ip"""
-        return {node.ip_address: node for node in self.nodes}
+        source = nodes if nodes is not None else self.nodes
+        return {node.ip_address: node for node in source}

--- a/unit_tests/lib/fake_cluster.py
+++ b/unit_tests/lib/fake_cluster.py
@@ -193,6 +193,7 @@ class DummyScyllaCluster(BaseScyllaCluster, BaseCluster):
         self.added_password_suffix = False
         self.log = logging.getLogger(self.name)
 
-    def get_ip_to_node_map(self):
+    def get_ip_to_node_map(self, nodes=None):
         """returns {ip: node} map for all nodes in cluster to get node by ip"""
-        return {node.myname: node for node in self.nodes}
+        source = nodes if nodes is not None else self.nodes
+        return {node.myname: node for node in source}

--- a/unit_tests/unit/test_ip_to_node_map.py
+++ b/unit_tests/unit/test_ip_to_node_map.py
@@ -1,0 +1,71 @@
+from unittest.mock import MagicMock, PropertyMock
+
+from sdcm.cluster import BaseCluster, BaseNode
+
+
+def _make_node(private_ip=None, public_ip=None, ipv6_ip=None):
+    node = MagicMock()
+    type(node).private_ip_address = PropertyMock(return_value=private_ip)
+    type(node).public_ip_address = PropertyMock(return_value=public_ip)
+    type(node).ipv6_ip_address = PropertyMock(return_value=ipv6_ip)
+    node.get_all_ip_addresses.return_value = [ip for ip in (private_ip, public_ip, ipv6_ip) if ip]
+    return node
+
+
+def _call_get_ip_to_node_map(nodes, subset=None):
+    cluster = MagicMock(spec=BaseCluster)
+    cluster.nodes = nodes
+    return BaseCluster.get_ip_to_node_map(cluster, nodes=subset)
+
+
+def test_returns_all_nodes_by_cached_ips():
+    node1 = _make_node(private_ip="10.0.0.1", public_ip="54.0.0.1", ipv6_ip="2001:db8::1")
+    node2 = _make_node(private_ip="10.0.0.2", public_ip="54.0.0.2", ipv6_ip="2001:db8::2")
+
+    result = _call_get_ip_to_node_map([node1, node2])
+
+    assert len(result) == 6
+    assert result["10.0.0.1"] is node1
+    assert result["54.0.0.1"] is node1
+    assert result["2001:db8::1"] is node1
+    assert result["10.0.0.2"] is node2
+    assert result["54.0.0.2"] is node2
+    assert result["2001:db8::2"] is node2
+
+
+def test_subset_returns_only_requested_nodes():
+    node1 = _make_node(private_ip="10.0.0.1", public_ip="54.0.0.1")
+    node2 = _make_node(private_ip="10.0.0.2", public_ip="54.0.0.2")
+    node3 = _make_node(private_ip="10.0.0.3", public_ip="54.0.0.3")
+
+    result = _call_get_ip_to_node_map([node1, node2, node3], subset=[node1, node3])
+
+    assert result["10.0.0.1"] is node1
+    assert result["54.0.0.3"] is node3
+    assert "10.0.0.2" not in result
+    assert "54.0.0.2" not in result
+
+
+def test_none_ips_excluded():
+    node1 = _make_node(private_ip="10.0.0.1", public_ip=None, ipv6_ip="2001:db8::1")
+    node2 = _make_node(private_ip=None, public_ip="54.0.0.2", ipv6_ip=None)
+
+    result = _call_get_ip_to_node_map([node1, node2])
+
+    assert len(result) == 3
+    assert result["10.0.0.1"] is node1
+    assert result["2001:db8::1"] is node1
+    assert result["54.0.0.2"] is node2
+    assert None not in result
+
+
+def test_get_all_ip_addresses_uses_properties_not_refresh():
+    node = MagicMock(spec=BaseNode)
+    type(node).private_ip_address = PropertyMock(return_value="10.0.0.1")
+    type(node).public_ip_address = PropertyMock(return_value="54.0.0.1")
+    type(node).ipv6_ip_address = PropertyMock(return_value="2001:db8::1")
+
+    result = BaseNode.get_all_ip_addresses(node)
+
+    assert set(result) == {"10.0.0.1", "54.0.0.1", "2001:db8::1"}
+    node._refresh_instance_state.assert_not_called()


### PR DESCRIPTION
## Problem

`wait_for_init()` hangs for the full 3h hard-timeout when growing a 40→60 node cluster ([SCT-623](https://scylladb.atlassian.net/browse/SCT-623)).

**Root cause**: Logging a new node's rack info during `wait_for_init` triggers:
`node_rack` → `get_rack_names_per_datacenter_and_rack_idx(db_nodes=[self])` → `get_nodes_status()` → `get_ip_to_node_map()` → `get_all_ip_addresses()` on **every** node → `_refresh_instance_state()` → `refresh_network_interfaces_info()` → SSH `ip -j link` per node.

This is an **O(new_nodes × cluster_size)** SSH sweep. With 60 nodes and ~18.5min per sweep, 9 of 10 new nodes are processed before the 3h timeout fires — even though ScyllaDB itself bootstrapped all 10 nodes within ~2 minutes.

## Fix

### 1. `get_all_ip_addresses()` reimplemented — no more `_refresh_instance_state()`

Returns the node's cached IP properties (`private_ip_address`, `public_ip_address`, `ipv6_ip_address`) instead of calling `_refresh_instance_state()`. These are lazy-cached: populated on first access and only refreshed on explicit `refresh_ip_address()` calls.

K8s nodes override `get_all_ip_addresses()` to also include the service `cluster_ip`.

### 2. `get_ip_to_node_map(nodes=)` — partial node subsets

Accepts an optional `nodes` parameter so callers like `node_rack` (which only needs the joining node) avoid building the full cluster map. Threaded through `get_nodes_status(nodes=)` → `get_rack_names_per_datacenter_and_rack_idx(db_nodes=)`.

## Changes

| File | Change |
|------|--------|
| `sdcm/cluster.py` | `get_all_ip_addresses()` uses cached properties; `get_ip_to_node_map(nodes=)` supports subsets; `get_nodes_status(nodes=)` threads subset |
| `sdcm/cluster_k8s/__init__.py` | Override `get_all_ip_addresses()` to include service `cluster_ip` |
| `unit_tests/lib/dummy_remote.py` | Updated `get_ip_to_node_map` override signature |
| `unit_tests/lib/fake_cluster.py` | Updated `get_ip_to_node_map` override signature |
| `unit_tests/unit/test_ip_to_node_map.py` | 4 tests: cached IPs, subset filtering, None exclusion, no refresh trigger |

## Backends Affected
- [x] AWS - Primary beneficiary (SSH `ip -j link` no longer triggered per node)
- [x] K8S - Override `get_all_ip_addresses()` to preserve `cluster_ip`
- [ ] GCE
- [ ] Azure
- [ ] Docker


[SCT-623]: https://scylladb.atlassian.net/browse/SCT-623?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ