### PR TITLE
feature(oci): add oracle DB cluster support for gemini tests on OCI

### DIFF
--- a/configurations/oci/gemini-basic-3h.yaml
+++ b/configurations/oci/gemini-basic-3h.yaml
@@ -1,0 +1,15 @@
+user_prefix: 'gemini-basic-3h-oci'
+
+#NOTE: default ScyllaDB version for oracle is '2026.1', but lowest available
+#      in OCI is '2026.2.0'. So, redefine it here.
+oracle_scylla_version: '2026.2.0'
+
+# oci_instance_type_db: 'VM.DenseIO.E5.Flex:8'
+# oci_instance_type_db_oracle: 'VM.DenseIO.E5.Flex:8'
+# oci_instance_type_loader: 'VM.Standard3.Flex:4:32'
+sizing_db:
+  vcpu: 16
+  memory: '>=60'
+sizing_db_oracle:
+  vcpu: 16
+  memory: '>=60'

--- a/defaults/oci_config.yaml
+++ b/defaults/oci_config.yaml
@@ -10,6 +10,8 @@ oci_region_name:
   - us-ashburn-1
 
 oci_instance_type_db: ''
+oci_instance_type_db_oracle: ''
+oci_image_db_oracle: ''
 oci_instance_type_loader: ''
 oci_image_loader: ""  # NOTE: Code will automatically take latest ubuntu:24.04
 ami_loader_user: 'ubuntu'

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -321,7 +321,7 @@ Format version of the user-data to use for scylla images,<br>default to what tag
 
 ## **oracle_scylla_version** / SCT_ORACLE_SCYLLA_VERSION
 
-Version of scylla to use as oracle cluster with gemini tests, ex. '3.0.11'<br>Automatically lookup AMIs for formal versions.<br>WARNING: can't be used together with 'ami_id_db_oracle'
+Version of scylla to use as oracle cluster with gemini tests, ex. '3.0.11'<br>Automatically looks up cloud images for formal versions.<br>WARNING: can't be used together with 'ami_id_db_oracle' and 'oci_image_db_oracle'
 
 **default:** 2026.1
 
@@ -2454,6 +2454,15 @@ Oracle Cloud instance shape to use for 'oracle' (2nd ref cluster) ScylladbDB clu
 ## **oci_image_db** / SCT_OCI_IMAGE_DB
 
 Oracle Cloud image to use for DB node(s)
+
+**default:** N/A
+
+**type:** str (appendable)
+
+
+## **oci_image_db_oracle** / SCT_OCI_IMAGE_DB_ORACLE
+
+Oracle Cloud image to use for oracle (2nd ref cluster) DB node(s). If not set and 'oracle_scylla_version' is provided, it will be resolved automatically.
 
 **default:** N/A
 

--- a/jenkins-pipelines/oss/gemini/gemini-3h-oci.jenkinsfile
+++ b/jenkins-pipelines/oss/gemini/gemini-3h-oci.jenkinsfile
@@ -1,0 +1,12 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'oci',
+    oci_region_name: 'us-phoenix-1',
+    instance_provision: 'on_demand', // DenseIO OCI shapes cannot be 'spot'
+    test_name: 'gemini_test.GeminiTest.test_random_load',
+    test_config: '''["test-cases/gemini/gemini-basic-3h.yaml", "configurations/oci/gemini-basic-3h.yaml"]''',
+)

--- a/sdcm/cluster_oci.py
+++ b/sdcm/cluster_oci.py
@@ -435,6 +435,7 @@ class ScyllaOciCluster(cluster.BaseScyllaCluster, OciCluster):
         n_nodes=3,
         params=None,
         region_names=None,
+        node_type="scylla-db",
     ):
         cluster_prefix = cluster.prepend_user_prefix(user_prefix, "db-cluster")
         node_prefix = cluster.prepend_user_prefix(user_prefix, "db-node")
@@ -450,7 +451,7 @@ class ScyllaOciCluster(cluster.BaseScyllaCluster, OciCluster):
             n_nodes=n_nodes,
             params=params,
             region_names=region_names,
