### PR TITLE
fix(aws-provision): report config init failures to Argus during provisioning

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -41,7 +41,7 @@ import pytest
 import click
 import yaml
 from rich.table import Table
-from argus.client.sct.types import LogLink
+from argus.client.sct.types import EventsInfo, LogLink
 from argus.client.base import ArgusClientError
 from argus.common.enums import TestStatus
 from argus.common.sct_types import RawEventPayload
@@ -328,39 +328,38 @@ def provision_resources(backend, test_name: str, config: str):
         os.environ["SCT_CLUSTER_BACKEND"] = backend
 
     add_file_logger()
+
+    params = None
+    test_config = None
+
     try:
         params = init_and_verify_sct_config()
-    except Exception as exc:
-        LOGGER.error("Configuration validation failed - aborting the test...", exc_info=True)
-        _report_provision_error_to_argus(backend or os.environ.get("SCT_CLUSTER_BACKEND", "unknown"), exc)
-        sys.exit(1)
-    test_config = get_test_config()
-    test_config.set_test_name(test_name)
-    test_id = params.get("test_id")
-    if not test_id or test_id == "None":
-        raise ValueError("No test_id was provided. Aborting provisioning.")
-    test_config.set_test_id_only(test_id)
-    localhost = LocalHost(user_prefix=params.get("user_prefix"), test_id=test_config.test_id())
+        test_config = get_test_config()
+        test_config.set_test_name(test_name)
+        test_id = params.get("test_id")
+        if not test_id or test_id == "None":
+            raise ValueError("No test_id was provided. Aborting provisioning.")
+        test_config.set_test_id_only(test_id)
+        localhost = LocalHost(user_prefix=params.get("user_prefix"), test_id=test_config.test_id())
 
-    if params.get("logs_transport") == "syslog-ng":
-        click.echo("Provision syslog-ng logging service")
-        test_config.configure_syslogng(localhost)
-    elif params.get("logs_transport") == "vector":
-        click.echo("Provision vector logging service")
-        test_config.configure_vector(localhost)
-    else:
-        click.echo("No need provision logging service")
+        if params.get("logs_transport") == "syslog-ng":
+            click.echo("Provision syslog-ng logging service")
+            test_config.configure_syslogng(localhost)
+        elif params.get("logs_transport") == "vector":
+            click.echo("Provision vector logging service")
+            test_config.configure_vector(localhost)
+        else:
+            click.echo("No need provision logging service")
 
-    agent_config = params.get("agent")
-    if agent_config.get("enabled") and agent_config.get("binary_url"):
-        click.echo("Generate SCT agent API key")
-        test_config.generate_and_save_agent_api_key()
+        agent_config = params.get("agent")
+        if agent_config.get("enabled") and agent_config.get("binary_url"):
+            click.echo("Generate SCT agent API key")
+            test_config.generate_and_save_agent_api_key()
 
-    original_region = " ".join(params.region_names) if params.region_names else None
-    handoff_test_id = params.get("reuse_cluster") or test_id
+        original_region = " ".join(params.region_names) if params.region_names else None
+        handoff_test_id = params.get("reuse_cluster") or test_id
 
