### PR TITLE
feature(provision/gce): add whole-cluster region fallback on capacity exhaustion

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -354,7 +354,7 @@ pipeline {
                                                         if (curr_params.backend == 'xcloud') {
                                                             echo "Scylla Cloud backend selected: provisioning loader nodes only on ${curr_params.xcloud_provider} cloud provider"
                                                         }
-                                                        if (curr_params.backend == 'xcloud' || curr_params.backend == 'aws' || curr_params.backend == 'azure' || curr_params.backend == 'oci') {
+                                                        if (curr_params.backend == 'xcloud' || curr_params.backend == 'aws' || curr_params.backend == 'gce' || curr_params.backend == 'azure' || curr_params.backend == 'oci') {
                                                             provisionResources(curr_params, builder.region)
                                                         } else if (curr_params.backend.contains('docker')) {
                                                             sh """

--- a/defaults/gce_config.yaml
+++ b/defaults/gce_config.yaml
@@ -1,6 +1,11 @@
 instance_provision: 'spot'
 gce_datacenter: 'us-east1'
 gce_network: 'qa-vpc'
+
+# On capacity exhaustion, retry the next zone in the region, then relocate the whole
+# single-node/single-region cluster to another eligible region (mirrors aws_config.yaml).
+fallback_to_next_availability_zone: true
+fallback_to_next_region: true
 gce_project: '' # empty mean default one, can be overwritten to use different one
 
 gce_image_db: '' # so we can use `scylla_version` as needed

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -4239,7 +4239,7 @@ On capacity errors, automatically retry provisioning in the next available AZ in
 **type:** bool
 
 **backend overrides:**
-- `True`: aws, aws-siren, k8s-local-kind-aws, k8s-eks
+- `True`: aws, gce, aws-siren, gce-siren, k8s-local-kind-aws, k8s-gke, k8s-eks
 
 
 ## **pre_filter_unavailable_availability_zones** / SCT_PRE_FILTER_UNAVAILABLE_AVAILABILITY_ZONES
@@ -4269,7 +4269,7 @@ On capacity errors, after all AZs/zones in the configured region are exhausted, 
 **type:** bool
 
 **backend overrides:**
-- `True`: aws, aws-siren, k8s-local-kind-aws, k8s-eks
+- `True`: aws, gce, aws-siren, gce-siren, k8s-local-kind-aws, k8s-gke, k8s-eks
 
 
 ## **num_nodes_to_rollback** / SCT_NUM_NODES_TO_ROLLBACK

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -4262,7 +4262,7 @@ Before provisioning, probe capacity by launching and terminating one on-demand i
 
 ## **fallback_to_next_region** / SCT_FALLBACK_TO_NEXT_REGION
 
-On capacity errors, after all AZs in the configured region are exhausted, relocate the entire cluster to the next eligible region (should be VPC-peered with the runner region with infra-prepared and AMI available). Only applies during initial setup, to single region tests. AWS-only.
+On capacity errors, after all AZs/zones in the configured region are exhausted, relocate to the next eligible region: a single-region cluster moves as a whole, while in a multi-region test only the exhausted datacenter is relocated (to a region no other datacenter occupies) and the cluster is retried. On AWS the target region should be VPC-peered with the runner region with infra-prepared and AMI available; on GCE the global VPC and global images make any supported region eligible. Only applies during initial setup. Supported backends: AWS, GCE.
 
 **default:** False
 

--- a/docs/plans/mini-plans/2026-07-14-gce-region-fallback.md
+++ b/docs/plans/mini-plans/2026-07-14-gce-region-fallback.md
@@ -1,0 +1,162 @@
+# Mini-Plan: GCE Region Fallback (SCT-296)
+
+**Date:** 2026-07-14
+**Estimated LOC:** ~450 (impl ~250, tests ~200) — **actual: ~1675 across 25 files** (scope grew, see below)
+**Related PR:** [#15427](https://github.com/scylladb/scylla-cluster-tests/pull/15427)
+**Jira:** SCT-296 — Provision/GCE: upfront capacity validation and automatic zone/region fallback
+
+## Status: ✅ DONE
+
+All planned behavior is implemented, unit-tested, and manually verified on real GCE (see
+[test plan](2026-07-16-gce-region-fallback-testplan.md)). The final implementation went beyond the
+original single-region plan; the notable deviations from **Approach** below are:
+
+- **Multi-DC region fallback added** (not just single-region). The original plan rejected multi-DC via
+  `enforce_single_region_gate`; the final design keeps that gate for the *single-region* loop but adds
+  a `provision_with_dc_fallback` loop that relocates only the exhausted DC in a multi-region cluster.
+  A single **router** (`gce/region_fallback.provision_with_fallback`) dispatches single- vs multi-DC.
+- **Centralized, backend-agnostic loop.** The fallback control flow lives in a new
+  `sdcm/provision/common/region_fallback.py` (shared shape ready for OCI/Azure/AWS), with a thin GCE
+  binding in `sdcm/provision/gce/region_fallback.py`. Both the legacy tester path and the modern
+  `provision_sct_resources` path delegate to the same router.
+- **Enable-gate moved to a leaf module.** `is_az_fallback_enabled` / `is_region_fallback_enabled` were
+  moved out of `aws/az_resolver.py` into `sdcm/provision/common/fallback.py` so neither backend imports
+  the other's package; `is_region_fallback_enabled` now accepts `("aws", "gce")`.
+- **Lazy candidate resolution.** `get_region_fallback_candidates` / `get_dc_fallback_candidates` are
+  generators — candidates are resolved only after the configured placement is exhausted, and each
+  region's zone/machine-type availability is probed only when the loop reaches it (a run that
+  provisions in its configured placement never probes other regions).
+- **Concurrent cleanup.** Exhausted-region instances are deleted concurrently (was serial), so a
+  `wait=True` cleanup before relocating no longer serializes slow per-instance deletes.
+- **Placement handoff for the split pipeline.** The modern path persists the relocated placement
+  (`persist_resolved_placement_if_changed`) and the run step re-applies it for GCE
+  (`_apply_resolved_placement`), so a `provision-resources` relocation is picked up by a later
+  `run-test`, mirroring AWS.
+- **Enabled by default for GCE** (`defaults/gce_config.yaml`) and the **Jenkins provision step now runs
+  for the gce backend**, so the modern path is exercised in CI.
+- Modern path is wired as `provision_sct_resources` → `_provision_gce_resources` (folds resolve +
+  fallback + handoff), rather than a separate top-level `provision_gce_resources()`.
+
+## Problem
+
+GCE already has upfront zone filtering, capacity-error detection, and runtime **zone (AZ) fallback**
+(landed in `5a72b47d44` + follow-ups). The remaining SCT-296 scope is **region fallback**: when the
+configured GCE datacenter has no capacity in any of its zones, relocate the whole (single-node,
+single-region) cluster to another region. Today `is_region_fallback_enabled()` is hardcoded to
+`cluster_backend == "aws"` and the entire region-fallback orchestration is AWS-only, so
+`fallback_to_next_region` is a no-op on GCE.
+
+The implementation mirrors the AWS design but drops machinery GCE does not need:
+- **No VPC-peering gate** — the SCT GCE network is a single *global* VPC
+  (`projects/{project}/global/networks/{name}`), so every region's subnet is reachable.
+- **No per-region image re-resolution** — GCE images are *global* resources (`gce_image_db` is a
+  global image path), so AWS's `resolve_amis` / `RegionAMINotFoundError` / `remap_dc_ami` are moot.
+
+Region fallback must work and be tested in **both** provisioning paths, exactly like AWS:
+- **Legacy / test runtime:** `sdcm/tester.py::get_cluster_gce`
+- **Modern / `provision-resources` step:** `sct.py` GCE branch → `provision_sct_resources()`
+
+## Approach
+
+1. **Enable-gate** — generalize `is_region_fallback_enabled()` (`sdcm/provision/aws/az_resolver.py:107`)
+   to accept `cluster_backend in ("aws", "gce")`. Update `fallback_to_next_region` docstring in
+   `sdcm/sct_config.py:2154` (drop "AWS-only", note single-node/single-region).
+2. **Candidate generation** — add `GceAZResolver.get_region_fallback_candidates()` in
+   `sdcm/provision/gce/zone_resolver.py`, mirroring `AZResolver.get_region_fallback_candidates`
+   **minus the peering check**. Reuse existing `_common_supported_letters` / `required_machine_types`.
+   Iterate a new `SUPPORTED_GCE_REGIONS` constant; skip current region; keep regions that supply the
+   configured zone-cardinality supporting all required machine types.
+3. **Region constant** — add `SUPPORTED_GCE_REGIONS` to `sdcm/provision/gce/constants.py`
+   (mirrors `AWS_SUPPORTED_REGIONS`; the four documented regions + any others we support).
+4. **Shared switch/cleanup helpers** — new `sdcm/provision/gce/region_fallback.py` with
+   `enforce_single_region_gate`, `switch_region` (env-first `SCT_GCE_DATACENTER` + `gce_datacenter` +
+   `availability_zone`), `restore_region`, `cleanup_region`. `cleanup_region` runs a **per-region
+   cleanup inside the loop** (see step 5/6), sweeping the exhausted region via
+   `GceProvisioner(region=...).cleanup(test_id)` plus a caller-supplied partial-cleanup callback.
+   No `resolve_amis`, no reservation reset (GCE has neither).
+5. **Legacy path** — in `sdcm/tester.py`, refactor `get_cluster_gce` into `_get_cluster_gce_once`
+   (existing body) + `_get_cluster_gce_with_region_fallback` mirroring
+   `_get_cluster_aws_with_region_fallback` (`tester.py:1912`). Loop `[None, *candidates]`; on
+   capacity exhaustion `cleanup_region(source_region)` **immediately in the loop iteration** then
+   continue; non-capacity errors → `restore_region` + re-raise; success → return; total failure →
+   `restore_region` + `CriticalTestFailure`. No `RegionAMINotFoundError` skip branch (images global).
+6. **Modern path** — in `sct.py` GCE branch (`sct.py:373-378`), wrap `provision_sct_resources()` in
+   the same loop using the shared helpers (extract a small `_provision_gce_with_region_fallback`
+   helper, callable from both `sct.py` and reusable logic). Per-region cleanup happens in the loop.
+   Gate on `is_region_fallback_enabled(params) and len(params.gce_datacenters) == 1`.
+7. **Cleanup widening** — NOT NEEDED for GCE. `clean_instances_gce` (`resources_cleanup.py:193`)
+   takes no `regions` arg; GCE cleanup is project-wide (aggregated list across all zones by tag), so
+   it already reaps fallback regions. The AWS region-widening exists only because AWS cleanup is
+   per-region. Left unchanged.
+8. **Tests** — unit tests for candidate generation, gate, switch/restore/cleanup helpers, and the
+   fallback loops in both paths (mirror `unit_tests/unit/provisioner/test_az_fallback.py` structure).
+
+## Encryption at rest (GCP KMS) — no change needed
+
+`ClusterTester.setUp` prepares KMS **before** `init_resources()`, so anything the KMS setup derives
+from the configured region goes stale the moment the fallback loop relocates the cluster. On AWS this
+is a live bug (SCT-718): `prepare_kms_host` creates `alias/testid-<test_id>` only in the configured
+region, `switch_region` does not recreate it, and `kms_hosts.*.aws_region: auto` is then resolved
+per node to the *relocated* region — Scylla aborts at startup with `kms_error (NotFoundException)`.
+
+GCE is not exposed to this, for two independent reasons:
+
+- **The Cloud KMS API is not region-scoped.** `sdcm/utils/gcp_kms.py` builds one
+  `KeyManagementServiceClient` against the global `cloudkms.googleapis.com` endpoint; a key is
+  addressed by its full resource path (`projects/*/locations/*/keyRings/*/cryptoKeys/*`) and the
+  location is a property of the *key*, not the caller. A VM in any region may use a key in any
+  location, gated only by project-scoped IAM. Contrast `sdcm/utils/aws_kms.py`, which builds one
+  boto3 client *per region* because a KMS alias is a per-region resource.
+- **SCT never derives the location from the run region.** It comes from the keystore
+  (`gcp_kms_config.keyring_location`, currently `us-east1`), and `prepare_gcp_kms` writes
+  `gcp_location` explicitly into `append_scylla_yaml["gcp_hosts"]` — there is no `auto` sentinel and
+  therefore nothing to re-resolve per node.
+
+Two consequences worth recording:
+
+- With `fallback_to_next_region` now on by default and `gce_datacenter` defaulting to `us-east1`, the
+  keyring is normally *co-located* with the cluster. A relocated run (e.g. `europe-west1`) makes every
+  DEK wrap/unwrap a cross-region call. Functionally fine and infrequent (per-sstable, not per-op), but
+  it is a latency profile the default path has not exercised before.
+- The immunity is incidental, not enforced. Pinning `keyring_location` to the run region, or a
+  `constraints/gcp.resourceLocations` org policy forcing keys local, would reintroduce the AWS
+  failure mode. Guarded by a docstring on `GcpKmsProvider`; SCT-738 tracks provisioning the key pool
+  in every supported region (with IAM) should we ever want same-region keys.
+
+## Files to Modify
+
+- `sdcm/provision/aws/az_resolver.py` — generalize `is_region_fallback_enabled` to aws+gce.
+- `sdcm/provision/gce/zone_resolver.py` — add `get_region_fallback_candidates()` to `GceAZResolver`.
+- `sdcm/provision/gce/constants.py` — add `SUPPORTED_GCE_REGIONS`.
+- `sdcm/provision/gce/region_fallback.py` — **new**: `enforce_single_region_gate`, `switch_region`,
+  `restore_region`, `cleanup_region` (per-region cleanup helper).
+- `sdcm/tester.py` — split `get_cluster_gce` into `_get_cluster_gce_once` +
+  `_get_cluster_gce_with_region_fallback`; wire gate into `get_cluster_gce`.
+- `sct.py` — GCE branch (lines 373-378) now calls new `provision_gce_resources()` (resolve + region-fallback loop).
+- `sdcm/sct_provision/instances_provider.py` — new `provision_gce_resources()` + `_provision_gce_with_region_fallback()`.
+- `sdcm/sct_config.py` — update `fallback_to_next_region` docstring (line ~2154).
+- `unit_tests/unit/provisioner/test_gce_region_fallback.py` — **new**: candidate gen, gate, helpers,
+  both-path loop behavior (capacity → relocate + per-region cleanup; non-capacity → propagate).
+
+## Verification
+
+- [x] `is_region_fallback_enabled` returns True for gce backend with `fallback_to_next_region=true`
+      (now in `common/fallback.py`, backends `("aws", "gce")`).
+- [x] `get_region_fallback_candidates()` excludes current region, filters by machine-type zone
+      availability, and returns `(region, az_letters)` with correct cardinality — **no** peering call
+      (now a lazy generator; also added `get_dc_fallback_candidates()` for multi-DC).
+- [x] Legacy path: simulated `ZoneResourcesExhaustedError` in region A relocates to region B, cleans
+      up region A **within the loop iteration**, and provisions successfully; non-capacity error in A
+      propagates without relocation; all-exhausted raises `CriticalTestFailure`.
+- [x] Modern path (`provision_sct_resources`): same relocate + per-region cleanup + propagate behavior.
+- [x] Region switch updates `SCT_GCE_DATACENTER` env, `gce_datacenter`, and `availability_zone`;
+      `restore_region` reverts all three on total failure (env-first confirmed: `environment` is a
+      plain property, `gce_datacenters` reads env first).
+- [x] Multi-datacenter config: the **single-region** loop rejects it via `enforce_single_region_gate`;
+      the router instead dispatches multi-DC configs to `provision_with_dc_fallback` (per-DC relocation).
+- [x] Unit tests pass: `uv run python -m pytest unit_tests/unit/provisioner/test_gce_region_fallback.py -v`
+- [x] AWS region-fallback tests still pass (shared gate change): `uv run python -m pytest unit_tests/unit/provisioner/ -v` (243 passed, 1 skipped)
+- [x] `uv run sct.py pre-commit` passes (enforced on every commit via hooks).
+- [x] Manual verification on real GCE — single-region relocation, multi-DC relocation, and split
+      provision→run handoff — via the `BUILD_SIMULATE_GCE_EXHAUSTION` hook (see
+      [test plan §8](2026-07-16-gce-region-fallback-testplan.md)).

--- a/docs/plans/mini-plans/2026-07-16-gce-region-fallback-testplan.md
+++ b/docs/plans/mini-plans/2026-07-16-gce-region-fallback-testplan.md
@@ -1,0 +1,134 @@
+# Test Plan — GCE AZ / Region / Multi-DC Fallback (PR #15427)
+
+Scope: whole-cluster region fallback and per-DC (multi-region) fallback for GCE, the centralized
+fallback loop shared with the legacy tester and modern provisioning paths, the placement handoff
+across provision→run steps, and enabling AZ+region fallback by default for GCE.
+
+Coverage mirrors the AWS fallback tests (`unit_tests/unit/provisioner/test_az_fallback.py`,
+`test_az_resolver.py`) since GCE deliberately follows the same design.
+
+Legend: [x] covered by unit tests in this PR · [~] partially covered · [ ] verify manually / follow-up.
+
+## 1. Zone (AZ) resolver — `GceAZResolver`  (`test_gce_zone_resolver.py`, `test_gce_region_fallback.py`)
+- [x] `resolve()` disabled (`pre_filter_unavailable_availability_zones=false`) leaves AZ unchanged.
+- [x] `resolve()` replaces an unsupported AZ letter with a valid alternative in the same region.
+- [x] `resolve()` with unset `availability_zone` picks a random valid zone letter.
+- [x] `resolve()` raises `NoValidAvailabilityZoneError` when no zone supports the machine types.
+- [x] `get_region_fallback_candidates()` excludes the current region and regions lacking supported zones.
+- [x] `get_region_fallback_candidates()` never performs a peering lookup (global VPC).
+- [x] `get_dc_fallback_candidates(idx)` excludes ALL in-use DC regions and filters by zone support.
+- [ ] Machine-type gating: a type whose node count is 0 (e.g. vector store) does not constrain candidates.
+
+## 2. Single-region whole-cluster fallback (`provision_with_region_fallback`)
+- [x] Success on first attempt: no switch, no cleanup, placement unchanged.
+- [x] `ZoneResourcesExhaustedError` → relocate to next region → success; exhausted region cleaned up.
+- [x] Capacity-class `ProvisionError` (`is_zone_capacity_error`) treated as exhaustion → relocate.
+- [x] Non-capacity error propagates unchanged and restores original region/AZ/env.
+- [x] All candidates exhausted → `error_factory` raised; original placement + env restored.
+- [x] Multi-DC config rejected by `enforce_single_region_gate` (single-region loop only).
+- [x] `switch_region` / `restore_region` update `gce_datacenter`, `availability_zone`, and `SCT_GCE_DATACENTER`.
+- [x] Env isolation: `SCT_GCE_DATACENTER` popped when originally unset / restored to prior value.
+
+## 3. Multi-DC per-DC fallback (`provision_with_dc_fallback`)  — new
+- [x] Exhausted DC relocated to a candidate region, whole cluster retried, success; only that DC moves.
+- [x] Failing DC exhausts its candidates → `error_factory` raised; original multi-DC placement restored.
+- [x] Non-capacity error propagates and restores; no cleanup performed.
+- [x] Unattributable capacity error (no configured region named) → stop, no relocation/retry.
+- [x] `switch_dc_region` updates only the target DC and leaves the global `availability_zone` untouched.
+- [x] `_failed_dc_index` attributes the error to the DC whose region appears in the message (or None).
+- [ ] Two different DCs exhaust in sequence across retries (per-DC candidate iterators advance independently).
+- [ ] `dc_count` upper bound on attempts prevents an infinite loop when relocation keeps failing.
+
+## 4. Routing — both paths delegate to the centralized router (`provision_with_fallback`)
+- [x] Router: single-region config → `provision_with_region_fallback`; multi-region → `provision_with_dc_fallback`.
+- [x] Modern path (`provision_sct_resources`): fallback enabled → router; disabled → provision once.
+- [x] Modern path: multi-DC + enabled → router (dispatches to per-DC fallback).
+- [x] Legacy path (`get_cluster_gce`): fallback enabled (single or multi-DC) → fallback wrapper; disabled → once.
+- [x] Legacy wrapper delegates to the router (candidates computed internally, `error_factory=CriticalTestFailure`).
+
+## 5. Cleanup / state hygiene
+- [x] `_cleanup_legacy_partial_gce_clusters` destroys clusters, resets attrs to `None`, clears `credentials`.
+- [x] `cleanup_region` sweeps only the matching region; discovery failure is swallowed (logged).
+- [~] Multi-DC cleanup sweeps every currently-configured DC region before a retry (covered indirectly).
+- [ ] No leaked instances after a mid-fallback abort (verify against real GCE project sweep).
+
+## 6. Placement handoff (split provision→run pipeline)
+- [x] `_apply_resolved_placement` applies a persisted region to `gce_datacenter`/`SCT_GCE_DATACENTER` for GCE.
+- [~] `provision_sct_resources` persists the relocated `gce_datacenter` only when it changed.
+- [ ] End-to-end: `sct.py provision-resources` relocates a region, the separate Run Test step picks it up.
+
+## 7. Config defaults
+- [x] `is_region_fallback_enabled` true for aws/gce, false for other backends / when flag off.
+- [ ] `defaults/gce_config.yaml` enables `fallback_to_next_availability_zone` + `fallback_to_next_region`
+      and they propagate to gce-derived backends (verified via regenerated `configuration_options.md`).
+- [ ] A multi-DC GCE test inheriting the defaulted flag provisions normally (fallback is a graceful no-op
+      when no capacity error occurs).
+
+## 8. Manual / CI verification (not unit-testable)
+Verified manually against real GCE by injecting a simulated capacity stockout: a throwaway local patch
+made `VirtualMachineProvider.get_or_create` raise `ZONE_RESOURCE_POOL_EXHAUSTED` for zones matching a
+`BUILD_SIMULATE_GCE_EXHAUSTION` env var (comma-separated zone-name substrings), so the scenarios below
+did not have to wait on a real stockout.
+
+That patch is deliberately **not** part of this PR: a hook that aborts real VM creation and kicks off
+cleanup/relocation has no business on the production provisioning path, where any environment that
+happened to export the variable would trip it. Reproducing the runs below means re-applying it locally.
+
+- [x] `Jenkinsfile` runs the provision step for the `gce` backend (new), so the modern path is exercised.
+- [x] **Scenario A — single-region relocation** (region fallback): exhausting the whole configured
+      region relocates the cluster to the next region and the run proceeds against it.
+
+      ```bash
+      export SCT_SCYLLA_VERSION=master:latest
+      export SCT_TEST_ID=$(uuidgen)
+      export BUILD_SIMULATE_GCE_EXHAUSTION="us-east1"
+      uv run sct.py provision-resources -b gce -t longevity_test.LongevityTest.test_custom_time \
+        -c test-cases/PR-provision-test.yaml \
+        --config configurations/network_config/test_communication_public.yaml
+      uv run sct.py run-test longevity_test.LongevityTest.test_custom_time --backend gce \
+        --config test-cases/PR-provision-test.yaml \
+        --config configurations/network_config/test_communication_public.yaml
+      ```
+
+- [x] **Scenario B — multi-DC relocation** (per-DC fallback): exhausting one DC's region relocates
+      only that DC, and the whole (multi-DC) cluster is retried against the updated placement.
+
+      ```bash
+      export SCT_IP_SSH_CONNECTIONS=public
+      export SCT_SCYLLA_VERSION=master:latest
+      export SCT_N_DB_NODES='3 3'
+      export SCT_TEST_ID=$(uuidgen)
+      export SCT_GCE_DATACENTER="us-east1 us-west1"
+      export BUILD_SIMULATE_GCE_EXHAUSTION="us-west1"
+      uv run sct.py provision-resources -b gce -t longevity_test.LongevityTest.test_custom_time \
+        -c test-cases/PR-provision-test.yaml \
+        --config configurations/network_config/test_communication_public.yaml
+      uv run sct.py run-test longevity_test.LongevityTest.test_custom_time --backend gce \
+        --config test-cases/PR-provision-test.yaml \
+        --config configurations/network_config/test_communication_public.yaml
+      ```
+
+- [x] **Scenario C — split provision→run handoff**: `provision-resources` relocates the region and
+      persists it to `resolved_placement.yaml`; the separate `run-test` step (with the simulation
+      unset) picks up the relocated placement.
+
+      ```bash
+      export SCT_IP_SSH_CONNECTIONS=public
+      export SCT_SCYLLA_VERSION=master:latest
+      export SCT_TEST_ID=$(uuidgen)
+      export SCT_CONFIG_FILES='["test-cases/PR-provision-test.yaml", "configurations/network_config/test_communication_public.yaml"]'
+      export BUILD_SIMULATE_GCE_EXHAUSTION="us-east1"
+      uv run sct.py provision-resources -b gce -t longevity_test.LongevityTest.test_custom_time
+      cat ~/sct-results/$SCT_TEST_ID/resolved_placement.yaml
+      unset BUILD_SIMULATE_GCE_EXHAUSTION
+      uv run sct.py run-test longevity_test.LongevityTest.test_custom_time -b gce
+      ```
+
+## Notes / intentional differences from AWS
+- No VPC-peering eligibility gate (single global VPC) and no per-region image re-resolution
+  (global images), so GCE has no analogue of AWS's `test_region_fallback_skips_region_without_equivalent_ami`
+  or peering tests.
+- GCE `availability_zone` is a single global setting (zones chosen per region at provision time), so
+  multi-DC relocation moves the region only, not a per-DC AZ.
+- Multi-DC fallback retries the whole cluster per relocation (uniform for both provisioning paths) rather
+  than AWS's surgical per-DC DB provisioning; acceptable because capacity exhaustion is rare.

--- a/sct.py
+++ b/sct.py
@@ -370,10 +370,8 @@ def provision_resources(backend, test_name: str, config: str):
                 amis={key: params.get(key) for key in params.ami_id_params if params.get(key)},
             )
         elif backend in ("azure", "gce", "oci"):
-            if backend == "gce":
-                from sdcm.provision.gce.zone_resolver import GceAZResolver  # noqa: PLC0415
-
-                GceAZResolver(params).resolve()
+            # GCE region fallback + placement handoff live inside provision_sct_resources now, so all
+            # three backends share the same entry point (Azure/OCI simply have no fallback yet).
             provision_sct_resources(params=params, test_config=test_config)
         elif backend == "xcloud":
             cloud_provider = params.get("xcloud_provider").lower()

--- a/sdcm/provision/aws/az_resolver.py
+++ b/sdcm/provision/aws/az_resolver.py
@@ -93,22 +93,6 @@ class NoValidAvailabilityZoneError(Exception):
     """Raised when no AZ supports all required instance types in the configured region(s)."""
 
 
-def is_az_fallback_enabled(params) -> bool:
-    """Return True when AZ fallback on capacity errors is enabled.
-
-    Reads `fallback_to_next_availability_zone` (new, backend-agnostic).
-    Falls back to the deprecated `aws_fallback_to_next_availability_zone` alias.
-    """
-    if (value := params.get("fallback_to_next_availability_zone")) is not None:
-        return bool(value)
-    return bool(params.get("aws_fallback_to_next_availability_zone"))
-
-
-def is_region_fallback_enabled(params) -> bool:
-    """Return True when whole-cluster region fallback on capacity errors is enabled."""
-    return bool(params.get("fallback_to_next_region")) and params.get("cluster_backend") == "aws"
-
-
 class AZResolver:
     """Resolve `availability_zone` config to AZs supporting all required instance types."""
 

--- a/sdcm/provision/common/fallback.py
+++ b/sdcm/provision/common/fallback.py
@@ -1,0 +1,37 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2026 ScyllaDB
+
+"""Backend-agnostic gates for capacity-error fallback behavior.
+
+Both AWS and GCE provisioning consult these to decide whether to retry provisioning in the next
+availability zone (AZ fallback) or relocate the whole cluster to another region (region fallback).
+They live here - not under a single backend - so neither backend imports the other's package.
+"""
+
+FALLBACK_SUPPORTED_BACKENDS: tuple[str, ...] = ("aws", "gce")
+
+
+def is_az_fallback_enabled(params) -> bool:
+    """Return True when AZ fallback on capacity errors is enabled.
+
+    Reads `fallback_to_next_availability_zone` (backend-agnostic), falling back to the deprecated
+    `aws_fallback_to_next_availability_zone` alias.
+    """
+    if (value := params.get("fallback_to_next_availability_zone")) is not None:
+        return bool(value)
+    return bool(params.get("aws_fallback_to_next_availability_zone"))
+
+
+def is_region_fallback_enabled(params) -> bool:
+    """Return True when whole-cluster region fallback on capacity errors is enabled."""
+    return bool(params.get("fallback_to_next_region")) and params.get("cluster_backend") in FALLBACK_SUPPORTED_BACKENDS

--- a/sdcm/provision/common/region_fallback.py
+++ b/sdcm/provision/common/region_fallback.py
@@ -1,0 +1,209 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2026 ScyllaDB
+
+"""Backend-agnostic whole-cluster region-fallback loop.
+
+Relocates a single-region cluster to another region when the configured region's capacity is
+exhausted. The loop itself is backend-neutral; each backend injects how to switch/restore/clean up a
+region and how to recognise a capacity error, so the same logic can serve GCE today and OCI/Azure
+(and eventually AWS) without duplicating the control flow.
+"""
+
+import logging
+from collections.abc import Callable, Iterable, Iterator
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _restoring_on_error(
+    candidates: Callable[[], Iterable[tuple[str, list[str]]]],
+    restore: Callable[[], None],
+) -> Iterator[tuple[str, list[str]]]:
+    """Iterate ``candidates()``, restoring the original placement if candidate resolution itself fails.
+
+    Resolution probes the cloud API (zone / machine-type availability), so it can raise both on the
+    initial call and on any later ``next()`` - by which point an earlier iteration may already have
+    relocated the cluster. Restoring before re-raising keeps the restore-on-error contract intact
+    instead of leaving config/env on an abandoned fallback placement.
+
+    A failure in the *consumer* (the loop body) is not our business: the for-loop closes the generator
+    with ``GeneratorExit``, which is a ``BaseException`` and so passes through untouched.
+    """
+    try:
+        yield from candidates()
+    except Exception:
+        restore()
+        raise
+
+
+def provision_with_region_fallback(
+    *,
+    original_region: str | None,
+    region_candidates: Callable[[], Iterable[tuple[str, list[str]]]],
+    provision_once: Callable[[], None],
+    switch_region: Callable[[str, list[str]], None],
+    restore_region: Callable[[], None],
+    cleanup_region: Callable[[str | None], None],
+    is_capacity_error: Callable[[BaseException], bool],
+    error_factory: Callable[[str], BaseException],
+) -> None:
+    """Provision in the configured region, relocating to fallback regions on capacity exhaustion.
+
+    The configured region is tried first; on a capacity error the region is cleaned up and the next
+    candidate is tried. A non-capacity error restores the original placement and propagates. When the
+    configured region and every candidate are exhausted, the original placement is restored and
+    ``error_factory`` builds the raised exception (so each caller keeps its own failure type).
+
+    Args:
+        original_region: Currently configured region (starting point, for logging/messages).
+        region_candidates: Callable returning an iterable of the ordered ``(region, az_letters)``
+            fallback targets (current region excluded). Resolved lazily - only after the configured
+            region is exhausted, and each candidate is probed only when the loop reaches it - so a
+            successful configured-region run never probes the fallback regions, and a fallback that
+            succeeds early never scans the remaining ones.
+        provision_once: Provisions the whole cluster in the currently configured region/AZ.
+        switch_region: Relocate config/env to ``(region, az_letters)`` before the next attempt.
+        restore_region: Undo any relocation, restoring the original region/AZ (and env).
+        cleanup_region: Tear down abandoned resources left in the given exhausted region.
+        is_capacity_error: True when an exception is a capacity/exhaustion error (retry elsewhere)
+            rather than a hard failure (propagate).
+        error_factory: Builds the exception raised when every region is exhausted.
+
+    Raises:
+        BaseException: Any non-capacity error from ``provision_once`` propagates unchanged after the
+            original region is restored; otherwise the result of ``error_factory`` on full exhaustion.
+    """
+    last_error: BaseException | None = None
+
+    def attempt(region: str | None) -> bool:
+        """Run ``provision_once`` in ``region``; return True on success, False on capacity exhaustion."""
+        nonlocal last_error
+        try:
+            provision_once()
+            return True
+        except Exception as exc:  # noqa: BLE001
+            if not is_capacity_error(exc):
+                restore_region()
+                raise
+            last_error = exc
+        cleanup_region(region)
+        return False
+
+    if attempt(original_region):
+        return
+
+    # Resolve fallback candidates only now (configured region exhausted), and consume them lazily so
+    # each region's zone availability is probed only when we actually reach it - the common path where
+    # the configured region succeeds never probes any fallback region, and a fallback that succeeds
+    # early never scans the rest.
+    tried_regions: list[str] = []
+    # Candidate resolution hits the cloud API (zone/machine-type availability), so it can fail on its
+    # own - and by then an earlier iteration may already have relocated us. Restore before propagating
+    # so we never leave the config/env pointing at an abandoned fallback region.
+    candidates = _restoring_on_error(region_candidates, restore_region)
+    for target_region, az_letters in candidates:
+        tried_regions.append(target_region)
+        LOGGER.warning(
+            "Region '%s' exhausted; relocating whole cluster to '%s' (fallback region #%d)",
+            original_region,
+            target_region,
+            len(tried_regions),
+        )
+        switch_region(target_region, az_letters)
+        if attempt(target_region):
+            return
+
+    restore_region()
+    tried = ", ".join(tried_regions) or "(no eligible candidates)"
+    raise error_factory(
+        f"Failed creating clusters in region '{original_region}' and all fallback candidates [{tried}]: {last_error}"
+    )
+
+
+def provision_with_dc_fallback(
+    *,
+    dc_candidates: Callable[[int], Iterable[tuple[str, list[str]]]],
+    provision_once: Callable[[], None],
+    failed_dc_index: Callable[[BaseException], int | None],
+    switch_dc_region: Callable[[int, str, list[str]], None],
+    restore: Callable[[], None],
+    cleanup: Callable[[], None],
+    is_capacity_error: Callable[[BaseException], bool],
+    error_factory: Callable[[str], BaseException],
+) -> None:
+    """Provision a multi-DC cluster, relocating the exhausted DC to another region on capacity errors.
+
+    Unlike the single-region loop, the whole cluster is (re)provisioned each attempt. On a capacity
+    error the failing DC - identified by ``failed_dc_index`` from the error - is relocated to its next
+    candidate region and the whole cluster is retried (so already-placed DCs are cleaned up and rebuilt
+    against the updated placement). This keeps the control flow identical for the legacy and modern
+    provisioning paths, which each expose only a whole-cluster ``provision_once``.
+
+    A DC that runs out of candidates, an unattributable capacity error, or any non-capacity error
+    restores the original placement and stops (via ``error_factory`` for the capacity cases).
+
+    Args:
+        dc_candidates: ``dc_index -> iterable of ordered (region, az_letters)`` relocation targets,
+            resolved lazily the first time a given DC is exhausted (a DC that never fails is never
+            probed), and each candidate region probed only when that DC needs it.
+        provision_once: Provisions the whole (multi-DC) cluster in the current placement.
+        failed_dc_index: Maps a capacity error to the index of the DC whose region was exhausted, or
+            None when it cannot be attributed.
+        switch_dc_region: Relocate the DC at ``index`` to ``(region, az_letters)``.
+        restore: Undo all relocations, restoring the original placement (and env).
+        cleanup: Tear down the partial cluster left by a failed attempt (all current DC regions).
+        is_capacity_error: True when an exception is a capacity/exhaustion error.
+        error_factory: Builds the exception raised when a DC exhausts its candidates.
+    """
+    dc_iterators: dict[int, Iterator[tuple[str, list[str]]]] = {}
+
+    def next_candidate(dc_index: int) -> tuple[str, list[str]] | None:
+        """Pull a DC's next fallback candidate, resolving its iterator on first use so idle DCs cost
+        nothing and each candidate region is probed only when that DC actually reaches it.
+
+        Resolution probes the cloud API and can therefore fail on its own; by then an earlier DC may
+        already have been relocated, so restore the original placement before propagating.
+        """
+        try:
+            if dc_index not in dc_iterators:
+                dc_iterators[dc_index] = iter(dc_candidates(dc_index))
+            return next(dc_iterators[dc_index], None)
+        except Exception:
+            restore()
+            raise
+
+    # Terminates naturally: every capacity failure either consumes one (finite) candidate for the
+    # failing DC or stops once that DC runs out - no eager precompute of any DC's candidates is needed.
+    while True:
+        try:
+            provision_once()
+            return
+        except Exception as exc:  # noqa: BLE001
+            if not is_capacity_error(exc):
+                restore()
+                raise
+            dc_index = failed_dc_index(exc)
+            cleanup()
+            candidate = next_candidate(dc_index) if dc_index is not None else None
+            if candidate is None:
+                restore()
+                raise error_factory(
+                    f"Failed creating multi-DC clusters; DC {dc_index} exhausted its fallback candidates: {exc}"
+                ) from exc
+            target_region, az_letters = candidate
+            LOGGER.warning(
+                "DC %d region exhausted; relocating it to '%s' and retrying the whole cluster",
+                dc_index,
+                target_region,
+            )
+            switch_dc_region(dc_index, target_region, az_letters)

--- a/sdcm/provision/gce/constants.py
+++ b/sdcm/provision/gce/constants.py
@@ -32,3 +32,13 @@ DEFAULT_BOOT_DISK_SIZE_GB = 50
 # Network tags for firewall rules
 NETWORK_TAG_SCT_NETWORK_ONLY = "sct-network-only"
 NETWORK_TAG_SCT_ALLOW_PUBLIC = "sct-allow-public"
+
+# Regions eligible for whole-cluster region fallback (mirror of AWS_SUPPORTED_REGIONS).
+# The SCT GCE network is a single global VPC and images are global resources, so any
+# region with SCT infra prepared is reachable without peering or image re-resolution.
+SUPPORTED_GCE_REGIONS: list[str] = [
+    "us-east1",
+    "us-east4",
+    "us-west1",
+    "us-central1",
+]

--- a/sdcm/provision/gce/kms_provider.py
+++ b/sdcm/provision/gce/kms_provider.py
@@ -10,10 +10,27 @@ LOGGER = logging.getLogger(__name__)
 
 @dataclass
 class GcpKmsProvider:
+    """Resolve the GCP KMS keyring/key pool used for encryption at rest.
+
+    The keyring location is a fixed keystore value (`keyring_location`), deliberately *not* derived
+    from the region the test runs in. Cloud KMS is reached through a single global endpoint
+    (`cloudkms.googleapis.com`) and a key is addressed by its full resource path, so a VM in any
+    region can use a key in any location - only project-scoped IAM gates it. This is what makes GCE
+    region fallback (`fallback_to_next_region`) safe: relocating the cluster changes `gce_datacenter`
+    but leaves the key URI valid, and `prepare_gcp_kms` writes `gcp_location` explicitly (there is no
+    per-node `auto` resolution like the AWS `kms_hosts.*.aws_region`).
+
+    Keep it that way. Making the location follow the run region - or a data-residency org policy
+    (`constraints/gcp.resourceLocations`) forcing keys into the local region - would reintroduce the
+    AWS failure mode (SCT-718): a key provisioned in the originally configured region and a node
+    booting in the relocated one.
+    """
+
     def __post_init__(self):
         self._gcp_kms_config = KeyStore().get_gcp_kms_config()
         gcp_credentials = KeyStore().get_gcp_credentials()
         self._project_id = gcp_credentials["project_id"]
+        # Region-independent by design - see the class docstring before changing this.
         self._location = self._gcp_kms_config["keyring_location"]
 
     @classmethod

--- a/sdcm/provision/gce/provisioner.py
+++ b/sdcm/provision/gce/provisioner.py
@@ -16,6 +16,7 @@ Main GCE provisioner implementation.
 """
 
 import logging
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
 from typing import List, Dict
 
@@ -248,18 +249,24 @@ class GceProvisioner(Provisioner):
         """
         Clean up all resources for this test.
 
+        Instances are deleted concurrently, so a waited cleanup (``wait=True``) does not serialize the
+        slow per-instance deletions - all deletes are issued at once and awaited together.
+
         Args:
-            wait: Whether to wait for cleanup to complete
+            wait: Whether to wait for each deletion to complete
         """
         LOGGER.info("Cleaning up instances for test %s in zone %s", self.test_id, self.zone)
 
-        # Delete all cached instances
+        # Delete all cached instances concurrently (deletion is slow; serial wait=True would take minutes).
         instance_names = list(self._cache.keys())
-        for name in instance_names:
-            try:
-                self.terminate_instance(name, wait=wait)
-            except Exception as exc:  # noqa: BLE001
-                LOGGER.warning("Failed to terminate instance %s: %s", name, exc)
+        if instance_names:
+            with ThreadPoolExecutor(max_workers=min(len(instance_names), 10)) as executor:
+                futures = {executor.submit(self.terminate_instance, name, wait=wait): name for name in instance_names}
+                for future in as_completed(futures):
+                    try:
+                        future.result()
+                    except Exception as exc:  # noqa: BLE001
+                        LOGGER.warning("Failed to terminate instance %s: %s", futures[future], exc)
 
         # Clear cache
         self._cache.clear()

--- a/sdcm/provision/gce/region_fallback.py
+++ b/sdcm/provision/gce/region_fallback.py
@@ -1,0 +1,362 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2026 ScyllaDB
+
+"""Shared helpers for GCE region fallback.
+
+Both the modern provisioning path (`sct.py` -> `instances_provider.provision_sct_resources`) and the
+legacy tester path (`tester.ClusterTester.get_cluster_gce`) relocate the full cluster to another
+region when region capacity is exhausted. This module shares their placement and cleanup logic.
+
+Unlike AWS region fallback, GCE needs neither VPC-peering checks (single global VPC) nor per-region
+image re-resolution (images are global resources), so switching is a plain config/env update.
+"""
+
+import logging
+import os
+from collections.abc import Callable, Iterable
+
+from sdcm.provision.common.fallback import is_az_fallback_enabled
+from sdcm.provision.common.region_fallback import (
+    provision_with_dc_fallback as _provision_with_dc_fallback,
+    provision_with_region_fallback as _provision_with_region_fallback,
+)
+from sdcm.provision.gce.capacity_errors import is_zone_capacity_error
+from sdcm.provision.gce.provisioner import GceProvisioner
+from sdcm.provision.gce.zone_resolver import GceAZResolver
+from sdcm.provision.provisioner import ProvisionError, ZoneResourcesExhaustedError
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _is_capacity_error(exc: BaseException) -> bool:
+    """True for GCE capacity/exhaustion errors that should trigger relocation to another region."""
+    if isinstance(exc, ZoneResourcesExhaustedError):
+        return True
+    return isinstance(exc, ProvisionError) and is_zone_capacity_error(exc)
+
+
+def _current_datacenters(params) -> list[str]:
+    """Live list of configured GCE datacenters, reading the value ``switch_dc_region`` mutates.
+
+    Uses ``gce_datacenter`` (updated in place on relocation) rather than the ``gce_datacenters``
+    property so multi-DC relocations are visible across fallback retries.
+    """
+    raw = params.get("gce_datacenter")
+    if isinstance(raw, list):
+        return list(raw)
+    return raw.split() if raw else []
+
+
+def enforce_single_region_gate(params) -> None:
+    """Require exactly one configured GCE datacenter for the whole-cluster region-fallback loop.
+
+    An internal invariant, not a config rule: multi-DC configs *are* supported, they just go through
+    the per-DC loop instead (see :func:`provision_with_fallback`, which routes by DC count). Reaching
+    here with several DCs means a caller bypassed the router.
+    """
+    datacenters = params.gce_datacenters
+    if len(datacenters) != 1:
+        raise ValueError(
+            f"whole-cluster region fallback requires a single GCE datacenter (got {datacenters}); "
+            "multi-DC configs must go through provision_with_dc_fallback instead."
+        )
+
+
+def switch_region(params, region: str, az_letters: list[str]) -> None:
+    """Switch to a target GCE region and its availability zones.
+
+    `gce_datacenter` is env-first (like `region_name` on AWS), so the env var is updated as well.
+    Unlike AWS, GCE needs no cache invalidation here: images are global and the resolver holds no
+    region-bound instance state.
+    """
+    os.environ["SCT_GCE_DATACENTER"] = region
+    params["gce_datacenter"] = region
+    params["availability_zone"] = ",".join(az_letters)
+
+
+def restore_region(params, region: str | None, availability_zone: str, env_region: str | None) -> None:
+    """Restore original region and AZ values after a failed relocation."""
+    if env_region is None:
+        os.environ.pop("SCT_GCE_DATACENTER", None)
+    else:
+        os.environ["SCT_GCE_DATACENTER"] = env_region
+
+    if region is not None:
+        params["gce_datacenter"] = region
+    params["availability_zone"] = availability_zone
+
+
+def switch_dc_region(params, dc_index: int, region: str, az_letters: list[str]) -> None:  # noqa: ARG001
+    """Relocate the DC at ``dc_index`` to ``region`` in the space-joined ``gce_datacenter`` list.
+
+    GCE ``availability_zone`` is a single global setting shared by every DC, so - unlike the
+    single-region switch - it is deliberately left untouched here: rewriting it for one relocating DC
+    would change the zones of all the others too.
+
+    That is safe only because :meth:`GceAZResolver.get_dc_fallback_candidates` qualifies a candidate
+    region *by the configured letters* and yields those same letters back, so ``az_letters`` is always
+    the AZ value already in effect. It is accepted for signature parity with the shared loop.
+    """
+    datacenters = _current_datacenters(params)
+    datacenters[dc_index] = region
+    joined = " ".join(datacenters)
+    os.environ["SCT_GCE_DATACENTER"] = joined
+    params["gce_datacenter"] = joined
+
+
+def _failed_dc_index(params, exc: BaseException) -> int | None:
+    """Best-effort: which configured DC's region the capacity error refers to.
+
+    GCE capacity errors name the exhausted zone (e.g. ``us-east1-c``), so the DC is the one whose
+    configured region is a substring of the error message. Returns None when it cannot be attributed.
+    """
+    message = str(exc)
+    for index, region in enumerate(_current_datacenters(params)):
+        if region and region in message:
+            return index
+    return None
+
+
+def cleanup_region(
+    test_id: str,
+    region: str,
+    network_name: str,
+    partial_cleanup: Callable[[], None] | None = None,
+) -> None:
+    """Clean up abandoned resources in the old region.
+
+    First runs the caller-supplied partial cleanup (legacy path destroys the in-memory cluster
+    objects), then sweeps any instances left in ``region`` for this test across all its zones.
+    The sweep is essential for the modern path, which has no cluster objects to destroy.
+    """
+    if partial_cleanup is not None:
+        partial_cleanup()
+
+    try:
+        provisioners = GceProvisioner.discover_regions(test_id, network_name=network_name)
+    except Exception as exc:  # noqa: BLE001
+        LOGGER.warning("Region fallback: failed to discover GCE resources for cleanup in %s: %s", region, exc)
+        return
+
+    for provisioner in provisioners:
+        if provisioner.region != region:
+            continue
+        LOGGER.info("Region fallback: cleaning up abandoned GCE resources in %s (zone %s)", region, provisioner.zone)
+        try:
+            # wait=True is essential: instance names are not region-scoped, so a relocation recreates
+            # the same names in the new region. Deletion must fully complete before we retry there,
+            # otherwise GCE rejects the create with 409 "resource already exists".
+            provisioner.cleanup(wait=True)
+        except Exception as exc:  # noqa: BLE001
+            LOGGER.warning("Region fallback: cleanup failed for %s: %s", provisioner, exc)
+
+
+def provision_with_az_fallback(
+    *,
+    params,
+    test_id: str,
+    network_name: str,
+    provision_once: Callable[[], None],
+    partial_cleanup: Callable[[], None] | None = None,
+) -> Callable[[], None]:
+    """Wrap ``provision_once`` so an exhausted zone retries the region's other zones first.
+
+    The legacy cluster path does its own per-node zone retry in :mod:`sdcm.cluster_gce`; the modern
+    provisioning path had none, so a single exhausted zone escalated straight to relocating the whole
+    cluster to another region even with ``fallback_to_next_availability_zone`` enabled. This closes
+    that gap: the capacity error only reaches the region / multi-DC loop once the current region's
+    remaining zones are exhausted too.
+
+    Candidates are re-derived from live config on every call, so after a region relocation it is the
+    *new* region's zones that get probed, not the original one's.
+
+    Returns ``provision_once`` unchanged when zone fallback is disabled, so callers can wire this in
+    unconditionally.
+    """
+    if not is_az_fallback_enabled(params):
+        return provision_once
+
+    def provision_with_zone_retry() -> None:
+        original_az = params.get("availability_zone")
+
+        def attempt() -> BaseException | None:
+            """Run ``provision_once``; return the capacity error to retry on, or None on success."""
+            try:
+                provision_once()
+            except Exception as exc:  # noqa: BLE001
+                if not _is_capacity_error(exc):
+                    params["availability_zone"] = original_az
+                    raise
+                return exc
+            return None
+
+        last_error = attempt()
+        if last_error is None:
+            return
+
+        for az_letters in GceAZResolver(params).get_az_fallback_candidates():
+            # Sweep the exhausted zone before retrying: instance names are reused across zones, and a
+            # partial cluster left behind would both leak and collide with the retry. partial_cleanup
+            # destroys in-memory clusters, so it runs once - not once per configured region.
+            if partial_cleanup is not None:
+                partial_cleanup()
+            for region in dict.fromkeys(_current_datacenters(params)):
+                cleanup_region(test_id, region, network_name=network_name, partial_cleanup=None)
+            LOGGER.warning(
+                "Zone(s) '%s' exhausted; retrying the cluster in zone(s) '%s' of region(s) %s",
+                params.get("availability_zone"),
+                ",".join(az_letters),
+                _current_datacenters(params),
+            )
+            params["availability_zone"] = ",".join(az_letters)
+            last_error = attempt()
+            if last_error is None:
+                return
+
+        # Every eligible zone in the configured region(s) is exhausted. Put the AZ back so the caller's
+        # region / multi-DC fallback starts from the configured placement, then let the error through.
+        params["availability_zone"] = original_az
+        raise last_error
+
+    return provision_with_zone_retry
+
+
+def provision_with_region_fallback(
+    *,
+    params,
+    test_id: str,
+    network_name: str,
+    region_candidates: Callable[[], Iterable[tuple[str, list[str]]]],
+    provision_once: Callable[[], None],
+    error_factory: Callable[[str], BaseException],
+    partial_cleanup: Callable[[], None] | None = None,
+) -> None:
+    """Provision in the configured GCE region, relocating to fallback regions on capacity exhaustion.
+
+    Thin GCE binding over the backend-agnostic loop in
+    :func:`sdcm.provision.common.region_fallback.provision_with_region_fallback`: it enforces the
+    single-region gate, captures the original placement, and supplies GCE-specific switch / restore /
+    cleanup and capacity-error detection. Single-node / single-region only.
+
+    Args:
+        params: SCT configuration; ``gce_datacenter`` / ``availability_zone`` are mutated on relocation.
+        test_id: Test id used to discover and clean up abandoned resources in an exhausted region.
+        network_name: GCE network (global VPC) used both to provision and to scope cleanup.
+        region_candidates: Callable returning the ordered ``(region, az_letters)`` fallback targets;
+            invoked lazily only after the configured region is exhausted.
+        provision_once: Provisions the whole cluster in the currently configured region/AZ.
+        error_factory: Builds the exception raised when every region is exhausted (each path keeps
+            its own failure type, e.g. ``CriticalTestFailure`` vs ``ProvisionUnrecoverableError``).
+        partial_cleanup: Optional per-region cleanup (the legacy path destroys in-memory clusters).
+
+    Raises:
+        ValueError: If more than one GCE datacenter is configured (multi-DC is unsupported here).
+    """
+    enforce_single_region_gate(params)
+
+    original_region = params.gce_datacenters[0] if params.gce_datacenters else None
+    original_az = params.get("availability_zone")
+    original_env_region = os.environ.get("SCT_GCE_DATACENTER")
+
+    _provision_with_region_fallback(
+        original_region=original_region,
+        region_candidates=region_candidates,
+        provision_once=provision_once,
+        switch_region=lambda region, az_letters: switch_region(params, region, az_letters),
+        restore_region=lambda: restore_region(params, original_region, original_az, original_env_region),
+        cleanup_region=lambda region: cleanup_region(
+            test_id, region, network_name=network_name, partial_cleanup=partial_cleanup
+        ),
+        is_capacity_error=_is_capacity_error,
+        error_factory=error_factory,
+    )
+
+
+def provision_with_dc_fallback(
+    *,
+    params,
+    test_id: str,
+    network_name: str,
+    provision_once: Callable[[], None],
+    error_factory: Callable[[str], BaseException],
+    partial_cleanup: Callable[[], None] | None = None,
+) -> None:
+    """Provision a multi-DC GCE cluster, relocating an exhausted DC's region on capacity errors.
+
+    GCE binding over :func:`sdcm.provision.common.region_fallback.provision_with_dc_fallback`. Captures
+    the original multi-DC placement, computes per-DC candidates (no peering / image checks), and
+    supplies GCE-specific relocation, cleanup and capacity-error attribution.
+    """
+    original_datacenters = " ".join(params.gce_datacenters) if params.gce_datacenters else None
+    original_az = params.get("availability_zone")
+    original_env_region = os.environ.get("SCT_GCE_DATACENTER")
+    resolver = GceAZResolver(params)
+
+    def restore() -> None:
+        restore_region(params, original_datacenters, original_az, original_env_region)
+
+    def cleanup() -> None:
+        # Destroy in-memory clusters (legacy path) once, then sweep every currently-configured region.
+        if partial_cleanup is not None:
+            partial_cleanup()
+        for region in dict.fromkeys(_current_datacenters(params)):
+            cleanup_region(test_id, region, network_name=network_name, partial_cleanup=None)
+
+    _provision_with_dc_fallback(
+        dc_candidates=resolver.get_dc_fallback_candidates,
+        provision_once=provision_once,
+        failed_dc_index=lambda exc: _failed_dc_index(params, exc),
+        switch_dc_region=lambda index, region, az_letters: switch_dc_region(params, index, region, az_letters),
+        restore=restore,
+        cleanup=cleanup,
+        is_capacity_error=_is_capacity_error,
+        error_factory=error_factory,
+    )
+
+
+def provision_with_fallback(
+    *,
+    params,
+    test_id: str,
+    network_name: str,
+    provision_once: Callable[[], None],
+    error_factory: Callable[[str], BaseException],
+    partial_cleanup: Callable[[], None] | None = None,
+) -> None:
+    """Route GCE capacity-error fallback: whole-cluster (single region) or per-DC (multi region).
+
+    This is the single entry both the legacy tester path and the modern provisioning path call, so all
+    fallback control flow lives here rather than in the callers. Fallback candidates are resolved
+    lazily (only if a capacity error actually triggers relocation), so a run that provisions in the
+    configured placement never probes zone availability across the other regions.
+    """
+    if len(params.gce_datacenters) > 1:
+        provision_with_dc_fallback(
+            params=params,
+            test_id=test_id,
+            network_name=network_name,
+            provision_once=provision_once,
+            error_factory=error_factory,
+            partial_cleanup=partial_cleanup,
+        )
+        return
+
+    provision_with_region_fallback(
+        params=params,
+        test_id=test_id,
+        network_name=network_name,
+        region_candidates=lambda: GceAZResolver(params).get_region_fallback_candidates(),
+        provision_once=provision_once,
+        error_factory=error_factory,
+        partial_cleanup=partial_cleanup,
+    )

--- a/sdcm/provision/gce/zone_resolver.py
+++ b/sdcm/provision/gce/zone_resolver.py
@@ -13,8 +13,9 @@
 
 import logging
 import random
-from typing import Callable
+from typing import Callable, Iterator
 
+from sdcm.provision.gce.constants import SUPPORTED_GCE_REGIONS
 from sdcm.utils.gce_utils import GceZoneResolver
 
 LOGGER = logging.getLogger(__name__)
@@ -157,6 +158,127 @@ class GceAZResolver:
             LOGGER.info(
                 "GceAZResolver: availability_zone '%s' already valid for regions %s", original_value, region_names
             )
+
+    def get_region_fallback_candidates(self) -> Iterator[tuple[str, list[str]]]:
+        """Yield ordered ``(region, az_letters)`` candidates for cluster region fallback.
+
+        A region is eligible only if it can supply the configured number of zones
+        that support all required machine types. The current region is excluded (it
+        is the starting point).
+
+        Candidates are yielded lazily: each region's zone/machine-type availability is
+        probed only when the consumer actually reaches it, so a fallback that succeeds on
+        the first candidate never pays to scan the remaining regions.
+
+        Unlike AWS there is NO peering check: the SCT GCE network is a single global
+        VPC, so every region's subnet is reachable, and GCE images are global, so no
+        per-region image re-resolution is needed.
+        """
+        region_names = self._region_names()
+        if not region_names:
+            return
+        current_region = region_names[0]
+        configured_letters = self._configured_az_letters()
+        cardinality = len(configured_letters) or 1
+        machine_types = self.required_machine_types()
+
+        for region in SUPPORTED_GCE_REGIONS:
+            if region == current_region:
+                continue
+            letters = self._common_supported_letters([region], configured_letters, machine_types)
+            if len(letters) < cardinality:
+                LOGGER.info(
+                    "Region fallback: skipping %s (only %d zone(s) support %s, need %d)",
+                    region,
+                    len(letters),
+                    machine_types,
+                    cardinality,
+                )
+                continue
+            yield region, letters[:cardinality]
+
+    def get_dc_fallback_candidates(self, dc_index: int) -> Iterator[tuple[str, list[str]]]:
+        """Yield ordered ``(region, az_letters)`` candidates to relocate the DC at ``dc_index``.
+
+        A region is eligible if no DC currently occupies it and it supports the *configured* zone
+        letters for all required machine types. Like the single-region variant there is NO peering or
+        image check (global VPC, global images).
+
+        Two properties the multi-DC fallback loop depends on:
+
+        * The in-use region set is re-read from live config before every candidate. The loop holds one
+          generator per DC for its whole lifetime while *other* DCs keep relocating, so a set
+          snapshotted on first use goes stale and can hand back a region a sibling DC has since moved
+          into - landing two DCs in the same region.
+        * Only regions supporting the configured letters qualify, and those same letters are yielded.
+          GCE ``availability_zone`` is a single global setting that DC relocation deliberately leaves
+          alone, so qualifying a region through some *alternative* letter would aim the retry at a
+          zone that region does not have.
+
+        Candidates are yielded lazily: each region is probed only when the consumer reaches it,
+        so a DC that relocates on its first candidate never scans the remaining regions.
+        """
+        if dc_index >= len(self._region_names()):
+            return
+        configured_letters = self._configured_az_letters()
+        cardinality = len(configured_letters) or 1
+        machine_types = self.required_machine_types()
+
+        for region in SUPPORTED_GCE_REGIONS:
+            # Re-read per candidate: sibling DCs may have relocated since the previous yield.
+            if region in set(self._region_names()):
+                continue
+            letters = self._common_supported_letters([region], configured_letters, machine_types)
+            if configured_letters:
+                if missing := [letter for letter in configured_letters if letter not in letters]:
+                    LOGGER.info(
+                        "Region fallback (DC %d): skipping %s (configured zone(s) %s do not support %s)",
+                        dc_index,
+                        region,
+                        ",".join(missing),
+                        machine_types,
+                    )
+                    continue
+                yield region, list(configured_letters)
+            elif len(letters) < cardinality:
+                LOGGER.info(
+                    "Region fallback (DC %d): skipping %s (only %d zone(s) support %s, need %d)",
+                    dc_index,
+                    region,
+                    len(letters),
+                    machine_types,
+                    cardinality,
+                )
+            else:
+                yield region, letters[:cardinality]
+
+    def get_az_fallback_candidates(self) -> Iterator[list[str]]:
+        """Yield alternative zone-letter sets within the currently configured region(s).
+
+        Backs `fallback_to_next_availability_zone` on the modern provisioning path: one exhausted zone
+        should retry the region's remaining zones before the cluster relocates to a different region.
+
+        Restricted to single-AZ configs, mirroring the legacy cluster path (:mod:`sdcm.cluster_gce`),
+        which only retries zones for single-node provisioning. With several configured letters there is
+        no way to tell which one the capacity error refers to without re-deriving the whole placement,
+        so nothing is yielded and region fallback takes over.
+        """
+        configured_letters = self._configured_az_letters()
+        if len(configured_letters) != 1:
+            LOGGER.info(
+                "Zone fallback: skipping, availability_zone '%s' is not a single zone",
+                ",".join(configured_letters) or "(unset)",
+            )
+            return
+        region_names = self._region_names()
+        if not region_names:
+            return
+
+        machine_types = self.required_machine_types()
+        for letter in self._common_supported_letters(region_names, configured_letters, machine_types):
+            if letter in configured_letters:
+                continue
+            yield [letter]
 
     def _common_supported_letters(
         self, region_names: list[str], configured_letters: list[str], machine_types: list[str]

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -2167,9 +2167,12 @@ class SCTConfiguration(BaseModel):
         "trigger AZ/region fallback. Costs ~1 min per type. AWS-only.",
     )
     fallback_to_next_region: Boolean = SctField(
-        description="On capacity errors, after all AZs in the configured region are exhausted, relocate the entire cluster "
-        "to the next eligible region (should be VPC-peered with the runner region with infra-prepared and AMI available). "
-        "Only applies during initial setup, to single region tests. AWS-only.",
+        description="On capacity errors, after all AZs/zones in the configured region are exhausted, relocate to the next "
+        "eligible region: a single-region cluster moves as a whole, while in a multi-region test only the exhausted "
+        "datacenter is relocated (to a region no other datacenter occupies) and the cluster is retried. On AWS the target "
+        "region should be VPC-peered with the runner region with infra-prepared and AMI available; on GCE the global VPC "
+        "and global images make any supported region eligible. Only applies during initial setup. "
+        "Supported backends: AWS, GCE.",
     )
     num_nodes_to_rollback: int = SctField(
         description="Number of nodes to upgrade and rollback in test_generic_cluster_upgrade",
@@ -3359,13 +3362,20 @@ class SCTConfiguration(BaseModel):
         availability_zone = placement.get("availability_zone")
         amis = placement.get("amis")
         if region_name:
-            os.environ["SCT_REGION_NAME"] = region_name
-            self["region_name"] = region_name
-            if amis:
-                for key, value in amis.items():
-                    self[key] = value
-            elif original_region_list and region_name != original_region_list:
-                self._resolved_placement_source_region = original_first_region
+            if self.get("cluster_backend") == "gce":
+                # GCE has no AWS-style region_name or per-region AMIs: the relocated region is
+                # carried in gce_datacenter (env-first), so a split provision->run pipeline picks
+                # up the region chosen by region fallback instead of the original one.
+                os.environ["SCT_GCE_DATACENTER"] = region_name
+                self["gce_datacenter"] = region_name
+            else:
+                os.environ["SCT_REGION_NAME"] = region_name
+                self["region_name"] = region_name
+                if amis:
+                    for key, value in amis.items():
+                        self[key] = value
+                elif original_region_list and region_name != original_region_list:
+                    self._resolved_placement_source_region = original_first_region
         if availability_zone:
             os.environ["SCT_AVAILABILITY_ZONE"] = availability_zone
             self["availability_zone"] = availability_zone

--- a/sdcm/sct_provision/aws/layout.py
+++ b/sdcm/sct_provision/aws/layout.py
@@ -20,10 +20,9 @@ from botocore.exceptions import ClientError
 from sdcm.exceptions import CapacityReservationError
 from sdcm.provision.aws.az_resolver import (
     AZResolver,
-    is_az_fallback_enabled,
-    is_region_fallback_enabled,
     run_pre_flight_capacity_probe,
 )
+from sdcm.provision.common.fallback import is_az_fallback_enabled, is_region_fallback_enabled
 from sdcm.provision.aws.capacity_errors import (
     ProvisioningCapacityExhausted,
     RegionAMINotFoundError,

--- a/sdcm/sct_provision/instances_provider.py
+++ b/sdcm/sct_provision/instances_provider.py
@@ -16,11 +16,15 @@ from typing import List, Any
 
 
 from sdcm.provision import provisioner_factory
+from sdcm.provision.common.fallback import is_region_fallback_enabled
+from sdcm.provision.gce import region_fallback as gce_region_fallback
+from sdcm.provision.gce.zone_resolver import GceAZResolver
 from sdcm.provision.helpers.cloud_init import wait_cloud_init_completes
 from sdcm.provision.provisioner import (
     PricingModel,
     VmInstance,
     ProvisionError,
+    ProvisionUnrecoverableError,
     Provisioner,
     InstanceDefinition,
     OperationPreemptedError,
@@ -72,8 +76,27 @@ def provision_instances_with_fallback(
     return provisioned_instances
 
 
-def provision_sct_resources(params: SCTConfiguration, test_config: TestConfig, **provisioner_config: Any):
-    """Provisions instances according to SCT Configuration."""
+def provision_sct_resources(params: SCTConfiguration, test_config: TestConfig, **provisioner_config: Any) -> None:
+    """Provision instances per SCT config, with optional backend region fallback and placement handoff.
+
+    Backends that support whole-cluster region fallback (currently GCE) get a pre-provision zone/AZ
+    resolve, drive provisioning through the shared region-fallback loop for a single-region config,
+    and persist the resolved placement so a later Run Test step picks up any relocated region. Other
+    backends (AWS uses its own layout; Azure/OCI have no fallback yet) provision once, unchanged - the
+    shared shape is ready for them to opt in.
+    """
+
+    def provision_once() -> None:
+        _provision_sct_resources_once(params=params, test_config=test_config, **provisioner_config)
+
+    if params.get("cluster_backend") == "gce":
+        _provision_gce_resources(params, test_config, provision_once)
+    else:
+        provision_once()
+
+
+def _provision_sct_resources_once(params: SCTConfiguration, test_config: TestConfig, **provisioner_config: Any) -> None:
+    """Provision every region's instances once in the currently configured region/AZ."""
     builder = region_definition_builder.get_builder(params=params, test_config=test_config)
     definitions_per_region = builder.build_all_region_definitions()
     pricing_model = PricingModel(params.get("instance_provision"))
@@ -97,3 +120,47 @@ def provision_sct_resources(params: SCTConfiguration, test_config: TestConfig, *
             pricing_model=pricing_model,
             fallback_on_demand=provision_fallback_on_demand,
         )
+
+
+def _provision_gce_resources(params: SCTConfiguration, test_config: TestConfig, provision_once: Any) -> None:
+    """GCE provisioning: upfront zone filter, optional zone/region fallback, placement handoff.
+
+    Capacity exhaustion escalates in two steps, each independently gated by its own config flag:
+    ``fallback_to_next_availability_zone`` retries the remaining zones of the configured region, and
+    only once those are gone does ``fallback_to_next_region`` relocate - the whole cluster for a
+    single-region config, or just the exhausted DC for a multi-region one. Either way a relocated
+    placement is persisted to the resolved-placement handoff so the later Run Test step (a separate
+    hydra command) picks it up, mirroring AWS.
+    """
+    GceAZResolver(params).resolve()
+    original_region = " ".join(params.gce_datacenters) if params.gce_datacenters else None
+    test_id = str(test_config.test_id())
+    network_name = params.get("gce_network")
+
+    # Zone fallback wraps the single provisioning attempt, so it is exhausted before the region loop
+    # below ever sees a capacity error. The legacy cluster path has its own per-node zone retry in
+    # sdcm.cluster_gce; this is the modern path's equivalent.
+    provision_attempt = gce_region_fallback.provision_with_az_fallback(
+        params=params,
+        test_id=test_id,
+        network_name=network_name,
+        provision_once=provision_once,
+    )
+
+    if is_region_fallback_enabled(params):
+        gce_region_fallback.provision_with_fallback(
+            params=params,
+            test_id=test_id,
+            network_name=network_name,
+            provision_once=provision_attempt,
+            error_factory=ProvisionUnrecoverableError,
+        )
+    else:
+        provision_attempt()
+
+    test_config.persist_resolved_placement_if_changed(
+        params.get("reuse_cluster") or str(test_config.test_id()),
+        original_region=original_region,
+        region_name=" ".join(params.gce_datacenters) if params.gce_datacenters else None,
+        availability_zone=params.get("availability_zone"),
+    )

--- a/sdcm/sct_provision/instances_provider.py
+++ b/sdcm/sct_provision/instances_provider.py
@@ -81,7 +81,7 @@ def provision_sct_resources(params: SCTConfiguration, test_config: TestConfig, *
 
     Backends that support whole-cluster region fallback (currently GCE) get a pre-provision zone/AZ
     resolve, drive provisioning through the shared region-fallback loop for a single-region config,
-    and persist the resolved placement so a later Run Test step picks up any relocated region. Other
+    and persist the resolved placement so a later Run Test step picks up any relocated region or zone. Other
     backends (AWS uses its own layout; Azure/OCI have no fallback yet) provision once, unchanged - the
     shared shape is ready for them to opt in.
     """
@@ -128,12 +128,20 @@ def _provision_gce_resources(params: SCTConfiguration, test_config: TestConfig, 
     Capacity exhaustion escalates in two steps, each independently gated by its own config flag:
     ``fallback_to_next_availability_zone`` retries the remaining zones of the configured region, and
     only once those are gone does ``fallback_to_next_region`` relocate - the whole cluster for a
-    single-region config, or just the exhausted DC for a multi-region one. Either way a relocated
-    placement is persisted to the resolved-placement handoff so the later Run Test step (a separate
-    hydra command) picks it up, mirroring AWS.
+    single-region config, or just the exhausted DC for a multi-region one.
+
+    Any final placement that differs from the configured one - a relocated region, but also a
+    zone-only change from AZ fallback or from the resolver picking a zone when none is configured -
+    is persisted to the resolved-placement handoff. Unlike AWS, which finds instances region-wide by
+    ``test_id`` tag, GCE instance discovery is zone-scoped, so the later Run Test step (a separate
+    hydra command) must be pointed at the exact zone or it provisions a duplicate cluster.
     """
-    GceAZResolver(params).resolve()
+    # Both baselines must be captured before the resolver runs: with no availability_zone configured
+    # it picks a random valid zone, and that pick has to be detected as a change so the Run Test step
+    # reuses it instead of rolling its own.
     original_region = " ".join(params.gce_datacenters) if params.gce_datacenters else None
+    original_az = params.get("availability_zone")
+    GceAZResolver(params).resolve()
     test_id = str(test_config.test_id())
     network_name = params.get("gce_network")
 
@@ -158,9 +166,11 @@ def _provision_gce_resources(params: SCTConfiguration, test_config: TestConfig, 
     else:
         provision_attempt()
 
-    test_config.persist_resolved_placement_if_changed(
-        params.get("reuse_cluster") or str(test_config.test_id()),
-        original_region=original_region,
-        region_name=" ".join(params.gce_datacenters) if params.gce_datacenters else None,
-        availability_zone=params.get("availability_zone"),
-    )
+    region_name = " ".join(params.gce_datacenters) if params.gce_datacenters else None
+    availability_zone = params.get("availability_zone")
+    if region_name and (region_name != original_region or availability_zone != original_az):
+        test_config.write_resolved_placement(
+            params.get("reuse_cluster") or str(test_config.test_id()),
+            region_name=region_name,
+            availability_zone=availability_zone,
+        )

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -80,10 +80,9 @@ from sdcm.cql_stress_cassandra_stress_thread import CqlStressCassandraStressThre
 from sdcm.mgmt import get_scylla_manager_tool
 from sdcm.provision.aws.az_resolver import (
     AZResolver,
-    is_az_fallback_enabled,
-    is_region_fallback_enabled,
     run_pre_flight_capacity_probe,
 )
+from sdcm.provision.common.fallback import is_az_fallback_enabled, is_region_fallback_enabled
 from sdcm.provision.aws.capacity_errors import ProvisioningCapacityExhausted, RegionAMINotFoundError, is_capacity_error
 from sdcm.provision.aws.capacity_reservation import SCTCapacityReservation
 from sdcm.provision.aws.region_fallback import (
@@ -99,6 +98,7 @@ from sdcm.kafka.kafka_producer import KafkaProducerThread, KafkaValidatorThread
 from sdcm.provision.aws.dedicated_host import SCTDedicatedHosts
 from sdcm.provision.azure.provisioner import AzureProvisioner
 from sdcm.provision.gce.provisioner import GceProvisioner
+from sdcm.provision.gce import region_fallback as gce_region_fallback
 from sdcm.provision.network_configuration import ssh_connection_ip_type
 from sdcm.provision.oci.provisioner import OciProvisioner
 from sdcm.provision.provisioner import ProvisionError, ProvisionUnrecoverableError, provisioner_factory
@@ -1634,7 +1634,49 @@ class ClusterTester(unittest.TestCase):
         self.log.debug("Nemesis threads %s", nemesis_threads)
         return nemesis_threads
 
-    def get_cluster_gce(self, loader_info, db_info, monitor_info):  # noqa: PLR0912, PLR0914
+    def get_cluster_gce(self, loader_info, db_info, monitor_info):
+        """Provision GCE cluster with optional region fallback (whole-cluster or per-DC)."""
+        if is_region_fallback_enabled(self.params):
+            self._get_cluster_gce_with_region_fallback(loader_info, db_info, monitor_info)
+            return
+        self._get_cluster_gce_once(loader_info, db_info, monitor_info)
+
+    def _get_cluster_gce_with_region_fallback(self, loader_info, db_info, monitor_info):
+        """Provision via the centralized GCE fallback router.
+
+        Single-region configs relocate the whole cluster on capacity exhaustion; multi-region configs
+        relocate the exhausted DC. GCE images are global and the SCT network is a single global VPC, so
+        relocation is a plain region switch with no image re-resolution or peering checks.
+        """
+        gce_region_fallback.provision_with_fallback(
+            params=self.params,
+            test_id=str(TestConfig().test_id()),
+            network_name=self.params.get("gce_network"),
+            provision_once=lambda: self._get_cluster_gce_once(loader_info, db_info, monitor_info),
+            partial_cleanup=self._cleanup_legacy_partial_gce_clusters,
+            error_factory=CriticalTestFailure,
+        )
+
+    def _cleanup_legacy_partial_gce_clusters(self) -> None:
+        """Destroy GCE clusters created during a failed region attempt and drop stale references.
+
+        Resetting each attribute to None (and clearing credentials) mirrors the AWS cleanup so a later
+        fallback retry - or the test teardown, if fallback fails entirely - does not touch a destroyed
+        cluster or append duplicate credentials on each retry.
+        """
+        for attr in ("db_cluster", "cs_db_cluster", "loaders", "monitors"):
+            cluster = getattr(self, attr, None)
+            if cluster is None or isinstance(cluster, NoMonitorSet):
+                continue
+            try:
+                cluster.destroy()
+            except Exception as exc:  # noqa: BLE001
+                self.log.warning("Region fallback: failed to destroy %s during cleanup: %s", attr, exc)
+            setattr(self, attr, None)
+
+        self.credentials = []
+
+    def _get_cluster_gce_once(self, loader_info, db_info, monitor_info):  # noqa: PLR0912, PLR0914
         GceAZResolver(self.params).resolve()
 
         datacenters = self.params.gce_datacenters

--- a/unit_tests/lib/dot_dict.py
+++ b/unit_tests/lib/dot_dict.py
@@ -1,0 +1,24 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2026 ScyllaDB
+
+
+class DotDict(dict):
+    """A dict that also supports attribute access, standing in for SCTConfiguration in tests.
+
+    Provides both item access (``d["key"] = ...``) and attribute access (``d.key``), which the
+    provisioning code relies on (e.g. ``params.get(...)`` alongside ``params.gce_datacenters``).
+    """
+
+    __getattr__ = dict.__getitem__
+    __setattr__ = dict.__setitem__
+    __delattr__ = dict.__delitem__

--- a/unit_tests/unit/provisioner/test_az_fallback.py
+++ b/unit_tests/unit/provisioner/test_az_fallback.py
@@ -28,11 +28,7 @@ from sdcm.provision.aws.region_fallback import cleanup_region, switch_region
 from sdcm.sct_provision.aws.layout import SCTProvisionAWSLayout
 from sdcm.tester import ClusterTester
 
-
-class _DotDict(dict):
-    __getattr__ = dict.__getitem__
-    __setattr__ = dict.__setitem__
-    __delattr__ = dict.__delitem__
+from unit_tests.lib.dot_dict import DotDict
 
 
 def _capacity_error() -> ClientError:
@@ -43,7 +39,7 @@ def _capacity_error() -> ClientError:
 
 
 def _make_layout_params(**overrides):
-    params = _DotDict(
+    params = DotDict(
         {
             "cluster_backend": "aws",
             "region_name": "us-east-1",
@@ -228,8 +224,8 @@ def test_get_instances_returns_empty_when_az_idx_out_of_bounds(patched_ec2_for_g
     assert result == []
 
 
-def _make_tester_params(**overrides) -> _DotDict:
-    return _DotDict(
+def _make_tester_params(**overrides) -> DotDict:
+    return DotDict(
         {
             "region_name": "us-east-1",
             "availability_zone": "a",
@@ -343,7 +339,7 @@ def test_provision_legacy_with_az_fallback_non_capacity_error_propagates():
     assert stub._provision_legacy_aws_clusters.call_count == 1
 
 
-class _RegionParams(_DotDict):
+class _RegionParams(DotDict):
     """Params stub that derives `region_names` from `region_name` like `SCTConfiguration`."""
 
     ami_id_params = ["ami_id_db_scylla", "ami_id_loader"]
@@ -632,7 +628,7 @@ def test_cleanup_region_skips_kms_cleanup_without_region():
 
 
 def test_switch_region_sets_placement_resolves_amis_and_invalidates(restore_region_env):  # noqa: ARG001
-    params = _DotDict({"region_name": "us-east-1", "availability_zone": "a"})
+    params = DotDict({"region_name": "us-east-1", "availability_zone": "a"})
     params.region_names = ["us-east-1"]
     params.resolve_amis = MagicMock()
     invalidate = MagicMock()

--- a/unit_tests/unit/provisioner/test_az_resolver.py
+++ b/unit_tests/unit/provisioner/test_az_resolver.py
@@ -20,20 +20,16 @@ from sdcm.provision.aws.az_resolver import (
     AZResolver,
     NoValidAvailabilityZoneError,
     _node_count_positive,
-    is_az_fallback_enabled,
     run_pre_flight_capacity_probe,
 )
+from sdcm.provision.common.fallback import is_az_fallback_enabled
 from sdcm.provision.aws.capacity_errors import ProvisioningCapacityExhausted
 
-
-class _DotDict(dict):
-    __getattr__ = dict.__getitem__
-    __setattr__ = dict.__setitem__
-    __delattr__ = dict.__delitem__
+from unit_tests.lib.dot_dict import DotDict
 
 
 def _make_params(**overrides):
-    params = _DotDict(
+    params = DotDict(
         {
             "cluster_backend": "aws",
             "region_name": "us-east-1",

--- a/unit_tests/unit/provisioner/test_capacity_reservation.py
+++ b/unit_tests/unit/provisioner/test_capacity_reservation.py
@@ -17,6 +17,8 @@ import pytest
 from sdcm.provision.aws.capacity_reservation import SCTCapacityReservation
 from sdcm.exceptions import CapacityReservationError
 
+from unit_tests.lib.dot_dict import DotDict
+
 
 @pytest.fixture(autouse=True)
 def reset_reservations():
@@ -25,11 +27,6 @@ def reset_reservations():
 
 @pytest.fixture(name="params")
 def params_fixture():
-    class DotDict(dict):
-        __getattr__ = dict.__getitem__
-        __setattr__ = dict.__setitem__
-        __delattr__ = dict.__delitem__
-
     return DotDict(
         {
             "test_id": "example-test-id",

--- a/unit_tests/unit/provisioner/test_gce_region_fallback.py
+++ b/unit_tests/unit/provisioner/test_gce_region_fallback.py
@@ -837,6 +837,65 @@ def test_provision_gce_resources_uses_zone_fallback_even_without_region_fallback
     wrapper.assert_called_once()  # provisioning still goes through the zone-retry wrapper
 
 
+def test_provision_gce_resources_persists_zone_only_change():
+    """A zone changed by AZ fallback (region untouched) is persisted for the separate Run Test step.
+
+    Regression: the handoff used to be written only on region change, but GCE instance discovery is
+    zone-scoped (no AWS-style region-wide test_id search), so a Run Test step aimed at the configured
+    zone would miss the instances and provision a duplicate cluster.
+    """
+    params = _make_params(fallback_to_next_region=False, fallback_to_next_availability_zone=True)
+    test_config = MagicMock()
+    test_config.test_id.return_value = "tid-1"
+
+    def zone_fallback_wrapper():
+        params["availability_zone"] = "c"
+
+    with (
+        patch("sdcm.sct_provision.instances_provider.GceAZResolver"),
+        patch(
+            "sdcm.sct_provision.instances_provider.gce_region_fallback.provision_with_az_fallback",
+            return_value=zone_fallback_wrapper,
+        ),
+    ):
+        provision_sct_resources(params=params, test_config=test_config)
+    test_config.write_resolved_placement.assert_called_once_with("tid-1", region_name="us-east1", availability_zone="c")
+
+
+def test_provision_gce_resources_persists_resolver_selected_zone():
+    """A zone the resolver picks when none is configured is persisted too.
+
+    With availability_zone unset the resolver chooses a random valid zone, so a separate Run Test
+    step would roll its own pick unless the provisioning step's choice is handed off.
+    """
+    params = _make_params(fallback_to_next_region=False, availability_zone=None)
+    test_config = MagicMock()
+    test_config.test_id.return_value = "tid-1"
+
+    def fake_resolve():
+        params["availability_zone"] = "d"
+
+    with (
+        patch("sdcm.sct_provision.instances_provider.GceAZResolver") as resolver,
+        patch("sdcm.sct_provision.instances_provider._provision_sct_resources_once"),
+    ):
+        resolver.return_value.resolve.side_effect = fake_resolve
+        provision_sct_resources(params=params, test_config=test_config)
+    test_config.write_resolved_placement.assert_called_once_with("tid-1", region_name="us-east1", availability_zone="d")
+
+
+def test_provision_gce_resources_skips_handoff_when_placement_unchanged():
+    """No handoff file is written when provisioning ends up in the configured region and zone."""
+    params = _make_params(fallback_to_next_region=False)
+    test_config = MagicMock()
+    with (
+        patch("sdcm.sct_provision.instances_provider.GceAZResolver"),
+        patch("sdcm.sct_provision.instances_provider._provision_sct_resources_once"),
+    ):
+        provision_sct_resources(params=params, test_config=test_config)
+    test_config.write_resolved_placement.assert_not_called()
+
+
 def test_provision_gce_resources_routes_to_fallback_when_multi_dc_enabled():
     """Multi-DC GCE configs also go through the fallback router (it dispatches to per-DC fallback)."""
     params = _make_params(fallback_to_next_region=True, gce_datacenter="us-east1 us-west1")

--- a/unit_tests/unit/provisioner/test_gce_region_fallback.py
+++ b/unit_tests/unit/provisioner/test_gce_region_fallback.py
@@ -1,0 +1,900 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2026 ScyllaDB
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from sdcm.provision.common.fallback import is_region_fallback_enabled
+from sdcm.provision.gce import region_fallback as rf
+from sdcm.provision.gce.constants import SUPPORTED_GCE_REGIONS
+from sdcm.provision.gce.zone_resolver import GceAZResolver
+from sdcm.provision.provisioner import ProvisionError, ProvisionUnrecoverableError, ZoneResourcesExhaustedError
+from sdcm.sct_provision.instances_provider import provision_sct_resources
+from sdcm.tester import ClusterTester, CriticalTestFailure
+
+from unit_tests.lib.dot_dict import DotDict
+
+CAPACITY_MSG = "Operation failed: ZONE_RESOURCE_POOL_EXHAUSTED"
+
+
+class _GceParams(DotDict):
+    """Params stand-in whose ``gce_datacenters`` is re-derived on every access.
+
+    ``SCTConfiguration.gce_datacenters`` is a plain (uncached) property over ``gce_datacenter``, which
+    is exactly what lets the fallback loops observe a relocation. Snapshotting it in the test double
+    would hide staleness bugs that bite in production, so mirror the real liveness here.
+    """
+
+    @property
+    def gce_datacenters(self) -> list[str]:
+        raw = self.get("gce_datacenter") or ""
+        return raw.split() if isinstance(raw, str) else list(raw)
+
+
+def _make_params(**overrides):
+    """Build a minimal single-DC GCE params object with region fallback enabled by default."""
+    return _GceParams(
+        {
+            "cluster_backend": "gce",
+            "gce_datacenter": "us-east1",
+            "availability_zone": "b",
+            "gce_instance_type_db": "n2-highmem-8",
+            "gce_instance_type_loader": "e2-standard-2",
+            "gce_instance_type_monitor": "n2-highmem-8",
+            "gce_network": "qa-vpc",
+            "n_db_nodes": 1,
+            "n_loaders": 1,
+            "n_monitor_nodes": 1,
+            "fallback_to_next_region": True,
+            "pre_filter_unavailable_availability_zones": True,
+            **overrides,
+        }
+    )
+
+
+# --------------------------------------------------------------------------- gate
+
+
+def test_is_region_fallback_enabled_gce():
+    """Region fallback is enabled for GCE when fallback_to_next_region is set."""
+    assert is_region_fallback_enabled(_make_params(fallback_to_next_region=True)) is True
+
+
+def test_is_region_fallback_enabled_disabled():
+    """Region fallback is disabled when fallback_to_next_region is false."""
+    assert is_region_fallback_enabled(_make_params(fallback_to_next_region=False)) is False
+
+
+def test_is_region_fallback_enabled_other_backend():
+    """Region fallback is rejected for unsupported backends even if the flag is set."""
+    params = _make_params(cluster_backend="docker", fallback_to_next_region=True)
+    assert is_region_fallback_enabled(params) is False
+
+
+def test_enforce_single_region_gate_ok():
+    """A single configured GCE datacenter passes the region-fallback gate."""
+    rf.enforce_single_region_gate(_make_params())  # does not raise
+
+
+def test_enforce_single_region_gate_rejects_multi_dc():
+    """More than one configured GCE datacenter is rejected by the gate."""
+    params = _make_params(gce_datacenter="us-east1 us-west1")
+    with pytest.raises(ValueError, match="single GCE datacenter"):
+        rf.enforce_single_region_gate(params)
+
+
+# ------------------------------------------------------------------ switch/restore
+
+
+def test_switch_region_updates_params_and_env(monkeypatch):
+    """switch_region updates gce_datacenter, availability_zone, and the env override."""
+    monkeypatch.delenv("SCT_GCE_DATACENTER", raising=False)
+    params = _make_params()
+    rf.switch_region(params, "us-west1", ["a", "b"])
+    assert params["gce_datacenter"] == "us-west1"
+    assert params["availability_zone"] == "a,b"
+    assert os.environ["SCT_GCE_DATACENTER"] == "us-west1"
+
+
+def test_restore_region_pops_env_when_originally_unset(monkeypatch):
+    """restore_region drops the env override when the region was not originally set in the env."""
+    monkeypatch.setenv("SCT_GCE_DATACENTER", "us-west1")
+    params = _make_params()
+    rf.restore_region(params, "us-east1", "b", None)
+    assert params["gce_datacenter"] == "us-east1"
+    assert params["availability_zone"] == "b"
+    assert "SCT_GCE_DATACENTER" not in os.environ
+
+
+def test_restore_region_restores_prior_env(monkeypatch):
+    """restore_region puts back the original env value when there was one."""
+    monkeypatch.setenv("SCT_GCE_DATACENTER", "us-west1")
+    params = _make_params()
+    rf.restore_region(params, "us-east1", "b", "us-east1")
+    assert os.environ["SCT_GCE_DATACENTER"] == "us-east1"
+
+
+# ------------------------------------------------------------------- cleanup_region
+
+
+def test_cleanup_region_sweeps_only_matching_region():
+    """cleanup_region runs the partial cleanup and sweeps only provisioners in the target region."""
+    prov_east = MagicMock(region="us-east1", zone="us-east1-b")
+    prov_west = MagicMock(region="us-west1", zone="us-west1-a")
+    partial = MagicMock()
+    with patch.object(rf.GceProvisioner, "discover_regions", return_value=[prov_east, prov_west]) as discover:
+        rf.cleanup_region("test-id", "us-east1", network_name="qa-vpc", partial_cleanup=partial)
+    partial.assert_called_once()
+    discover.assert_called_once_with("test-id", network_name="qa-vpc")
+    # wait=True so the old region is fully torn down before a relocation reuses the same names
+    prov_east.cleanup.assert_called_once_with(wait=True)
+    prov_west.cleanup.assert_not_called()
+
+
+def test_cleanup_region_swallows_discovery_failure():
+    """A discovery failure during cleanup is logged and swallowed; partial cleanup still runs."""
+    partial = MagicMock()
+    with patch.object(rf.GceProvisioner, "discover_regions", side_effect=RuntimeError("boom")):
+        rf.cleanup_region("test-id", "us-east1", network_name="qa-vpc", partial_cleanup=partial)
+    partial.assert_called_once()  # partial cleanup still ran; discovery error did not propagate
+
+
+# ------------------------------------------------------ get_region_fallback_candidates
+
+
+def test_get_region_fallback_candidates_excludes_current_and_filters_by_zone_support():
+    """Candidates exclude the current region and any region without enough supported zones."""
+    params = _make_params()  # current region us-east1, configured letter "b"
+    zone_table = {
+        "us-east4": ["us-east4-a", "us-east4-b"],
+        "us-west1": ["us-west1-b"],
+        "us-central1": [],  # no zone supports the machine types -> excluded
+    }
+    with patch("sdcm.provision.gce.zone_resolver.GceZoneResolver") as mock_cls:
+        mock_cls.return_value.get_common_zones.side_effect = lambda region, machine_types, preferred_zones: (
+            zone_table.get(region, [])
+        )
+        candidates = list(GceAZResolver(params).get_region_fallback_candidates())
+
+    regions = [region for region, _ in candidates]
+    assert "us-east1" not in regions  # current region excluded
+    assert "us-central1" not in regions  # unsupported region excluded
+    assert candidates == [("us-east4", ["b"]), ("us-west1", ["b"])]
+
+
+def test_get_region_fallback_candidates_never_checks_peering():
+    """GCE uses a global VPC; the candidate path must never perform an AWS-style peering lookup."""
+    params = _make_params()
+    with patch("sdcm.provision.gce.zone_resolver.GceZoneResolver") as mock_cls:
+        mock_cls.return_value.get_common_zones.return_value = ["us-west1-b"]
+        candidates = list(GceAZResolver(params).get_region_fallback_candidates())
+    assert all(isinstance(letters, list) for _, letters in candidates)
+    assert not hasattr(rf, "_is_region_peered")
+
+
+# ------------------------------------------------- shared loop (exercises both paths)
+
+
+def test_loop_success_first_attempt_no_switch_no_cleanup():
+    """When the configured region succeeds, no relocation or cleanup happens."""
+    params = _make_params()
+    provision_once = MagicMock()
+    with patch.object(rf, "cleanup_region") as cleanup:
+        rf.provision_with_region_fallback(
+            params=params,
+            test_id="t",
+            network_name="qa-vpc",
+            region_candidates=lambda: [("us-west1", ["a"])],
+            provision_once=provision_once,
+            error_factory=ProvisionUnrecoverableError,
+        )
+    provision_once.assert_called_once()
+    cleanup.assert_not_called()
+    assert params["gce_datacenter"] == "us-east1"  # unchanged
+
+
+def test_loop_success_does_not_resolve_candidates():
+    """A run that provisions in the configured region must never invoke the (costly) candidate resolver."""
+    params = _make_params()
+    provision_once = MagicMock()  # succeeds on the first attempt
+    candidates = MagicMock(return_value=[("us-west1", ["a"])])
+    with patch.object(rf, "cleanup_region"):
+        rf.provision_with_region_fallback(
+            params=params,
+            test_id="t",
+            network_name="qa-vpc",
+            region_candidates=candidates,
+            provision_once=provision_once,
+            error_factory=ProvisionUnrecoverableError,
+        )
+    provision_once.assert_called_once()
+    candidates.assert_not_called()  # lazy: fallback regions are not probed on the success path
+
+
+def test_loop_relocates_on_zone_exhausted_then_succeeds(monkeypatch):
+    """A ZoneResourcesExhaustedError relocates to the next region, which then succeeds."""
+    monkeypatch.delenv("SCT_GCE_DATACENTER", raising=False)
+    params = _make_params()
+    provision_once = MagicMock(side_effect=[ZoneResourcesExhaustedError(CAPACITY_MSG), None])
+    with patch.object(rf, "cleanup_region") as cleanup:
+        rf.provision_with_region_fallback(
+            params=params,
+            test_id="t",
+            network_name="qa-vpc",
+            region_candidates=lambda: [("us-west1", ["a"])],
+            provision_once=provision_once,
+            error_factory=ProvisionUnrecoverableError,
+        )
+    assert provision_once.call_count == 2
+    cleanup.assert_called_once_with("t", "us-east1", network_name="qa-vpc", partial_cleanup=None)
+    assert params["gce_datacenter"] == "us-west1"  # relocated
+    assert params["availability_zone"] == "a"
+
+
+def test_loop_relocates_on_capacity_provision_error(monkeypatch):
+    """A capacity-class ProvisionError is treated like exhaustion and triggers relocation."""
+    monkeypatch.delenv("SCT_GCE_DATACENTER", raising=False)
+    params = _make_params()
+    provision_once = MagicMock(side_effect=[ProvisionError(CAPACITY_MSG), None])
+    with patch.object(rf, "cleanup_region"):
+        rf.provision_with_region_fallback(
+            params=params,
+            test_id="t",
+            network_name="qa-vpc",
+            region_candidates=lambda: [("us-west1", ["a"])],
+            provision_once=provision_once,
+            error_factory=ProvisionUnrecoverableError,
+        )
+    assert provision_once.call_count == 2
+
+
+def test_loop_non_capacity_error_propagates_and_restores(monkeypatch):
+    """A non-capacity error propagates unchanged and restores the original region/AZ."""
+    monkeypatch.delenv("SCT_GCE_DATACENTER", raising=False)
+    params = _make_params()
+    provision_once = MagicMock(side_effect=ProvisionError("permission denied creating instance"))
+    with patch.object(rf, "cleanup_region") as cleanup:
+        with pytest.raises(ProvisionError, match="permission denied"):
+            rf.provision_with_region_fallback(
+                params=params,
+                test_id="t",
+                network_name="qa-vpc",
+                region_candidates=lambda: [("us-west1", ["a"])],
+                provision_once=provision_once,
+                error_factory=ProvisionUnrecoverableError,
+            )
+    cleanup.assert_not_called()
+    assert params["gce_datacenter"] == "us-east1"  # restored
+    assert params["availability_zone"] == "b"
+
+
+def test_loop_all_regions_exhausted_raises_via_error_factory(monkeypatch):
+    """When the configured region and every candidate are exhausted, error_factory builds the error."""
+    monkeypatch.delenv("SCT_GCE_DATACENTER", raising=False)
+    params = _make_params()
+    provision_once = MagicMock(side_effect=ZoneResourcesExhaustedError(CAPACITY_MSG))
+    with patch.object(rf, "cleanup_region") as cleanup:
+        with pytest.raises(ProvisionUnrecoverableError, match="all fallback candidates"):
+            rf.provision_with_region_fallback(
+                params=params,
+                test_id="t",
+                network_name="qa-vpc",
+                region_candidates=lambda: [("us-west1", ["a"]), ("us-east4", ["b"])],
+                provision_once=provision_once,
+                error_factory=ProvisionUnrecoverableError,
+            )
+    assert provision_once.call_count == 3  # original + 2 candidates
+    assert cleanup.call_count == 3  # each exhausted region cleaned up inside the loop
+    assert params["gce_datacenter"] == "us-east1"  # restored
+    assert "SCT_GCE_DATACENTER" not in os.environ
+
+
+def test_loop_restores_placement_when_candidate_resolution_fails(monkeypatch):
+    """A candidate generator that blows up mid-iteration must not leave us on the fallback region.
+
+    Resolution probes the cloud API, so it can fail *after* an earlier candidate already relocated us;
+    the original placement has to be restored before the error propagates.
+    """
+    monkeypatch.delenv("SCT_GCE_DATACENTER", raising=False)
+    params = _make_params()
+    provision_once = MagicMock(side_effect=ZoneResourcesExhaustedError(CAPACITY_MSG))
+
+    def candidates():
+        yield "us-west1", ["a"]
+        raise RuntimeError("zone list API blew up")
+
+    with patch.object(rf, "cleanup_region"):
+        with pytest.raises(RuntimeError, match="zone list API blew up"):
+            rf.provision_with_region_fallback(
+                params=params,
+                test_id="t",
+                network_name="qa-vpc",
+                region_candidates=candidates,
+                provision_once=provision_once,
+                error_factory=ProvisionUnrecoverableError,
+            )
+    assert params["gce_datacenter"] == "us-east1"  # relocation to us-west1 undone
+    assert params["availability_zone"] == "b"
+    assert "SCT_GCE_DATACENTER" not in os.environ
+
+
+def test_loop_rejects_multi_dc():
+    """The shared loop refuses to run for a multi-DC config."""
+    params = _make_params(gce_datacenter="us-east1 us-west1")
+    with pytest.raises(ValueError, match="single GCE datacenter"):
+        rf.provision_with_region_fallback(
+            params=params,
+            test_id="t",
+            network_name="qa-vpc",
+            region_candidates=list,
+            provision_once=MagicMock(),
+            error_factory=ProvisionUnrecoverableError,
+        )
+
+
+# ----------------------------------------------------- multi-DC: candidates / switch / attribution
+
+
+def test_get_dc_fallback_candidates_excludes_in_use_and_filters_by_zone_support():
+    """DC candidates exclude every in-use region and regions without enough supported zones."""
+    params = _make_params(gce_datacenter="us-east1 us-west1")  # in use: us-east1, us-west1
+    zone_table = {
+        "us-east4": ["us-east4-b"],
+        "us-central1": [],  # no supported zone -> excluded
+    }
+    with patch("sdcm.provision.gce.zone_resolver.GceZoneResolver") as mock_cls:
+        mock_cls.return_value.get_common_zones.side_effect = lambda region, machine_types, preferred_zones: (
+            zone_table.get(region, [])
+        )
+        candidates = list(GceAZResolver(params).get_dc_fallback_candidates(0))
+
+    regions = [region for region, _ in candidates]
+    assert "us-east1" not in regions and "us-west1" not in regions  # in-use DCs excluded
+    assert "us-central1" not in regions  # unsupported region excluded
+    assert candidates == [("us-east4", ["b"])]
+
+
+def test_get_dc_fallback_candidates_skips_regions_missing_the_configured_zone():
+    """A region that qualifies only through some *other* zone letter is skipped, not silently retargeted.
+
+    switch_dc_region deliberately leaves the global availability_zone alone, so a candidate qualified
+    by an alternative letter would aim the retry at a zone the target region does not have.
+    """
+    params = _make_params(gce_datacenter="us-east1 us-west1", availability_zone="b")
+    zone_table = {
+        "us-east4": ["us-east4-a", "us-east4-c"],  # supports 'a'/'c' but NOT the configured 'b'
+        "us-central1": ["us-central1-b"],  # supports the configured 'b'
+    }
+    with patch("sdcm.provision.gce.zone_resolver.GceZoneResolver") as mock_cls:
+        mock_cls.return_value.get_common_zones.side_effect = lambda region, machine_types, preferred_zones: (
+            zone_table.get(region, [])
+        )
+        candidates = list(GceAZResolver(params).get_dc_fallback_candidates(0))
+
+    assert candidates == [("us-central1", ["b"])]  # us-east4 rejected: no 'b' zone
+
+
+def test_get_dc_fallback_candidates_rechecks_live_regions_between_yields():
+    """The in-use region set is re-read per candidate, so a region a sibling DC just took is skipped.
+
+    The multi-DC loop holds one generator per DC for its whole lifetime while *other* DCs keep
+    relocating. A set snapshotted on first use would hand back an already-occupied region and land two
+    DCs in the same one.
+    """
+    params = _make_params(gce_datacenter="us-east1 us-west1", availability_zone="b")
+    with patch("sdcm.provision.gce.zone_resolver.GceZoneResolver") as mock_cls:
+        # Every region supports the configured zone, so only occupancy can filter candidates.
+        mock_cls.return_value.get_common_zones.side_effect = lambda region, machine_types, preferred_zones: (
+            [f"{region}-b"]
+        )
+        candidates = GceAZResolver(params).get_dc_fallback_candidates(0)
+        first_region, _ = next(candidates)
+        # Simulate DC 1 relocating into a region this generator has not offered yet.
+        stolen = next(r for r in SUPPORTED_GCE_REGIONS if r not in (first_region, "us-east1", "us-west1"))
+        params["gce_datacenter"] = f"us-east1 {stolen}"
+        remaining = [region for region, _ in candidates]
+
+    assert stolen not in remaining  # would be a duplicate-region placement
+
+
+def test_switch_dc_region_updates_only_target_dc(monkeypatch):
+    """switch_dc_region relocates just the chosen DC and leaves the global availability_zone alone.
+
+    Safe only because get_dc_fallback_candidates yields back the configured letters (see
+    test_get_dc_fallback_candidates_skips_regions_missing_the_configured_zone).
+    """
+    monkeypatch.delenv("SCT_GCE_DATACENTER", raising=False)
+    params = _make_params(gce_datacenter="us-east1 us-west1")
+    rf.switch_dc_region(params, 1, "us-east4", ["b"])
+    assert params["gce_datacenter"] == "us-east1 us-east4"
+    assert os.environ["SCT_GCE_DATACENTER"] == "us-east1 us-east4"
+    assert params["availability_zone"] == "b"  # global AZ untouched (candidate already supports it)
+
+
+def test_failed_dc_index_attributes_region_from_error():
+    """A capacity error naming a zone is attributed to the DC whose region it belongs to."""
+    params = _make_params(gce_datacenter="us-east1 us-west1")
+    assert rf._failed_dc_index(params, ZoneResourcesExhaustedError("Zone us-west1-b exhausted")) == 1
+    assert rf._failed_dc_index(params, ZoneResourcesExhaustedError("Zone us-east1-c exhausted")) == 0
+    assert rf._failed_dc_index(params, ZoneResourcesExhaustedError("vague error, no region")) is None
+
+
+def test_required_machine_types_excludes_gated_off_types():
+    """A machine type whose node count is 0 (e.g. vector store) is not required, so it never constrains candidates."""
+    params = _make_params(instance_type_vector_store="e2-medium", n_vector_store_nodes=0)
+    types = GceAZResolver(params).required_machine_types()
+    assert "e2-medium" not in types  # gated off (no vector-store nodes)
+    assert "n2-highmem-8" in types  # db type is always required
+
+
+# ------------------------------------------------------------- multi-DC fallback loop
+
+
+def test_dc_loop_relocates_exhausted_dc_then_succeeds(monkeypatch):
+    """The exhausted DC is relocated to a candidate region and the whole cluster retried to success."""
+    monkeypatch.delenv("SCT_GCE_DATACENTER", raising=False)
+    params = _make_params(gce_datacenter="us-east1 us-west1")
+    provision_once = MagicMock(
+        side_effect=[ZoneResourcesExhaustedError("Zone us-west1-b resource pool exhausted"), None]
+    )
+    with (
+        patch.object(rf, "cleanup_region") as cleanup,
+        patch.object(rf, "GceAZResolver") as resolver,
+    ):
+        resolver.return_value.get_dc_fallback_candidates.side_effect = lambda idx: (
+            [("us-east4", ["b"])] if idx == 1 else []
+        )
+        rf.provision_with_dc_fallback(
+            params=params,
+            test_id="t",
+            network_name="qa-vpc",
+            provision_once=provision_once,
+            error_factory=ProvisionUnrecoverableError,
+        )
+    assert provision_once.call_count == 2
+    assert cleanup.called  # exhausted attempt cleaned up before retry
+    assert params["gce_datacenter"] == "us-east1 us-east4"  # only DC 1 relocated
+
+
+def test_dc_loop_success_does_not_resolve_candidates(monkeypatch):
+    """A successful multi-DC run must never resolve any DC's fallback candidates."""
+    monkeypatch.delenv("SCT_GCE_DATACENTER", raising=False)
+    params = _make_params(gce_datacenter="us-east1 us-west1")
+    provision_once = MagicMock()  # succeeds on the first attempt
+    with patch.object(rf, "cleanup_region"), patch.object(rf, "GceAZResolver") as resolver:
+        rf.provision_with_dc_fallback(
+            params=params,
+            test_id="t",
+            network_name="qa-vpc",
+            provision_once=provision_once,
+            error_factory=ProvisionUnrecoverableError,
+        )
+    provision_once.assert_called_once()
+    resolver.return_value.get_dc_fallback_candidates.assert_not_called()  # lazy per-DC resolution
+
+
+def test_dc_loop_all_candidates_exhausted_raises(monkeypatch):
+    """When the failing DC runs out of candidates, error_factory builds the raised error."""
+    monkeypatch.delenv("SCT_GCE_DATACENTER", raising=False)
+    params = _make_params(gce_datacenter="us-east1 us-west1")
+
+    def always_exhaust_dc1(*_args, **_kwargs):
+        raise ZoneResourcesExhaustedError(f"Zone {params['gce_datacenter'].split()[1]}-b resource pool exhausted")
+
+    provision_once = MagicMock(side_effect=always_exhaust_dc1)
+    with (
+        patch.object(rf, "cleanup_region"),
+        patch.object(rf, "GceAZResolver") as resolver,
+    ):
+        resolver.return_value.get_dc_fallback_candidates.side_effect = lambda idx: (
+            [("us-east4", ["b"])] if idx == 1 else []
+        )
+        with pytest.raises(ProvisionUnrecoverableError, match="exhausted its fallback candidates") as exc_info:
+            rf.provision_with_dc_fallback(
+                params=params,
+                test_id="t",
+                network_name="qa-vpc",
+                provision_once=provision_once,
+                error_factory=ProvisionUnrecoverableError,
+            )
+    assert provision_once.call_count == 2  # original + one candidate
+    assert params["gce_datacenter"] == "us-east1 us-west1"  # restored
+    # Chained, so the traceback still shows which capacity error actually ended the run.
+    assert isinstance(exc_info.value.__cause__, ZoneResourcesExhaustedError)
+
+
+def test_dc_loop_restores_placement_when_candidate_resolution_fails(monkeypatch):
+    """A per-DC candidate generator failing after a relocation must restore the original placement."""
+    monkeypatch.delenv("SCT_GCE_DATACENTER", raising=False)
+    params = _make_params(gce_datacenter="us-east1 us-west1")
+
+    def always_exhaust_dc1(*_args, **_kwargs):
+        raise ZoneResourcesExhaustedError(f"Zone {params['gce_datacenter'].split()[1]}-b resource pool exhausted")
+
+    def candidates_then_boom(_dc_index):
+        yield "us-east4", ["b"]
+        raise RuntimeError("zone list API blew up")
+
+    provision_once = MagicMock(side_effect=always_exhaust_dc1)
+    with patch.object(rf, "cleanup_region"), patch.object(rf, "GceAZResolver") as resolver:
+        resolver.return_value.get_dc_fallback_candidates.side_effect = candidates_then_boom
+        with pytest.raises(RuntimeError, match="zone list API blew up"):
+            rf.provision_with_dc_fallback(
+                params=params,
+                test_id="t",
+                network_name="qa-vpc",
+                provision_once=provision_once,
+                error_factory=ProvisionUnrecoverableError,
+            )
+    assert provision_once.call_count == 2  # original + the one candidate before resolution broke
+    assert params["gce_datacenter"] == "us-east1 us-west1"  # us-east4 relocation undone
+    assert "SCT_GCE_DATACENTER" not in os.environ
+
+
+def test_dc_loop_non_capacity_error_propagates_and_restores(monkeypatch):
+    """A non-capacity error propagates unchanged and restores the original multi-DC placement."""
+    monkeypatch.delenv("SCT_GCE_DATACENTER", raising=False)
+    params = _make_params(gce_datacenter="us-east1 us-west1")
+    provision_once = MagicMock(side_effect=ProvisionError("permission denied creating instance"))
+    with (
+        patch.object(rf, "cleanup_region") as cleanup,
+        patch.object(rf, "GceAZResolver") as resolver,
+    ):
+        resolver.return_value.get_dc_fallback_candidates.return_value = [("us-east4", ["b"])]
+        with pytest.raises(ProvisionError, match="permission denied"):
+            rf.provision_with_dc_fallback(
+                params=params,
+                test_id="t",
+                network_name="qa-vpc",
+                provision_once=provision_once,
+                error_factory=ProvisionUnrecoverableError,
+            )
+    cleanup.assert_not_called()
+    assert params["gce_datacenter"] == "us-east1 us-west1"  # restored
+
+
+def test_dc_loop_unattributable_capacity_error_raises(monkeypatch):
+    """A capacity error that names no configured region cannot be relocated and stops the loop."""
+    monkeypatch.delenv("SCT_GCE_DATACENTER", raising=False)
+    params = _make_params(gce_datacenter="us-east1 us-west1")
+    provision_once = MagicMock(side_effect=ZoneResourcesExhaustedError("capacity exhausted, region unknown"))
+    with (
+        patch.object(rf, "cleanup_region"),
+        patch.object(rf, "GceAZResolver") as resolver,
+    ):
+        resolver.return_value.get_dc_fallback_candidates.return_value = [("us-east4", ["b"])]
+        with pytest.raises(ProvisionUnrecoverableError):
+            rf.provision_with_dc_fallback(
+                params=params,
+                test_id="t",
+                network_name="qa-vpc",
+                provision_once=provision_once,
+                error_factory=ProvisionUnrecoverableError,
+            )
+    assert provision_once.call_count == 1  # could not attribute -> no relocation/retry
+
+
+def test_dc_loop_relocates_two_dcs_in_sequence(monkeypatch):
+    """Independent per-DC candidate lists let two different DCs each relocate across retries."""
+    monkeypatch.delenv("SCT_GCE_DATACENTER", raising=False)
+    params = _make_params(gce_datacenter="us-east1 us-west1")
+    calls = {"n": 0}
+
+    def side_effect(*_args, **_kwargs):
+        calls["n"] += 1
+        dcs = params["gce_datacenter"].split()
+        if calls["n"] == 1:
+            raise ZoneResourcesExhaustedError(f"Zone {dcs[0]}-b resource pool exhausted")
+        if calls["n"] == 2:
+            raise ZoneResourcesExhaustedError(f"Zone {dcs[1]}-b resource pool exhausted")
+
+    provision_once = MagicMock(side_effect=side_effect)
+    with patch.object(rf, "cleanup_region"), patch.object(rf, "GceAZResolver") as resolver:
+        resolver.return_value.get_dc_fallback_candidates.side_effect = lambda idx: (
+            [("us-east4", ["b"])] if idx == 0 else [("us-central1", ["b"])]
+        )
+        rf.provision_with_dc_fallback(
+            params=params,
+            test_id="t",
+            network_name="qa-vpc",
+            provision_once=provision_once,
+            error_factory=ProvisionUnrecoverableError,
+        )
+    assert provision_once.call_count == 3  # DC0 relocate, DC1 relocate, then success
+    assert params["gce_datacenter"] == "us-east4 us-central1"  # both DCs relocated independently
+
+
+def test_dc_loop_is_bounded_when_relocation_keeps_failing(monkeypatch):
+    """The attempt count is bounded by the per-DC candidate lists, so a persistently-failing DC stops."""
+    monkeypatch.delenv("SCT_GCE_DATACENTER", raising=False)
+    params = _make_params(gce_datacenter="us-east1 us-west1")
+
+    def always_exhaust_dc0(*_args, **_kwargs):
+        raise ZoneResourcesExhaustedError(f"Zone {params['gce_datacenter'].split()[0]}-b resource pool exhausted")
+
+    provision_once = MagicMock(side_effect=always_exhaust_dc0)
+    with patch.object(rf, "cleanup_region"), patch.object(rf, "GceAZResolver") as resolver:
+        resolver.return_value.get_dc_fallback_candidates.side_effect = lambda idx: (
+            [("us-east4", ["b"]), ("us-central1", ["b"])] if idx == 0 else []
+        )
+        with pytest.raises(ProvisionUnrecoverableError):
+            rf.provision_with_dc_fallback(
+                params=params,
+                test_id="t",
+                network_name="qa-vpc",
+                provision_once=provision_once,
+                error_factory=ProvisionUnrecoverableError,
+            )
+    assert provision_once.call_count == 3  # original + 2 DC0 candidates, then stop (no infinite loop)
+
+
+# ------------------------------------------------------------------ zone (AZ) fallback
+
+
+def test_get_az_fallback_candidates_yields_the_regions_other_supported_zones():
+    """Zone candidates are the region's other supported letters, with the configured one excluded."""
+    params = _make_params(availability_zone="b")
+    with patch("sdcm.provision.gce.zone_resolver.GceZoneResolver") as mock_cls:
+        mock_cls.return_value.get_common_zones.return_value = ["us-east1-b", "us-east1-c", "us-east1-d"]
+        assert list(GceAZResolver(params).get_az_fallback_candidates()) == [["c"], ["d"]]
+
+
+def test_get_az_fallback_candidates_skips_multi_az_configs():
+    """Multi-AZ configs yield nothing: which letter to swap is ambiguous, so region fallback takes over."""
+    params = _make_params(availability_zone="b,c")
+    with patch("sdcm.provision.gce.zone_resolver.GceZoneResolver") as mock_cls:
+        mock_cls.return_value.get_common_zones.return_value = ["us-east1-b", "us-east1-c", "us-east1-d"]
+        assert list(GceAZResolver(params).get_az_fallback_candidates()) == []
+
+
+def test_az_fallback_disabled_returns_the_original_callable():
+    """With fallback_to_next_availability_zone off, provision_once is handed back untouched."""
+    params = _make_params(fallback_to_next_availability_zone=False)
+    provision_once = MagicMock()
+    wrapped = rf.provision_with_az_fallback(
+        params=params, test_id="t", network_name="qa-vpc", provision_once=provision_once
+    )
+    assert wrapped is provision_once
+
+
+def test_az_fallback_retries_next_zone_in_the_same_region():
+    """An exhausted zone retries the region's next supported zone, without relocating the cluster."""
+    params = _make_params(fallback_to_next_availability_zone=True)
+    provision_once = MagicMock(side_effect=[ZoneResourcesExhaustedError(CAPACITY_MSG), None])
+    with patch.object(rf, "cleanup_region") as cleanup, patch.object(rf, "GceAZResolver") as resolver:
+        resolver.return_value.get_az_fallback_candidates.return_value = iter([["c"], ["d"]])
+        rf.provision_with_az_fallback(
+            params=params, test_id="t", network_name="qa-vpc", provision_once=provision_once
+        )()
+    assert provision_once.call_count == 2
+    assert params["availability_zone"] == "c"  # moved to the next zone
+    assert params["gce_datacenter"] == "us-east1"  # region untouched
+    assert cleanup.called  # exhausted zone swept before the retry
+
+
+def test_az_fallback_success_never_resolves_candidates():
+    """A first-attempt success must not probe zone candidates at all."""
+    params = _make_params(fallback_to_next_availability_zone=True)
+    provision_once = MagicMock()
+    with patch.object(rf, "GceAZResolver") as resolver:
+        rf.provision_with_az_fallback(
+            params=params, test_id="t", network_name="qa-vpc", provision_once=provision_once
+        )()
+    provision_once.assert_called_once()
+    resolver.return_value.get_az_fallback_candidates.assert_not_called()
+
+
+def test_az_fallback_restores_zone_and_escalates_when_all_zones_exhausted():
+    """Once every zone is exhausted the AZ is restored and the capacity error escalates to the caller.
+
+    This is what hands control to region / multi-DC fallback - and it must start from the configured
+    placement, not from the last zone we tried.
+    """
+    params = _make_params(fallback_to_next_availability_zone=True)
+    provision_once = MagicMock(side_effect=ZoneResourcesExhaustedError(CAPACITY_MSG))
+    with patch.object(rf, "cleanup_region"), patch.object(rf, "GceAZResolver") as resolver:
+        resolver.return_value.get_az_fallback_candidates.return_value = iter([["c"]])
+        with pytest.raises(ZoneResourcesExhaustedError):
+            rf.provision_with_az_fallback(
+                params=params, test_id="t", network_name="qa-vpc", provision_once=provision_once
+            )()
+    assert provision_once.call_count == 2  # configured zone + one candidate
+    assert params["availability_zone"] == "b"  # restored
+
+
+def test_az_fallback_propagates_non_capacity_error_and_restores_zone():
+    """A non-capacity failure is not a zone problem: restore the AZ and propagate straight away."""
+    params = _make_params(fallback_to_next_availability_zone=True)
+    provision_once = MagicMock(side_effect=ProvisionError("permission denied creating instance"))
+    with patch.object(rf, "GceAZResolver") as resolver:
+        with pytest.raises(ProvisionError, match="permission denied"):
+            rf.provision_with_az_fallback(
+                params=params, test_id="t", network_name="qa-vpc", provision_once=provision_once
+            )()
+    provision_once.assert_called_once()
+    resolver.return_value.get_az_fallback_candidates.assert_not_called()
+    assert params["availability_zone"] == "b"
+
+
+# ----------------------------------------------------------------- fallback router
+
+
+def test_router_single_region_routes_to_region_fallback():
+    """provision_with_fallback sends a single-DC config to the whole-cluster region loop."""
+    params = _make_params()
+    with (
+        patch.object(rf, "GceAZResolver"),
+        patch.object(rf, "provision_with_region_fallback") as region,
+        patch.object(rf, "provision_with_dc_fallback") as multi_dc,
+    ):
+        rf.provision_with_fallback(
+            params=params,
+            test_id="t",
+            network_name="qa-vpc",
+            provision_once=MagicMock(),
+            error_factory=ProvisionUnrecoverableError,
+        )
+    region.assert_called_once()
+    multi_dc.assert_not_called()
+
+
+def test_router_multi_dc_routes_to_dc_fallback():
+    """provision_with_fallback sends a multi-DC config to the per-DC loop."""
+    params = _make_params(gce_datacenter="us-east1 us-west1")
+    with (
+        patch.object(rf, "provision_with_region_fallback") as region,
+        patch.object(rf, "provision_with_dc_fallback") as multi_dc,
+    ):
+        rf.provision_with_fallback(
+            params=params,
+            test_id="t",
+            network_name="qa-vpc",
+            provision_once=MagicMock(),
+            error_factory=ProvisionUnrecoverableError,
+        )
+    multi_dc.assert_called_once()
+    region.assert_not_called()
+
+
+# ------------------------------------------------ modern path routing (provision_sct_resources)
+
+
+def test_provision_gce_resources_routes_to_fallback_when_enabled():
+    """provision_sct_resources drives the fallback router when region fallback is enabled."""
+    params = _make_params(fallback_to_next_region=True)
+    with (
+        patch("sdcm.sct_provision.instances_provider.GceAZResolver") as resolver,
+        patch("sdcm.sct_provision.instances_provider.gce_region_fallback.provision_with_fallback") as fallback,
+        patch("sdcm.sct_provision.instances_provider._provision_sct_resources_once") as once,
+    ):
+        provision_sct_resources(params=params, test_config=MagicMock())
+    resolver.return_value.resolve.assert_called_once()
+    fallback.assert_called_once()
+    once.assert_not_called()
+
+
+def test_provision_gce_resources_routes_to_plain_when_disabled():
+    """Without region fallback, GCE provisions once (no fallback router)."""
+    params = _make_params(fallback_to_next_region=False)
+    with (
+        patch("sdcm.sct_provision.instances_provider.GceAZResolver") as resolver,
+        patch("sdcm.sct_provision.instances_provider.gce_region_fallback.provision_with_fallback") as fallback,
+        patch("sdcm.sct_provision.instances_provider._provision_sct_resources_once") as once,
+    ):
+        provision_sct_resources(params=params, test_config=MagicMock())
+    resolver.return_value.resolve.assert_called_once()
+    fallback.assert_not_called()
+    once.assert_called_once()
+
+
+def test_provision_gce_resources_wraps_provisioning_in_zone_fallback():
+    """The modern path hands the region loop a zone-fallback-wrapped attempt, not the bare one.
+
+    Regression: without this the modern path ignored fallback_to_next_availability_zone entirely, so a
+    single exhausted zone relocated the whole cluster instead of trying the region's other zones.
+    """
+    params = _make_params(fallback_to_next_region=True, fallback_to_next_availability_zone=True)
+    sentinel = MagicMock(name="zone_fallback_wrapper")
+    with (
+        patch("sdcm.sct_provision.instances_provider.GceAZResolver"),
+        patch(
+            "sdcm.sct_provision.instances_provider.gce_region_fallback.provision_with_az_fallback",
+            return_value=sentinel,
+        ) as az_fallback,
+        patch("sdcm.sct_provision.instances_provider.gce_region_fallback.provision_with_fallback") as fallback,
+    ):
+        provision_sct_resources(params=params, test_config=MagicMock())
+    az_fallback.assert_called_once()
+    assert fallback.call_args.kwargs["provision_once"] is sentinel
+
+
+def test_provision_gce_resources_uses_zone_fallback_even_without_region_fallback():
+    """Zone fallback is gated by its own flag, so it still applies when region fallback is off."""
+    params = _make_params(fallback_to_next_region=False, fallback_to_next_availability_zone=True)
+    wrapper = MagicMock(name="zone_fallback_wrapper")
+    with (
+        patch("sdcm.sct_provision.instances_provider.GceAZResolver"),
+        patch(
+            "sdcm.sct_provision.instances_provider.gce_region_fallback.provision_with_az_fallback",
+            return_value=wrapper,
+        ),
+        patch("sdcm.sct_provision.instances_provider.gce_region_fallback.provision_with_fallback") as fallback,
+    ):
+        provision_sct_resources(params=params, test_config=MagicMock())
+    fallback.assert_not_called()
+    wrapper.assert_called_once()  # provisioning still goes through the zone-retry wrapper
+
+
+def test_provision_gce_resources_routes_to_fallback_when_multi_dc_enabled():
+    """Multi-DC GCE configs also go through the fallback router (it dispatches to per-DC fallback)."""
+    params = _make_params(fallback_to_next_region=True, gce_datacenter="us-east1 us-west1")
+    with (
+        patch("sdcm.sct_provision.instances_provider.GceAZResolver"),
+        patch("sdcm.sct_provision.instances_provider.gce_region_fallback.provision_with_fallback") as fallback,
+        patch("sdcm.sct_provision.instances_provider._provision_sct_resources_once") as once,
+    ):
+        provision_sct_resources(params=params, test_config=MagicMock())
+    fallback.assert_called_once()
+    once.assert_not_called()
+
+
+# --------------------------------------------------------- legacy path (tester) routing
+
+
+def _fake_tester(params):
+    """Build a MagicMock tester bound to the given params for exercising ClusterTester methods."""
+    fake = MagicMock()
+    fake.params = params
+    return fake
+
+
+def test_legacy_get_cluster_gce_dispatches_to_region_fallback_when_enabled():
+    """get_cluster_gce routes to the fallback path for a single-DC config with fallback on."""
+    fake = _fake_tester(_make_params(fallback_to_next_region=True))
+    ClusterTester.get_cluster_gce(fake, loader_info={}, db_info={}, monitor_info={})
+    fake._get_cluster_gce_with_region_fallback.assert_called_once()
+    fake._get_cluster_gce_once.assert_not_called()
+
+
+def test_legacy_get_cluster_gce_uses_once_path_when_disabled():
+    """get_cluster_gce uses the single-attempt path when region fallback is disabled."""
+    fake = _fake_tester(_make_params(fallback_to_next_region=False))
+    ClusterTester.get_cluster_gce(fake, loader_info={}, db_info={}, monitor_info={})
+    fake._get_cluster_gce_with_region_fallback.assert_not_called()
+    fake._get_cluster_gce_once.assert_called_once()
+
+
+def test_legacy_get_cluster_gce_dispatches_to_fallback_when_multi_dc():
+    """get_cluster_gce routes multi-DC configs to the fallback path too (per-DC fallback)."""
+    fake = _fake_tester(_make_params(fallback_to_next_region=True, gce_datacenter="us-east1 us-west1"))
+    ClusterTester.get_cluster_gce(fake, loader_info={}, db_info={}, monitor_info={})
+    fake._get_cluster_gce_with_region_fallback.assert_called_once()
+    fake._get_cluster_gce_once.assert_not_called()
+
+
+def test_legacy_region_fallback_delegates_to_router():
+    """The legacy wrapper delegates to the centralized router (which computes candidates itself)."""
+    fake = _fake_tester(_make_params(fallback_to_next_region=True))
+    with (
+        patch("sdcm.tester.TestConfig") as test_config,
+        patch("sdcm.tester.gce_region_fallback.provision_with_fallback") as router,
+    ):
+        test_config.return_value.test_id.return_value = "test-id"
+        ClusterTester._get_cluster_gce_with_region_fallback(fake, loader_info={}, db_info={}, monitor_info={})
+    router.assert_called_once()
+    kwargs = router.call_args.kwargs
+    assert kwargs["error_factory"] is CriticalTestFailure
+    assert kwargs["network_name"] == "qa-vpc"
+    assert "region_candidates" not in kwargs  # router resolves candidates internally

--- a/unit_tests/unit/provisioner/test_gce_zone_resolver.py
+++ b/unit_tests/unit/provisioner/test_gce_zone_resolver.py
@@ -18,15 +18,11 @@ import pytest
 from sdcm.provision.gce.zone_resolver import GceAZResolver, NoValidAvailabilityZoneError, _node_count_positive
 from sdcm.utils.gce_utils import get_alternative_zones
 
-
-class _DotDict(dict):
-    __getattr__ = dict.__getitem__
-    __setattr__ = dict.__setitem__
-    __delattr__ = dict.__delitem__
+from unit_tests.lib.dot_dict import DotDict
 
 
 def _make_params(**overrides):
-    params = _DotDict(
+    params = DotDict(
         {
             "cluster_backend": "gce",
             "gce_datacenter": "us-east1",

--- a/unit_tests/unit/test_config.py
+++ b/unit_tests/unit/test_config.py
@@ -994,6 +994,65 @@ def test_resolved_placement_with_amis_applies_directly_and_skips_re_resolution(m
     assert conf["ami_id_db_scylla"] == "ami-persisted-west"
 
 
+def _set_gce_overlay_env(monkeypatch, test_id, original_datacenter):
+    """Env for a GCE run whose placement handoff should be picked up at config load."""
+    monkeypatch.setenv("SCT_CLUSTER_BACKEND", "gce")
+    monkeypatch.setenv("SCT_CONFIG_FILES", "unit_tests/test_configs/minimal_test_case.yaml")
+    _set_gce_instance_types(monkeypatch)
+    monkeypatch.setenv(
+        "SCT_GCE_IMAGE_DB",
+        "https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-stream-9",
+    )
+    monkeypatch.setenv("SCT_GCE_DATACENTER", original_datacenter)
+    monkeypatch.setenv("SCT_TEST_ID", test_id)
+    monkeypatch.setenv("SCT_USE_MGMT", "false")
+    monkeypatch.delenv("SCT_IGNORE_RESOLVED_PLACEMENT", raising=False)
+
+
+def test_gce_resolved_placement_applies_relocated_datacenter(monkeypatch, placement_logdir):  # noqa: ARG001
+    """A GCE region-fallback relocation is picked up by the next hydra command (the Run Test step).
+
+    GCE carries the region in `gce_datacenter` rather than AWS's `region_name`/AMIs, and
+    `gce_datacenters` is env-first - so the overlay has to rewrite SCT_GCE_DATACENTER, not just the
+    config value, or the split provision->run pipeline snaps back to the original region.
+    """
+    test_id = "33333333-3333-3333-3333-333333333333"
+    _set_gce_overlay_env(monkeypatch, test_id, original_datacenter="us-east1")
+    TestConfig.write_resolved_placement(test_id, region_name="us-west1", availability_zone="c")
+
+    conf = sct_config.SCTConfiguration()
+
+    assert os.environ["SCT_GCE_DATACENTER"] == "us-west1"
+    assert conf.gce_datacenters == ["us-west1"]
+    assert conf["availability_zone"] == "c"
+    assert os.environ["SCT_AVAILABILITY_ZONE"] == "c"
+
+
+def test_gce_resolved_placement_applies_relocated_multi_dc(monkeypatch, placement_logdir):  # noqa: ARG001
+    """The handoff round-trips a multi-DC placement, so per-DC relocation survives the step boundary."""
+    test_id = "44444444-4444-4444-4444-444444444444"
+    _set_gce_overlay_env(monkeypatch, test_id, original_datacenter="us-east1 us-west1")
+    TestConfig.write_resolved_placement(test_id, region_name="us-east1 us-east4", availability_zone="b")
+
+    conf = sct_config.SCTConfiguration()
+
+    assert conf.gce_datacenters == ["us-east1", "us-east4"]  # only the exhausted DC moved
+    assert os.environ["SCT_GCE_DATACENTER"] == "us-east1 us-east4"
+
+
+def test_gce_resolved_placement_ignored_when_disabled(monkeypatch, placement_logdir):  # noqa: ARG001
+    """SCT_IGNORE_RESOLVED_PLACEMENT keeps the configured GCE region, handoff file or not."""
+    test_id = "55555555-5555-5555-5555-555555555555"
+    _set_gce_overlay_env(monkeypatch, test_id, original_datacenter="us-east1")
+    TestConfig.write_resolved_placement(test_id, region_name="us-west1", availability_zone="c")
+    monkeypatch.setenv("SCT_IGNORE_RESOLVED_PLACEMENT", "1")
+
+    conf = sct_config.SCTConfiguration()
+
+    assert conf.gce_datacenters == ["us-east1"]
+    assert os.environ["SCT_GCE_DATACENTER"] == "us-east1"
+
+
 @pytest.mark.parametrize(
     "release_label, expected_error",
     [

--- a/unit_tests/unit/test_dedicated_hosts.py
+++ b/unit_tests/unit/test_dedicated_hosts.py
@@ -16,6 +16,8 @@ import pytest
 
 from sdcm.provision.aws.dedicated_host import SCTDedicatedHosts
 
+from unit_tests.lib.dot_dict import DotDict
+
 
 @pytest.fixture(autouse=True)
 def reset_hosts():
@@ -24,11 +26,6 @@ def reset_hosts():
 
 @pytest.fixture(name="params")
 def params_fixture():
-    class DotDict(dict):
-        __getattr__ = dict.__getitem__
-        __setattr__ = dict.__setitem__
-        __delattr__ = dict.__delitem__
-
     return DotDict(
         {
             "test_id": "example-test-id",


### PR DESCRIPTION
## What / Why

Implements the remaining scope of [SCT-296](https://scylladb.atlassian.net/browse/SCT-296): **capacity-exhaustion fallback for GCE**, mirroring the existing AWS region-fallback design.

GCE already had upfront zone filtering plus runtime zone fallback on the legacy cluster path. This PR completes the escalation ladder and makes it available on **both** provisioning paths:

1. **Zone fallback** — an exhausted zone retries the region's other zones that support the required machine types.
2. **Region fallback** (single-region cluster) — once every zone in the configured region is gone, the whole cluster relocates to the next eligible region.
3. **Per-DC fallback** (multi-region cluster) — only the exhausted DC is relocated, to a region no other DC occupies, and the whole cluster is retried against the updated placement.

Each step is gated by its own existing config flag (`fallback_to_next_availability_zone`, `fallback_to_next_region`), and `defaults/gce_config.yaml` turns both on for GCE.

## Design

The control flow is backend-agnostic and lives in `sdcm/provision/common/region_fallback.py` (`provision_with_region_fallback` for whole-cluster, `provision_with_dc_fallback` for per-DC). Each backend injects how to switch / restore / clean up a placement and how to recognise a capacity error, so OCI and Azure — and eventually AWS, which still has its own copy — can adopt the same loops without duplicating them.

`sdcm/provision/gce/region_fallback.py::provision_with_fallback` is the single entry point both provisioning paths call; it routes by configured DC count so the callers hold no fallback logic:

- **Legacy tester path:** `ClusterTester.get_cluster_gce` → `_get_cluster_gce_once` / `_get_cluster_gce_with_region_fallback`
- **Modern path:** `sct.py` → `instances_provider.provision_sct_resources` → `_provision_gce_resources`

Because the SCT GCE network is a single **global VPC** and GCE images are **global resources**, the GCE variant drops the AWS-only machinery: no VPC-peering eligibility gate and no per-region image re-resolution. A region is eligible if it can supply the configured zones supporting all required machine types.

Notable properties:

- **Lazy candidates.** Fallback candidates are resolved only once a capacity error actually fires, and each region is probed only when the loop reaches it — a run that provisions in its configured placement never probes any other region.
- **Live placement.** Per-DC candidate generators re-read the in-use region set before every candidate, so a DC can't relocate into a region a sibling DC has since taken.
- **Zones survive relocation.** Per-DC candidates are qualified by (and yield back) the *configured* zone letters, because `availability_zone` is one global setting shared by every DC and DC relocation deliberately leaves it alone.
- **Restore on failure.** Any non-capacity error — including a failure inside candidate resolution itself — restores the original placement before propagating.
- **Cleanup before retry.** An exhausted placement is swept (instances deleted concurrently, `wait=True`) before relocating, since instance names are reused across zones/regions.
- **Placement handoff.** A relocated placement is persisted to `resolved_placement.yaml` and re-applied at config load, so the split provision→run pipeline picks up the region fallback chose instead of the original one. For GCE that means `gce_datacenter` / `SCT_GCE_DATACENTER` rather than AWS's `region_name` / AMIs.
- **KMS is unaffected.** GCP Cloud KMS is not region-scoped and SCT takes the keyring location from a static keystore value, so relocation cannot reproduce the AWS `kms_error` failure mode (SCT-718). Recorded as a docstring so it stays that way.

## Testing

- `unit_tests/unit/provisioner/test_gce_region_fallback.py` — 52 tests: zone/region/per-DC candidate generation, switch/restore/cleanup helpers, all three loops (success / relocate-on-capacity / non-capacity-propagate / exhausted / unattributable / bounded), restore-on-resolution-failure, and routing through **both** paths.
- `unit_tests/unit/test_config.py` — 3 new tests for the GCE placement handoff (single-region, multi-DC, and `SCT_IGNORE_RESOLVED_PLACEMENT`).
- Full unit suite green; `sct.py pre-commit` passes.
- Manually verified on real GCE — single-region relocation, per-DC relocation, and the split provision→run handoff — by injecting a simulated stockout with a local throwaway patch (deliberately not part of this PR; see test plan §8).

Design notes and test plan in `docs/plans/mini-plans/2026-07-14-gce-region-fallback.md` and `docs/plans/mini-plans/2026-07-16-gce-region-fallback-testplan.md`.


[SCT-296]: https://scylladb.atlassian.net/browse/SCT-296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