### PR TITLE
provision/gce: remove unused constants from constants.py

### DIFF
--- a/sdcm/provision/gce/constants.py
+++ b/sdcm/provision/gce/constants.py
@@ -15,39 +15,20 @@
 Constants for GCE provisioning.
 """
 
-# Timeout values (in seconds)
-OPERATION_TIMEOUT = 600  # 10 minutes for general operations
-SPOT_REQUEST_TIMEOUT = 300  # 5 minutes for spot instance requests
-INSTANCE_READY_TIMEOUT = 300  # 5 minutes for instance to be ready
-
-# Instance name constraints
-MAX_INSTANCE_NAME_LENGTH = 63  # GCE maximum instance name length
-INSTANCE_NAME_PATTERN = r"^[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?$"
-
 # Label constraints (GCE labels are more restrictive than AWS tags)
 MAX_LABEL_KEY_LENGTH = 63
 MAX_LABEL_VALUE_LENGTH = 63
-LABEL_KEY_PATTERN = r"^[a-z](?:[-a-z0-9_]{0,62})?$"
-LABEL_VALUE_PATTERN = r"^(?:[-a-z0-9_]{0,63})?$"
 
 # Disk types
 DISK_TYPE_PD_STANDARD = "pd-standard"
-DISK_TYPE_PD_SSD = "pd-ssd"
-DISK_TYPE_PD_BALANCED = "pd-balanced"
 DISK_TYPE_LOCAL_SSD = "local-ssd"
 
 # Disk interfaces
 DISK_INTERFACE_NVME = "NVME"
-DISK_INTERFACE_SCSI = "SCSI"
 
 # Default configurations
 DEFAULT_BOOT_DISK_SIZE_GB = 50
-DEFAULT_ROOT_DISK_TYPE = DISK_TYPE_PD_STANDARD
 
 # Network tags for firewall rules
 NETWORK_TAG_SCT_NETWORK_ONLY = "sct-network-only"
 NETWORK_TAG_SCT_ALLOW_PUBLIC = "sct-allow-public"
-
-# Retry configuration
-MAX_RETRIES = 3
-RETRY_DELAY = 5  # seconds


### PR DESCRIPTION
Remove 13 constants that are not imported or referenced anywhere in the codebase: OPERATION_TIMEOUT, SPOT_REQUEST_TIMEOUT, INSTANCE_READY_TIMEOUT, MAX_INSTANCE_NAME_LENGTH,
INSTANCE_NAME_PATTERN, LABEL_KEY_PATTERN, LABEL_VALUE_PATTERN, DISK_TYPE_PD_SSD, DISK_TYPE_PD_BALANCED, DISK_INTERFACE_SCSI, DEFAULT_ROOT_DISK_TYPE, MAX_RETRIES, RETRY_DELAY.

Fixes: https://scylladb.atlassian.net/browse/SCT-410

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [GCE longevity](https://argus.scylladb.com/tests/scylla-cluster-tests/fe3ddaa7-f23d-40cb-acc8-e51f2f0e2215)
- [x] GCE provision

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
