### PR TITLE
chore(jenkins): disable weekly sct-agent longevity trigger

### DIFF
--- a/jenkins-pipelines/master-triggers/sct_triggers/_deprecated_jobs.yaml
+++ b/jenkins-pipelines/master-triggers/sct_triggers/_deprecated_jobs.yaml
@@ -9,3 +9,5 @@ jobs:
     reason: "Replaced by oss/sct_triggers/tier1-trigger using triggerMatrixPipeline (configurations/triggers/tier1.yaml)"
   - name: "weekly-master-images-rolling-upgrades-trigger"
     reason: "Replaced by oss/sct_triggers/rolling-upgrade-trigger using triggerMatrixPipeline (configurations/triggers/rolling-upgrade.yaml)"
+  - name: "sct-agent-weekly-trigger"
+    reason: "Weekly sct-agent longevity is costly and should not run on a schedule; run on-demand via longevity/longevity-10gb-3h-agent-test"

--- a/jenkins-pipelines/master-triggers/sct_triggers/sct-agent-weekly-trigger.xml
+++ b/jenkins-pipelines/master-triggers/sct_triggers/sct-agent-weekly-trigger.xml
@@ -1,12 +1,12 @@
 <?xml version="1.1" encoding="UTF-8" standalone="no"?><project>
   <actions/>
-  <description>Triggers longevity test with sct-agent enabled, every Saturday at 10:00 UTC.
+  <description>Triggers longevity test with sct-agent enabled, every Saturday at 07:00 UTC.
 
   Validates sct-agent readiness by running a standard longevity workload with agent-based
   command execution instead of SSH.
   </description>
   <scm class="hudson.scm.NullSCM"/>
-  <disabled>false</disabled>
+  <disabled>true</disabled>
   <triggers>
     <hudson.triggers.TimerTrigger>
       <spec>00 07 * * 6</spec>


### PR DESCRIPTION
Weekly sct-agent longevity is costly and shouldn't run on a schedule. Disable the trigger in XML and register in _deprecated_jobs.yaml so the seed job keeps it disabled.

Fixes: SCT-674

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
