### PR TITLE
fix(nemesis): use re.escape for SSL reload log pattern matching

### DIFF
--- a/sdcm/nemesis/__init__.py
+++ b/sdcm/nemesis/__init__.py
@@ -4234,11 +4234,18 @@ class NemesisRunner:
         else:
             context_manager = contextlib.nullcontext()
 
+        # Build a regex pattern that handles multiple Scylla log formats across versions.
+        # Scylla may log the reloaded cert path in different ways:
+        #   - messaging_service - Reloaded {"/etc/scylla/ssl_conf/db.crt"}     (quoted, single file)
+        #   - messaging_service - Reloaded {/etc/scylla/ssl_conf/db.crt}       (unquoted)
+        #   - messaging_service - Reloaded {"/path/db.crt", "/path/db.key"}    (multiple files)
+        # Use re.escape on the path and match it anywhere after "Reloaded".
+        escaped_cert_path = re.escape(ssl_files_location)
+        ssl_reload_pattern = re.compile(rf"messaging_service - Reloaded.*{escaped_cert_path}", re.IGNORECASE)
+
         with context_manager:
             for node in self.cluster.nodes:
-                node_system_logs[node] = node.follow_system_log(
-                    patterns=[f'messaging_service - Reloaded {{"{ssl_files_location}"}}']
-                )
+                node_system_logs[node] = node.follow_system_log(patterns=[ssl_reload_pattern])
                 update_certificate(node)
                 node.remoter.send_files(src=str(node.ssl_conf_dir / TLSAssets.DB_CERT), dst="/tmp")
                 self.actions_log.info(f"Update certificate file on {node.name} node")


### PR DESCRIPTION
## Summary

The `HotReloadingInternodeCertificate` nemesis fails with `LogContentNotFound` on Scylla 2025.1 because `check_ssl_reload_log()` uses an f-string pattern with unescaped regex special characters.

## Root Cause

The pattern `f'messaging_service - Reloaded {{"{ssl_files_location}"}}'}` is passed to `follow_system_log()` which compiles it via `re.compile()`. This has two issues:

1. **Dots in the cert path** (e.g., `db.crt`) match any character in regex
2. **Curly braces** `{}` have special regex meaning — deprecated in Python 3.12+ and erroring in Python 3.14
3. **The pattern is too rigid** — it requires exact `{"/path"}` format, but Scylla versions may log multiple files or use different quoting

## Fix

Replace the raw f-string with a pre-compiled `re.Pattern` that:
- Uses `re.escape()` on the cert path to handle dots, slashes, and special chars safely
- Matches the cert path anywhere after `Reloaded` with a flexible `.*`
- Passes a compiled Pattern object to `follow_system_log()` (already supports `re.Pattern` inputs)

## Testing

- [x] 🟢   master - https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fruch/job/longevity-100gb-4h-fips-test/16/
- [x] 🟢   2025.1 - https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fruch/job/longevity-100gb-4h-fips-test/17/

### Regex pattern validation (Python 3.14):
```python
import re
path = '/etc/scylla/ssl_conf/db.crt'
pattern = re.compile(rf'messaging_service - Reloaded.*{re.escape(path)}', re.IGNORECASE)
# ✅ Matches: messaging_service - Reloaded {"/etc/scylla/ssl_conf/db.crt"}
# ✅ Matches: messaging_service - Reloaded {"/etc/scylla/ssl_conf/db.crt", "/path/db.key"}
# ✅ Matches: messaging_service - Reloaded {/etc/scylla/ssl_conf/db.crt}
```

Fixes https://scylladb.atlassian.net/browse/SCT-414

### PR pre-checks (self review)

- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code