### PR TITLE
fix(nemesis): don't mask add-node capacity failures

### DIFF
--- a/sdcm/nemesis/__init__.py
+++ b/sdcm/nemesis/__init__.py
@@ -1258,7 +1258,10 @@ class NemesisRunner:
                 **add_node_func_args
             )
         if not new_nodes:
-            raise NodeSetupFailed(f"Failed to add {count} new node(s): add_nodes returned {new_nodes!r}")
+            raise NodeSetupFailed(
+                node=self.target_node,
+                error_msg=f"Failed to add {count} new node(s): add_nodes returned {new_nodes!r}",
+            )
         self.monitoring_set.reconfigure_scylla_monitoring()
         nodes_names = ",".join([new_node.name for new_node in new_nodes])
         try:

--- a/sdcm/utils/decorators.py
+++ b/sdcm/utils/decorators.py
@@ -441,8 +441,8 @@ def skip_on_capacity_issues(func: Callable | None = None, db_cluster: BaseCluste
                         message=f"Test failed due to service availability issues: {ex} cluster is unbalanced, continuing with test would yield unknown results",
                         severity=Severity.CRITICAL,
                     ).publish()
-                else:
-                    raise UnsupportedNemesis("Capacity Issue") from ex
+                    raise
+                raise UnsupportedNemesis("Capacity Issue") from ex
             except ProvisionUnrecoverableError as ex:
                 # Azure stuck-VM recovery gave up - a capacity/provisioning issue
                 if check_cluster_layout(cluster):
@@ -456,6 +456,7 @@ def skip_on_capacity_issues(func: Callable | None = None, db_cluster: BaseCluste
                     ),
                     severity=Severity.CRITICAL,
                 ).publish()
+                raise
 
         return wrapper
 
@@ -492,6 +493,7 @@ def critical_on_capacity_issues(func: callable) -> callable:
                 "cluster is probably unbalanced, continuing with test would yield unknown results",
                 severity=Severity.CRITICAL,
             ).publish()
