### PR TITLE
fix(trigger-matrix): pass new_scylla_repo only to rolling-upgrade jobs

### DIFF
--- a/sdcm/utils/trigger_matrix.py
+++ b/sdcm/utils/trigger_matrix.py
@@ -707,6 +707,10 @@ def build_job_parameters(
     is_rolling_upgrade = str(params.get("rolling_upgrade_test", "")).lower() == "true"
     if is_rolling_upgrade:
         params["scylla_version"] = ""
+    else:
+        # new_scylla_repo is only relevant for rolling-upgrade jobs; passing it
+        # to regular tests (e.g. perf) causes them to install wrong packages.
+        params.pop("new_scylla_repo", None)
 
     # Resolve {branch} templates — use the original version (e.g., "master:latest")
     # not the resolved full tag (e.g., "2026.3.0~dev-...") which yields "2026.3".

--- a/unit_tests/trigger_matrix/test_rolling_upgrade.py
+++ b/unit_tests/trigger_matrix/test_rolling_upgrade.py
@@ -48,7 +48,8 @@ def test_branch_template_resolved_in_params():
         backend="gce",
         region="us-central1",
         params={
-            "new_scylla_repo": "http://downloads.scylladb.com/unstable/scylla/{branch}/rpm/centos/latest/scylla.repo"
+            "rolling_upgrade_test": "true",
+            "new_scylla_repo": "http://downloads.scylladb.com/unstable/scylla/{branch}/rpm/centos/latest/scylla.repo",
         },
     )
     params = build_job_parameters(job, {}, "master:latest", {})
@@ -63,7 +64,10 @@ def test_branch_template_from_simple_version():
         job_name="rolling-upgrade/test",
         backend="gce",
         region="us-central1",
-        params={"new_scylla_repo": "http://repo/{branch}/deb/scylla.list"},
+        params={
+            "rolling_upgrade_test": "true",
+            "new_scylla_repo": "http://repo/{branch}/deb/scylla.list",
+        },
     )
     params = build_job_parameters(job, {}, "2025.4", {})
     assert params["new_scylla_repo"] == "http://repo/2025.4/deb/scylla.list"
@@ -74,7 +78,10 @@ def test_branch_template_from_full_version_tag():
         job_name="rolling-upgrade/test",
         backend="aws",
         region="eu-west-1",
-        params={"new_scylla_repo": "http://repo/{branch}/rpm/scylla.repo"},
+        params={
+            "rolling_upgrade_test": "true",
+            "new_scylla_repo": "http://repo/{branch}/rpm/scylla.repo",
+        },
     )
     params = build_job_parameters(job, {}, "2025.4.1-0.20250601.abc123def456-1", {})
     assert params["new_scylla_repo"] == "http://repo/2025.4/rpm/scylla.repo"
@@ -85,7 +92,10 @@ def test_no_template_no_change():
         job_name="rolling-upgrade/test",
         backend="aws",
         region="eu-west-1",
-        params={"new_scylla_repo": "http://explicit-repo/scylla.repo"},
+        params={
+            "rolling_upgrade_test": "true",
+            "new_scylla_repo": "http://explicit-repo/scylla.repo",
+        },
     )
     params = build_job_parameters(job, {}, "master:latest", {})
     assert params["new_scylla_repo"] == "http://explicit-repo/scylla.repo"
@@ -96,7 +106,10 @@ def test_cli_override_wins_over_template():
         job_name="rolling-upgrade/test",
         backend="gce",
         region="us-central1",
-        params={"new_scylla_repo": "http://downloads/{branch}/rpm/scylla.repo"},
+        params={
+            "rolling_upgrade_test": "true",
+            "new_scylla_repo": "http://downloads/{branch}/rpm/scylla.repo",
+        },
     )
     params = build_job_parameters(job, {}, "master:latest", {"new_scylla_repo": "http://custom/release/scylla.repo"})
     assert params["new_scylla_repo"] == "http://custom/release/scylla.repo"
@@ -107,7 +120,10 @@ def test_empty_version_no_resolution():
         job_name="rolling-upgrade/test",
         backend="gce",
         region="us-central1",
-        params={"new_scylla_repo": "http://downloads/{branch}/rpm/scylla.repo"},
+        params={
+            "rolling_upgrade_test": "true",
+            "new_scylla_repo": "http://downloads/{branch}/rpm/scylla.repo",
+        },
     )
     params = build_job_parameters(job, {}, "", {})
     assert params["new_scylla_repo"] == "http://downloads/{branch}/rpm/scylla.repo"
