### PR TITLE
fix(triggers): switch tier1 jobs from include_versions to exclude_versions

### DIFF
--- a/configurations/triggers/tier1.yaml
+++ b/configurations/triggers/tier1.yaml
@@ -38,7 +38,7 @@ jobs:
     region: "eu-west-1"
     labels:
       - "weekly"
-    include_versions: ["master", "2026.2"]
+    exclude_versions: ["2024.1", "2025.1", "2025.4", "2026.1"]
 
   - job_name: "tier1/longevity-2tb-5days-test"
     backend: "aws"
@@ -123,7 +123,7 @@ jobs:
     labels:
       - "weekly"
       - "aarch64"
-    include_versions: ["master", "2026.2"]
+    exclude_versions: ["2024.1", "2025.1", "2025.4", "2026.1"]
 
   # ==================== GCE ====================
 


### PR DESCRIPTION
## What

Switch two tier1 trigger jobs from `include_versions` whitelisting to `exclude_versions` blacklisting.

## Why

With `include_versions`, every new Scylla release requires a manual config update to add the new version. By switching to `exclude_versions`, newly released versions are automatically included — only explicitly excluded (older) versions are skipped.

## Changes

- `configurations/triggers/tier1.yaml`: Replace `include_versions: ["master", "2026.2"]` with `exclude_versions: ["2024.1", "2025.1", "2025.4", "2026.1"]` for two jobs:
  - `tier1/longevity-10gb-3h-test` (line 41)
  - `tier1/longevity-cdc-test` (line 126)