+            raise
         except ProvisionUnrecoverableError as ex:
             # Azure stuck-VM recovery gave up - a capacity/provisioning issue
             TestFrameworkEvent(

--- a/unit_tests/unit/nemesis/execute_nemesis/test_basic.py
+++ b/unit_tests/unit/nemesis/execute_nemesis/test_basic.py
@@ -1,6 +1,9 @@
+from unittest.mock import MagicMock
+
 import pytest
 
 from argus.common.enums import NemesisStatus
+from sdcm.cluster import NodeSetupFailed
 from sdcm.exceptions import KillNemesis, UnsupportedNemesis
 from sdcm.sct_events import Severity
 
@@ -206,3 +209,12 @@ def test_execute_multiple_nemesis_in_sequence(nemesis, kill_nemesis, failing_nem
         assert nemesis_runner.operation_log[i]["start"] >= nemesis_runner.operation_log[i - 1]["start"], (
             f"operation_log[{i}] started before operation_log[{i - 1}]"
         )
+
+
+def test_add_and_init_new_cluster_nodes_raises_nodesetupfailed_when_add_nodes_returns_none(nemesis_runner):
+    """When add_nodes yields no nodes, the guard must raise a clear NodeSetupFailed, not a TypeError from bad args."""
+    nemesis_runner.set_target_node()
+    nemesis_runner.target_node.dc_idx = 0
+    nemesis_runner.cluster.add_nodes = MagicMock(return_value=None)
+    with pytest.raises(NodeSetupFailed):
+        nemesis_runner._add_and_init_new_cluster_nodes(count=1, rack=0)

--- a/unit_tests/unit/test_utils_decorators.py
+++ b/unit_tests/unit/test_utils_decorators.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
+from google.api_core.exceptions import ServiceUnavailable
 
 from sdcm.exceptions import UnsupportedNemesis
 from sdcm.provision.provisioner import ProvisionUnrecoverableError
@@ -50,6 +51,10 @@ def _raise_stuck_vm_give_up():
     raise ProvisionUnrecoverableError("Azure VM(s) node-x stuck in provisioning, giving up after 3 recovery attempts")
 
 
+def _raise_service_unavailable():
+    raise ServiceUnavailable("GCE capacity issue")
+
+
 def test_skip_on_capacity_issues_converts_stuck_vm_give_up_to_nemesis_skip():
     """Stuck VM recovery give-up on a balanced cluster must skip the nemesis, not fail it."""
     with patch("sdcm.utils.decorators.check_cluster_layout", return_value=True):
@@ -57,10 +62,39 @@ def test_skip_on_capacity_issues_converts_stuck_vm_give_up_to_nemesis_skip():
             skip_on_capacity_issues(db_cluster=MagicMock())(_raise_stuck_vm_give_up)()
 
 
+def test_skip_on_capacity_issues_reraises_stuck_vm_give_up_on_unbalanced_cluster():
+    """On an unbalanced cluster the give-up must publish a CRITICAL event AND re-raise, never return None."""
+    with patch("sdcm.utils.decorators.check_cluster_layout", return_value=False):
+        with patch("sdcm.utils.decorators.TestFrameworkEvent") as event_mock:
+            with pytest.raises(ProvisionUnrecoverableError):
+                skip_on_capacity_issues(db_cluster=MagicMock())(_raise_stuck_vm_give_up)()
+    assert event_mock.call_args.kwargs["severity"] == Severity.CRITICAL
+    event_mock.return_value.publish.assert_called_once()
+
+
+def test_skip_on_capacity_issues_reraises_service_unavailable_on_unbalanced_cluster():
+    """A GCE ServiceUnavailable on an unbalanced cluster must publish a CRITICAL event AND re-raise."""
+    with patch("sdcm.utils.decorators.check_cluster_layout", return_value=False):
+        with patch("sdcm.utils.decorators.TestFrameworkEvent") as event_mock:
+            with pytest.raises(ServiceUnavailable):
+                skip_on_capacity_issues(db_cluster=MagicMock())(_raise_service_unavailable)()
+    assert event_mock.call_args.kwargs["severity"] == Severity.CRITICAL
+    event_mock.return_value.publish.assert_called_once()
+
+
 def test_critical_on_capacity_issues_publishes_critical_on_stuck_vm_give_up():
     """Stuck VM recovery give-up in a must-succeed topology change must raise a critical event."""
     with patch("sdcm.utils.decorators.TestFrameworkEvent") as event_mock:
         with pytest.raises(ProvisionUnrecoverableError):
             critical_on_capacity_issues(_raise_stuck_vm_give_up)()
+    assert event_mock.call_args.kwargs["severity"] == Severity.CRITICAL
+    event_mock.return_value.publish.assert_called_once()
+
+
+def test_critical_on_capacity_issues_reraises_on_service_unavailable():
+    """A GCE ServiceUnavailable in a must-succeed topology change must publish CRITICAL and re-raise."""
+    with patch("sdcm.utils.decorators.TestFrameworkEvent") as event_mock:
+        with pytest.raises(ServiceUnavailable):
+            critical_on_capacity_issues(_raise_service_unavailable)()
     assert event_mock.call_args.kwargs["severity"] == Severity.CRITICAL
     event_mock.return_value.publish.assert_called_once()


### PR DESCRIPTION
When Azure stuck-VM recovery gives up during an add-node sequence on an unbalanced cluster, `skip_on_capacity_issues` decorator publishes a CRITICAL event, but does not re-raise, so the wrapped `add_nodes` returns None. The `add-node` guard then hits an existing latent issue (NodeSetupFailed exception is instantiated without its required `error_msg` arg), raising TypeError and masking the real failure reason.

The change fixes this by:
- `skip_on_capacity_issues`: re-raise after publishing the CRITICAL event in the `ServiceUnavailable` and `ProvisionUnrecoverableError` unbalanced branches, so the exception propagates instead of a None return.
- `critical_on_capacity_issues`: similarly - re-raise on `ServiceUnavailable`, preventing the same None return value.
- `_add_and_init_new_cluster_nodes`: pass node/error_msg to `NodeSetupFailed` so the guard doesn't raise TypeError.

Fixes: SCT-672
Refs: SCT-632

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
The tests were executed with only DecommissionSeedNode and NodeTerminateAndReplace nemeses selected (those that add new nodes and can face the stuck VM issues).
- [x] :green_circle: [longevity-10gb-3h-azure-test](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/longevity-10gb-3h-azure-test/45/)
The test passed, no capacity issue during provisioning phase. 2 out of 5 executed nemeses had stuck-VM problems during node addition. One recovered on the 1st attempt, another recovered on the 3rd attempt.
- [x] :yellow_circle: [longevity-10gb-3h-azure-test](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/longevity-10gb-3h-azure-test/44/)
The test failed as expected - stuck-VM happenned during provisioning and 2 nemeses that were executed before test was interrupted, both had stuck VMs:
- during initial provisioning 2 VMs (eastus-4 and eastus) stuck, but recovery rescued all - the eastus-5 was recovered on 2nd attempt. the eastus-4 was recovered on 3rd attempt.
- 1st nemesis had a stuck VM which recovered on the 1st attempt
- 2nd nemesis had a VM that stuck and all 3 recovery attempts failed. So the cluster was considered unbalanced as per `check_cluster_layout` check and test was interrupted, and `ProvisionUnrecoverableError` error was raised.
During this run a new issue was identified (reported as https://scylladb.atlassian.net/browse/SCT-679)m will be addressed in a follow up PR.

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
