### PR TITLE
fix(remoter): stop shell-quoting rsync remote paths

### DIFF
--- a/sdcm/remote/remote_base.py
+++ b/sdcm/remote/remote_base.py
@@ -261,10 +261,10 @@ class RemoteCmdRunnerBase(CommandRunner, RetryMixin):
         try_scp = True
         if self.use_rsync():
             try:
-                remote_source = self._encode_remote_paths(src)
+                remote_sources = self._encode_rsync_remote_paths(src)
                 local_dest = quote(dst)
                 rsync = self._make_rsync_cmd(
-                    [remote_source], local_dest, delete_dst, preserve_symlinks, timeout, sudo=sudo
+                    remote_sources, local_dest, delete_dst, preserve_symlinks, timeout, sudo=sudo
                 )
                 result = LocalCmdRunner().run(rsync, timeout=timeout)
                 self.log.debug(result.exited)
@@ -377,7 +377,9 @@ class RemoteCmdRunnerBase(CommandRunner, RetryMixin):
         if self.use_rsync():
             try:
                 local_sources = [quote(os.path.expanduser(path)) for path in src]
-                rsync = self._make_rsync_cmd(local_sources, remote_dest, delete_dst, preserve_symlinks, sudo=sudo)
+                rsync = self._make_rsync_cmd(
+                    local_sources, self._encode_rsync_remote_paths([dst])[0], delete_dst, preserve_symlinks, sudo=sudo
+                )
                 LocalCmdRunner().run(rsync)
                 try_scp = False
             except (self.exception_failure, self.exception_unexpected) as details:
@@ -477,6 +479,18 @@ class RemoteCmdRunnerBase(CommandRunner, RetryMixin):
         if escape:
             paths = [self._scp_remote_escape(path) for path in paths]
         return '%s@[%s]:"%s"' % (self.user, self.hostname, " ".join(paths))
+
+    def _encode_rsync_remote_paths(self, paths: List[str]) -> List[str]:
+        """
+        Build rsync remote path args, one per path:
+        - first path is full: user@[host]:path
+        - remaining paths are short: :path (same remote host)
+
+        quote() is applied to each full path for local shell safety.
+        """
+        first_path = f"{self.user}@[{self.hostname}]:{paths[0]}"
+        other_paths = (f":{path}" for path in paths[1:])
+        return [quote(spec) for spec in (first_path, *other_paths)]
 
     def _make_scp_cmd(self, src: str, dst: str, connect_timeout: int = 300, alive_interval: int = 300) -> str:
         """
@@ -636,7 +650,8 @@ class RemoteCmdRunnerBase(CommandRunner, RetryMixin):
             sudo_cmd = "--rsync-path='sudo rsync'"
         else:
             sudo_cmd = ""
-        command = "rsync %s %s %s --timeout=%s --rsh='%s' -az %s %s"
+        # --secluded-args sends paths over the rsync protocol instead of the remote shell command line
+        command = "rsync --secluded-args %s %s %s --timeout=%s --rsh='%s' -az %s %s"
         return command % (symlink_flag, sudo_cmd, delete_flag, timeout, ssh_cmd, " ".join(src), dst)
 
     def _make_proxy_cmd(self):


### PR DESCRIPTION
Since rsync 3.2.4 remote args are no longer interpreted by the remote shell, so the shell quoting applied to remote paths reaches the remote side as literal quote characters and file/dirs transfer can fail with exit code 23.
One example of the problem manifestation is when monitoring stack collection started to fail for runs with `~` symbol in the archive name, resulting in monitor-set archives unrestorable by `hydra investigate show-monitor` command.

The fix encodes rsync remote paths as is (quoted only for the local shell) and adds `--secluded-args` option, so no shell on either side interprets them. The scp fallback keeps the old quoting.

Fixes: SCT-652

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :green_circle: [pr-provision-test](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/pr-provision-test/324/)
The test was executed with for the Scylla version that contains `~` symbol:
```
< t:2026-07-15 11:58:24,316 f:db_log_reader.py l:152  c:sdcm.db_log_reader   p:DEBUG > 2026-07-15T11:58:22.913 PR-provision-test-fix-moni-db-node-794d7d2e-1  !INFO | scylla[9321] Scylla version 2026.3.0~dev-0.20260710.9cda315bbab0 with build-id 7944965af8c138db00d72edc67e55096afb96cac starting ...
```
The monitoring stack data is collected an the stack can be restored:
```
❯ hydra investigate show-monitor 794d7d2e-a9fb-4d6a-b5af-12d55b86577b
...
    PR-provision-test-fix-moni-monitor-node-794d7d2e-1    
┏━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━┓
┃ Service            ┃ Container ┃ Link                  ┃
┡━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━┩
│ Grafana service    │ agraf     │ http://127.0.0.1:3000 │
│ Prometheus service │ aprom     │ http://127.0.0.1:9090 │
│ Alert service      │ aalert    │ http://127.0.0.1:6000 │
└────────────────────┴───────────┴───────────────────────┘
```

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
