### PR TITLE
fix(upgrade-versions): skip releases with unavailable repositories

### DIFF
--- a/utils/get_supported_scylla_base_versions.py
+++ b/utils/get_supported_scylla_base_versions.py
@@ -4,6 +4,7 @@ import sys
 import re
 import os
 
+from sdcm.utils.parallel_object import ParallelObjectException
 from sdcm.utils.session import create_retry_session
 from sdcm.utils.version_utils import (
     is_enterprise,
@@ -237,7 +238,13 @@ class UpgradeBaseVersion:
         """
         LOGGER.info("Filtering rc versions from base version list...")
         base_version_list = sorted(list(set(base_version_list)), key=ComparableScyllaVersion)
-        filter_rc = [v for v in get_all_versions(self.repo_maps[base_version_list[-1]]) if "rc" not in v]
+        try:
+            filter_rc = [v for v in get_all_versions(self.repo_maps[base_version_list[-1]]) if "rc" not in v]
+        except (ValueError, ParallelObjectException):
+            # Repository for this version doesn't exist yet (e.g. new release announced
+            # but no rc0 packages published). Treat it as unavailable and skip it.
+            LOGGER.warning("Skipping version %s: repository doesn't fully exist yet", base_version_list[-1])
+            filter_rc = []
         if not filter_rc:
             # if the release only has rc versions, we don't want to test it as a base version
             base_version_list = base_version_list[:-1]


### PR DESCRIPTION
When a new ScyllaDB release is announced but no packages (rc0) are
published yet, the repository URL exists in S3 mapping but the actual
package repository returns 404. This caused `get-scylla-base-versions`
to crash with a `ParallelObjectException` wrapping `ValueError`, breaking
all rolling upgrade pipeline jobs.

Catch the exception in `filter_rc_only_version` and treat such versions
as unavailable, allowing the version resolution to continue with the
remaining valid releases.

**Failing build:** https://jenkins.scylladb.com/job/scylla-master/job/rolling-upgrade/job/rolling-upgrade-ami-test/357

**Root cause:** `scylladb-2026.3` repo file exists in S3 but the actual
debian package repository at
`https://downloads.scylladb.com/downloads/scylla/deb/debian-ubuntu/scylladb-2026.3/`
does not exist yet (no rc0 published).

**Fix:** Catch `ValueError` and `ParallelObjectException` in
`filter_rc_only_version`, log a clean warning, and skip the version.