### PR TITLE
improvement(tester): run scylla-doctor on-failure collection in parallel

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -4036,7 +4036,7 @@ class ClusterTester(unittest.TestCase):
             try:
                 from utils.scylla_doctor import ScyllaDoctor, ScyllaDoctorException  # noqa: PLC0415
 
-                for node in ready_nodes:
+                def run_scylla_doctor_on_node(node):
                     try:
                         doctor = ScyllaDoctor(node=node, test_config=self.test_config, offline_install=True)
                         doctor.install_scylla_doctor()
@@ -4075,7 +4075,23 @@ class ClusterTester(unittest.TestCase):
 
                         self.log.info("Scylla-doctor completed for node %s", node.name)
                     except (ScyllaDoctorException, UnexpectedExit, Failure, AssertionError) as exc:
+                        # Swallow per-node scylla-doctor failures so one bad node does not prevent
+                        # collection from the rest; the outer parallel loop keeps going.
                         self.log.warning("Failed to run scylla-doctor on node %s: %s", node.name, exc)
+
+                # Run scylla-doctor on all nodes in parallel. It installs, runs and downloads results
+                # per node and can take tens of minutes per node, so a serial pass over a large
+                # cluster (e.g. 60 nodes) previously took 40+ minutes. Workers are capped to avoid
+                # spawning an unbounded number of threads/SSH sessions on very large clusters.
+                with ThreadPoolExecutor(max_workers=min(len(ready_nodes), 20)) as executor:
+                    for future in as_completed(
+                        executor.submit(run_scylla_doctor_on_node, node) for node in ready_nodes
+                    ):
+                        # run_scylla_doctor_on_node handles its own errors; guard against unexpected ones.
+                        try:
+                            future.result()
+                        except Exception as exc:  # noqa: BLE001
+                            self.log.warning("Unexpected error running scylla-doctor on a node: %s", exc)
             except Exception as exc:  # noqa: BLE001
                 self.log.warning("Unexpected error when collecting scylla-doctor info: %s", exc)
 


### PR DESCRIPTION
## Summary

When `use_scylla_doctor_on_failure` is enabled, `SCTTester.gather_failure_statistics()` runs scylla-doctor on **every** node in the cluster. Each node's collection installs scylla-doctor, runs it, downloads the vitals/logs (and optionally an analysis phase), which can take tens of minutes per node. The loop ran serially, so on scale tests (~60 nodes) it took **40+ minutes**, and it wasted time even on small clusters.

This change runs scylla-doctor on all ready nodes **concurrently**.

## Details

- Extracted the per-node logic into a `run_scylla_doctor_on_node` helper.
- Submit it for all ready nodes to a `ThreadPoolExecutor`, mirroring the pattern already used for the nodetool `gossipinfo`/`compactionstats` collection earlier in the same method.
- Worker count is capped at `min(len(ready_nodes), 20)` to avoid spawning an unbounded number of threads/SSH sessions on very large clusters.
- Preserves the existing per-node error handling (`ScyllaDoctorException`/`UnexpectedExit`/`Failure`/`AssertionError`) so one failing node does not block collection from the rest, plus the outer guard for unexpected errors.

## Testing

- `pre-commit` (ruff / ruff-format) passes on the changed file.

Fixes QAINFRA-124