### PR TITLE
improvement(tester): collect scylla shards from all live nodes in parallel

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -4836,15 +4836,42 @@ class ClusterTester(unittest.TestCase):
 
     def all_nodes_scylla_shards(self):
         all_nodes_shards = defaultdict(list)
-        for node in self.db_cluster.nodes:
+
+        def get_node_shards(node):
             ipv6 = node.ipv6_ip_address if node.ip_address == node.ipv6_ip_address else ""
-            all_nodes_shards["live_nodes"].append(
-                {
-                    "name": node.name,
-                    "ip": f"{node.public_ip_address} | {node.private_ip_address}{f' | {ipv6}' if ipv6 else ''}",
-                    "shards": node.scylla_shards,
-                }
+            return {
+                "name": node.name,
+                "ip": f"{node.public_ip_address} | {node.private_ip_address}{f' | {ipv6}' if ipv6 else ''}",
+                "shards": node.scylla_shards,
+            }
+
+        nodes = list(self.db_cluster.nodes)
+        if nodes:
+            # Collect shards data from all live nodes in parallel. `scylla_shards` runs remote SSH
+            # commands that may take up to a few minutes per node, so a single serial pass over
+            # hundreds of nodes would be prohibitively slow.
+            # ignore_exceptions=True is used deliberately: this data feeds the end-of-test email
+            # report, so one unreachable/slow node must not discard the results of all the others.
+            # The timeout is generous because ParallelObject shares a single timeout budget across
+            # futures (collected in submission order) and, once one future times out, marks all the
+            # remaining uncollected futures as timed-out too - so a tight timeout would cause a
+            # cascade of false failures.
+            results = ParallelObject(objects=nodes, timeout=600, num_workers=min(len(nodes), 100)).run(
+                get_node_shards, ignore_exceptions=True, unpack_objects=True
             )
+            for node, result in zip(nodes, results):
+                if result.exc:
+                    self.log.error("Failed to collect scylla shards for node %s: %s", node.name, result.exc)
+                    ipv6 = node.ipv6_ip_address if node.ip_address == node.ipv6_ip_address else ""
+                    all_nodes_shards["live_nodes"].append(
+                        {
+                            "name": node.name,
+                            "ip": f"{node.public_ip_address} | {node.private_ip_address}{f' | {ipv6}' if ipv6 else ''}",
+                            "shards": "N/A",
+                        }
+                    )
+                else:
+                    all_nodes_shards["live_nodes"].append(result.result)
 
         all_nodes_shards["dead_nodes"] = [asdict(node) for node in self.db_cluster.dead_nodes_list]
 


### PR DESCRIPTION
## Summary

`SCTTester.all_nodes_scylla_shards()` collects per-node shard counts for the end-of-test email report. Each `node.scylla_shards` access runs a remote SSH command (a `grep` on `SCYLLA_ARGS` in the scylla-server sysconfig), which can take up to a few minutes per node. Iterating serially over the nodes made teardown of large clusters (hundreds of nodes) prohibitively slow.

This change collects the data from all live nodes **concurrently** using `ParallelObject`.

## Details

- Extracted the per-node logic into a helper and run it across all nodes with a **capped worker pool** (`min(len(nodes), 100)`) to avoid spawning hundreds of threads and simultaneous SSH sessions.
- `ignore_exceptions=True` — a single slow/unreachable node no longer discards the shard data of every other node. Failed nodes are logged and still listed in the report with `"N/A"` shards.
- Generous `600s` timeout. `ParallelObject` shares one timeout budget across futures collected in submission order, and once one future times out it marks all remaining uncollected futures as timed-out too — so a tight timeout would cascade into false failures for nodes that actually succeeded.

## Testing

- `pre-commit` (ruff / ruff-format) passes on the changed file.

Fixes QAINFRA-125