### PR TITLE
fix(triggers): fix availability_zone param

### DIFF
--- a/configurations/triggers/tier1.yaml
+++ b/configurations/triggers/tier1.yaml
@@ -95,7 +95,8 @@ jobs:
   - job_name: "tier1/longevity-multidc-schema-topology-changes-12h-test"
     backend: "aws"
     region: '["eu-west-1", "eu-west-2"]'
-    availability_zone: "a,b,c"
+    params:
+      availability_zone: "a,b,c"
     labels:
       - "weekly"
 
@@ -130,7 +131,8 @@ jobs:
   - job_name: "tier1/longevity-large-partition-200k-pks-4days-gce-test"
     backend: "gce"
     region: "us-east1"
-    availability_zone: ""
+    params:
+      availability_zone: ""
     labels:
       - "weekly"
 
@@ -139,7 +141,8 @@ jobs:
   - job_name: "tier1/longevity-1tb-5days-azure-test"
     backend: "azure"
     region: "eastus"
-    availability_zone: ""
+    params:
+      availability_zone: ""
     labels:
       - "weekly"
     include_versions: ["2024.1", "2025.1", "2025.4", "2026.1", "2026.2"]


### PR DESCRIPTION
`availability_zone` needs to be under `params`, not standalone.
Otherwise it will be ignored and `c` default will be used.
See: https://argus.scylladb.com/tests/scylla-cluster-tests/b9217be7-0974-41e1-99c1-2bc7ca0ea09e

Before:

```
➜ uv run sct.py trigger-matrix --matrix configurations/triggers/tier1.yaml --scylla-version "2025.1.9" --dry-run
...
[DRY-RUN] Would trigger: branch-2025.1/tier1/longevity-mv-si-4days-streaming-test with params: {availability_zone=c, post_behavior_db_nodes=destroy, post_behavior_loader_nodes=destroy, post_behavior_monitor_nodes=destroy, provision_type=on_demand, region=eu-west-1, scylla_version=2025.1.9, stress_duration=1440}
[DRY-RUN] Would trigger: branch-2025.1/tier1/longevity-schema-topology-changes-12h-test with params: {availability_zone=c, post_behavior_db_nodes=destroy, post_behavior_loader_nodes=destroy, post_behavior_monitor_nodes=destroy, provision_type=on_demand, region=eu-west-1, scylla_version=2025.1.9, stress_duration=1440}
[DRY-RUN] Would trigger: branch-2025.1/tier1/longevity-twcs-48h-test with params: {availability_zone=c, post_behavior_db_nodes=destroy, post_behavior_loader_nodes=destroy, post_behavior_monitor_nodes=destroy, provision_type=on_demand, region=us-east-1, scylla_version=2025.1.9, stress_duration=1440}
[DRY-RUN] Would trigger: branch-2025.1/tier1/longevity-50gb-3days-test with params: {availability_zone=c, post_behavior_db_nodes=destroy, post_behavior_loader_nodes=destroy,post_behavior_monitor_nodes=destroy, provision_type=on_demand, region=eu-west-1, scylla_version=2025.1.9, stress_duration=1440}
[DRY-RUN] Would trigger: branch-2025.1/tier1/longevity-150gb-asymmetric-cluster-12h-test with params: {availability_zone=c, post_behavior_db_nodes=destroy, post_behavior_loader_nodes=destroy, post_behavior_monitor_nodes=destroy, provision_type=on_demand, region=us-east-1, scylla_version=2025.1.9, stress_duration=1440}
[DRY-RUN] Would trigger: branch-2025.1/tier1/longevity-multidc-schema-topology-changes-12h-test with params: {availability_zone=c, post_behavior_db_nodes=destroy, post_behavior_loader_nodes=destroy, post_behavior_monitor_nodes=destroy, provision_type=on_demand, region=["eu-west-1", "eu-west-2"], scylla_version=2025.1.9, stress_duration=1440}
[DRY-RUN] Would trigger: branch-2025.1/tier1/longevity-large-partition-200k-pks-4days-gce-test with params: {availability_zone=c, post_behavior_db_nodes=destroy, post_behavior_loader_nodes=destroy, post_behavior_monitor_nodes=destroy, provision_type=on_demand, region=us-east1, scylla_version=2025.1.9, stress_duration=1440}
[DRY-RUN] Would trigger: branch-2025.1/tier1/longevity-1tb-5days-azure-test with params: {availability_zone=c, post_behavior_db_nodes=destroy, post_behavior_loader_nodes=destroy, post_behavior_monitor_nodes=destroy, provision_type=on_demand, region=eastus, scylla_version=2025.1.9, stress_duration=1440}
Summary: 8 triggered, 6 skipped, 0 failed
...
```

