### PR TITLE
refactor(email): remove dead email_data collection code

### DIFF
--- a/artifacts_test.py
+++ b/artifacts_test.py
@@ -566,28 +566,3 @@ class ArtifactsTest(ClusterTester):
                 if scylla_doctor.is_full_edition:
                     scylla_doctor.run_analysis_phase()
                     scylla_doctor.analyze_and_verify_analysis_results()
-
-    def get_email_data(self):
-        self.log.info("Prepare data for email")
-        email_data = self._get_common_email_data()
-        try:
-            node = self.node
-        except (ValueError, IndexError):
-            node = None
-        if node:
-            scylla_packages = node.scylla_packages_installed
-        else:
-            scylla_packages = None
-        if not scylla_packages:
-            scylla_packages = ["No scylla packages are installed. Please check log files."]
-        email_data.update(
-            {
-                "scylla_node_image": node.image if node else "Node has not been initialized",
-                "scylla_packages_installed": scylla_packages,
-                "unified_package": self.params.get("unified_package"),
-                "nonroot_offline_install": self.params.get("nonroot_offline_install"),
-                "scylla_repo": self.params.get("scylla_repo"),
-            }
-        )
-
-        return email_data

--- a/cdc_replication_test.py
+++ b/cdc_replication_test.py
@@ -434,21 +434,3 @@ class CDCReplicationTest(ClusterTester):
         res = loader_node.remoter.run(cmd=f"wget {REPLICATOR_URL} -O replicator.jar")
         if res.exit_status != 0:
             self.fail("Could not obtain CDC replicator.")
-
-    def get_email_data(self) -> dict:
-        self.log.info("Prepare data for email")
-
-        email_data = self._get_common_email_data()
-        email_data.update(
-            {
-                "nemesis_details": self.get_nemesises_stats(),
-                "nemesis_name": str(self.params.get("nemesis_class_name")),
-                "scylla_ami_id": self.params.get("ami_id_db_scylla") or "-",
-                "number_of_oracle_nodes": self.params.get("n_test_oracle_db_nodes"),
-                "oracle_ami_id": self.params.get("ami_id_db_oracle"),
-                "oracle_db_version": self.cs_db_cluster.nodes[0].scylla_version if self.cs_db_cluster else "N/A",
-                "oracle_instance_type": self.params.get("instance_type_db_oracle"),
-                "consistency_status": self.consistency_ok,
-            }
-        )
-        return email_data

--- a/cluster_configuration_tests.py
+++ b/cluster_configuration_tests.py
@@ -25,11 +25,6 @@ class ClusterConfigurationTests(ClusterTester):
 
     default_params = {"timeout": 650000}
 
