### PR TITLE
fix(perf-regression): align regions with groovy pipeline and add job_throttle_category support

### DIFF
--- a/configurations/triggers/perf-regression.yaml
+++ b/configurations/triggers/perf-regression.yaml
@@ -57,33 +57,37 @@ jobs:
 
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-i8g-vnodes"
     backend: "aws"
-    region: "us-east-1"
+    region: "eu-west-2"
     include_versions: ["master"]
     labels: ["master-monthly"]
+    job_throttle_category: "SCT-perf-eu-west-2-i8g"
     params:
       sub_tests: '["test_read_gradual_increase_load", "test_mixed_gradual_increase_load", "test_write_gradual_increase_load", "test_read_disk_only_gradual_increase_load"]'
 
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-i8g-vnodes"
     backend: "aws"
-    region: "us-east-1"
+    region: "eu-west-2"
     exclude_versions: ["2025.2", "2025.1", "2024.2", "2024.1", "master"]
     labels: []
+    job_throttle_category: "SCT-perf-eu-west-2-i8g"
     params:
       sub_tests: '["test_mixed_gradual_increase_load"]'
 
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-with-nemesis-i8g-vnodes"
     backend: "aws"
-    region: "us-east-2"
+    region: "eu-north-1"
     include_versions: ["master"]
     labels: ["master-monthly"]
+    job_throttle_category: "SCT-perf-eu-north-1-i8g"
     params:
       sub_tests: '["test_latency_mixed_with_nemesis", "test_latency_read_with_nemesis", "test_latency_write_with_nemesis"]'
 
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-with-nemesis-i8g-vnodes"
     backend: "aws"
-    region: "us-east-2"
+    region: "eu-west-1"
     exclude_versions: ["2025.2", "2025.1", "2024.2", "2024.1", "master"]
     labels: []
+    job_throttle_category: "SCT-perf-eu-west-1-i8g"
     params:
       sub_tests: '["test_latency_mixed_with_nemesis"]'
 
@@ -208,14 +212,16 @@ jobs:
     region: "us-east-1"
     include_versions: ["master"]
     labels: ["master-weekly"]
+    job_throttle_category: "SCT-perf-us-east-1-i8g"
     params:
       sub_tests: '["test_read_gradual_increase_load", "test_mixed_gradual_increase_load", "test_write_gradual_increase_load", "test_read_disk_only_gradual_increase_load"]'
 
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-i8g-tablets"
     backend: "aws"
-    region: "us-east-1"
+    region: "us-west-2"
     exclude_versions: ["2025.2", "2025.1", "2024.1", "2024.2", "master"]
     labels: []
+    job_throttle_category: "SCT-perf-us-west-2-i8g"
     params:
       sub_tests: '["test_read_gradual_increase_load", "test_mixed_gradual_increase_load", "test_write_gradual_increase_load", "test_read_disk_only_gradual_increase_load"]'
 
@@ -262,18 +268,20 @@ jobs:
 
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-during-rolling-upgrade-i8g-tablets"
     backend: "aws"
-    region: "us-west-2"
+    region: "us-east-2"
     include_versions: ["master"]
     labels: ["master-3weeks"]
+    job_throttle_category: "SCT-perf-us-east-2-i8g"
     params:
       sub_tests: '["test_latency_mixed_with_upgrade"]'
       rolling_upgrade_test: "true"
 
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-during-rolling-upgrade-i8g-tablets"
     backend: "aws"
-    region: "us-west-2"
+    region: "eu-west-2"
     exclude_versions: ["2025.2", "2025.1", "2024.2", "2024.1", "master"]
     labels: []
+    job_throttle_category: "SCT-perf-eu-west-2-i8g"
     params:
       sub_tests: '["test_latency_mixed_with_upgrade"]'
       rolling_upgrade_test: "true"
@@ -282,17 +290,19 @@ jobs:
 
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-with-nemesis-i8g-tablets"
     backend: "aws"
-    region: "us-east-2"
+    region: "eu-north-1"
     include_versions: ["master"]
     labels: ["master-3weeks"]
+    job_throttle_category: "SCT-perf-eu-north-1-i8g"
     params:
       sub_tests: '["test_latency_mixed_with_nemesis"]'
 
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-with-nemesis-i8g-tablets"
     backend: "aws"
-    region: "us-east-2"
+    region: "eu-west-2"
     exclude_versions: ["2025.2", "2025.1", "2024.2", "2024.1", "master"]
     labels: []
+    job_throttle_category: "SCT-perf-eu-west-2-i8g"
     params:
       sub_tests: '["test_latency_read_with_nemesis", "test_latency_mixed_with_nemesis"]'
 

--- a/sdcm/utils/trigger_matrix.py
+++ b/sdcm/utils/trigger_matrix.py
@@ -326,6 +326,7 @@ class JobConfig(BaseModel):
     include_versions: list[str] = Field(default_factory=list)
     exclude_versions: list[str] = Field(default_factory=list)
     pre_release: list[str] = Field(default_factory=list)
+    job_throttle_category: str = ""
     params: dict = Field(default_factory=dict)
     wait: bool = False
     wait_timeout: int = WAIT_TIMEOUT
@@ -700,6 +701,8 @@ def build_job_parameters(
         params["scylla_version"] = scylla_version
     if job.region:
         params.setdefault("region", job.region)
+    if job.job_throttle_category:
+        params.setdefault("job_throttle_category", job.job_throttle_category)
 
     is_rolling_upgrade = str(params.get("rolling_upgrade_test", "")).lower() == "true"
     if is_rolling_upgrade:


### PR DESCRIPTION
## Summary

Aligns regions in `configurations/triggers/perf-regression.yaml` to match the `testRegionMatrix` in `vars/perfRegressionParallelPipelinebyRegion.groovy` (current source of truth), and adds `job_throttle_category` support to the trigger_matrix Python logic.

## Region Alignment

| Job | Version filter | Before | After (from Groovy) |
|-----|------|--------|---------|
| predefined-throughput-steps-i8g-vnodes | master | us-east-1 | eu-west-2 |
| predefined-throughput-steps-i8g-vnodes | >=2025.3 | us-east-1 | eu-west-2 |
| latency-650gb-with-nemesis-i8g-vnodes | master | us-east-2 | eu-north-1 |
| latency-650gb-with-nemesis-i8g-vnodes | >=2025.3 | us-east-2 | eu-west-1 |
| predefined-throughput-steps-i8g-tablets | >=2025.3 | us-east-1 | us-west-2 |
| rolling-upgrade-i8g-tablets | master | us-west-2 | us-east-2 |
| rolling-upgrade-i8g-tablets | >=2025.3 | us-west-2 | eu-west-2 |
| nemesis-i8g-tablets | master | us-east-2 | eu-north-1 |
| nemesis-i8g-tablets | >=2025.3 | us-east-2 | eu-west-2 |

## job_throttle_category Support

- Added optional `job_throttle_category` field to `JobConfig` model in `sdcm/utils/trigger_matrix.py`
- When set, it is passed through as a Jenkins parameter (matching the groovy behavior of `string(name: 'job_throttle_category', value: job_throttle_category)`)
- Added values to all i8g job entries in the YAML, matching the groovy pipeline's per-job throttle categories

## Backends Affected
- [x] AWS — region routing changes for perf regression jobs