After
```
➜ uv run sct.py trigger-matrix --matrix configurations/triggers/tier1.yaml --scylla-version "2025.1.9" --dry-run
...
[DRY-RUN] Would trigger: branch-2025.1/tier1/longevity-mv-si-4days-streaming-test with params: {availability_zone=c, post_behavior_db_nodes=destroy, post_behavior_loader_nodes=destroy, post_behavior_monitor_nodes=destroy, provision_type=on_demand, region=eu-west-1, scylla_version=2025.1.9, stress_duration=1440}
[DRY-RUN] Would trigger: branch-2025.1/tier1/longevity-schema-topology-changes-12h-test with params: {availability_zone=c, post_behavior_db_nodes=destroy, post_behavior_loader_nodes=destroy, post_behavior_monitor_nodes=destroy, provision_type=on_demand, region=eu-west-1, scylla_version=2025.1.9, stress_duration=1440}
[DRY-RUN] Would trigger: branch-2025.1/tier1/longevity-twcs-48h-test with params: {availability_zone=c, post_behavior_db_nodes=destroy, post_behavior_loader_nodes=destroy, post_behavior_monitor_nodes=destroy, provision_type=on_demand, region=us-east-1, scylla_version=2025.1.9, stress_duration=1440}
[DRY-RUN] Would trigger: branch-2025.1/tier1/longevity-50gb-3days-test with params: {availability_zone=c, post_behavior_db_nodes=destroy, post_behavior_loader_nodes=destroy,post_behavior_monitor_nodes=destroy, provision_type=on_demand, region=eu-west-1, scylla_version=2025.1.9, stress_duration=1440}
[DRY-RUN] Would trigger: branch-2025.1/tier1/longevity-150gb-asymmetric-cluster-12h-test with params: {availability_zone=c, post_behavior_db_nodes=destroy, post_behavior_loader_nodes=destroy, post_behavior_monitor_nodes=destroy, provision_type=on_demand, region=us-east-1, scylla_version=2025.1.9, stress_duration=1440}
[DRY-RUN] Would trigger: branch-2025.1/tier1/longevity-multidc-schema-topology-changes-12h-test with params: {availability_zone=a,b,c, post_behavior_db_nodes=destroy, post_behavior_loader_nodes=destroy, post_behavior_monitor_nodes=destroy, provision_type=on_demand, region=["eu-west-1", "eu-west-2"], scylla_version=2025.1.9, stress_duration=1440}
[DRY-RUN] Would trigger: branch-2025.1/tier1/longevity-large-partition-200k-pks-4days-gce-test with params: {availability_zone=, post_behavior_db_nodes=destroy, post_behavior_loader_nodes=destroy, post_behavior_monitor_nodes=destroy, provision_type=on_demand, region=us-east1, scylla_version=2025.1.9, stress_duration=1440}
[DRY-RUN] Would trigger: branch-2025.1/tier1/longevity-1tb-5days-azure-test with params: {availability_zone=, post_behavior_db_nodes=destroy, post_behavior_loader_nodes=destroy, post_behavior_monitor_nodes=destroy, provision_type=on_demand, region=eastus, scylla_version=2025.1.9, stress_duration=1440}
Summary: 8 triggered, 6 skipped, 0 failed
...
```

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
