### PR TITLE
fix(perf-regression): add elasticity job schedule

### DIFF
--- a/configurations/triggers/perf-regression.yaml
+++ b/configurations/triggers/perf-regression.yaml
@@ -293,17 +293,20 @@ jobs:
     params:
       sub_tests: '["test_latency_read_with_nemesis", "test_latency_mixed_with_nemesis"]'
 
-  # === Elasticity (3-weekly) ===
+  # === Elasticity (monthly) ===
 
-  - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-elasticity"
+  - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-2.5tb-i8g-elasticity"
     backend: "aws"
     region: "eu-north-1"
-    exclude_versions: ["2024.1", "2024.2", "master"]
-    labels: ["master-3weeks"]
-    params:
-      sub_tests: '["test_latency_mixed_with_nemesis", "test_latency_write_with_nemesis"]'
-
-  - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-elasticity"
-    backend: "aws"
-    region: "eu-north-1"
+    exclude_versions: ["2024.1", "2024.2", "2025.1", "2025.4", "master"]
     labels: []
+    params:
+      sub_tests: '["test_latency_mixed_with_nemesis"]'
+
+  - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-2.5tb-i8g-elasticity"
+    backend: "aws"
+    region: "eu-north-1"
+    include_versions: ["master"]
+    labels: ["master-monthly"]
+    params:
+      sub_tests: '["test_latency_mixed_with_nemesis"]'


### PR DESCRIPTION
Add performance regression testing for elasticity using the i8g.4xlarge instance type and a 2.5T dataset.
- Trigger the job monthly on the master branch.
- Enable on-demand triggers for all 2026+ release branches.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
