### PR TITLE
feature(matrix-trigger): add disabled field to skip jobs without removing them

### DIFF
--- a/configurations/triggers/perf-regression.yaml
+++ b/configurations/triggers/perf-regression.yaml
@@ -110,6 +110,7 @@ jobs:
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-during-rolling-upgrade"
     backend: "aws"
     region: "eu-west-1"
+    disabled: true
     labels: []
     params:
       rolling_upgrade_test: "true"
@@ -129,6 +130,7 @@ jobs:
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-with-nemesis-rbno-disabled"
     backend: "aws"
     region: "eu-west-3"
+    disabled: true
     labels: []
 
   # === Weekly microbenchmarks ===
@@ -166,6 +168,7 @@ jobs:
   - job_name: "/scylla-master/perf-regression/perf-regression-predefined-throughput-steps-sanity-vnodes"
     backend: "aws"
     region: ""
+    disabled: true
     labels: ["master-daily"]
 
   # === Weekly alternator perf (master-only) ===

--- a/sdcm/utils/trigger_matrix.py
+++ b/sdcm/utils/trigger_matrix.py
@@ -321,6 +321,7 @@ class JobConfig(BaseModel):
     job_name: str
     backend: Literal["aws", "gce", "azure", "docker", "oci"]
     region: str = ""
+    disabled: bool = False
     labels: list[str] = Field(default_factory=list)
     include_versions: list[str] = Field(default_factory=list)
     exclude_versions: list[str] = Field(default_factory=list)
@@ -525,6 +526,10 @@ def filter_jobs(
 
     result = []
     for job in jobs:
+        if job.disabled:
+            logger.debug("Skipping job '%s': disabled", job.job_name)
+            continue
+
         # Skip by name
         if job.job_name in skip_set:
             logger.debug("Skipping job '%s': in skip list", job.job_name)

--- a/unit_tests/trigger_matrix/test_filtering.py
+++ b/unit_tests/trigger_matrix/test_filtering.py
@@ -187,3 +187,13 @@ def test_pre_release_checks_resolved_version():
     assert len(result) == 1
     result = filter_jobs(jobs, scylla_version="2025.1:latest", resolved_version="2025.1.3-0.abc")
     assert len(result) == 0
+
+
+def test_disabled_jobs_are_skipped():
+    jobs = [
+        JobConfig(job_name="active-job", backend="aws", region=""),
+        JobConfig(job_name="disabled-job", backend="aws", region="", disabled=True),
+    ]
+    result = filter_jobs(jobs, scylla_version="2025.4")
+    assert len(result) == 1
+    assert result[0].job_name == "active-job"


### PR DESCRIPTION
Add a `disabled: true` option to `JobConfig` so jobs can be temporarily
excluded from triggering without deleting them from the YAML. This is
useful when a job is broken or under maintenance.

Disabled `perf-regression-predefined-throughput-steps-sanity-vnodes`
which should not be triggered for now.

### Testing
- Unit test added for disabled job filtering

### PR pre-checks (self review)
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code