### PR TITLE
chore(sizing): migrate gemini non-CDC/ICS test configs to constraint-based sizing

### DIFF
--- a/test-cases/gemini/gemini-1tb-10h.yaml
+++ b/test-cases/gemini/gemini-1tb-10h.yaml
@@ -2,8 +2,13 @@ test_duration: 780
 n_db_nodes: 6
 n_test_oracle_db_nodes: 1
 n_loaders: 1
-instance_type_db: 'i7i.2xlarge'
-instance_type_loader: 'm7i.xlarge'
+sizing_db:  # no OCI match (min 16 vCPUs in OCI catalog)
+  vcpu: 8
+  memory: '>=64'
+  arch: x86_64
+sizing_loader:
+  vcpu: 4
+  memory: '>=16'
 
 user_prefix: 'gemini-1tb-10h'
 

--- a/test-cases/gemini/gemini-3h-with-nemesis.yaml
+++ b/test-cases/gemini/gemini-3h-with-nemesis.yaml
@@ -2,8 +2,13 @@ test_duration: 300
 n_db_nodes: 6
 n_test_oracle_db_nodes: 1
 n_loaders: 1
-instance_type_db: 'i7i.large'
-instance_type_loader: 'm7i.large'
+sizing_db:  # no OCI match (min 16 vCPUs in OCI catalog)
+  vcpu: 2
+  memory: '>=16'
+  arch: x86_64
+sizing_loader:
+  vcpu: 2
+  memory: '>=8'
 
 user_prefix: 'gemini-with-nemesis-3h-normal'
 

--- a/test-cases/gemini/gemini-3h-with-nondisruptive-nemesis.yaml
+++ b/test-cases/gemini/gemini-3h-with-nondisruptive-nemesis.yaml
@@ -2,8 +2,13 @@ test_duration: 500
 n_db_nodes: 3
 n_test_oracle_db_nodes: 1
 n_loaders: 1
-instance_type_db: 'i7i.xlarge'
-instance_type_loader: 'm7i.xlarge'
+sizing_db:  # no OCI match (min 16 vCPUs in OCI catalog)
+  vcpu: 4
+  memory: '>=32'
+  arch: x86_64
+sizing_loader:
+  vcpu: 4
+  memory: '>=16'
 
 user_prefix: 'gemini-basic-3h'
 

--- a/test-cases/gemini/gemini-8h-large-num-columns.yaml
+++ b/test-cases/gemini/gemini-8h-large-num-columns.yaml
@@ -2,8 +2,14 @@ test_duration: 500
 n_db_nodes: 6
 n_test_oracle_db_nodes: 1
 n_loaders: 1
-instance_type_db: 'i3en.3xlarge'
-instance_type_loader: 'c6i.4xlarge'
+sizing_db:  # no GCE/Azure/OCI match (12 vCPU tier unavailable on those clouds)
+  vcpu: 12
+  memory: '>=96'
+  arch: x86_64
+  local_disk_gb: '>=6000'  # ~80% of i3en.3xlarge's 7500GB
+sizing_loader:
+  vcpu: 16
+  memory: '>=32'
 
 user_prefix: 'gemini-8h-large-num-columns'
 

--- a/test-cases/gemini/gemini-basic-3h.yaml
+++ b/test-cases/gemini/gemini-basic-3h.yaml
@@ -2,8 +2,13 @@ test_duration: 500
 n_db_nodes: 3
 n_test_oracle_db_nodes: 1
 n_loaders: 1
-instance_type_db: 'i7i.large'
-instance_type_loader: 'm7i.large'
+sizing_db:  # no OCI match (min 16 vCPUs in OCI catalog)
+  vcpu: 2
+  memory: '>=16'
+  arch: x86_64
+sizing_loader:
+  vcpu: 2
+  memory: '>=8'
 
 user_prefix: 'gemini-basic-3h'
 

--- a/test-cases/gemini/gemini-cassandra-oracle-aws.yaml
+++ b/test-cases/gemini/gemini-cassandra-oracle-aws.yaml
@@ -2,9 +2,17 @@ test_duration: 30
 n_db_nodes: 3
 n_test_oracle_db_nodes: 1
 n_loaders: 1
-instance_type_db: 'i4i.xlarge'
-instance_type_db_oracle: 'r6i.xlarge'
-instance_type_loader: 'm6i.xlarge'
+sizing_db:  # no OCI match (min 16 vCPUs in OCI catalog)
+  vcpu: 4
+  memory: '>=32'
+  arch: x86_64
+sizing_db_oracle:  # no OCI match (min 16 vCPUs in OCI catalog)
+  vcpu: 4
+  memory: '>=32'
+  arch: x86_64
+sizing_loader:
+  vcpu: 4
+  memory: '>=16'
 
 db_type: mixed_cassandra
 cassandra_oracle_version: '4.1'


### PR DESCRIPTION
Replace literal instance_type_db/instance_type_loader/instance_type_db_oracle params with sizing_db/sizing_loader/sizing_db_oracle constraints in the 6 gemini test-case YAML files not matching *cdc*/*ics* (gemini-cassandra-oracle-docker.yaml needs no change since it has no instance_type_* params).

Tests: sizing preview on all 6 migrated test-cases/gemini/*.yaml files — all resolve without errors

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)

closes: SCT-594