### PR TITLE
fix(perf-pipeline): handle non-JSON sub_tests parameter gracefully

### DIFF
--- a/configurations/triggers/perf-regression.yaml
+++ b/configurations/triggers/perf-regression.yaml
@@ -176,7 +176,7 @@ jobs:
     include_versions: ["master"]
     labels: ["alternator-weekly"]
     params:
-      sub_tests: "test_full"
+      sub_tests: '["test_full"]'
 
   # === GCE custom monthly latte ===
 

--- a/vars/perfRegressionParallelPipeline.groovy
+++ b/vars/perfRegressionParallelPipeline.groovy
@@ -305,7 +305,12 @@ def call(Map pipelineParams) {
                         def params_mapping = [:]
                         def sub_tests
                         if (params.sub_tests) {
-                            sub_tests = new JsonSlurperClassic().parseText(params.sub_tests)
+                            try {
+                                sub_tests = new JsonSlurperClassic().parseText(params.sub_tests)
+                            } catch (groovy.json.JsonException e) {
+                                // Fallback: treat as a single, non-JSON sub-test name
+                                sub_tests = [params.sub_tests.trim()]
+                            }
                         } else {
                             sub_tests = [params.test_name]
                         }


### PR DESCRIPTION
Fix the weekly alternator perf trigger entry that passed `sub_tests` as a bare string (`"test_full"`) instead of a JSON array (`'["test_full"]'`), causing `groovy.json.JsonException` when the downstream pipeline tried to parse it.

Additionally, harden `perfRegressionParallelPipeline.groovy` to tolerate both a JSON array and a bare test name by wrapping the JSON parse in a try/catch with a single-element list fallback. This prevents the same class of failure regardless of trigger source (manual rebuild, bookmarked URL, or future trigger-config typo).

### Changes

1. **`configurations/triggers/perf-regression.yaml`** — Fix the alternator-weekly entry: `sub_tests: "test_full"` → `sub_tests: '["test_full"]'`
2. **`vars/perfRegressionParallelPipeline.groovy`** — Wrap `JsonSlurperClassic().parseText(params.sub_tests)` in try/catch, falling back to `[params.sub_tests.trim()]` on `JsonException`

### Testing

- The YAML fix is a data-only change matching the convention used by all other ~30 entries in the same file.
- The Groovy hardening is a pure defensive wrapper — existing valid JSON inputs parse identically; bare strings now gracefully become single-element lists instead of crashing.

Fixes https://scylladb.atlassian.net/browse/SCT-597