-    def get_email_data(self):
-        self.log.info("Prepare data for email")
-        email_data = self._get_common_email_data()
-        return email_data
-
     def test_build(self):
         """
         Build a Scylla cluster with params defined in data_dir/scylla.yaml

--- a/functional_tests/scylla_operator/libs/auxiliary.py
+++ b/functional_tests/scylla_operator/libs/auxiliary.py
@@ -28,17 +28,6 @@ class ScyllaOperatorFunctionalClusterTester(ClusterTester):
     test_data: dict = {}
     healthy_flag: bool = True
 
-    def get_email_data(self):
-        self.log.info("Prepare data for email")
-        email_data = self._get_common_email_data()
-        email_data.update(
-            {
-                "test_statuses": self.test_data,
-                "scylla_ami_id": self.params.get("ami_id_db_scylla") or "-",
-            }
-        )
-        return email_data
-
     def update_test_status(self, test_name, status, error=None):
         self.test_data[test_name] = (status, error)
 

--- a/gemini_test.py
+++ b/gemini_test.py
@@ -118,32 +118,3 @@ class GeminiTest(ClusterTester):
     def verify_results(self):
         if self.gemini_results["status"] == "FAILED":
             self.fail(self.gemini_results["results"])
-
-    def get_email_data(self):
-        self.log.info("Prepare data for email")
-
-        email_data = self._get_common_email_data()
-
-        if self.loaders:
-            gemini_version = self.loaders.gemini_version
-        else:
-            self.log.warning("Failed to get gemini version as loader instance is not created")
-            gemini_version = ""
-
-        email_data.update(
-            {
-                "gemini_cmd": self.gemini_results["cmd"],
-                "gemini_version": gemini_version,
-                "nemesis_details": self.get_nemesises_stats(),
-                "nemesis_name": self.params.get("nemesis_class_name"),
-                "number_of_oracle_nodes": self.params.get("n_test_oracle_db_nodes"),
-                "oracle_ami_id": self.params.get("ami_id_db_oracle"),
-                "oracle_db_version": self.cs_db_cluster.nodes[0].scylla_version if self.cs_db_cluster else "N/A",
-                "oracle_instance_type": self.params.get("instance_type_db_oracle"),
-                "results": self.gemini_results["results"],
-                "scylla_ami_id": self.params.get("ami_id_db_scylla"),
-                "status": self.gemini_results["status"],
-            }
-        )
-
-        return email_data

--- a/jepsen_test.py
+++ b/jepsen_test.py
@@ -109,15 +109,5 @@ class JepsenTest(ClusterTester):
 
         return jepsen_report.name
 
-    def get_email_data(self):
-        self.log.info("Prepare data for email")
-        email_data = self._get_common_email_data()
-        email_data.update(
-            {
-                "jepsen_report": self.save_jepsen_report(),
-                "jepsen_scylla_repo": self.params.get("jepsen_scylla_repo"),
-                "jepsen_test_cmd": self.params.get("jepsen_test_cmd"),
-                "scylla_repo": self.params.get("scylla_repo"),
-            }
-        )
-        return email_data
+    def collect_test_artifacts(self):
+        self.save_jepsen_report()

--- a/longevity_test.py
+++ b/longevity_test.py
@@ -530,25 +530,6 @@ class LongevityTest(ClusterTester, loader_utils.LoaderUtilsMixin):
         for node in self.db_cluster.nodes:
             node.run_nodetool("flush")
 
-    def get_email_data(self):
-        self.log.info("Prepare data for email")
-
-        email_data = self._get_common_email_data()
-
-        benchmarks_results = self.db_cluster.get_node_benchmarks_results() if self.db_cluster else {}
-        # If cluster was not created, not need to collect nemesis stats - they do not exist
-        nemeses_stats = self.get_nemesises_stats() if self.db_cluster else {}
-
-        email_data.update(
-            {
-                "node_benchmarks": benchmarks_results,
-                "nemesis_details": nemeses_stats,
-                "nemesis_name": str(self.params.get("nemesis_class_name")),
-                "scylla_ami_id": self.params.get("ami_id_db_scylla") or "-",
-            }
-        )
-        return email_data
-
     def create_templated_user_stress_params(self, idx, cs_profile) -> List[Dict]:
         params_list = []
         cs_duration = self.params.get("cs_duration")

--- a/mgmt_upgrade_test.py
+++ b/mgmt_upgrade_test.py
@@ -45,21 +45,6 @@ class ManagerUpgradeTest(ManagerTestFunctionsMixIn, ClusterTester):
         - Backup file integrity validation across versions
     """
 
-    def get_email_data(self) -> dict:
-        self.log.info("Prepare data for email")
-        email_data = self._get_common_email_data()
-        email_data.update(
-            {
-                "manager_server_repo": self.params.get("scylla_mgmt_address"),
-                "manager_agent_repo": (
-                    self.params.get("scylla_mgmt_agent_address") or self.params.get("scylla_mgmt_address")
-                ),
-                "target_manager_server_repo": self.params.get("target_scylla_mgmt_server_address"),
-                "target_manager_agent_repo": self.params.get("target_scylla_mgmt_agent_address"),
-            }
-        )
-        return email_data
-
     def _create_simple_table(self, table_name: str, keyspace_name: str = "ks1") -> None:
         with self.db_cluster.cql_connection_patient(self.db_node) as session:
             session.execute(

--- a/performance_regression_test.py
+++ b/performance_regression_test.py
@@ -845,9 +845,6 @@ class PerformanceRegressionTest(ClusterTester, loader_utils.LoaderUtilsMixin):
 
 
 class PerformanceRegressionUpgradeTest(PerformanceRegressionTest, UpgradeTest):
-    def get_email_data(self):
-        return PerformanceRegressionTest.get_email_data(self)
-
     @latency_calculator_decorator(legend="Upgrade Node")
     def upgrade_node(self, node, hdr_tags: list[str]):
         # NOTE: 'hdr_tags' will be used by the 'latency_calculator_decorator' decorator

--- a/performance_scale_up_test.py
+++ b/performance_scale_up_test.py
@@ -50,21 +50,3 @@ class ScaleUpTest(ClusterTester):
         node.remoter.sudo("find /var/lib/scylla/data/keyspace1/standard1-* -type f | sudo xargs rm -f")
         node.start_scylla_server()
         self.log.info("Data destroyed on node %s", node)
-
-    def get_email_data(self):
-        self.log.info("Prepare data for email")
-        email_data = {}
-
-        try:
-            email_data = self._get_common_email_data()
-        except Exception as error:
-            self.log.exception("Error in gathering common email data: Error:\n%s", error, exc_info=error)
-
-        email_data.update(
-            {
-                "ingest_time": self.ingest_time,
-                "rebuild_duration": self.rebuild_duration,
-                "subject": f"Scale up test results - {email_data['scylla_instance_type']}",
-            }
-        )
-        return email_data

--- a/scylla_cloud_e2e_test.py
+++ b/scylla_cloud_e2e_test.py
@@ -198,11 +198,6 @@ class ScyllaCloudTestBase(ClusterTester, LoaderUtilsMixin):
             cluster_name=self.db_cluster.name,
         )
 
