### PR TITLE
fix(upgrade-versions): fix UnboundLocalError in get_version for non-unstable repos

### DIFF
--- a/utils/get_supported_scylla_base_versions.py
+++ b/utils/get_supported_scylla_base_versions.py
@@ -63,15 +63,12 @@ class UpgradeBaseVersion:
         """
         LOGGER.info("Getting scylla product and major version for upgrade versions listing...")
         if scylla_version is None:
-            try:
-                assert "unstable/" in self.scylla_repo, (
-                    "Did not find 'unstable/' in scylla_repo. Scylla repo: %s" % self.scylla_repo
-                )
-                version = self.scylla_repo.split("unstable/")[1].split("/")[1]
-                scylla_version = version.replace("branch-", "").replace("enterprise-", "")
-            except AssertionError:
+            if "unstable/" in self.scylla_repo:
+                version_part = self.scylla_repo.split("unstable/")[1].split("/")[1]
+                scylla_version = version_part.replace("branch-", "").replace("enterprise-", "")
+            else:
                 scylla_version = get_branch_version(self.scylla_repo)
-        LOGGER.info("Scylla major version used for upgrade versions listing: %s", version)
+        LOGGER.info("Scylla major version used for upgrade versions listing: %s", scylla_version)
         return scylla_version
 
     def set_start_support_version(self, backend: str = None) -> None:


### PR DESCRIPTION
The `get_version` method used a `try/assert/except` pattern that left the
local variable `version` unbound when the `scylla_repo` URL did not
contain `"unstable/"` (e.g. `https://downloads.scylladb.com/deb/debian/scylla-2026.2.list`).

The `except` block also referenced a misspelled `AssertionError` instead of
`AssertionError`, so the assertion failure would propagate as an unhandled
exception rather than being caught.

**Fix**: Replace the `try/assert/except` with a simple `if/else` check
(matching the fix already on master), and log `scylla_version` instead of
the unbound `version` variable.

**Reproducer** (fails before, works after):
```bash
uv run sct.py get-scylla-base-versions --only-print-versions true --linux-distro ubuntu-focal --scylla-repo https://downloads.scylladb.com/deb/debian/scylla-2026.2.list --backend aws
```