-            node_type="scylla-db",
+            node_type=node_type,
         )
         self.version = "2.1"
 

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -701,8 +701,8 @@ class SCTConfiguration(BaseModel):
     )
     oracle_scylla_version: String = SctField(
         description="""Version of scylla to use as oracle cluster with gemini tests, ex. '3.0.11'
-                 Automatically lookup AMIs for formal versions.
-                 WARNING: can't be used together with 'ami_id_db_oracle'""",
+                 Automatically looks up cloud images for formal versions.
+                 WARNING: can't be used together with 'ami_id_db_oracle' and 'oci_image_db_oracle'""",
         appendable=False,
     )
     scylla_linux_distro: String = SctField(
@@ -1503,6 +1503,10 @@ class SCTConfiguration(BaseModel):
     )
     oci_image_db: String = SctField(
         description="Oracle Cloud image to use for DB node(s)",
+    )
+    oci_image_db_oracle: String = SctField(
+        description="Oracle Cloud image to use for oracle (2nd ref cluster) DB node(s). "
+        "If not set and 'oracle_scylla_version' is provided, it will be resolved automatically.",
     )
     oci_image_monitor: String = SctField(
         description="Oracle Cloud image to use for the monitor node. Empty value results into latest ubuntu image",
@@ -3052,8 +3056,33 @@ class SCTConfiguration(BaseModel):
                     )
                     ami_list.append(ami)
                 self["ami_id_db_oracle"] = " ".join(ami.image_id for ami in ami_list)
-            else:
+            elif self.get("cluster_backend") == "aws":
                 raise ValueError("'oracle_scylla_version' and 'ami_id_db_oracle' can't used together")
+            elif not self.get("oci_image_db_oracle") and self.get("cluster_backend") == "oci":
+                oci_oracle_images = []
+                oci_region_names = self.get("oci_region_name") or []
+                if not isinstance(oci_region_names, list):
+                    oci_region_names = [oci_region_names]
+                for region in oci_region_names:
+                    try:
+                        if ":" in oracle_scylla_version:
+                            oci_image = oci_utils.get_scylla_images_by_branch(oracle_scylla_version, region)[0]
+                        else:
+                            oci_image = oci_utils.get_scylla_images_by_version(oracle_scylla_version, region)[0]
+                    except Exception as ex:  # noqa: BLE001
+                        raise ValueError(
+                            f"OCI Image for oracle_scylla_version='{oracle_scylla_version}' not found in {region}"
+                        ) from ex
+                    self.log.debug(
+                        "Found OCI Image %s for oracle_scylla_version='%s' in %s",
+                        oci_image[1],
+                        oracle_scylla_version,
+                        region,
+                    )
+                    oci_oracle_images.append(oci_image)
+                self["oci_image_db_oracle"] = " ".join(image[2] for image in oci_oracle_images)
+            elif self.get("cluster_backend") == "oci":
+                raise ValueError("'oracle_scylla_version' and 'oci_image_db_oracle' can't used together")
 
         # 6.2) handle vector_store_version if exists
         if vs_version := self.get("vector_store_version"):

--- a/sdcm/sct_provision/common/types.py
+++ b/sdcm/sct_provision/common/types.py
@@ -12,4 +12,4 @@
 # Copyright (c) 2021 ScyllaDB
 from typing import Literal
 
-NodeTypeType = Literal["scylla-db", "loader", "monitor"]
+NodeTypeType = Literal["scylla-db", "oracle-db", "loader", "monitor"]

--- a/sdcm/sct_provision/oci/oci_region_definition_builder.py
+++ b/sdcm/sct_provision/oci/oci_region_definition_builder.py
@@ -41,8 +41,20 @@ monitor_map = ConfigParamsMap(
     root_disk_size="root_disk_size_monitor",
 )
 
+oracle_db_map = ConfigParamsMap(
+    image_id="oci_image_db_oracle",
+    type="oci_instance_type_db_oracle",
+    user_name="oci_image_username",
+    root_disk_size="root_disk_size_db",
+)
+
 LOGGER = logging.getLogger(__name__)
-mapper: Dict[NodeTypeType, ConfigParamsMap] = {"scylla-db": db_map, "loader": loader_map, "monitor": monitor_map}
+mapper: Dict[NodeTypeType, ConfigParamsMap] = {
+    "scylla-db": db_map,
+    "oracle-db": oracle_db_map,
+    "loader": loader_map,
+    "monitor": monitor_map,
+}
 
 
 class OciDefinitionBuilder(DefinitionBuilder):

