### PR TITLE
improvement(scale): Disable scylla-doctor collection in large scale tests

### DIFF
--- a/configurations/scale/scale-180-200.yaml
+++ b/configurations/scale/scale-180-200.yaml
@@ -7,5 +7,6 @@ user_prefix: 'cluster-scale-180-200-test'
 
 # Takes too long on big clusters
 cluster_health_check: false
+use_scylla_doctor_on_failure: false
 
 backtrace_decoding: false

--- a/configurations/scale/scale-40-60.yaml
+++ b/configurations/scale/scale-40-60.yaml
@@ -7,5 +7,6 @@ user_prefix: 'cluster-scale-40-60-test'
 
 # Takes too long on big clusters
 cluster_health_check: false
+use_scylla_doctor_on_failure: false
 
 backtrace_decoding: false

--- a/configurations/scale/scale-450-500.yaml
+++ b/configurations/scale/scale-450-500.yaml
@@ -7,5 +7,6 @@ user_prefix: 'cluster-scale-450-500-test'
 
 # Takes too long on big clusters
 cluster_health_check: false
+use_scylla_doctor_on_failure: false
 
 backtrace_decoding: false


### PR DESCRIPTION
The collection of scylla-doctor metrics takes substantial amount of time in large scale clusters (opened QAINFRA-124) in order to improve it. However, these metrics aren't needed in very big clusters anyway.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
