### PR TITLE
fix(trigger-matrix): add missing rolling_upgrade_test flag and cron guard for releng-testing

### DIFF
--- a/configurations/triggers/rolling-upgrade.yaml
+++ b/configurations/triggers/rolling-upgrade.yaml
@@ -25,6 +25,8 @@ defaults:
   post_behavior_loader_nodes: "destroy"
   post_behavior_monitor_nodes: "destroy"
   gce_project: "gcp-sct-project-1"
+  rolling_upgrade_test: "true"
+  new_scylla_repo: "http://downloads.scylladb.com.s3.amazonaws.com/unstable/scylla/{branch}/deb/unified/latest/scylladb-{branch}/scylla.list"
 
 jobs:
   # ===========================================================================

--- a/vars/triggerMatrixPipeline.groovy
+++ b/vars/triggerMatrixPipeline.groovy
@@ -18,9 +18,10 @@ def call(Map pipelineParams = [:]) {
     def cronSpec = pipelineParams.get('cron', '')
     def defaultLabelsSelector = pipelineParams.get('labels_selector', '')
 
-    // Only enable cron on production master triggers — never on staging, PRs, or release branches
-    if (cronSpec && env.JOB_NAME && !env.JOB_NAME.startsWith('scylla-master/')) {
-        println("Cron disabled: job '${env.JOB_NAME}' is not under scylla-master/")
+    // Only enable cron on production master triggers — never on staging, PRs, release branches,
+    // or releng-testing (which mirrors production jobs for pipeline development).
+    if (cronSpec && env.JOB_NAME && (!env.JOB_NAME.startsWith('scylla-master/') || env.JOB_NAME.contains('/releng-testing/'))) {
+        println("Cron disabled: job '${env.JOB_NAME}' is not a production scylla-master trigger")
         cronSpec = ''
     }
 


### PR DESCRIPTION
## Problem

The `rolling-upgrade-ami-test` job (and all other rolling-upgrade jobs triggered via the trigger matrix) fail immediately with:

```
Error: Got unexpected extra argument (aws)
```

**Root cause**: `build_job_parameters()` in `trigger_matrix.py` checks for `rolling_upgrade_test` flag to decide whether to keep `new_scylla_repo`. Without `rolling_upgrade_test: "true"` in the YAML defaults, it strips `new_scylla_repo` from all job params. The downstream `rollingUpgradePipeline` then passes an empty `--scylla-repo` to `get-scylla-base-versions`, and Click consumes `--backend` as its value, leaving `aws` as an unexpected positional argument.

Additionally, the cron guard in `triggerMatrixPipeline.groovy` only checked `startsWith("scylla-master/")`, which also matches `scylla-master/releng-testing/sct_triggers/...`, causing duplicate cron triggers from the releng-testing folder.

**Evidence**: Jenkins builds [#355](https://jenkins.scylladb.com/job/scylla-master/job/rolling-upgrade/job/rolling-upgrade-ami-test/355/) and [#356](https://jenkins.scylladb.com/job/scylla-master/job/rolling-upgrade/job/rolling-upgrade-ami-test/356/) both failed identically.

## Fix

1. **`configurations/triggers/rolling-upgrade.yaml`**: Added `rolling_upgrade_test: "true"` and a default `new_scylla_repo` (DEB URL) to the `defaults` section. This tells `build_job_parameters()` to preserve `new_scylla_repo` and clear `scylla_version` (correct behavior for rolling upgrades). Rocky10 RPM URL override still takes precedence via per-job params.

2. **`vars/triggerMatrixPipeline.groovy`**: Added `/releng-testing/` exclusion to the cron guard so trigger jobs under `scylla-master/releng-testing/` never fire on schedule.

## Backends Affected
- [x] AWS - rolling-upgrade-ami-test, rolling-upgrade-ami-arm-test, rolling-upgrade-multidc-test
- [x] GCE - rolling-upgrade-gce-image-test, rolling-upgrade-debian/ubuntu/rocky/alternator tests
- [x] Azure - rolling-upgrade-azure-image-test
