### PR TITLE
feat(nemesis): add an event that signals whether prepare is in progress

### DIFF
--- a/sdcm/nemesis/monkey/add_remove_dc.py
+++ b/sdcm/nemesis/monkey/add_remove_dc.py
@@ -275,6 +275,11 @@ class AddRemoveDcNemesis(NemesisBaseClass):
                 "Skipped for multi-dc scenario (https://github.com/scylladb/scylla-cluster-tests/issues/5369)"
             )
 
+        if self.runner.tester.prepare_phase_active.is_set():
+            raise UnsupportedNemesis(
+                "Skipped during prepare phase, due to stress commands potentially writing to the new DC."
+            )
+
         with ExitStack() as context_manager:
             context_manager.push(self.finalizer)
             self.create_new_dc_keyspace()

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -437,6 +437,7 @@ class ClusterTester(unittest.TestCase):
         super().__init__(methodName=methodName)
         # Initialize test_config (was previously done in TestStatsMixin which was removed)
         self.test_config = TestConfig()
+        self.prepare_phase_active = threading.Event()
 
     def _init_test_duration(self):
         self._stress_duration: int = self.params.get("stress_duration")

--- a/sdcm/utils/loader_utils.py
+++ b/sdcm/utils/loader_utils.py
@@ -282,6 +282,9 @@ class LoaderUtilsMixin:
             # Wait for some data (according to the param in the yaml) to be populated, for multi keyspace need to
             # pay attention to the fact it checks only on keyspace1
             self.db_cluster.wait_total_space_used_per_node(keyspace=None)
+            # Some nemesis should not run during the prepare phase,
+            # so we need to set the flag to let them know the prepare phase is active
+            self.prepare_phase_active.set()
             self.db_cluster.start_nemesis()
 
         # Wait on the queue till all threads come back.
@@ -319,6 +322,8 @@ class LoaderUtilsMixin:
             for node in self.db_cluster.nodes:
                 node.run_nodetool("compact")
             self.wait_no_compactions_running(n=prepare_wait_no_compactions_timeout)
+
+        self.prepare_phase_active.clear()
         self.log.info("Prepare finished")
 
     @staticmethod

--- a/unit_tests/unit/nemesis/monkey/test_add_remove_dc.py
+++ b/unit_tests/unit/nemesis/monkey/test_add_remove_dc.py
@@ -1,5 +1,6 @@
 """Tests for sdcm.nemesis.monkey.add_remove_dc module."""
 
+from threading import Event
 from unittest.mock import MagicMock, call, patch
 
 import pytest
@@ -91,6 +92,7 @@ def runner(base_runner):
     base_runner.cluster.racks = ["rack1"]
     base_runner.cluster.nodes = list(base_runner.cluster.data_nodes)
     base_runner.cluster.is_features_enabled_on_node.return_value = True
+    base_runner.tester.prepare_phase_active = Event()
     base_runner.decommission_nodes = MagicMock()
     base_runner.run_repair = MagicMock()
     base_runner.current_disruption = "AddRemoveDcNemesis"
@@ -118,6 +120,34 @@ def test_disrupt_raises_unsupported_for_multi_region(runner):
     runner.run_repair.assert_not_called()
     runner.decommission_nodes.assert_not_called()
     assert not runner.executed
+
+
+@pytest.mark.parametrize(
+    "prepare_phase_active,error_type,expected_error",
+    [
+        pytest.param(True, UnsupportedNemesis, "prepare phase", id="active"),
+        pytest.param(False, RuntimeError, "workflow started", id="inactive"),
+    ],
+)
+def test_disrupt_prepare_phase_gate(runner, prepare_phase_active, error_type, expected_error):
+    """disrupt() should skip only while the prepare phase event is set."""
+    if prepare_phase_active:
+        runner.tester.prepare_phase_active.set()
+
+    monkey = AddRemoveDcNemesis(runner)
+    monkey.create_new_dc_keyspace = MagicMock(side_effect=RuntimeError("workflow started"))
+
+    with pytest.raises(error_type, match=expected_error):
+        monkey.disrupt()
+
+    if prepare_phase_active:
+        monkey.create_new_dc_keyspace.assert_not_called()
+    else:
+        monkey.create_new_dc_keyspace.assert_called_once_with()
+
+    runner.cluster.add_nodes.assert_not_called()
+    runner.run_repair.assert_not_called()
+    runner.decommission_nodes.assert_not_called()
 
 
 def test_disrupt_updates_replication_and_cleans_new_dc(runner):


### PR DESCRIPTION
Some nemesis should not run during prepare.
For example, AddRemoveDCNemesis, we do not want for it to be in progress when prepare finishes and new stress commands start.

```
PREPARE_WRITE_CMD         STRESS_CMD
writes to DC1             writes to DC1 + DC2 => fail due to RF > nodes
├───────────────────────┤├───────────────────────────────────────>
                 
AddRemoveDCNemesis
        ├─────────────────────────────────────────────────────────>
               Adds DC2
```

Fixes: SCT-505

> [!NOTE]
> Changing the nemesis the add 3 nodes, which would allow writes to not fail would only push the problem later, because when it ends and removes the nodes, those writes will fail: https://argus.scylladb.com/tests/scylla-cluster-tests/e2207ee9-e6e2-4dcd-91af-910949136d3f/sct-events 

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://jenkins.scylladb.com/job/scylla-staging/job/cezar/job/features/job/rf-changes/job/AddRemoveDcNemesis/38/
 Extreme example, since it's the only nemesis selected.

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
