### PR TITLE
fix(matrix-trigger): pass release versions as-is without AMI resolution

### DIFF
--- a/sdcm/utils/trigger_matrix.py
+++ b/sdcm/utils/trigger_matrix.py
@@ -77,6 +77,9 @@ FULL_VERSION_TAG_RE = re.compile(
     r"[~-][a-zA-Z0-9._~]+-?\d*\.\d{8}\.[0-9a-f]+(?:-\d+)?$"
 )
 
+# Regex for release version strings like: 2026.1.8, 2025.4.1 (three-part, specific release)
+RELEASE_VERSION_RE = re.compile(r"^(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)$")
+
 # Regex for simple version strings like: 2025.4, 2025.4.0, 5.2.1
 SIMPLE_VERSION_RE = re.compile(r"^(?P<major>\d+)\.(?P<minor>\d+)(?:\.\d+)?$")
 
@@ -121,6 +124,9 @@ def resolve_to_full_version(
         TriggerMatrixError: If the version cannot be resolved.
     """
     if is_full_version_tag(scylla_version):
+        return scylla_version
+
+    if RELEASE_VERSION_RE.match(scylla_version):
         return scylla_version
 
     # For branch:qualifier or simple versions, resolve via AMI lookup

--- a/unit_tests/trigger_matrix/test_resolve_version.py
+++ b/unit_tests/trigger_matrix/test_resolve_version.py
@@ -30,14 +30,25 @@ FULL_TAG = "2025.4.1-0.20250601.abc123def456-1"
     ],
 )
 def test_full_version_tag_returned_as_is(full_version):
-    """Already-full version tags bypass AMI lookup entirely."""
     result = resolve_to_full_version(full_version)
     assert result == full_version
 
 
+@pytest.mark.parametrize(
+    "release_version",
+    [
+        pytest.param("2026.1.8", id="release_2026"),
+        pytest.param("2025.4.1", id="release_2025"),
+        pytest.param("5.2.1", id="oss_release"),
+    ],
+)
+def test_release_version_returned_as_is(release_version):
+    result = resolve_to_full_version(release_version)
+    assert result == release_version
+
+
 @patch("sdcm.utils.trigger_matrix._resolve_version_via_branched_ami")
 def test_branch_qualifier_version_passes_as_is(mock_resolve):
-    """branch:qualifier versions (e.g. master:latest) are forwarded verbatim."""
     mock_resolve.return_value = FULL_TAG
 
     result = resolve_to_full_version("master:latest")
@@ -48,11 +59,6 @@ def test_branch_qualifier_version_passes_as_is(mock_resolve):
 
 @patch("sdcm.utils.trigger_matrix._resolve_version_via_branched_ami")
 def test_simple_version_passed_as_is_not_with_latest(mock_resolve):
-    """Simple versions like '2025.4' must be passed as-is, NOT as '2025.4:latest'.
-
-    Regression test for 588466ad06: appending ':latest' to release versions
-    would never work with get_branched_ami.
-    """
     mock_resolve.return_value = FULL_TAG
 
     result = resolve_to_full_version("2025.4")
@@ -62,19 +68,7 @@ def test_simple_version_passed_as_is_not_with_latest(mock_resolve):
 
 
 @patch("sdcm.utils.trigger_matrix._resolve_version_via_branched_ami")
-def test_simple_three_part_version_passed_as_is(mock_resolve):
-    """Three-part simple versions (e.g. '2025.4.0') are also passed verbatim."""
-    mock_resolve.return_value = FULL_TAG
-
-    result = resolve_to_full_version("2025.4.0")
-
-    assert result == FULL_TAG
-    mock_resolve.assert_called_once_with("2025.4.0", "eu-west-1")
-
-
-@patch("sdcm.utils.trigger_matrix._resolve_version_via_branched_ami")
 def test_custom_region_forwarded(mock_resolve):
-    """Explicit region is forwarded to the AMI lookup."""
     mock_resolve.return_value = FULL_TAG
 
     result = resolve_to_full_version("2025.4", region="us-east-1")
@@ -85,7 +79,6 @@ def test_custom_region_forwarded(mock_resolve):
 
 @patch("sdcm.utils.trigger_matrix._resolve_version_via_branched_ami")
 def test_raises_when_version_cannot_be_resolved(mock_resolve):
-    """Raises TriggerMatrixError when AMI lookup returns empty for simple version."""
     mock_resolve.return_value = ""
 
     with pytest.raises(TriggerMatrixError, match="Cannot resolve '2025.4'"):
@@ -94,7 +87,6 @@ def test_raises_when_version_cannot_be_resolved(mock_resolve):
 
 @patch("sdcm.utils.trigger_matrix._resolve_version_via_branched_ami")
 def test_branch_version_fallthrough_raises(mock_resolve):
-    """Raises when branch:qualifier format also fails to resolve."""
     mock_resolve.return_value = ""
 
     with pytest.raises(TriggerMatrixError, match="Cannot resolve 'branch-2025.4:latest'"):


### PR DESCRIPTION
Three-part release versions like "2026.1.8" are specific enough for
downstream Jenkins jobs to resolve their own images via scylla_version.
Attempting to resolve them via `get_branched_ami` was failing because
that API only handles branch lookups, not release versions.

Added `RELEASE_VERSION_RE` to detect three-part versions and return
them immediately without AMI lookup.

### Testing
- Unit tests added covering release version pass-through

### PR pre-checks (self review)
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code