-    def get_email_data(self):
-        self.log.info("Prepare data for email")
-        email_data = self._get_common_email_data()
-        return email_data
-
 
 class XCloudVectorSearchTest(ScyllaCloudTestBase):
     """Verify that vector search operations remain functional during XCloud cluster auto-scaling."""

--- a/sdcm/mgmt/operations.py
+++ b/sdcm/mgmt/operations.py
@@ -762,31 +762,6 @@ class ManagerTestFunctionsMixIn(
     test_config = TestConfig()
     manager_test_metrics = ManagerTestMetrics()
 
-    def get_email_data(self):
-        self.log.info("Prepare data for email")
-
-        email_data = self._get_common_email_data()
-
-        restore_parameters = self.params.get("mgmt_restore_extra_params")
-
-        agent_backup_config = self.params.get("mgmt_agent_backup_config")
-        if agent_backup_config:
-            agent_backup_config = agent_backup_config.model_dump()
-
-        email_data.update(
-            {
-                "manager_server_repo": self.params.get("scylla_mgmt_address"),
-                "manager_agent_repo": (
-                    self.params.get("scylla_mgmt_agent_address") or self.params.get("scylla_mgmt_address")
-                ),
-                "backup_time": str(self.manager_test_metrics.backup_time),
-                "restore_time": str(self.manager_test_metrics.restore_time),
-                "restore_parameters": restore_parameters,
-                "agent_backup_config": agent_backup_config,
-            }
-        )
-        return email_data
-
     @cached_property
     def db_node(self):
         return self.db_cluster.nodes[0]

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -17,7 +17,6 @@ import importlib
 from collections import defaultdict
 from copy import deepcopy
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from dataclasses import asdict
 
 import random
 import logging
@@ -28,7 +27,7 @@ import time
 import traceback
 import unittest
 from pathlib import Path
-from typing import NamedTuple, Optional, Union, List, Dict, Any
+from typing import NamedTuple, Optional, Union, List, Any
 from uuid import uuid4
 from functools import partial, wraps, cache
 import threading
@@ -133,7 +132,6 @@ from sdcm.utils.aws_utils import (
 )
 from sdcm.utils.ci_tools import get_job_name, get_job_url
 from sdcm.utils.common import (
-    format_timestamp,
     wait_ami_available,
     download_dir_from_cloud,
     get_post_behavior_actions,
@@ -4190,10 +4188,14 @@ class ClusterTester(unittest.TestCase):
         if self.params.get("collect_logs"):
             self.collect_logs()
         self.collect_ssl_conf()
+        # NOTE: collect artifacts before clean_resources() destroys db_cluster/monitors/loaders
+        self.collect_relocatable_package()
+        self.collect_grafana_screenshots()
+        with silence(parent=self, name="Collecting test artifacts"):
+            self.collect_test_artifacts()
+        time.sleep(1)  # Sleep is needed to let events from artifact collection being processed
         self.clean_resources()
         time.sleep(1)  # Sleep is needed to let final event being saved into files
-        self.save_email_data()
-        time.sleep(1)  # Sleep is needed to let events from save_email_data being processed
         self.argus_collect_gemini_results()
         self.destroy_localhost()
         if not self.test_config.KEEP_ALIVE_DB_NODES:
@@ -4797,165 +4799,35 @@ class ClusterTester(unittest.TestCase):
             used_capacity = self.get_used_capacity(node=node)
             self.log.debug(f"Node {node.name} ({node.private_ip_address}) used capacity is: {used_capacity}")
 
-    def get_nemesises_stats(self):
-        nemesis_stats = {}
-        if self.db_cluster:
-            for nem in self.db_cluster.nemesis:
-                nemesis_stats.update(nem.stats)
-        else:
-            self.log.warning("No nemesises as cluster was not created")
+    @silence()
+    def collect_relocatable_package(self):
+        """Submits the relocatable package (unified installer) url to Argus, if resolvable.
 
-        if nemesis_stats:
-            for detail in nemesis_stats.values():
-                for run in detail.get("runs", []):
-                    run["start"] = format_timestamp(float(run["start"]))
-                    run["end"] = format_timestamp(float(run["end"]))
-                for failure in detail.get("failures", []):
-                    failure["start"] = format_timestamp(float(failure["start"]))
-                    failure["end"] = format_timestamp(float(failure["end"]))
-        return nemesis_stats
+        What is relocatable package:
+        https://docs.scylladb.com/stable/getting-started/install-scylla/unified-installer.html
+        """
+        alive_node = self._get_live_node()
+        scylla_version = alive_node.scylla_version_detailed if alive_node else None
+        if not scylla_version:
+            return
+        if relocatable_pkg := get_relocatable_pkg_url(scylla_version):
+            self.test_config.argus_client().submit_packages(
+                [Package(name="relocatable_pkg", date="", version=relocatable_pkg, revision_id="", build_id="")]
+            )
 
     @silence()
-    def save_email_data(self):
-        email_data = {}
-
-        try:
-            email_data = self.get_email_data()
-            self._argus_add_relocatable_pkg(email_data)
-        except Exception as exc:  # noqa: BLE001
-            self.log.error("Error while saving email data. Error: %s\nTraceback: %s", exc, traceback.format_exc())
-
-        grafana_screenshots = []
-        try:
-            grafana_screenshots = (
-                self.monitors.get_grafana_screenshots_from_all_monitors(self.start_time) if self.monitors else {}
-            )
-            self.argus_collect_screenshots(grafana_screenshots)
-        except Exception as exc:  # noqa: BLE001
-            self.log.exception("Error while collecting screenshots:", exc_info=exc)
+    def collect_grafana_screenshots(self):
+        grafana_screenshots = (
+            self.monitors.get_grafana_screenshots_from_all_monitors(self.start_time) if self.monitors else {}
+        )
+        self.argus_collect_screenshots(grafana_screenshots)
 
     def argus_collect_screenshots(self, grafana_screenshots: list) -> None:
         if grafana_screenshots:
             self.test_config.argus_client().submit_screenshots(grafana_screenshots)
 
-    def _argus_add_relocatable_pkg(self, email_data):
-        """Adds Package with url to relocatable package in Argus.
-
-        What is relocatable package:
-        https://docs.scylladb.com/stable/getting-started/install-scylla/unified-installer.html
-        """
-        if relocatable_pkg := email_data.get("relocatable_pkg"):
-            self.test_config.argus_client().submit_packages(
-                [Package(name="relocatable_pkg", date="", version=relocatable_pkg, revision_id="", build_id="")]
-            )
-
-    def get_email_data(self):
-        """prepare data to generate and send via email
-
-        Have to return the dict which is used to build the
-        html content with email template.
-        Required field:
-        - email_template: path to file with html template
-        - email_subject: subject of email
-        have to be implemented in child class.
-        """
-        return {}
-
-    def all_nodes_scylla_shards(self):
-        all_nodes_shards = defaultdict(list)
-        for node in self.db_cluster.nodes:
-            ipv6 = node.ipv6_ip_address if node.ip_address == node.ipv6_ip_address else ""
-            all_nodes_shards["live_nodes"].append(
-                {
-                    "name": node.name,
-                    "ip": f"{node.public_ip_address} | {node.private_ip_address}{f' | {ipv6}' if ipv6 else ''}",
-                    "shards": node.scylla_shards,
-                }
-            )
-
-        all_nodes_shards["dead_nodes"] = [asdict(node) for node in self.db_cluster.dead_nodes_list]
-
-        return all_nodes_shards
-
-    def _get_common_email_data(self) -> Dict[str, Any]:
-        """Helper for subclasses which extracts common data for email."""
-
-        if self.db_cluster:
-            nodes_shards = self.all_nodes_scylla_shards()
-        else:
-            nodes_shards = defaultdict(list)
-
-        alive_node = self._get_live_node() or None
-
-        start_time = format_timestamp(self.start_time)
-        config_file_name = ";".join(
-            os.path.splitext(os.path.basename(cfg))[0] for cfg in self.params.get("config_files")
-        )
-        test_status = self.get_test_status()
-        backend = self.params.get("cluster_backend")
-        build_id = f"#{os.environ.get('BUILD_NUMBER')}" if os.environ.get("BUILD_NUMBER", "") else ""
-        scylla_version = alive_node.scylla_version_detailed if alive_node else "N/A"
-        kernel_version = alive_node.kernel_version if alive_node else "N/A"
-
-        if backend in ("aws", "aws-siren", "k8s-eks"):
-            scylla_instance_type = self.params.get("instance_type_db") or "Unknown"
-            region_name = self.params.region_names
-        elif backend in ("gce", "gce-siren", "k8s-gke"):
-            scylla_instance_type = self.params.get("gce_instance_type_db") or "Unknown"
-            region_name = self.params.get("gce_datacenter")
-        elif backend in ("azure",):
-            scylla_instance_type = self.params.get("azure_instance_type_db") or "Unknown"
-            region_name = self.params.get("azure_region_name")
-        elif backend in ("oci",):
-            scylla_instance_type = self.params.get("oci_instance_type_db") or "Unknown"
-            region_name = self.params.get("oci_region_name")
-        elif backend in ("baremetal", "docker"):
-            scylla_instance_type = "N/A"
-            region_name = "N/A"
-        elif backend == "xcloud":
-            scylla_instance_type = self.params.get("cloud_instance_type_db") or "Unknown"
-            region_name = self.params.get("cloud_region")
-        else:
-            self.log.error("Don't know how to get instance type for the '%s' backend.", backend)
-            scylla_instance_type = "N/A"
-            region_name = "N/A"
-
-        job_name = os.environ.get("JOB_NAME").split("/")[-1] if os.environ.get("JOB_NAME") else config_file_name
-        restore_monitor_job_base_link = (
-            "https://jenkins.scylladb.com/view/QA/job/QA-tools/job/hydra-show-monitor/parambuild/?"
-        )
-        if build_id:
-            sct_branch = os.environ.get("GIT_BRANCH", "master").rsplit("/", maxsplit=1)[-1]
-            restore_monitor_job_base_link += f"sct_branch={sct_branch}&"
-
-        return {
-            "backend": backend,
-            "build_id": os.environ.get("BUILD_NUMBER", ""),
-            "job_url": os.environ.get("BUILD_URL"),
-            "end_time": format_timestamp(time.time()),
-            "events_summary": self.get_event_summary(),
-            "last_events": get_events_grouped_by_category(limit=100, _registry=self.events_processes_registry),
-            "nodes": [],
-            "number_of_db_nodes": self.params.get("n_db_nodes"),
-            "region_name": region_name,
-            "scylla_instance_type": scylla_instance_type,
-            "scylla_version": scylla_version,
-            "live_nodes_shards": nodes_shards.get("live_nodes"),
-            "dead_nodes_shards": nodes_shards.get("dead_nodes"),
-            "kernel_version": kernel_version,
-            "start_time": start_time,
-            "subject": f"{test_status}: {os.environ.get('JOB_NAME') or config_file_name}{build_id}: {start_time}",
-            "job_name": job_name,
-            "config_files": self.params["config_files"],
-            "test_id": self.test_id,
-            "test_name": self.id(),
-            "test_status": test_status,
-            "username": get_username(),
-            "shard_awareness_driver": self.is_shard_awareness_driver,
-            "rack_aware_policy": self.is_rack_aware_policy,
-            "restore_monitor_job_base_link": restore_monitor_job_base_link,
-            "relocatable_pkg": get_relocatable_pkg_url(scylla_version) or "",
-        }
+    def collect_test_artifacts(self):
+        """Hook for subclasses to collect test-type-specific artifacts during teardown."""
 
     def get_test_results(self, source, severity=None):
         output = []
@@ -4984,14 +4856,6 @@ class ClusterTester(unittest.TestCase):
         node.wait_ssh_up(verbose=False, timeout=50)
 
         return node
-
-    @property
-    def is_shard_awareness_driver(self) -> bool:
-        all_events = get_events_grouped_by_category()
-        for event_str in all_events["NORMAL"]:
-            if "type=ShardAwareDriver" in event_str:
-                return True
-        return False
 
     @property
     def is_rack_aware_policy(self) -> bool:

--- a/sla_per_user_system_test.py
+++ b/sla_per_user_system_test.py
@@ -940,27 +940,6 @@ class SlaPerUserTest(LongevityTest):
             self.log.info("Failed to compare c-s results for batch and interactiveworkloads.")
             raise
 
-    # NOTE: Workload type comparison results can be uploaded to Argus if needed
-
-    def get_email_data(self):
-        self.log.info("Prepare data for email for SLA test")
-        email_data = {}
-
-        try:
-            email_data = self._get_common_email_data()
-        except Exception as error:  # noqa: BLE001
-            self.log.error("Error in gathering common email data: Error:\n%s", error)
-
-        email_data.update(
-            {
-                "scylla_ami_id": self.params.get("ami_id_db_scylla") or "-",
-                "region": self.params.get("region_name") or "-",
-                "workload_comparison": self._comparison_results if self._comparison_results else {},
-            }
-        )
-
-        return email_data
-
     def get_test_status(self) -> str:
         if self._comparison_results:
             try:

--- a/snitch_test.py
+++ b/snitch_test.py
@@ -55,9 +55,3 @@ class SnitchTest(ClusterTester):
 
     def check_nodetool_status_output_aws(self):
         pass  # TODO: Add aws snitch test option
-
-    def get_email_data(self):
-        self.log.info("Prepare data for email")
-        email_data = self._get_common_email_data()
-
-        return email_data

--- a/tablet_split_merge_test.py
+++ b/tablet_split_merge_test.py
@@ -155,16 +155,3 @@ class TabletSplitMergeTest(LongevityTest):
         res = self.loaders.nodes[0].remoter.run(cmd=replicator_script)
         if res.failed:
             self.fail("Could not start CDC replicator.")
-
-    def get_email_data(self) -> dict:
-        email_data = super().get_email_data()
-        if self.enable_cdc:
-            email_data.update(
-                {
-                    "number_of_oracle_nodes": self.params.get("n_test_oracle_db_nodes"),
-                    "oracle_ami_id": self.params.get("ami_id_db_oracle"),
-                    "oracle_db_version": self.cs_db_cluster.nodes[0].scylla_version if self.cs_db_cluster else "N/A",
-                    "oracle_instance_type": self.params.get("instance_type_db_oracle"),
-                }
-            )
-        return email_data

--- a/uda_udf_test.py
+++ b/uda_udf_test.py
@@ -63,12 +63,6 @@ class UDAUDFTest(ClusterTester):
         self.verify_stress_thread(pre_thread)
         self.log.info("Database pre write completed")
 
-    def get_email_data(self):
-        self.log.info("Prepare data for email")
-        email_data = self._get_common_email_data()
-
-        return email_data
-
     def _verify_udf_functions(self):
         row_query = UDVerification(
             name="row_query",

--- a/unit_tests/lib/fake_tester.py
+++ b/unit_tests/lib/fake_tester.py
@@ -91,7 +91,11 @@ class ClusterTesterForTests(ClusterTester):
         return None
 
     @silence()
-    def save_email_data(self):
+    def collect_relocatable_package(self):
+        pass
+
+    @silence()
+    def collect_grafana_screenshots(self):
         pass
 
     def argus_collect_manager_version(self):

--- a/unit_tests/unit/test_longevity.py
+++ b/unit_tests/unit/test_longevity.py
@@ -49,7 +49,10 @@ class DummyLongevityTest(LongevityTest):
     def init_argus_run(self):
         pass
 
-    def save_email_data(self):
+    def collect_relocatable_package(self):
+        pass
+
+    def collect_grafana_screenshots(self):
         pass
 
     def argus_finalize_test_run(self):

--- a/unit_tests/unit/test_tester.py
+++ b/unit_tests/unit/test_tester.py
@@ -41,7 +41,7 @@ class SubtestAndTeardownFailsTest(ClusterTesterForTests):
         raise ValueError("Main test also failed")
 
     @silence()
-    def save_email_data(self):
+    def collect_relocatable_package(self):
         raise ValueError()
 
 
@@ -71,7 +71,7 @@ class SubtestAssertAndTeardownFailsTest(ClusterTesterForTests):
         assert False, "Main test also failed"
 
     @silence()
-    def save_email_data(self):
+    def collect_relocatable_package(self):
         raise ValueError()
 
 
@@ -80,7 +80,7 @@ class TeardownFailsTest(ClusterTesterForTests):
         pass
 
     @silence()
-    def save_email_data(self):
+    def collect_relocatable_package(self):
         raise ValueError()
 
 
@@ -118,7 +118,11 @@ class SubtestsSuccessTest(ClusterTesterForTests):
         pytest.param(
             TeardownFailsTest,
             {"passed": 1},
-            ["EVENT_SUMMARY: {'NORMAL': 2, 'ERROR': 1}", "TEST_STATUS: FAILED", "ERROR 0: save_email_data (silenced)"],
+            [
+                "EVENT_SUMMARY: {'NORMAL': 2, 'ERROR': 1}",
+                "TEST_STATUS: FAILED",
+                "ERROR 0: collect_relocatable_package (silenced)",
+            ],
             id="TeardownFailsTest",
         ),
         pytest.param(
@@ -158,7 +162,7 @@ class SubtestsSuccessTest(ClusterTesterForTests):
             [
                 "EVENT_SUMMARY: {'NORMAL': 2, 'ERROR': 1}",
                 "TEST_STATUS: FAILED",
-                "ERROR 0: save_email_data (silenced)",
+                "ERROR 0: collect_relocatable_package (silenced)",
                 "E           ValueError: Subtest1 failed",
                 "E           ValueError: Subtest2 failed",
                 "E       ValueError: Main test also failed",
@@ -171,7 +175,7 @@ class SubtestsSuccessTest(ClusterTesterForTests):
             [
                 "EVENT_SUMMARY: {'NORMAL': 2, 'ERROR': 1}",
                 "TEST_STATUS: FAILED",
-                "ERROR 0: save_email_data (silenced)",
+                "ERROR 0: collect_relocatable_package (silenced)",
                 "E           AssertionError: Subtest1 failed",
                 "E           AssertionError: Subtest2 failed",
                 "E       AssertionError: Main test also failed",

--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -1606,20 +1606,6 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
                 self.search_for_idx_token_error_after_upgrade(node=node, step=step)
         return schema_load_error_num
 
-    def get_email_data(self):
-        self.log.info("Prepare data for email")
-
-        email_data = self._get_common_email_data()
-        email_data.update(
-            {
-                "new_scylla_repo": self.params.get("new_scylla_repo"),
-                "new_version": self.new_ver,
-                "scylla_ami_id": self.params.get("ami_id_db_scylla") or "-",
-            }
-        )
-
-        return email_data
-
     @cache
     def _update_argus_upgraded_version(self, node, new_version):
         try:


### PR DESCRIPTION
## Summary
- The `email_data` dict built by `get_email_data()` / `_get_common_email_data()` was fully superseded when the SMTP/Jinja2 email pipeline (`sdcm/send_email.py`) was removed in favor of Argus-based email reporting. Only its `relocatable_pkg` field still had a consumer.
- Replaced `save_email_data()` with two focused methods, `collect_relocatable_package()` and `collect_grafana_screenshots()`, and dropped ~15 dead `get_email_data()` overrides across test classes.
- `jepsen_test.py`'s real `save_jepsen_report()` side effect (writes `jepsen_report.html`) is relocated into a new `collect_test_artifacts()` teardown hook instead of being deleted along with the dead code.

## Test plan
- [x] `ruff check` clean on all touched files
- [x] `pytest unit_tests/unit/test_tester.py unit_tests/unit/test_longevity.py` — 32 passed
- [x] `pytest --collect-only unit_tests/unit` — 2543 tests collected, no import errors

closes: SCT-662