--- a/sdcm/sct_provision/region_definition_builder.py
+++ b/sdcm/sct_provision/region_definition_builder.py
@@ -115,8 +115,10 @@ class DefinitionBuilder(abc.ABC):
         user_prefix = self.params.get("user_prefix")
         common_tags = TestConfig.common_tags()
         node_type_short = "db" if "db" in node_type else node_type
+        # Use distinct name prefix for oracle-db to avoid name collision with scylla-db
+        node_type_name = "oracle-db" if node_type == "oracle-db" else node_type_short
         short_test_id = self.test_config.test_id()[:8]
-        name = self.instance_name(user_prefix, node_type_short, short_test_id, region, index, dc_idx)
+        name = self.instance_name(user_prefix, node_type_name, short_test_id, region, index, dc_idx)
         action = self.params.get(f"post_behavior_{node_type_short}_nodes")
         tags = common_tags | {
             "NodeType": node_type,

--- a/sdcm/sct_provision/user_data_objects/scylla.py
+++ b/sdcm/sct_provision/user_data_objects/scylla.py
@@ -21,7 +21,7 @@ from sdcm.sct_provision.user_data_objects import SctUserDataObject
 class ScyllaUserDataObject(SctUserDataObject):
     @property
     def is_applicable(self) -> bool:
-        return self.node_type == "scylla-db"
+        return self.node_type in ("scylla-db", "oracle-db")
 
     @property
     def scylla_machine_image_json(self) -> str:

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1869,6 +1869,21 @@ class ClusterTester(unittest.TestCase):
         else:
             self.monitors = NoMonitorSet()
 
+        db_type = self.params.get("db_type")
+        if db_type == "mixed_scylla":
+            self.test_config.mixed_cluster(True)
+            oracle_image = self.params.get("oci_image_db_oracle") or oci_image
+            self.cs_db_cluster = ScyllaOciCluster(
+                image_id=oracle_image,
+                root_disk_size=db_info["disk_size"],
+                instance_type=self.params.get("oci_instance_type_db_oracle"),
+                provisioners=provisioners,
+                n_nodes=self.params.get("n_test_oracle_db_nodes"),
+                user_name=self.params.get("oci_image_username"),
+                node_type="oracle-db",
+                **(common_params | {"user_prefix": user_prefix + "-oracle"}),
+            )
+
     def get_cluster_aws(self, loader_info, db_info, monitor_info):
         """Provision AWS cluster with optional region fallback."""
         if is_region_fallback_enabled(self.params) and len(self.params.region_names) == 1:


### PR DESCRIPTION
Add support for running gemini tests with a mixed_scylla (oracle) cluster on the OCI backend.

Key changes:

- Add `oci_image_db_oracle` and `oci_instance_type_db_oracle` config params with defaults in `oci_config.yaml`
- Extend `sct_config.py` to resolve OCI images from `oracle_scylla_version` (mirroring the existing AWS AMI resolution logic)
- Add `oracle-db` to `NodeTypeType` and register it in the OCI definition builder's param mapper
- Make `ScyllaOciCluster` accept a `node_type` parameter so it can be instantiated as an oracle-db cluster
- Create the oracle cluster in `tester.py::get_cluster_oci()` when `db_type == "mixed_scylla"`
- Fix instance name collision: use `"oracle-db"` as the name component (instead of collapsing to `"db"` like scylla-db) to prevent the oracle cluster from stealing pre-provisioned regular DB instances from the provisioner cache
- Apply `ScyllaUserDataObject` to oracle-db nodes so they get `start_scylla_on_first_boot: False` in user_data
- Export `SCT_ORACLE_SCYLLA_VERSION` in all Jenkins pipeline stages that instantiate SCTConfiguration (getJobTimeouts, createArgusTestRun, createSctRunner, finishArgusTestRun, runCollectLogs, runCleanupResource)
- Add `oracle_scylla_version` Jenkins parameter to longevityPipeline
- Add gemini-3h-oci Jenkinsfile with oracle_scylla_version override (2026.2.0, since 2026.1 is not available in OCI)
- Update gemini-basic-3h test case with OCI instance types

Closes: #SCT-316

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/valerii/job/vp-gemini-3h-oci/16

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