@@ -138,7 +154,8 @@ def test_branch_source_version_overrides_resolved_version():
         backend="gce",
         region="us-central1",
         params={
-            "new_scylla_repo": "http://downloads.scylladb.com.s3.amazonaws.com/unstable/scylla/{branch}/deb/unified/latest/scylladb-{branch}/scylla.list"
+            "rolling_upgrade_test": "true",
+            "new_scylla_repo": "http://downloads.scylladb.com.s3.amazonaws.com/unstable/scylla/{branch}/deb/unified/latest/scylladb-{branch}/scylla.list",
         },
     )
     params = build_job_parameters(
@@ -147,7 +164,7 @@ def test_branch_source_version_overrides_resolved_version():
     assert params["new_scylla_repo"] == (
         "http://downloads.scylladb.com.s3.amazonaws.com/unstable/scylla/master/deb/unified/latest/scylladb-master/scylla.list"
     )
-    assert params["scylla_version"] == "2026.3.0~dev-0.20260710.9cda315bbab0"
+    assert params["scylla_version"] == ""
 
 
 def test_branch_source_version_none_falls_back_to_scylla_version():
@@ -156,7 +173,10 @@ def test_branch_source_version_none_falls_back_to_scylla_version():
         job_name="rolling-upgrade/test",
         backend="gce",
         region="us-central1",
-        params={"new_scylla_repo": "http://repo/{branch}/rpm/scylla.repo"},
+        params={
+            "rolling_upgrade_test": "true",
+            "new_scylla_repo": "http://repo/{branch}/rpm/scylla.repo",
+        },
     )
     params = build_job_parameters(job, {}, "2025.4.1-0.20250601.abc123def456-1", {}, branch_source_version=None)
     assert params["new_scylla_repo"] == "http://repo/2025.4/rpm/scylla.repo"
@@ -208,3 +228,30 @@ def test_non_rolling_upgrade_keeps_scylla_version():
     )
     params = build_job_parameters(job, {}, "2026.3.0~dev-0.20260710.9cda315bbab0", {})
     assert params["scylla_version"] == "2026.3.0~dev-0.20260710.9cda315bbab0"
+
+
+def test_non_rolling_upgrade_strips_new_scylla_repo_from_overrides():
+    """new_scylla_repo passed via CLI overrides must not reach non-upgrade jobs."""
+    job = JobConfig(
+        job_name="perf-regression/throughput-test",
+        backend="aws",
+        region="us-east-1",
+        params={"sub_tests": '["test_read"]'},
+    )
+    overrides = {"new_scylla_repo": "http://downloads/master/rpm/scylla.repo"}
+    params = build_job_parameters(job, {}, "2026.3.0~dev-0.20260710.9cda315bbab0", overrides)
+    assert "new_scylla_repo" not in params
+    assert params["scylla_version"] == "2026.3.0~dev-0.20260710.9cda315bbab0"
+
+
+def test_non_rolling_upgrade_strips_new_scylla_repo_from_defaults():
+    """new_scylla_repo in matrix defaults must not reach non-upgrade jobs."""
+    job = JobConfig(
+        job_name="perf-regression/latency-test",
+        backend="aws",
+        region="eu-west-1",
+        params={},
+    )
+    defaults = {"new_scylla_repo": "http://downloads/master/rpm/scylla.repo"}
+    params = build_job_parameters(job, defaults, "master:latest", {})
+    assert "new_scylla_repo" not in params


### PR DESCRIPTION
## Problem

`build_job_parameters()` unconditionally merged `new_scylla_repo` from CLI
overrides and matrix defaults into **all** triggered jobs. Non-upgrade jobs
(e.g. perf-regression throughput/latency tests) received a repo URL meant
only for rolling-upgrade tests, causing them to install wrong ScyllaDB
packages and fail.

## Fix

After the existing `is_rolling_upgrade` check in `build_job_parameters()`,
strip `new_scylla_repo` from the parameter dict when the job does **not**
have `rolling_upgrade_test=true`. Upgrade jobs continue to receive it as
before.

## Tests

- Updated 8 existing tests to properly declare `rolling_upgrade_test: "true"`
  (they were already testing upgrade-job scenarios but were not setting the flag)
- Added 2 new tests verifying `new_scylla_repo` is stripped from non-upgrade
  jobs regardless of whether it comes via CLI overrides or matrix defaults

## Files changed

- `sdcm/utils/trigger_matrix.py` — 4-line fix in `build_job_parameters()`
- `unit_tests/trigger_matrix/test_rolling_upgrade.py` — test corrections + new tests