-    click.echo(f"Provision {backend} cloud resources")
-    try:
+        click.echo(f"Provision {backend} cloud resources")
         if backend == "aws":
             SCTProvisionLayout(params=params).provision()
             test_config.persist_resolved_placement_if_changed(
@@ -399,8 +398,96 @@ def provision_resources(backend, test_name: str, config: str):
             raise ValueError(f"backend {backend} is not supported")
     except Exception as exc:
         LOGGER.error("Unable to provision resources - aborting the test...", exc_info=True)
-        _report_provision_error_to_argus(backend, exc)
+        _report_provision_error_to_argus(exc, params=params, test_config=test_config, backend=backend)
         sys.exit(1)
+
+
+def _report_provision_error_to_argus(
+    exc: Exception,
+    params: "SCTConfiguration | None",
+    test_config: object | None,
+    backend: str,
+) -> None:
+    """Report a provisioning error to Argus.
+
+    Handles scenarios where params or test_config may not be available yet
+    (e.g., when init_and_verify_sct_config() itself fails).
+    """
+    if test_config is None:
+        test_config = get_test_config()
+
+    # Determine test_id: prefer params, fall back to environment variable
+    test_id = None
+    if params:
+        test_id = params.get("test_id")
+    if not test_id or test_id == "None":
+        test_id = os.environ.get("SCT_TEST_ID")
+
+    if not test_id or test_id == "None":
+        LOGGER.warning("No test_id available - cannot report error to Argus")
+        return
+
+    test_config.set_test_id_only(test_id)
+
+    if params:
+        # params available — use standard init which checks enable_argus
+        try:
+            test_config.init_argus_client(params)
+        except Exception as init_exc:  # noqa: BLE001
+            LOGGER.warning("Failed to initialize Argus client: %s", init_exc)
+            return
+        argus_client = test_config.argus_client()
+    else:
+        # params not available (config init failed) — create client directly
+        # bypassing enable_argus check since we must report the critical error
+        try:
+            argus_client = get_argus_client(run_id=test_id)
+        except Exception as init_exc:  # noqa: BLE001
+            LOGGER.warning("Failed to initialize Argus client: %s", init_exc)
+            return
+
+    # Create and submit error event to Argus
+    error_message = (
+        f"(TestFrameworkEvent Severity.CRITICAL) Failed to provision {backend} resources: {type(exc).__name__}: {exc}"
+    )
+    event_payload: RawEventPayload = {
+        "run_id": str(test_id),
+        "severity": "CRITICAL",
+        "ts": time.time(),
+        "message": error_message,
+        "event_type": "TestFrameworkEvent",
+        "received_timestamp": None,
+        "nemesis_name": None,
+        "duration": None,
+        "node": None,
+        "target_node": None,
+        "known_issue": None,
+        "nemesis_status": None,
+    }
+
+    try:
+        argus_client.submit_event(event_payload)
+        LOGGER.info("Error event submitted to Argus successfully")
+    except Exception as argus_exc:  # noqa: BLE001
+        LOGGER.warning("Failed to submit error event to Argus: %s", argus_exc)
+
+    # Submit events summary so the error appears in the Argus events tab
+    try:
+        events_summary = [EventsInfo(severity="CRITICAL", total_events=1, messages=[error_message])]
+        argus_client.submit_events(events_summary)
+        LOGGER.info("Events summary submitted to Argus successfully")
+    except Exception as summary_exc:  # noqa: BLE001
+        LOGGER.warning("Failed to submit events summary to Argus: %s", summary_exc)
+
+    try:
+        argus_client.set_sct_run_status(TestStatus.TEST_ERROR)
+    except Exception as status_exc:  # noqa: BLE001
+        LOGGER.warning("Failed to set Argus run status: %s", status_exc)
+
+    try:
+        argus_client.finalize_sct_run()
+    except Exception as finalize_exc:  # noqa: BLE001
+        LOGGER.warning("Failed to finalize Argus run: %s", finalize_exc)
 
 
 @cli.command("clean-aws-kms-aliases", help="clean AWS KMS old aliases")

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -4393,14 +4393,20 @@ class SCTConfiguration(BaseModel):
 
         if unified_package := self.get("unified_package"):
             with tempfile.TemporaryDirectory() as tmpdirname:
-                LOCALRUNNER.run(
-                    shell_script_cmd(f"""
-                    cd {tmpdirname}
-                    {curl_with_retry(unified_package, output="./unified_package.tar.gz", follow_redirects=True, fail_early=True)}
-                    tar xvfz ./unified_package.tar.gz
-                    """),
-                    verbose=False,
-                )
+                try:
+                    LOCALRUNNER.run(
+                        shell_script_cmd(f"""
+                        cd {tmpdirname}
+                        {curl_with_retry(unified_package, output="./unified_package.tar.gz", follow_redirects=True, fail_early=True)}
+                        tar xvfz ./unified_package.tar.gz
+                        """),
+                        verbose=False,
+                    )
+                except Exception as exc:
+                    raise FileNotFoundError(
+                        f"Unified package not found or failed to download: {unified_package}. "
+                        f"The URL may not exist or is not accessible."
+                    ) from exc
 
                 scylla_version = next(pathlib.Path(tmpdirname).glob("**/SCYLLA-VERSION-FILE")).read_text()
                 scylla_product = next(pathlib.Path(tmpdirname).glob("**/SCYLLA-PRODUCT-FILE")).read_text()

--- a/unit_tests/unit/test_provision_error_event.py
+++ b/unit_tests/unit/test_provision_error_event.py
@@ -80,3 +80,129 @@ def test_provision_resources_sends_error_event_to_argus():
 
         # Verify TEST_ERROR status was set
         mock_argus_client.set_sct_run_status.assert_called_once()
+
+        # Verify events summary was submitted so the error appears in Argus events tab
+        mock_argus_client.submit_events.assert_called_once()
+        events_summary = mock_argus_client.submit_events.call_args[0][0]
+        assert len(events_summary) == 1
+        assert events_summary[0].severity == "CRITICAL"
+        assert events_summary[0].total_events == 1
+        assert "Failed to provision aws resources" in events_summary[0].messages[0]
+
+        # Verify the run was finalized
+        mock_argus_client.finalize_sct_run.assert_called_once()
+
+
+def test_provision_resources_reports_config_init_failure_to_argus():
+    """Test that provision_resources reports to Argus when init_and_verify_sct_config fails.
+
+    This covers the scenario where the unified package download fails with 404,
+    raising a FileNotFoundError before provisioning even begins.
+    When params is None, get_argus_client is used directly to bypass the
+    enable_argus check that would silently swallow the error with MagicMock.
+    """
+
+    with (
+        patch("sct.init_and_verify_sct_config") as mock_config,
+        patch("sct.get_test_config") as mock_test_config,
+        patch("sct.get_argus_client") as mock_get_argus_client,
+        patch("sct.add_file_logger"),
+        patch.dict(os.environ, {"SCT_TEST_ID": "test-id-67890"}),
+    ):
+        # init_and_verify_sct_config raises FileNotFoundError (unified package 404)
+        config_error = FileNotFoundError(
+            "Unified package not found or failed to download: "
+            "https://downloads.scylladb.com/unstable/scylla/master/relocatable/latest/"
+            "scylla-unified-2026.2.0~dev-0.20260330.x86_64.tar.gz. "
+            "The URL may not exist or is not accessible."
+        )
+        mock_config.side_effect = config_error
+
+        test_config_instance = MagicMock()
+        test_config_instance.test_id.return_value = "test-id-67890"
+        mock_test_config.return_value = test_config_instance
+
+        # Mock get_argus_client to return a real mock client
+        mock_argus_client = MagicMock()
+        mock_get_argus_client.return_value = mock_argus_client
+
+        from sct import provision_resources  # noqa: PLC0415
+
+        runner = CliRunner()
+        result = runner.invoke(provision_resources, ["--backend", "aws", "--test-name", "test"])
+
+        # Verify command exited with error code 1
+        assert result.exit_code == 1
+
+        # Verify get_argus_client was called directly with test_id (not via test_config.init_argus_client)
+        mock_get_argus_client.assert_called_once_with(run_id="test-id-67890")
+
+        # Verify test_config.init_argus_client was NOT called (params is None)
+        test_config_instance.init_argus_client.assert_not_called()
+
+        # Verify test_id was set from environment variable
+        test_config_instance.set_test_id_only.assert_called_with("test-id-67890")
+
+        # Verify submit_event was called on the directly-created client
+        assert mock_argus_client.submit_event.called
+
+        # Get the event payload that was submitted
+        call_args = mock_argus_client.submit_event.call_args
+        event_payload = call_args[0][0] if call_args[0] else call_args[1].get("event_payload")
+
+        # Verify the event payload contains FileNotFoundError details
+        assert event_payload is not None
+        assert event_payload["run_id"] == "test-id-67890"
+        assert event_payload["severity"] == "CRITICAL"
+        assert event_payload["event_type"] == "TestFrameworkEvent"
+        assert "FileNotFoundError" in event_payload["message"]
+        assert "Failed to provision aws resources" in event_payload["message"]
+
+        # Verify TEST_ERROR status was set
+        mock_argus_client.set_sct_run_status.assert_called_once()
+
+        # Verify events summary was submitted so the error appears in Argus events tab
+        mock_argus_client.submit_events.assert_called_once()
+        events_summary = mock_argus_client.submit_events.call_args[0][0]
+        assert len(events_summary) == 1
+        assert events_summary[0].severity == "CRITICAL"
+        assert events_summary[0].total_events == 1
+        assert "FileNotFoundError" in events_summary[0].messages[0]
+
+        # Verify the run was finalized
+        mock_argus_client.finalize_sct_run.assert_called_once()
+
+
+def test_provision_resources_no_argus_report_without_test_id():
+    """Test that Argus reporting is skipped when no test_id is available."""
+
+    with (
+        patch("sct.init_and_verify_sct_config") as mock_config,
+        patch("sct.get_test_config") as mock_test_config,
+        patch("sct.add_file_logger"),
+        patch.dict(os.environ, {}, clear=False),
+    ):
+        # Ensure SCT_TEST_ID is not set
+        os.environ.pop("SCT_TEST_ID", None)
+
+        # init_and_verify_sct_config raises an error
+        mock_config.side_effect = FileNotFoundError("Package not found")
+
+        test_config_instance = MagicMock()
+        mock_argus_client = MagicMock()
+        test_config_instance.argus_client.return_value = mock_argus_client
+        mock_test_config.return_value = test_config_instance
+
+        from sct import provision_resources  # noqa: PLC0415
+
+        runner = CliRunner()
+        result = runner.invoke(provision_resources, ["--backend", "aws", "--test-name", "test"])
+
+        # Verify command exited with error code 1
+        assert result.exit_code == 1
+
+        # Verify argus_client was NOT initialized (no test_id available)
+        test_config_instance.init_argus_client.assert_not_called()
+
+        # Verify submit_event was NOT called
+        assert not mock_argus_client.submit_event.called


### PR DESCRIPTION
When init_and_verify_sct_config() fails during the provisioning phase (e.g., unified package URL returns 404), the error was not reported to Argus because the try/except block only wrapped the provisioning step, not the config initialization. This left test runs in an unknown state in Argus with no error information.

Changes:
- Wrap the entire provisioning flow (config init + resource provisioning) in a single try/except so all failures are caught and reported
- Extract Argus error reporting into _report_provision_error_to_argus() helper that handles missing params by falling back to SCT_TEST_ID env
- Raise FileNotFoundError with a clear message when unified package download fails in get_version_based_on_conf(), replacing the opaque UnexpectedExit from curl exit code 22
- Add unit tests for config init failure and missing test_id scenarios

Task: https://scylladb.atlassian.net/browse/SCT-540

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] AWS provision test
- [x] [longevity](https://argus.scylladb.com/tests/scylla-cluster-tests/858d2f96-7c91-42b4-a28d-8fbf6bda45ed)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
