### PR TITLE
fix(matrix-trigger): release version should be passed as is

### DIFF
--- a/sdcm/utils/trigger_matrix.py
+++ b/sdcm/utils/trigger_matrix.py
@@ -135,7 +135,7 @@ def resolve_to_full_version(
 
     if SIMPLE_VERSION_RE.match(scylla_version):
         # e.g., 2025.4 — try as branch:latest
-        version = _resolve_version_via_branched_ami(f"{scylla_version}:latest", lookup_region)
+        version = _resolve_version_via_branched_ami(scylla_version, lookup_region)
         if version:
             return version
 

--- a/unit_tests/trigger_matrix/test_resolve_version.py
+++ b/unit_tests/trigger_matrix/test_resolve_version.py
@@ -1,0 +1,101 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2026 ScyllaDB
+
+from unittest.mock import patch
+
+import pytest
+
+from sdcm.utils.trigger_matrix import TriggerMatrixError, resolve_to_full_version
+
+
+FULL_TAG = "2025.4.1-0.20250601.abc123def456-1"
+
+
+@pytest.mark.parametrize(
+    "full_version",
+    [
+        pytest.param("2024.2.5-0.20250221.cb9e2a54ae6d-1", id="release_tag"),
+        pytest.param("2026.2.0~dev-0.20260322.f51126483167", id="dev_nightly_tag"),
+        pytest.param("2025.1.3-0.20260101.abcdef123456-1", id="full_tag_with_suffix"),
+    ],
+)
+def test_full_version_tag_returned_as_is(full_version):
+    """Already-full version tags bypass AMI lookup entirely."""
+    result = resolve_to_full_version(full_version)
+    assert result == full_version
+
+
+@patch("sdcm.utils.trigger_matrix._resolve_version_via_branched_ami")
+def test_branch_qualifier_version_passes_as_is(mock_resolve):
+    """branch:qualifier versions (e.g. master:latest) are forwarded verbatim."""
+    mock_resolve.return_value = FULL_TAG
+
+    result = resolve_to_full_version("master:latest")
+
+    assert result == FULL_TAG
+    mock_resolve.assert_called_once_with("master:latest", "eu-west-1")
+
+
+@patch("sdcm.utils.trigger_matrix._resolve_version_via_branched_ami")
+def test_simple_version_passed_as_is_not_with_latest(mock_resolve):
+    """Simple versions like '2025.4' must be passed as-is, NOT as '2025.4:latest'.
+
+    Regression test for 588466ad06: appending ':latest' to release versions
+    would never work with get_branched_ami.
+    """
+    mock_resolve.return_value = FULL_TAG
+
+    result = resolve_to_full_version("2025.4")
+
+    assert result == FULL_TAG
+    mock_resolve.assert_called_once_with("2025.4", "eu-west-1")
+
+
+@patch("sdcm.utils.trigger_matrix._resolve_version_via_branched_ami")
+def test_simple_three_part_version_passed_as_is(mock_resolve):
+    """Three-part simple versions (e.g. '2025.4.0') are also passed verbatim."""
+    mock_resolve.return_value = FULL_TAG
+
+    result = resolve_to_full_version("2025.4.0")
+
+    assert result == FULL_TAG
+    mock_resolve.assert_called_once_with("2025.4.0", "eu-west-1")
+
+
+@patch("sdcm.utils.trigger_matrix._resolve_version_via_branched_ami")
+def test_custom_region_forwarded(mock_resolve):
+    """Explicit region is forwarded to the AMI lookup."""
+    mock_resolve.return_value = FULL_TAG
+
+    result = resolve_to_full_version("2025.4", region="us-east-1")
+
+    assert result == FULL_TAG
+    mock_resolve.assert_called_once_with("2025.4", "us-east-1")
+
+
+@patch("sdcm.utils.trigger_matrix._resolve_version_via_branched_ami")
+def test_raises_when_version_cannot_be_resolved(mock_resolve):
+    """Raises TriggerMatrixError when AMI lookup returns empty for simple version."""
+    mock_resolve.return_value = ""
+
+    with pytest.raises(TriggerMatrixError, match="Cannot resolve '2025.4'"):
+        resolve_to_full_version("2025.4")
+
+
+@patch("sdcm.utils.trigger_matrix._resolve_version_via_branched_ami")
+def test_branch_version_fallthrough_raises(mock_resolve):
+    """Raises when branch:qualifier format also fails to resolve."""
+    mock_resolve.return_value = ""
+
+    with pytest.raises(TriggerMatrixError, match="Cannot resolve 'branch-2025.4:latest'"):
+        resolve_to_full_version("branch-2025.4:latest")


### PR DESCRIPTION
it was a mistake appending ":latest" to those versions, it would never gonna work, dropping that logic.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
