### PR TITLE
fix(cleanup): skip failing steps so one bad region can't abort cleanup

### DIFF
--- a/sdcm/provision/aws/dedicated_host.py
+++ b/sdcm/provision/aws/dedicated_host.py
@@ -25,8 +25,7 @@ import tenacity
 from sdcm.wait import exponential_retry
 from sdcm.utils.aws_region import AwsRegion
 from sdcm.utils.aws_utils import tags_as_ec2_tags
-from sdcm.utils.common import all_aws_regions
-from sdcm.utils.parallel_object import ParallelObject
+from sdcm.utils.common import all_aws_regions, run_per_region_ignore_failures, AWS_SCAN_FAIL_FAST_CONFIG
 from sdcm.test_config import TestConfig
 
 
@@ -161,7 +160,7 @@ class SCTDedicatedHosts:
             if verbose:
                 LOGGER.info('Going to list aws region "%s"', region)
             time.sleep(random.random())
-            client = boto3.client("ec2", region_name=region)
+            client = boto3.client("ec2", region_name=region, config=AWS_SCAN_FAIL_FAST_CONFIG)
             custom_filter = []
             if tags_dict:
                 custom_filter = [
@@ -174,7 +173,7 @@ class SCTDedicatedHosts:
             if verbose:
                 LOGGER.info("%s: done [%s/%s]", region, len(list(hosts.keys())), len(aws_regions))
 
-        ParallelObject(aws_regions, timeout=100, num_workers=len(aws_regions)).run(get_host, ignore_exceptions=False)
+        run_per_region_ignore_failures(aws_regions, get_host, "dedicated hosts")
 
         if not group_as_region:
             hosts = list(itertools.chain(*list(hosts.values())))  # flatten the list of lists

--- a/sdcm/provision/aws/emr_provisioner.py
+++ b/sdcm/provision/aws/emr_provisioner.py
@@ -18,6 +18,7 @@ import time
 
 import boto3
 import botocore
+from botocore.config import Config
 
 from sdcm.utils.aws_region import AwsRegion
 from sdcm.utils.decorators import retrying
@@ -331,7 +332,9 @@ def list_emr_clusters(tags_dict, region_name):
     Returns:
         list: List of matching EMR cluster summaries with cluster IDs.
     """
-    emr_client = boto3.client("emr", region_name=region_name)
+    # fail fast on unreachable regions
+    fail_fast_config = Config(connect_timeout=10, read_timeout=30, retries={"total_max_attempts": 1})
+    emr_client = boto3.client("emr", region_name=region_name, config=fail_fast_config)
     matching_clusters = []
 
     paginator = emr_client.get_paginator("list_clusters")

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -50,6 +50,7 @@ from collections import OrderedDict
 
 import requests
 import boto3
+from botocore.config import Config
 from botocore.exceptions import ClientError
 from mypy_boto3_s3 import S3Client, S3ServiceResource
 from mypy_boto3_ec2 import EC2Client, EC2ServiceResource
@@ -107,6 +108,17 @@ SCYLLA_GCE_IMAGES_PROJECT = "scylla-images"
 CREATE_TABLE_REGEX = re.compile(
     r"CREATE\s+TABLE\s+(?P<keyspace>[^\s.]+)\.(?P<table>[^\s(]+)\s*\([^)]+\)(?P<options>[^;]*)"
 )
+
+AWS_SCAN_FAIL_FAST_CONFIG = Config(connect_timeout=10, read_timeout=30, retries={"total_max_attempts": 1})
+
+
+def run_per_region_ignore_failures(regions, scan_func, resource_name, timeout=100):
+    """Run scan_func per region in parallel; log and skip regions that fail."""
+    results = ParallelObject(regions, timeout=timeout, num_workers=len(regions)).run(scan_func, ignore_exceptions=True)
+    failures = [(res.obj, res.exc) for res in results if res.exc]
+    for region, exc in failures:
+        LOGGER.warning("Failed to scan %s in region %s, skipping: %s", resource_name, region, exc)
+    return failures
 
 
 def deprecation(message):
@@ -768,7 +780,7 @@ def list_load_balancers_aws(tags_dict=None, regions=None, group_as_region=False,
         if verbose:
             LOGGER.info('Going to list aws region "%s"', region)
         time.sleep(random.random())
-        tagging = boto3.client("resourcegroupstaggingapi", region_name=region)
+        tagging = boto3.client("resourcegroupstaggingapi", region_name=region, config=AWS_SCAN_FAIL_FAST_CONFIG)
         paginator = tagging.get_paginator("get_resources")
         tag_filter = [{"Key": key, "Values": [value]} for key, value in tags_dict.items() if key != "NodeType"]
 
@@ -782,9 +794,7 @@ def list_load_balancers_aws(tags_dict=None, regions=None, group_as_region=False,
         if verbose:
             LOGGER.info("%s: done [%s/%s]", region, len(list(load_balancers.keys())), len(aws_regions))
 
-    ParallelObject(aws_regions, timeout=100, num_workers=len(aws_regions)).run(
-        get_load_balancers, ignore_exceptions=False
-    )
+    run_per_region_ignore_failures(aws_regions, get_load_balancers, "load balancers")
 
     if not group_as_region:
         load_balancers = list(itertools.chain(*list(load_balancers.values())))  # flatten the list of lists
@@ -814,7 +824,7 @@ def list_cloudformation_stacks_aws(tags_dict=None, regions=None, group_as_region
         if verbose:
             LOGGER.info('Going to list aws region "%s"', region)
         time.sleep(random.random())
-        tagging = boto3.client("resourcegroupstaggingapi", region_name=region)
+        tagging = boto3.client("resourcegroupstaggingapi", region_name=region, config=AWS_SCAN_FAIL_FAST_CONFIG)
         paginator = tagging.get_paginator("get_resources")
         tag_filter = [{"Key": key, "Values": [value]} for key, value in tags_dict.items() if key != "NodeType"]
 
@@ -826,7 +836,7 @@ def list_cloudformation_stacks_aws(tags_dict=None, regions=None, group_as_region
         if verbose:
             LOGGER.info("%s: done [%s/%s]", region, len(list(cloudformation_stacks.keys())), len(aws_regions))
 
-    ParallelObject(aws_regions, timeout=100, num_workers=len(aws_regions)).run(get_stacks, ignore_exceptions=False)
+    run_per_region_ignore_failures(aws_regions, get_stacks, "CloudFormation stacks")
 
     if not group_as_region:
         cloudformation_stacks = list(
@@ -856,7 +866,7 @@ def list_launch_templates_aws(tags_dict=None, regions=None, verbose=False):
         if verbose:
             LOGGER.info("Going to list AWS region '%s'", region)
         time.sleep(random.random())
-        ec2_client = boto3.client("ec2", region_name=region)
+        ec2_client = boto3.client("ec2", region_name=region, config=AWS_SCAN_FAIL_FAST_CONFIG)
         paginator = ec2_client.get_paginator("describe_launch_templates")
         tags_filters = [{"Name": f"tag:{k}", "Values": [v]} for k, v in tags_dict.items() if k != "NodeType"]
         launch_templates[region] = []
@@ -866,9 +876,7 @@ def list_launch_templates_aws(tags_dict=None, regions=None, verbose=False):
         if verbose:
             LOGGER.info("%s: done [%s/%s]", region, len(launch_templates), len(aws_regions))
 
-    ParallelObject(aws_regions, timeout=120, num_workers=len(aws_regions)).run(
-        get_launch_templates, ignore_exceptions=False
-    )
+    run_per_region_ignore_failures(aws_regions, get_launch_templates, "launch templates", timeout=120)
 
     if verbose:
         total_items = sum([len(value) for value in launch_templates.values()])

--- a/sdcm/utils/resources_cleanup.py
+++ b/sdcm/utils/resources_cleanup.py
@@ -18,6 +18,7 @@ import time
 import ipaddress
 import tempfile
 from collections import defaultdict
+from contextlib import contextmanager
 
 from botocore.exceptions import ClientError
 import boto3
@@ -59,6 +60,7 @@ from sdcm.utils.common import (
     list_placement_groups_aws,
     list_resources_docker,
     list_test_security_groups,
+    run_per_region_ignore_failures,
 )
 from sdcm.utils.parallel_object import ParallelObject
 from sdcm.utils.context_managers import environment
@@ -103,11 +105,23 @@ def clean_cloud_resources(tags_dict, config=None, dry_run=False):
     :param config: instance of the 'SCTConfiguration' class
     :param tags_dict: key-value pairs used for filtering
     :param dry_run: boolean value which defines whether we should really cleanup resources or not
-    :return: None
+    :return: True when the cleanup flow completed, False when neither TestId nor RunByUser tag is
+        provided, None for local K8S backends (no remote resources to clean)
     """
     if "TestId" not in tags_dict and "RunByUser" not in tags_dict:
         LOGGER.error("Can't clean cloud resources, TestId or RunByUser is missing")
         return False
+
+    failures: list[tuple[str, Exception]] = []
+
+    @contextmanager
+    def cleanup_step(name):
+        """Run a cleanup step in isolation so a failure does not stop the rest of the cleanup."""
+        try:
+            yield
+        except Exception as exc:  # noqa: BLE001
+            LOGGER.warning("Cleanup step '%s' failed, skipping: %s", name, exc)
+            failures.append((name, exc))
 
     cluster_backend = config.get("cluster_backend") or ""
     aws_regions = config.region_names
@@ -124,56 +138,82 @@ def clean_cloud_resources(tags_dict, config=None, dry_run=False):
         LOGGER.info("No remote resources are expected in the local K8S setups. Skipping.")
         return
     if cluster_backend in ("k8s-eks", ""):
-        clean_clusters_eks(tags_dict, regions=aws_regions, dry_run=dry_run)
-        clean_launch_templates_aws(tags_dict, regions=aws_regions, dry_run=dry_run)
-        clean_load_balancers_aws(tags_dict, regions=aws_regions, dry_run=dry_run)
-        clean_cloudformation_stacks_aws(tags_dict, regions=aws_regions, dry_run=dry_run)
+        for name, clean_func in (
+            ("EKS clusters", clean_clusters_eks),
+            ("AWS launch templates", clean_launch_templates_aws),
+            ("AWS load balancers", clean_load_balancers_aws),
+            ("AWS CloudFormation stacks", clean_cloudformation_stacks_aws),
+        ):
+            with cleanup_step(name):
+                clean_func(tags_dict, regions=aws_regions, dry_run=dry_run)
     if cluster_backend in ("k8s-gke", ""):
         for project in gce_projects:
             with environment(SCT_GCE_PROJECT=project):
-                clean_clusters_gke(tags_dict, dry_run=dry_run)
-                clean_orphaned_gke_disks(tags_dict, dry_run=dry_run)
+                with cleanup_step("GKE clusters"):
+                    clean_clusters_gke(tags_dict, dry_run=dry_run)
+                with cleanup_step("GKE orphaned disks"):
+                    clean_orphaned_gke_disks(tags_dict, dry_run=dry_run)
 
     if cluster_backend in ("aws", ""):
-        clean_emr_clusters(tags_dict, regions=aws_regions, dry_run=dry_run)
+        with cleanup_step("EMR clusters"):
+            clean_emr_clusters(tags_dict, regions=aws_regions, dry_run=dry_run)
     if cluster_backend in ("aws", "k8s-eks", ""):
-        clean_instances_aws(tags_dict, regions=aws_regions, dry_run=dry_run)
-        if config.region_names:
-            SCTCapacityReservation.get_cr_from_aws(config, force_fetch=True)
-            SCTCapacityReservation.cancel(config)
-        else:
-            SCTCapacityReservation.cancel_all_regions(config.get("test_id"))
-        # cleanup capacity reservations across all regions as region fallback can leave an idle CR in an abandoned region
-        if not dry_run and (test_id := config.get("test_id")):
-            SCTCapacityReservation.cancel_all_regions(test_id)
-        SCTDedicatedHosts.release_by_tags(tags_dict, regions=aws_regions, dry_run=dry_run)
-        clean_elastic_ips_aws(tags_dict, regions=aws_regions, dry_run=dry_run)
-        clean_test_security_groups(tags_dict, regions=aws_regions, dry_run=dry_run)
-        clean_placement_groups_aws(tags_dict, regions=aws_regions, dry_run=dry_run)
+        with cleanup_step("AWS instances"):
+            clean_instances_aws(tags_dict, regions=aws_regions, dry_run=dry_run)
+        with cleanup_step("AWS capacity reservations"):
+            if config.region_names:
+                SCTCapacityReservation.get_cr_from_aws(config, force_fetch=True)
+                SCTCapacityReservation.cancel(config)
+            else:
+                SCTCapacityReservation.cancel_all_regions(config.get("test_id"))
+            # cleanup capacity reservations across all regions as region fallback can leave an idle CR in an abandoned region
+            if not dry_run and (test_id := config.get("test_id")):
+                SCTCapacityReservation.cancel_all_regions(test_id)
+        with cleanup_step("AWS dedicated hosts"):
+            SCTDedicatedHosts.release_by_tags(tags_dict, regions=aws_regions, dry_run=dry_run)
+        for name, clean_func in (
+            ("AWS elastic IPs", clean_elastic_ips_aws),
+            ("AWS security groups", clean_test_security_groups),
+            ("AWS placement groups", clean_placement_groups_aws),
+        ):
+            with cleanup_step(name):
+                clean_func(tags_dict, regions=aws_regions, dry_run=dry_run)
         if cluster_backend == "aws" and not dry_run:
-            clean_aws_kms_alias(tags_dict, aws_regions or all_aws_regions())
+            with cleanup_step("AWS KMS aliases"):
+                clean_aws_kms_alias(tags_dict, aws_regions or all_aws_regions())
         if not dry_run and (test_id := tags_dict.get("TestId")):
             from sdcm.test_config import TestConfig  # noqa: PLC0415  # avoid import cycle at module load
 
-            TestConfig.delete_resolved_placement(test_id)
+            with cleanup_step("AWS resolved placement"):
+                TestConfig.delete_resolved_placement(test_id)
     if cluster_backend in ("gce", "k8s-gke", ""):
         for project in gce_projects:
             with environment(SCT_GCE_PROJECT=project):
-                clean_instances_gce(tags_dict, dry_run=dry_run)
+                with cleanup_step("GCE instances"):
+                    clean_instances_gce(tags_dict, dry_run=dry_run)
     if cluster_backend in ("azure", ""):
         azure_regions = config.get("azure_region_name") or []
-        clean_instances_azure(tags_dict, regions=azure_regions, dry_run=dry_run)
+        with cleanup_step("Azure instances"):
+            clean_instances_azure(tags_dict, regions=azure_regions, dry_run=dry_run)
     # Always clean local Docker resources for all backends (except k8s-local which has no resources)
     # Tests on any backend may create local Docker containers for stress tools, monitoring, etc.
     if not cluster_backend.startswith("k8s-local"):
-        clean_resources_docker(tags_dict, dry_run=dry_run)
+        with cleanup_step("Docker resources"):
+            clean_resources_docker(tags_dict, dry_run=dry_run)
     if cluster_backend in ("xcloud",):
-        clean_clusters_scylla_cloud(tags_dict, config, dry_run=dry_run)
+        with cleanup_step("xcloud clusters"):
+            clean_clusters_scylla_cloud(tags_dict, config, dry_run=dry_run)
     if cluster_backend in ("oci", ""):
-        clean_instances_oci(tags_dict, dry_run=dry_run)
-        clean_orphan_block_volumes_oci(
-            tags_dict=tags_dict,
-            dry_run=dry_run,
+        with cleanup_step("OCI instances"):
+            clean_instances_oci(tags_dict, dry_run=dry_run)
+        with cleanup_step("OCI block volumes"):
+            clean_orphan_block_volumes_oci(tags_dict=tags_dict, dry_run=dry_run)
+
+    if failures:
+        LOGGER.warning(
+            "clean_cloud_resources finished with %d skipped step(s): %s",
+            len(failures),
+            ", ".join(name for name, _ in failures),
         )
     return True
 
@@ -721,7 +761,7 @@ def clean_clusters_eks(tags_dict: dict, regions: list = None, dry_run: bool = Fa
     ParallelObject(eks_clusters_to_clean, timeout=180).run(delete_cluster, ignore_exceptions=True)
 
 
-def clean_emr_clusters(tags_dict: dict, regions: list = None, dry_run: bool = False) -> None:
+def clean_emr_clusters(tags_dict: dict, regions: list = None, dry_run: bool = False) -> list[tuple[str, Exception]]:
     """Discover and terminate EMR clusters matching the given tags.
 
     Args:
@@ -732,11 +772,11 @@ def clean_emr_clusters(tags_dict: dict, regions: list = None, dry_run: bool = Fa
     assert tags_dict, "tags_dict not provided (can't clean all EMR clusters)"
     regions = regions or all_aws_regions()
 
-    for region in regions:
+    def clean_region(region):
         matching_clusters = list_emr_clusters(tags_dict=tags_dict, region_name=region)
         if not matching_clusters:
             LOGGER.info("No EMR clusters to clean up in %s", region)
-            continue
+            return
 
         emr_client = boto3.client("emr", region_name=region)
         for cluster_info in matching_clusters:
@@ -755,6 +795,8 @@ def clean_emr_clusters(tags_dict: dict, regions: list = None, dry_run: bool = Fa
                     LOGGER.info("EMR cluster %s termination initiated", cluster_id)
                 except Exception as exc:  # noqa: BLE001
                     LOGGER.error("Failed to terminate EMR cluster %s: %s", cluster_id, exc)
+
+    return run_per_region_ignore_failures(regions, clean_region, "EMR clusters", timeout=120)
 
 
 def clean_resources_according_post_behavior(params, config, logdir, dry_run=False):

--- a/unit_tests/unit/test_clean_cloud_resources_func.py
+++ b/unit_tests/unit/test_clean_cloud_resources_func.py
@@ -401,3 +401,12 @@ class TestCleanCloudResources:
         params = {"RunByUser": "test", "TestId": "1111", "NodeType": "monitor"}
         res = clean_cloud_resources(params, self.config)
         assert res
+
+    def test_step_failure_does_not_abort_cleanup(self):
+        # SCT-507: a cleanup step that raises (e.g. an unreachable region) must not
+        # abort the whole run; later steps still execute.
+        resources_cleanup.SCTDedicatedHosts.release_by_tags.side_effect = RuntimeError("me-south-1 unreachable")
+        res = clean_cloud_resources({"RunByUser": "test"}, self.config)
+        assert res  # the run completed and did not propagate the exception
+        # clean_elastic_ips_aws runs right after the failing dedicated-hosts step
+        resources_cleanup.clean_elastic_ips_aws.assert_called()

--- a/unit_tests/unit/test_emr_provisioner.py
+++ b/unit_tests/unit/test_emr_provisioner.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import boto3
 import pytest
@@ -207,6 +207,19 @@ def test_list_emr_clusters_by_tags(moto_server, iam_roles):
     clusters_by_test = list_emr_clusters({"TestId": "list-test-001"}, region_name=AWS_REGION)
     assert len(clusters_by_test) >= 1
     assert all(c["Tags"].get("TestId") == "list-test-001" for c in clusters_by_test)
+
+
+def test_list_emr_clusters_uses_fail_fast_client_config():
+    """The EMR client must use fail-fast network settings for unreachable regions."""
+    emr_client = MagicMock()
+    emr_client.get_paginator.return_value.paginate.return_value = []
+
+    with patch("sdcm.provision.aws.emr_provisioner.boto3.client", return_value=emr_client) as mock_client:
+        list_emr_clusters({"RunByUser": "user1"}, region_name="me-south-1")
+
+    config = mock_client.call_args.kwargs["config"]
+    assert config.connect_timeout == 10
+    assert config.retries == {"total_max_attempts": 1}
 
 
 def test_build_instance_groups_default(provisioner):


### PR DESCRIPTION
clean_cloud_resources can run all-regions scan. With no error handling an unreachable region aborts the whole clean-resources sequence (affects EMR clusters, dedicated hosts, launch templates, load balancers and CloudFormation cleanups).

The change fixes this by wrapping every cleanup step in a context manager that logs and skips a failing step instead of aborting, so the remaining steps still run. The scanners that go through all regions and can potentially abort on a dead region (dedicated hosts, launch templates, etc.) also get a fail-fast client config and skip unreachable regions instead.

Fixes: SCT-507

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] local run which was failing so far:
```
❯ SCT_FALLBACK_TO_NEXT_REGION=false ./sct.py clean-resources --clean-runners --user dmytro.kruglov -b aws --dry-run
logged in as arn:aws:sts::797456418907:assumed-role/DeveloperAccessRole/dmytro.kruglov@scylladb.com
New directory created: /home/dmitriy/sct-results/20260712-213111-125896-clean-resources
...
No EMR clusters to clean up in ap-southeast-3
No EMR clusters to clean up in ap-east-1
Failed to scan EMR clusters in region me-south-1, skipping: Connect timeout on endpoint URL: "https://elasticmapreduce.me-south-1.amazonaws.com/"
There are no instances to remove in AWS region eu-south-1
There are no instances to remove in AWS region sa-east-1
...
No SCT Runners were found (Backend: 'aws', Filters: User: 'dmytro.kruglov')
No runners have been terminated
SCT runner cleanup for {'RunByUser': 'dmytro.kruglov', 'CreatedBy': 'SCT'} has been finished
❯
```

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
