### PR TITLE
fix(trigger-matrix): clear scylla_version for rolling upgrade tests and pass base_versions

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -3219,6 +3219,14 @@ def hdr_investigate(
     type=str,
     help="Scylla repo URL for rolling-upgrade jobs (RPM .repo or DEB .list). Overrides per-job template values.",
 )
+@click.option(
+    "--base-versions",
+    default=None,
+    type=str,
+    help="Passed from scylla-pkg release triggers. Only relevant for rolling upgrade tests. "
+    "Comma-separated base versions to upgrade FROM (e.g., '2025.1,2025.2'). "
+    "When empty, the downstream job auto-selects base versions.",
+)
 @click.option("--dry-run", is_flag=True, default=False, help="Preview mode — do not trigger jobs")
 @click.option(
     "--use-job-throttling/--no-use-job-throttling",
@@ -3247,6 +3255,7 @@ def trigger_matrix_cmd(  # noqa: PLR0912, PLR0913
     oci_image_db,
     unified_package,
     new_scylla_repo,
+    base_versions,
     dry_run,
     use_job_throttling,
     requested_by_user,
@@ -3316,6 +3325,8 @@ def trigger_matrix_cmd(  # noqa: PLR0912, PLR0913
         overrides["unified_package"] = unified_package
     if new_scylla_repo:
         overrides["new_scylla_repo"] = new_scylla_repo
+    if base_versions:
+        overrides["base_versions"] = base_versions
     if use_job_throttling is not None:
         overrides["use_job_throttling"] = use_job_throttling
 

--- a/sdcm/utils/trigger_matrix.py
+++ b/sdcm/utils/trigger_matrix.py
@@ -701,6 +701,10 @@ def build_job_parameters(
     if job.region:
         params.setdefault("region", job.region)
 
+    is_rolling_upgrade = str(params.get("rolling_upgrade_test", "")).lower() == "true"
+    if is_rolling_upgrade:
+        params["scylla_version"] = ""
+
     # Resolve {branch} templates — use the original version (e.g., "master:latest")
     # not the resolved full tag (e.g., "2026.3.0~dev-...") which yields "2026.3".
     branch = _extract_branch_from_version(branch_source_version or scylla_version)

--- a/unit_tests/trigger_matrix/test_rolling_upgrade.py
+++ b/unit_tests/trigger_matrix/test_rolling_upgrade.py
@@ -160,3 +160,51 @@ def test_branch_source_version_none_falls_back_to_scylla_version():
     )
     params = build_job_parameters(job, {}, "2025.4.1-0.20250601.abc123def456-1", {}, branch_source_version=None)
     assert params["new_scylla_repo"] == "http://repo/2025.4/rpm/scylla.repo"
+
+
+def test_rolling_upgrade_test_clears_scylla_version():
+    """When rolling_upgrade_test is true, scylla_version is sent empty."""
+    job = JobConfig(
+        job_name="perf-regression/rolling-upgrade-test",
+        backend="aws",
+        region="eu-west-1",
+        params={
+            "rolling_upgrade_test": "true",
+            "new_scylla_repo": "http://downloads/{branch}/deb/scylla.list",
+        },
+    )
+    params = build_job_parameters(
+        job, {}, "2026.3.0~dev-0.20260710.9cda315bbab0", {}, branch_source_version="master:latest"
+    )
+    assert params["scylla_version"] == ""
+    assert params["new_scylla_repo"] == "http://downloads/master/deb/scylla.list"
+    assert params["rolling_upgrade_test"] == "true"
+
+
+def test_rolling_upgrade_test_keeps_base_versions_from_override():
+    """base_versions from CLI overrides is passed to rolling upgrade jobs."""
+    job = JobConfig(
+        job_name="perf-regression/rolling-upgrade-test",
+        backend="aws",
+        region="eu-west-1",
+        params={
+            "rolling_upgrade_test": "true",
+            "new_scylla_repo": "http://downloads/{branch}/deb/scylla.list",
+        },
+    )
+    overrides = {"base_versions": "2025.1,2025.2"}
+    params = build_job_parameters(job, {}, "master:latest", overrides)
+    assert params["scylla_version"] == ""
+    assert params["base_versions"] == "2025.1,2025.2"
+
+
+def test_non_rolling_upgrade_keeps_scylla_version():
+    """Non-rolling-upgrade jobs still get scylla_version set normally."""
+    job = JobConfig(
+        job_name="perf-regression/throughput-test",
+        backend="aws",
+        region="us-east-1",
+        params={"sub_tests": '["test_read"]'},
+    )
+    params = build_job_parameters(job, {}, "2026.3.0~dev-0.20260710.9cda315bbab0", {})
+    assert params["scylla_version"] == "2026.3.0~dev-0.20260710.9cda315bbab0"

--- a/vars/triggerMatrixPipeline.groovy
+++ b/vars/triggerMatrixPipeline.groovy
@@ -70,6 +70,8 @@ def call(Map pipelineParams = [:]) {
                    description: 'URL to unified (relocatable) Scylla package — for PGO offline installer triggers')
             string(name: 'new_scylla_repo', defaultValue: '',
                    description: 'Scylla repo URL for rolling-upgrade jobs (RPM .repo or DEB .list). Overrides per-job template values when set.')
+            string(name: 'base_versions', defaultValue: '',
+                   description: 'Passed from scylla-pkg release triggers. Only relevant for rolling upgrade tests. Comma-separated base versions to upgrade FROM (e.g., "2025.1,2025.2"). When empty, the downstream job auto-selects base versions.')
             string(name: 'requested_by_user', defaultValue: '',
                    description: 'User requesting the run')
             string(name: 'billing_project', defaultValue: '',
@@ -189,6 +191,9 @@ def call(Map pipelineParams = [:]) {
                         }
                         if (params.new_scylla_repo?.trim()) {
                             cmd += " --new-scylla-repo '${params.new_scylla_repo}'"
+                        }
+                        if (params.base_versions?.trim()) {
+                            cmd += " --base-versions '${params.base_versions}'"
                         }
                         if (params.requested_by_user?.trim()) {
                             cmd += " --requested-by-user '${params.requested_by_user}'"


### PR DESCRIPTION
## Summary

When a job has `rolling_upgrade_test: "true"` in its params, the trigger matrix now sends `scylla_version` as empty so the downstream rolling upgrade job selects its own base version automatically.

Additionally, `base_versions` is now exposed as a CLI option and Groovy pipeline parameter, passed from scylla-pkg release triggers to rolling upgrade jobs. This mirrors the behavior of the old `perfRegressionParallelPipelinebyRegion.groovy` trigger.

## Changes

- **`sdcm/utils/trigger_matrix.py`** — `build_job_parameters()` clears `scylla_version` when `rolling_upgrade_test` is truthy
- **`sct.py`** — Added `--base-versions` CLI option (passed from scylla-pkg, relevant only for rolling upgrade tests)
- **`vars/triggerMatrixPipeline.groovy`** — Added `base_versions` pipeline parameter and CLI passthrough
- **`unit_tests/trigger_matrix/test_rolling_upgrade.py`** — 3 new tests

## Manual Testing Required

- [ ] Trigger perf-regression matrix with a rolling upgrade job in dry-run mode and verify `scylla_version` is empty in output
- [ ] Trigger rolling-upgrade matrix with `--base-versions "2025.1"` and verify it is forwarded to the job