### PR TITLE
refactor(nemesis): extract Scylla Manager nemesis into monkey/manager.py

### DIFF
--- a/sdcm/nemesis/__init__.py
+++ b/sdcm/nemesis/__init__.py
@@ -32,7 +32,6 @@ import json
 import itertools
 from abc import ABC, abstractmethod
 from contextlib import ExitStack
-from datetime import timedelta
 from typing import List, Optional, Callable, Union, Iterable, TYPE_CHECKING
 from functools import partial, cached_property
 from collections import defaultdict, Counter, namedtuple
@@ -47,7 +46,7 @@ from sdcm.nemesis.registry import NemesisRegistry
 from sdcm.utils.action_logger import get_action_logger
 
 from sdcm.utils.cql_utils import cql_unquote_if_needed, cql_quote_if_needed
-from sdcm import wait, mgmt
+from sdcm import wait
 from sdcm.audit import Audit, AuditConfiguration
 from sdcm.cluster import (
     BaseCluster,
@@ -70,10 +69,7 @@ from sdcm.cluster_k8s import (
 from sdcm.db_stats import PrometheusDBStats
 from sdcm.log import SDCMAdapter
 from sdcm.logcollector import save_kallsyms_map
-from sdcm.mgmt.common import TaskStatus, ScyllaManagerError, get_persistent_snapshots, ObjectStorageUploadMode
-from sdcm.mgmt.backup import run_manager_backup
-from sdcm.mgmt.argus_report import report_manager_backup_results_to_argus
-from sdcm.mgmt.helpers import get_dc_name_from_ks_statement, get_schema_create_statements_from_snapshot
+from sdcm.mgmt.common import TaskStatus, ScyllaManagerError
 from sdcm.prometheus import nemesis_metrics_obj
 from sdcm.provision.helpers.certificate import update_certificate, TLSAssets
 from sdcm.remote.libssh2_client.exceptions import UnexpectedExit as Libssh2UnexpectedExit
@@ -88,7 +84,6 @@ from sdcm.sct_events.group_common_events import (
     ignore_reactor_stall_errors,
     ignore_disk_quota_exceeded_errors,
     decorate_with_context_if_issues_open,
-    ignore_take_snapshot_failing,
     ignore_ipv6_failure_to_assign,
     ignore_raft_topology_cmd_failing,
     suppress_expected_unavailability_errors,
@@ -140,6 +135,7 @@ from sdcm.utils.ldap import SASLAUTHD_AUTHENTICATOR, LdapServerType
 from sdcm.utils.loader_utils import DEFAULT_USER, DEFAULT_USER_PASSWORD, SERVICE_LEVEL_NAME_TEMPLATE
 
 from sdcm.nemesis.utils import NEMESIS_TARGET_POOLS, DefaultValue, node_operations, unique_disruption_name
+from sdcm.nemesis.utils.common_ops import destroy_data_and_restart_scylla
 from sdcm.nemesis.utils.indexes import (
     ViewFinishedBuildingException,
     is_cf_a_view,
@@ -169,7 +165,6 @@ from sdcm.exceptions import (
     KillNemesis,
     NoFilesFoundToDestroy,
     NoKeyspaceFound,
-    FilesNotCorrupted,
     LogContentNotFound,
     LdapNotRunning,
     TimestampNotFound,
@@ -196,7 +191,6 @@ from sdcm.utils.topology_ops import FailedDecommissionOperationMonitoring
 
 if TYPE_CHECKING:
     from sdcm.audit import AuditStore
-    from sdcm.mgmt.cli import BackupTask
     from sdcm.tester import ClusterTester
 
 LOGGER = logging.getLogger(__name__)
@@ -1002,61 +996,10 @@ class NemesisRunner:
 
         return sstables
 
-    @decorate_with_context(suppress_expected_unavailability_errors)
     def _destroy_data_and_restart_scylla(self, keyspaces_for_destroy: list = None, sstables_to_destroy_perc: int = 50):
-        tables = self.cluster.get_non_system_ks_cf_list(
-            db_node=self.target_node, filter_empty_tables=False, filter_by_keyspace=keyspaces_for_destroy
+        destroy_data_and_restart_scylla(
+            self, keyspaces_for_destroy=keyspaces_for_destroy, sstables_to_destroy_perc=sstables_to_destroy_perc
         )
-        if not tables:
-            raise UnsupportedNemesis("Non-system keyspace and table are not found. The nemesis can't be run")
-
-        self.log.debug("Chosen tables: %s", tables)
-
-        # Stop scylla service before deleting sstables to avoid partial deletion of files that are under compaction
-        with self.action_log_scope(f"Stop Scylla on {self.target_node.name}"):
-            self.target_node.stop_scylla_server(verify_up=False, verify_down=True)
-
-        try:
-            # Remove data files
-            if not (all_files_to_destroy := self.get_all_sstables(tables=tables, node=self.target_node)):
-                raise UnsupportedNemesis("SStables for destroy are not found. The nemesis can't be run")
-
-            # How many SStables are going to be deleted
-            sstables_amount_to_destroy = int(len(all_files_to_destroy) * sstables_to_destroy_perc / 100)
-            self.log.debug(
-                "SStables amount to destroy (%s percent of all SStables): %s",
-                sstables_to_destroy_perc,
-                sstables_amount_to_destroy,
-            )
-
-            destroyed_files = 0
-            while sstables_amount_to_destroy > 0:
-                file_for_destroy = random.choice(all_files_to_destroy)
-                if not (
-                    file_group_for_destroy := self.replace_full_file_name_to_prefix(
-                        one_file=file_for_destroy, ks_cf_for_destroy=tables
-                    )
-                ):
-                    continue
-
-                with DbNodeLogger(
-                    self.cluster.nodes,
-                    "remove data",
-                    target_node=self.target_node,
-                    additional_info=file_group_for_destroy,
-                ):
-                    result = self.target_node.remoter.sudo("rm -f %s" % file_group_for_destroy)
-                if result.stderr:
-                    raise FilesNotCorrupted(f"Files were not removed. The nemesis can't be run. Error: {result}")
-                all_files_to_destroy.remove(file_for_destroy)
-                sstables_amount_to_destroy -= 1
-                destroyed_files += 1
-                self.log.debug(f"Files {file_for_destroy} were destroyed")
-            self.actions_log.info(f"removed {destroyed_files} files in tables: {tables} on {self.target_node.name}")
-
-        finally:
-            with self.action_log_scope(f"Start Scylla on {self.target_node.name} node"):
-                self.target_node.start_scylla_server(verify_up=True, verify_down=False)
 
     def disrupt(self):
         raise NotImplementedError("Derived classes must implement disrupt()")
@@ -2836,303 +2779,6 @@ class NemesisRunner:
 
     def disrupt_toggle_table_gc_mode(self):
         self.toggle_table_gc_mode()
-
-    def _run_manager_backup(
-        self, mgr_cluster, object_storage_upload_mode: ObjectStorageUploadMode, timeout: int
-    ) -> "BackupTask":
-        with self.action_log_scope("Scylla Manager backup"):
-            task = run_manager_backup(mgr_cluster, self.tester.locations, object_storage_upload_mode, timeout)
-        return task
-
-    def _manager_backup_and_report(self, method: ObjectStorageUploadMode, label) -> "BackupTask":
-        """
-        Run a backup using Scylla Manager and report the result to Argus.
-
-        :param method: The transfer mode for object storage (e.g., RCLONE or NATIVE).
-        :param label: A label for reporting.
-        :return: BackupTask object representing the backup operation.
-        """
-        timeout = int(timedelta(hours=14).total_seconds())
-        manager_tool = self.get_manager_tool()
-        mgr_cluster = self.tester.ensure_and_get_cluster(manager_tool)
-        decorated = latency_calculator_decorator(legend="Scylla-Manager Backup", cycle_name=label)(
-            self._run_manager_backup
-        )
-        task = decorated(mgr_cluster, method, timeout)
-        report_manager_backup_results_to_argus(self.tester.monitors, self.tester.test_config, label, task, mgr_cluster)
-        return task
-
-    def disrupt_manager_backup(self, object_storage_upload_mode: ObjectStorageUploadMode, label):
-        """
-        Perform a Manager backup as a nemesis.
-        Deletes created snapshot at end.
-        Args:
-            object_storage_upload_mode: The upload mode (e.g., RCLONE or NATIVE).
-            label: Label for reporting to Argus.
-        """
-
-        time_postfix = datetime.datetime.now().strftime("_%m%d_%H%M")
-        label_with_time = f"{label}{time_postfix}"
-        task = self._manager_backup_and_report(object_storage_upload_mode, label_with_time)
-        with self.action_log_scope("Delete Manager backup snapshot"):
-            task.delete_backup_snapshot()
-
-    def get_manager_tool(self):
-        return mgmt.get_scylla_manager_tool(manager_node=self.tester.monitors.nodes[0])
-
-    def disrupt_mgmt_backup_specific_keyspaces(self):
-        self._mgmt_backup(backup_specific_tables=True)
-
-    def disrupt_mgmt_backup(self):
-        self._mgmt_backup(backup_specific_tables=False)
-
-    def disrupt_mgmt_restore(self):  # noqa: PLR0914
-        def get_total_scylla_partition_size():
-            result = self.cluster.data_nodes[0].remoter.run("df -k | grep /var/lib/scylla")  # Size in KB
-            free_space_size = int(result.stdout.split()[1]) / 1024**2  # Converting to GB
-            return free_space_size
-
-        def choose_snapshot(snapshots_dict, region: str):
-            snapshot_groups_by_size = snapshots_dict["snapshots_sizes"]
-            total_partition_size = get_total_scylla_partition_size()
-            all_snapshot_sizes = sorted(list(snapshot_groups_by_size.keys()), reverse=True)
-            fitting_snapshot_sizes = [size for size in all_snapshot_sizes if total_partition_size / size >= 20]
-            if self.tester.test_duration < 1000:
-                # Since verifying the restored data takes a long time, the nemesis limits the size of the restored
-                # backup based on the test duration
-                fitting_snapshot_sizes = [size for size in fitting_snapshot_sizes if size < 50]
-            # The restore should not take more than 5% of the space total space in /var/lib/scylla
-            assert fitting_snapshot_sizes, "There's not enough space for any snapshot restoration"
-
-            chosen_snapshot_size = self.random.choice(fitting_snapshot_sizes)
-            all_snapshots_per_region = snapshot_groups_by_size[chosen_snapshot_size]["snapshots"][region]
-
-            if self.cluster.nodes[0].is_enterprise:
-                snapshot_tag = self.random.choice(list(all_snapshots_per_region.keys()))
-            else:
-                oss_snapshots = [
-                    snapshot_key
-                    for snapshot_key, snapshot_value in all_snapshots_per_region.items()
-                    if snapshot_value["scylla_product"] == "oss"
-                ]
-                snapshot_tag = self.random.choice(oss_snapshots)
-
-            snapshot_info = all_snapshots_per_region[snapshot_tag]
-            snapshot_info.update(
-                {
-                    "expected_timeout": snapshot_groups_by_size[chosen_snapshot_size]["expected_timeout"],
-                    "number_of_rows": snapshot_groups_by_size[chosen_snapshot_size]["number_of_rows"],
-                }
-            )
-            return snapshot_tag, snapshot_info
-
-        def execute_data_validation_thread(command_template, keyspace_name, number_of_rows):
-            stress_queue = []
-            number_of_loaders = sum(self.tester.params.get("n_loaders"))
-            rows_per_loader = int(number_of_rows / number_of_loaders)
-            for loader_index in range(number_of_loaders):
-                stress_command = command_template.format(
-                    num_of_rows=rows_per_loader,
-                    keyspace_name=keyspace_name,
-                    sequence_start=rows_per_loader * loader_index + 1,
-                    sequence_end=rows_per_loader * (loader_index + 1),
-                )
-                read_thread = self.tester.run_stress_thread(
-                    stress_cmd=stress_command, round_robin=True, stop_test_on_failure=False
-                )
-                stress_queue.append(read_thread)
-            return stress_queue
-
-        def _restore_schema(locations: list, cluster_id: str, tag: str) -> None:
-            """Introduced to cover two flows:
-
-            - When a backup snapshot has different DC name than the current cluster's DC name -
-            restore schema out of the Manager applying CQL statements saved in schema.json file
-
-            - When backup snapshot has the same DC name as the current cluster's DC name -
-            restore schema using the Manager (sctool restore --restore-schema ...)
-            """
-            ks_statements, other_statements = get_schema_create_statements_from_snapshot(
-                bucket=locations[0].split(":")[-1],
-                mgr_cluster_id=cluster_id,
-                snapshot_tag=tag,
-            )
-
-            dc_under_test_name = next(iter(self.cluster.get_nodetool_status()))
-            # Test is supposed to work with single DC setups only, so we can take the first DC name
-            dc_from_backup_name = get_dc_name_from_ks_statement(ks_statements[0])[0]
-            self.log.debug("DC name from backup: %s, DC name under test: %s", dc_from_backup_name, dc_under_test_name)
-
-            if dc_under_test_name != dc_from_backup_name:
-                self.log.info(
-                    "DC names mismatch - restoring the schema manually altering cql statements and "
-                    "applying them one by one"
-                )
-                # Alter the dc_name in keyspace cql statements to match the current cluster's dc_name
-                old_dc_block = f"'{dc_from_backup_name}':"  # Include quotes and colon to avoid unintended replacements
-                new_dc_block = f"'{dc_under_test_name}':"
-                ks_statements = [stmt.replace(old_dc_block, new_dc_block) for stmt in ks_statements]
-                # Apply cql statements one by one to restore schema
-                for cql_stmt in ks_statements + other_statements:
-                    self.target_node.run_cqlsh(cql_stmt)
-            else:
-                self.log.info("Restoring the schema using the Scylla Manager")
-                task = mgr_cluster.create_restore_task(restore_schema=True, location_list=locations, snapshot_tag=tag)
-                task.wait_and_get_final_status(step=10, timeout=6 * 60)  # 6 giving minutes to restore the schema
-                assert task.status == TaskStatus.DONE, f"Schema restoration failed: snapshot tag - {tag}"
-
-        skip_issues = [
-            "https://github.com/scylladb/scylla-manager/issues/3829",
-            "https://github.com/scylladb/scylla-manager/issues/4049",
-        ]
-        is_multi_dc = (
-            len(self.cluster.params.region_names) > 1 or (self.cluster.params.get("simulated_regions") or 0) > 1
-        )
-        if SkipPerIssues(skip_issues, params=self.tester.params) and is_multi_dc:
-            raise UnsupportedNemesis("MultiDC cluster configuration is not supported by this nemesis")
-
-        if not (self.cluster.params.get("use_mgmt") or self.cluster.params.get("use_cloud_manager")):
-            raise UnsupportedNemesis("Scylla-manager configuration is not defined!")
-        if self.cluster.params.get("cluster_backend") not in ("aws", "k8s-eks"):
-            raise UnsupportedNemesis("The restore test only supports 'AWS' and 'K8S-EKS' backends.")
-
-        mgr_cluster = self.cluster.get_cluster_manager()
-        cluster_backend = self.cluster.params.get("cluster_backend")
-        if cluster_backend == "k8s-eks":
-            cluster_backend = "aws"
-
-        persistent_manager_snapshots_dict = get_persistent_snapshots()
-        region = next(iter(self.cluster.params.region_names), "")
-        target_bucket = persistent_manager_snapshots_dict[cluster_backend]["bucket"].format(region=region)
-        chosen_snapshot_tag, chosen_snapshot_info = choose_snapshot(
-            snapshots_dict=persistent_manager_snapshots_dict[cluster_backend], region=region
-        )
-
-        self.log.info("Restoring the keyspace %s", chosen_snapshot_info["keyspace_name"])
-        location_list = [f"{self.cluster.params.get('backup_bucket_backend')}:{target_bucket}"]
-        test_keyspaces = [cql_unquote_if_needed(keyspace) for keyspace in self.cluster.get_test_keyspaces()]
-        # Keyspace names that start with a digit are surrounded by quotation marks in the output of a describe query
-        if chosen_snapshot_info["keyspace_name"] not in test_keyspaces:
-            self.log.info("Restoring the schema of the keyspace '%s'", chosen_snapshot_info["keyspace_name"])
-            _restore_schema(
-                locations=location_list,
-                cluster_id=chosen_snapshot_info["cluster_id"],
-                tag=chosen_snapshot_tag,
-            )
-            with suppress_expected_unavailability_errors():
-                self.cluster.restart_scylla()  # After schema restoration, you should restart the nodes
-
-            # TODO: Bring it back after the implementation of https://github.com/scylladb/scylla-manager/issues/4049
-            # which will unblock schema restore into a different DC. For now, we can restore schema only within one DC.
-            # According to https://github.com/scylladb/scylla-manager/issues/4041#issuecomment-2565489699, the step
-            # below is not needed if restoring the schema within one DC.
-            #
-            # self.tester.set_ks_strategy_to_network_and_rf_according_to_cluster(
-            #    keyspace=chosen_snapshot_info["keyspace_name"], repair_after_alter=False)
-        try:
-            restore_task = mgr_cluster.create_restore_task(
-                restore_data=True, location_list=location_list, snapshot_tag=chosen_snapshot_tag
-            )
-            restore_task.wait_and_get_final_status(step=30, timeout=chosen_snapshot_info["expected_timeout"])
-            assert restore_task.status == TaskStatus.DONE, f"Data restoration of {chosen_snapshot_tag} has failed!"
-
-            confirmation_stress_template = (persistent_manager_snapshots_dict)[cluster_backend][
-                "confirmation_stress_template"
-            ]
-            stress_queue = execute_data_validation_thread(
-                command_template=confirmation_stress_template,
-                keyspace_name=chosen_snapshot_info["keyspace_name"],
-                number_of_rows=chosen_snapshot_info["number_of_rows"],
-            )
-
-            for stress in stress_queue:
-                is_passed = self.tester.verify_stress_thread(stress)
-                assert is_passed, (
-                    "Data verification stress command, triggered by the 'mgmt_restore' nemesis, has failed"
-                )
-        finally:
-            self.log.info("Cleaning up restored keyspace '%s'", chosen_snapshot_info["keyspace_name"])
-            drop_ks_stmt = f'DROP KEYSPACE IF EXISTS "{chosen_snapshot_info["keyspace_name"]}";'
-            try:
-                self.target_node.run_cqlsh(drop_ks_stmt)
-            except Exception as drop_err:  # noqa: BLE001
-                self.log.warning("Failed to drop restored keyspace: %s", drop_err)
-
-    def _delete_existing_backups(self, mgr_cluster):
-        deleted_tasks = []
-        existing_backup_tasks = mgr_cluster.backup_task_list
-        for backup_task in existing_backup_tasks:
-            if backup_task.status in [TaskStatus.NEW, TaskStatus.RUNNING, TaskStatus.STARTING, TaskStatus.ERROR]:
-                deleted_tasks.append(backup_task.id)
-                mgr_cluster.delete_task(backup_task)
-        if deleted_tasks:
-            self.log.warning(
-                "Deleted the following backup tasks before the nemesis starts: %s", ", ".join(deleted_tasks)
-            )
-
-    @decorate_with_context_if_issues_open(
-        ignore_take_snapshot_failing, issue_refs=["https://github.com/scylladb/scylla-manager/issues/3389"]
-    )
-    def _mgmt_backup(self, backup_specific_tables):
-        if not self.cluster.params.get("use_mgmt") and not self.cluster.params.get("use_cloud_manager"):
-            raise UnsupportedNemesis("Scylla-manager configuration is not defined!")
-        mgr_cluster = self.cluster.get_cluster_manager()
-        if self.cluster.params.get("use_cloud_manager"):
-            auto_backup_task = mgr_cluster.backup_task_list[0]
-            #  An example of the auto generated backup task of cloud manager is:
-            #  │ backup/8e40b8b4-5394-42d3-9884-a4ce8ab69687
-            #  │ --dc 'AWS_US_EAST_1' -L AWS_US_EAST_1:s3:scylla-cloud-backup-9952-10120-4q4w4d --retention 14
-            #  --rate-limit AWS_US_EAST_1:100 --snapshot-parallel '<nil>' --upload-parallel '<nil>'
-            #  │ 06 Jun 21 18:10:05 UTC (+1d)  │ NEW
-            location = auto_backup_task.get_task_info_dict()["location"]
-        else:
-            if not self.cluster.params.get("backup_bucket_location"):
-                raise UnsupportedNemesis("backup bucket location configuration is not defined!")
-
-            backup_bucket_backend = self.cluster.params.get("backup_bucket_backend")
-            region = next(iter(self.cluster.params.region_names), "")
-            backup_bucket_location = self.cluster.params.get("backup_bucket_location")[0].format(region=region)
-            location = f"{backup_bucket_backend}:{backup_bucket_location}"
-        self._delete_existing_backups(mgr_cluster)
-        if backup_specific_tables:
-            non_test_keyspaces = [cql_unquote_if_needed(ks) for ks in self.cluster.get_test_keyspaces()]
-            self.actions_log.info(f"Starting Scylla Manager backup task for keyspaces: {non_test_keyspaces}")
-            mgr_task = mgr_cluster.create_backup_task(
-                location_list=[
-                    location,
-                ],
-                keyspace_list=non_test_keyspaces,
-            )
-        else:
-            self.actions_log.info("Starting Scylla Manager backup task for all keyspaces")
-            mgr_task = mgr_cluster.create_backup_task(
-                location_list=[
-                    location,
-                ]
-            )
-
-        assert mgr_task is not None, "Backup task wasn't created"
-
-        status = mgr_task.wait_and_get_final_status(timeout=54000, step=5, only_final=True)
-        self.actions_log.info(f"Scylla Manager backup task finished with status: {status}")
-        if status == TaskStatus.DONE:
-            self.log.info("Task: %s is done.", mgr_task.id)
-        elif status in (TaskStatus.ERROR, TaskStatus.ERROR_FINAL):
-            assert False, f"Backup task {mgr_task.id} failed"
-        else:
-            mgr_task.stop()
-            assert False, f"Backup task {mgr_task.id} timed out - while on status {status}"
-
-    def disrupt_mgmt_repair_cli(self):
-        if not self.cluster.params.get("use_mgmt") and not self.cluster.params.get("use_cloud_manager"):
-            raise UnsupportedNemesis("Scylla-manager configuration is not defined!")
-        self.run_repair_manager()
-
-    def disrupt_mgmt_corrupt_then_repair(self):
-        if not self.cluster.params.get("use_mgmt") and not self.cluster.params.get("use_cloud_manager"):
-            raise UnsupportedNemesis("Scylla-manager configuration is not defined!")
-        self._destroy_data_and_restart_scylla()
-        self.run_repair_manager()
 
     def disrupt_abort_repair(self):
         """

--- a/sdcm/nemesis/__init__.py
+++ b/sdcm/nemesis/__init__.py
@@ -31,7 +31,6 @@ import traceback
 import json
 import itertools
 from abc import ABC, abstractmethod
-from datetime import timedelta
 from typing import List, Optional, Callable, Union, Iterable, TYPE_CHECKING
 from functools import partial, cached_property
 from collections import defaultdict, Counter, namedtuple
@@ -45,8 +44,7 @@ from argus.common.enums import NemesisStatus
 from sdcm.nemesis.registry import NemesisRegistry
 from sdcm.utils.action_logger import get_action_logger
 
-from sdcm.utils.cql_utils import cql_unquote_if_needed
-from sdcm import wait, mgmt
+from sdcm import wait
 from sdcm.audit import Audit, AuditConfiguration
 from sdcm.cluster import (
     BaseCluster,
@@ -68,16 +66,7 @@ from sdcm.cluster_k8s import (
 )
 from sdcm.log import SDCMAdapter
 from sdcm.logcollector import save_kallsyms_map
-from sdcm.mgmt.common import (
-    TaskStatus,
-    TERMINAL_TASK_STATUSES,
-    ScyllaManagerError,
-    get_persistent_snapshots,
-    ObjectStorageUploadMode,
-)
-from sdcm.mgmt.backup import run_manager_backup
-from sdcm.mgmt.argus_report import report_manager_backup_results_to_argus
-from sdcm.mgmt.helpers import get_dc_name_from_ks_statement, get_schema_create_statements_from_snapshot
+from sdcm.mgmt.common import TaskStatus, ScyllaManagerError
 from sdcm.prometheus import nemesis_metrics_obj
 from sdcm.provision.helpers.certificate import update_certificate, TLSAssets
 from sdcm.remote.libssh2_client.exceptions import UnexpectedExit as Libssh2UnexpectedExit
@@ -92,7 +81,6 @@ from sdcm.sct_events.group_common_events import (
     ignore_reactor_stall_errors,
     ignore_disk_quota_exceeded_errors,
     decorate_with_context_if_issues_open,
-    ignore_take_snapshot_failing,
     ignore_ipv6_failure_to_assign,
     ignore_raft_topology_cmd_failing,
     suppress_expected_unavailability_errors,
@@ -142,6 +130,7 @@ from sdcm.utils.ldap import SASLAUTHD_AUTHENTICATOR, LdapServerType
 
 
 from sdcm.nemesis.utils import NEMESIS_TARGET_POOLS, DefaultValue, node_operations, unique_disruption_name
+from sdcm.nemesis.utils.common_ops import destroy_data_and_restart_scylla
 from sdcm.nemesis.utils.indexes import (
     is_cf_a_view,
 )
@@ -160,7 +149,6 @@ from sdcm.exceptions import (
     KillNemesis,
     NoFilesFoundToDestroy,
     NoKeyspaceFound,
-    FilesNotCorrupted,
     LogContentNotFound,
     LdapNotRunning,
     TimestampNotFound,
@@ -172,7 +160,6 @@ from sdcm.exceptions import (
     BootstrapStreamErrorFailure,
     QuotaConfigurationFailure,
     NemesisStressFailure,
-    WaitForTimeoutError,
 )
 from test_lib.compaction import (
     CompactionStrategy,
@@ -186,7 +173,6 @@ from sdcm.utils.topology_ops import FailedDecommissionOperationMonitoring
 
 if TYPE_CHECKING:
     from sdcm.audit import AuditStore
-    from sdcm.mgmt.cli import BackupTask
     from sdcm.tester import ClusterTester
 
 LOGGER = logging.getLogger(__name__)
@@ -1029,61 +1015,10 @@ class NemesisRunner:
 
         return sstables
 
-    @decorate_with_context(suppress_expected_unavailability_errors)
     def _destroy_data_and_restart_scylla(self, keyspaces_for_destroy: list = None, sstables_to_destroy_perc: int = 50):
-        tables = self.cluster.get_non_system_ks_cf_list(
-            db_node=self.target_node, filter_empty_tables=False, filter_by_keyspace=keyspaces_for_destroy
+        destroy_data_and_restart_scylla(
+            self, keyspaces_for_destroy=keyspaces_for_destroy, sstables_to_destroy_perc=sstables_to_destroy_perc
         )
-        if not tables:
-            raise UnsupportedNemesis("Non-system keyspace and table are not found. The nemesis can't be run")
-
-        self.log.debug("Chosen tables: %s", tables)
-
-        # Stop scylla service before deleting sstables to avoid partial deletion of files that are under compaction
-        with self.action_log_scope(f"Stop Scylla on {self.target_node.name}"):
-            self.target_node.stop_scylla_server(verify_up=False, verify_down=True)
-
-        try:
-            # Remove data files
-            if not (all_files_to_destroy := self.get_all_sstables(tables=tables, node=self.target_node)):
-                raise UnsupportedNemesis("SStables for destroy are not found. The nemesis can't be run")
-
-            # How many SStables are going to be deleted
-            sstables_amount_to_destroy = int(len(all_files_to_destroy) * sstables_to_destroy_perc / 100)
-            self.log.debug(
-                "SStables amount to destroy (%s percent of all SStables): %s",
-                sstables_to_destroy_perc,
-                sstables_amount_to_destroy,
-            )
-
-            destroyed_files = 0
-            while sstables_amount_to_destroy > 0:
-                file_for_destroy = random.choice(all_files_to_destroy)
-                if not (
-                    file_group_for_destroy := self.replace_full_file_name_to_prefix(
-                        one_file=file_for_destroy, ks_cf_for_destroy=tables
-                    )
-                ):
-                    continue
-
-                with DbNodeLogger(
-                    self.cluster.nodes,
-                    "remove data",
-                    target_node=self.target_node,
-                    additional_info=file_group_for_destroy,
-                ):
-                    result = self.target_node.remoter.sudo("rm -f %s" % file_group_for_destroy)
-                if result.stderr:
-                    raise FilesNotCorrupted(f"Files were not removed. The nemesis can't be run. Error: {result}")
-                all_files_to_destroy.remove(file_for_destroy)
-                sstables_amount_to_destroy -= 1
-                destroyed_files += 1
-                self.log.debug(f"Files {file_for_destroy} were destroyed")
-            self.actions_log.info(f"removed {destroyed_files} files in tables: {tables} on {self.target_node.name}")
-
-        finally:
-            with self.action_log_scope(f"Start Scylla on {self.target_node.name} node"):
-                self.target_node.start_scylla_server(verify_up=True, verify_down=False)
 
     def disrupt(self):
         raise NotImplementedError("Derived classes must implement disrupt()")
@@ -2891,339 +2826,6 @@ class NemesisRunner:
 
     def disrupt_toggle_table_gc_mode(self):
         self.toggle_table_gc_mode()
-
-    def _run_manager_backup(
-        self, mgr_cluster, object_storage_upload_mode: ObjectStorageUploadMode, timeout: int
-    ) -> "BackupTask":
-        with self.action_log_scope("Scylla Manager backup"):
-            task = run_manager_backup(mgr_cluster, self.tester.locations, object_storage_upload_mode, timeout)
-        return task
-
-    def _manager_backup_and_report(self, method: ObjectStorageUploadMode, label) -> "BackupTask":
-        """
-        Run a backup using Scylla Manager and report the result to Argus.
-
-        :param method: The transfer mode for object storage (e.g., RCLONE or NATIVE).
-        :param label: A label for reporting.
-        :return: BackupTask object representing the backup operation.
-        """
-        timeout = int(timedelta(hours=14).total_seconds())
-        manager_tool = self.get_manager_tool()
-        mgr_cluster = self.tester.ensure_and_get_cluster(manager_tool)
-        decorated = latency_calculator_decorator(legend="Scylla-Manager Backup", cycle_name=label)(
-            self._run_manager_backup
-        )
-        task = decorated(mgr_cluster, method, timeout)
-        report_manager_backup_results_to_argus(self.tester.monitors, self.tester.test_config, label, task, mgr_cluster)
-        return task
-
-    def disrupt_manager_backup(self, object_storage_upload_mode: ObjectStorageUploadMode, label):
-        """
-        Perform a Manager backup as a nemesis.
-        Deletes created snapshot at end.
-        Args:
-            object_storage_upload_mode: The upload mode (e.g., RCLONE or NATIVE).
-            label: Label for reporting to Argus.
-        """
-
-        time_postfix = datetime.datetime.now().strftime("_%m%d_%H%M")
-        label_with_time = f"{label}{time_postfix}"
-        task = self._manager_backup_and_report(object_storage_upload_mode, label_with_time)
-        with self.action_log_scope("Delete Manager backup snapshot"):
-            task.delete_backup_snapshot()
-
-    def get_manager_tool(self):
-        return mgmt.get_scylla_manager_tool(manager_node=self.tester.monitors.nodes[0])
-
-    def disrupt_mgmt_backup_specific_keyspaces(self):
-        self._mgmt_backup(backup_specific_tables=True)
-
-    def disrupt_mgmt_backup(self):
-        self._mgmt_backup(backup_specific_tables=False)
-
-    def disrupt_mgmt_restore(self):  # noqa: PLR0914
-        def get_total_scylla_partition_size():
-            result = self.cluster.data_nodes[0].remoter.run("df -k | grep /var/lib/scylla")  # Size in KB
-            free_space_size = int(result.stdout.split()[1]) / 1024**2  # Converting to GB
-            return free_space_size
-
-        def choose_snapshot(snapshots_dict, region: str):
-            snapshot_groups_by_size = snapshots_dict["snapshots_sizes"]
-            total_partition_size = get_total_scylla_partition_size()
-            all_snapshot_sizes = sorted(list(snapshot_groups_by_size.keys()), reverse=True)
-            fitting_snapshot_sizes = [size for size in all_snapshot_sizes if total_partition_size / size >= 20]
-            if self.tester.test_duration < 1000:
-                # Since verifying the restored data takes a long time, the nemesis limits the size of the restored
-                # backup based on the test duration
-                fitting_snapshot_sizes = [size for size in fitting_snapshot_sizes if size < 50]
-            # The restore should not take more than 5% of the space total space in /var/lib/scylla
-            assert fitting_snapshot_sizes, "There's not enough space for any snapshot restoration"
-
-            chosen_snapshot_size = self.random.choice(fitting_snapshot_sizes)
-            all_snapshots_per_region = snapshot_groups_by_size[chosen_snapshot_size]["snapshots"][region]
-
-            if self.cluster.nodes[0].is_enterprise:
-                snapshot_tag = self.random.choice(list(all_snapshots_per_region.keys()))
-            else:
-                oss_snapshots = [
-                    snapshot_key
-                    for snapshot_key, snapshot_value in all_snapshots_per_region.items()
-                    if snapshot_value["scylla_product"] == "oss"
-                ]
-                snapshot_tag = self.random.choice(oss_snapshots)
-
-            snapshot_info = all_snapshots_per_region[snapshot_tag]
-            snapshot_info.update(
-                {
-                    "expected_timeout": snapshot_groups_by_size[chosen_snapshot_size]["expected_timeout"],
-                    "number_of_rows": snapshot_groups_by_size[chosen_snapshot_size]["number_of_rows"],
-                }
-            )
-            return snapshot_tag, snapshot_info
-
-        def execute_data_validation_thread(command_template, keyspace_name, number_of_rows):
-            stress_queue = []
-            number_of_loaders = sum(self.tester.params.get("n_loaders"))
-            rows_per_loader = int(number_of_rows / number_of_loaders)
-            for loader_index in range(number_of_loaders):
-                stress_command = command_template.format(
-                    num_of_rows=rows_per_loader,
-                    keyspace_name=keyspace_name,
-                    sequence_start=rows_per_loader * loader_index + 1,
-                    sequence_end=rows_per_loader * (loader_index + 1),
-                )
-                read_thread = self.tester.run_stress_thread(
-                    stress_cmd=stress_command, round_robin=True, stop_test_on_failure=False
-                )
-                stress_queue.append(read_thread)
-            return stress_queue
-
-        def _restore_schema(locations: list, cluster_id: str, tag: str) -> None:
-            """Introduced to cover two flows:
-
-            - When a backup snapshot has different DC name than the current cluster's DC name -
-            restore schema out of the Manager applying CQL statements saved in schema.json file
-
-            - When backup snapshot has the same DC name as the current cluster's DC name -
-            restore schema using the Manager (sctool restore --restore-schema ...)
-            """
-            ks_statements, other_statements = get_schema_create_statements_from_snapshot(
-                bucket=locations[0].split(":")[-1],
-                mgr_cluster_id=cluster_id,
-                snapshot_tag=tag,
-            )
-
-            dc_under_test_name = next(iter(self.cluster.get_nodetool_status()))
-            # Test is supposed to work with single DC setups only, so we can take the first DC name
-            dc_from_backup_name = get_dc_name_from_ks_statement(ks_statements[0])[0]
-            self.log.debug("DC name from backup: %s, DC name under test: %s", dc_from_backup_name, dc_under_test_name)
-
-            if dc_under_test_name != dc_from_backup_name:
-                self.log.info(
-                    "DC names mismatch - restoring the schema manually altering cql statements and "
-                    "applying them one by one"
-                )
-                # Alter the dc_name in keyspace cql statements to match the current cluster's dc_name
-                old_dc_block = f"'{dc_from_backup_name}':"  # Include quotes and colon to avoid unintended replacements
-                new_dc_block = f"'{dc_under_test_name}':"
-                ks_statements = [stmt.replace(old_dc_block, new_dc_block) for stmt in ks_statements]
-                # Apply cql statements one by one to restore schema
-                for cql_stmt in ks_statements + other_statements:
-                    self.target_node.run_cqlsh(cql_stmt)
-            else:
-                self.log.info("Restoring the schema using the Scylla Manager")
-                task = mgr_cluster.create_restore_task(restore_schema=True, location_list=locations, snapshot_tag=tag)
-                task.wait_and_get_final_status(step=10, timeout=6 * 60)  # 6 giving minutes to restore the schema
-                assert task.status == TaskStatus.DONE, f"Schema restoration failed: snapshot tag - {tag}"
-
-        skip_issues = [
-            "https://github.com/scylladb/scylla-manager/issues/3829",
-            "https://github.com/scylladb/scylla-manager/issues/4049",
-        ]
-        is_multi_dc = (
-            len(self.cluster.params.region_names) > 1 or (self.cluster.params.get("simulated_regions") or 0) > 1
-        )
-        if SkipPerIssues(skip_issues, params=self.tester.params) and is_multi_dc:
-            raise UnsupportedNemesis("MultiDC cluster configuration is not supported by this nemesis")
-
-        if not (self.cluster.params.get("use_mgmt") or self.cluster.params.get("use_cloud_manager")):
-            raise UnsupportedNemesis("Scylla-manager configuration is not defined!")
-        if self.cluster.params.get("cluster_backend") not in ("aws", "k8s-eks"):
-            raise UnsupportedNemesis("The restore test only supports 'AWS' and 'K8S-EKS' backends.")
-
-        mgr_cluster = self.cluster.get_cluster_manager()
-        cluster_backend = self.cluster.params.get("cluster_backend")
-        if cluster_backend == "k8s-eks":
-            cluster_backend = "aws"
-
-        persistent_manager_snapshots_dict = get_persistent_snapshots()
-        region = next(iter(self.cluster.params.region_names), "")
-        target_bucket = persistent_manager_snapshots_dict[cluster_backend]["bucket"].format(region=region)
-        chosen_snapshot_tag, chosen_snapshot_info = choose_snapshot(
-            snapshots_dict=persistent_manager_snapshots_dict[cluster_backend], region=region
-        )
-
-        self.log.info("Restoring the keyspace %s", chosen_snapshot_info["keyspace_name"])
-        location_list = [f"{self.cluster.params.get('backup_bucket_backend')}:{target_bucket}"]
-        test_keyspaces = [cql_unquote_if_needed(keyspace) for keyspace in self.cluster.get_test_keyspaces()]
-        # Keyspace names that start with a digit are surrounded by quotation marks in the output of a describe query
-        if chosen_snapshot_info["keyspace_name"] not in test_keyspaces:
-            self.log.info("Restoring the schema of the keyspace '%s'", chosen_snapshot_info["keyspace_name"])
-            _restore_schema(
-                locations=location_list,
-                cluster_id=chosen_snapshot_info["cluster_id"],
-                tag=chosen_snapshot_tag,
-            )
-            with suppress_expected_unavailability_errors():
-                self.cluster.restart_scylla()  # After schema restoration, you should restart the nodes
-
-            # TODO: Bring it back after the implementation of https://github.com/scylladb/scylla-manager/issues/4049
-            # which will unblock schema restore into a different DC. For now, we can restore schema only within one DC.
-            # According to https://github.com/scylladb/scylla-manager/issues/4041#issuecomment-2565489699, the step
-            # below is not needed if restoring the schema within one DC.
-            #
-            # self.tester.set_ks_strategy_to_network_and_rf_according_to_cluster(
-            #    keyspace=chosen_snapshot_info["keyspace_name"], repair_after_alter=False)
-        restore_task = None
-        try:
-            restore_task = mgr_cluster.create_restore_task(
-                restore_data=True, location_list=location_list, snapshot_tag=chosen_snapshot_tag
-            )
-            restore_task.wait_and_get_final_status(step=30, timeout=chosen_snapshot_info["expected_timeout"])
-            assert restore_task.status == TaskStatus.DONE, f"Data restoration of {chosen_snapshot_tag} has failed!"
-
-            confirmation_stress_template = (persistent_manager_snapshots_dict)[cluster_backend][
-                "confirmation_stress_template"
-            ]
-            stress_queue = execute_data_validation_thread(
-                command_template=confirmation_stress_template,
-                keyspace_name=chosen_snapshot_info["keyspace_name"],
-                number_of_rows=chosen_snapshot_info["number_of_rows"],
-            )
-
-            for stress in stress_queue:
-                is_passed = self.tester.verify_stress_thread(stress)
-                assert is_passed, (
-                    "Data verification stress command, triggered by the 'mgmt_restore' nemesis, has failed"
-                )
-        finally:
-            self._stop_unfinished_restore_task(restore_task)
-            keyspace_name = chosen_snapshot_info["keyspace_name"]
-            self.log.info("Cleaning up restored keyspace '%s'", keyspace_name)
-            drop_ks_stmt = f'DROP KEYSPACE IF EXISTS "{keyspace_name}";'
-            try:
-                self.target_node.run_cqlsh(drop_ks_stmt)
-            except Exception as drop_err:  # noqa: BLE001
-                self.log.warning("Failed to drop restored keyspace: %s", drop_err)
-
-    def _stop_unfinished_restore_task(self, restore_task) -> None:
-        """Stop a Manager restore task that hasn't reached a final status yet.
-
-        A WaitForTimeoutError from wait_and_get_final_status only means SCT gave up waiting; the
-        task may still be RUNNING. This method issues an sctool stop and waits for a terminal
-        status so the task is no longer touching the keyspace before the caller cleans it up.
-
-        Best effort only: every failure here is logged and swallowed rather than masking the
-        original error that brought us into the finally block.
-        """
-        if restore_task is None:
-            return
-        try:
-            status = restore_task.status
-            if status in TERMINAL_TASK_STATUSES:
-                return
-            self.log.warning(
-                "Restore task %s is still in %s state - stopping it",
-                restore_task.id,
-                status,
-            )
-            try:
-                restore_task.stop()
-            except WaitForTimeoutError:
-                pass
-            restore_task.wait_for_status(list_status=TERMINAL_TASK_STATUSES, timeout=600, step=30)
-        except Exception as stop_err:  # noqa: BLE001
-            self.log.warning(
-                "Failed to stop the restore task %s: %s",
-                restore_task.id,
-                stop_err,
-            )
-
-    def _delete_existing_backups(self, mgr_cluster):
-        deleted_tasks = []
-        existing_backup_tasks = mgr_cluster.backup_task_list
-        for backup_task in existing_backup_tasks:
-            if backup_task.status in [TaskStatus.NEW, TaskStatus.RUNNING, TaskStatus.STARTING, TaskStatus.ERROR]:
-                deleted_tasks.append(backup_task.id)
-                mgr_cluster.delete_task(backup_task)
-        if deleted_tasks:
-            self.log.warning(
-                "Deleted the following backup tasks before the nemesis starts: %s", ", ".join(deleted_tasks)
-            )
-
-    @decorate_with_context_if_issues_open(
-        ignore_take_snapshot_failing, issue_refs=["https://github.com/scylladb/scylla-manager/issues/3389"]
-    )
-    def _mgmt_backup(self, backup_specific_tables):
-        if not self.cluster.params.get("use_mgmt") and not self.cluster.params.get("use_cloud_manager"):
-            raise UnsupportedNemesis("Scylla-manager configuration is not defined!")
-        mgr_cluster = self.cluster.get_cluster_manager()
-        if self.cluster.params.get("use_cloud_manager"):
-            auto_backup_task = mgr_cluster.backup_task_list[0]
-            #  An example of the auto generated backup task of cloud manager is:
-            #  │ backup/8e40b8b4-5394-42d3-9884-a4ce8ab69687
-            #  │ --dc 'AWS_US_EAST_1' -L AWS_US_EAST_1:s3:scylla-cloud-backup-9952-10120-4q4w4d --retention 14
-            #  --rate-limit AWS_US_EAST_1:100 --snapshot-parallel '<nil>' --upload-parallel '<nil>'
-            #  │ 06 Jun 21 18:10:05 UTC (+1d)  │ NEW
-            location = auto_backup_task.get_task_info_dict()["location"]
-        else:
-            if not self.cluster.params.get("backup_bucket_location"):
-                raise UnsupportedNemesis("backup bucket location configuration is not defined!")
-
-            backup_bucket_backend = self.cluster.params.get("backup_bucket_backend")
-            region = next(iter(self.cluster.params.region_names), "")
-            backup_bucket_location = self.cluster.params.get("backup_bucket_location")[0].format(region=region)
-            location = f"{backup_bucket_backend}:{backup_bucket_location}"
-        self._delete_existing_backups(mgr_cluster)
-        if backup_specific_tables:
-            non_test_keyspaces = [cql_unquote_if_needed(ks) for ks in self.cluster.get_test_keyspaces()]
-            self.actions_log.info(f"Starting Scylla Manager backup task for keyspaces: {non_test_keyspaces}")
-            mgr_task = mgr_cluster.create_backup_task(
-                location_list=[
-                    location,
-                ],
-                keyspace_list=non_test_keyspaces,
-            )
-        else:
-            self.actions_log.info("Starting Scylla Manager backup task for all keyspaces")
-            mgr_task = mgr_cluster.create_backup_task(
-                location_list=[
-                    location,
-                ]
-            )
-
-        assert mgr_task is not None, "Backup task wasn't created"
-
-        status = mgr_task.wait_and_get_final_status(timeout=54000, step=5, only_final=True)
-        self.actions_log.info(f"Scylla Manager backup task finished with status: {status}")
-        if status == TaskStatus.DONE:
-            self.log.info("Task: %s is done.", mgr_task.id)
-        elif status in (TaskStatus.ERROR, TaskStatus.ERROR_FINAL):
-            assert False, f"Backup task {mgr_task.id} failed"
-        else:
-            mgr_task.stop()
-            assert False, f"Backup task {mgr_task.id} timed out - while on status {status}"
-
-    def disrupt_mgmt_repair_cli(self):
-        if not self.cluster.params.get("use_mgmt") and not self.cluster.params.get("use_cloud_manager"):
-            raise UnsupportedNemesis("Scylla-manager configuration is not defined!")
-        self.run_repair_manager()
-
-    def disrupt_mgmt_corrupt_then_repair(self):
-        if not self.cluster.params.get("use_mgmt") and not self.cluster.params.get("use_cloud_manager"):
-            raise UnsupportedNemesis("Scylla-manager configuration is not defined!")
-        self._destroy_data_and_restart_scylla()
-        self.run_repair_manager()
 
     def disrupt_abort_repair(self):
         """

--- a/sdcm/nemesis/monkey/__init__.py
+++ b/sdcm/nemesis/monkey/__init__.py
@@ -4,6 +4,13 @@ Classes can be used in nemesis_selector
 """
 
 from sdcm.nemesis import target_all_nodes, NemesisBaseClass, target_data_nodes
+from sdcm.nemesis.monkey.manager import (  # noqa: F401 — re-export for backward compatibility
+    MgmtBackup,
+    MgmtBackupSpecificKeyspaces,
+    MgmtCorruptThenRepair,
+    MgmtRepair,
+    MgmtRestore,
+)
 from sdcm.nemesis.utils import NEMESIS_TARGET_POOLS
 
 
@@ -372,65 +379,6 @@ class ToggleGcModeMonkey(NemesisBaseClass):
 
     def disrupt(self):
         self.runner.disrupt_toggle_table_gc_mode()
-
-
-@target_data_nodes
-class MgmtBackup(NemesisBaseClass):
-    manager_operation = True
-    disruptive = False
-    limited = True
-    supports_high_disk_utilization = False  # Snapshot/Restore operations consume disk space
-
-    def disrupt(self):
-        self.runner.disrupt_mgmt_backup()
-
-
-@target_data_nodes
-class MgmtBackupSpecificKeyspaces(NemesisBaseClass):
-    manager_operation = True
-    disruptive = False
-    limited = True
-    supports_high_disk_utilization = False  # Snapshot/Restore operations consume disk space
-
-    def disrupt(self):
-        self.runner.disrupt_mgmt_backup_specific_keyspaces()
-
-
-@target_data_nodes
-class MgmtRestore(NemesisBaseClass):
-    manager_operation = True
-    disruptive = True
-    kubernetes = True
-    xcloud = True
-    limited = True
-    supports_high_disk_utilization = False  # Snapshot/Restore operations consume disk space
-
-    def disrupt(self):
-        self.runner.disrupt_mgmt_restore()
-
-
-@target_data_nodes
-class MgmtRepair(NemesisBaseClass):
-    manager_operation = True
-    disruptive = False
-    kubernetes = True
-    limited = True
-
-    def disrupt(self):
-        self.runner.log.info("disrupt_mgmt_repair_cli Nemesis begin")
-        self.runner.disrupt_mgmt_repair_cli()
-        self.runner.log.info("disrupt_mgmt_repair_cli Nemesis end")
-        # For Manager APIs test, use: self.runner.disrupt_mgmt_repair_api()
-
-
-@target_data_nodes
-class MgmtCorruptThenRepair(NemesisBaseClass):
-    manager_operation = True
-    disruptive = True
-    kubernetes = True
-
-    def disrupt(self):
-        self.runner.disrupt_mgmt_corrupt_then_repair()
 
 
 class AbortRepairMonkey(NemesisBaseClass):

--- a/sdcm/nemesis/monkey/__init__.py
+++ b/sdcm/nemesis/monkey/__init__.py
@@ -4,6 +4,13 @@ Classes can be used in nemesis_selector
 """
 
 from sdcm.nemesis import target_all_nodes, NemesisBaseClass, target_data_nodes
+from sdcm.nemesis.monkey.manager import (  # noqa: F401 — re-export for backward compatibility
+    MgmtBackup,
+    MgmtBackupSpecificKeyspaces,
+    MgmtCorruptThenRepair,
+    MgmtRepair,
+    MgmtRestore,
+)
 
 
 @target_all_nodes
@@ -343,65 +350,6 @@ class ToggleGcModeMonkey(NemesisBaseClass):
 
     def disrupt(self):
         self.runner.disrupt_toggle_table_gc_mode()
-
-
-@target_data_nodes
-class MgmtBackup(NemesisBaseClass):
-    manager_operation = True
-    disruptive = False
-    limited = True
-    supports_high_disk_utilization = False  # Snapshot/Restore operations consume disk space
-
-    def disrupt(self):
-        self.runner.disrupt_mgmt_backup()
-
-
-@target_data_nodes
-class MgmtBackupSpecificKeyspaces(NemesisBaseClass):
-    manager_operation = True
-    disruptive = False
-    limited = True
-    supports_high_disk_utilization = False  # Snapshot/Restore operations consume disk space
-
-    def disrupt(self):
-        self.runner.disrupt_mgmt_backup_specific_keyspaces()
-
-
-@target_data_nodes
-class MgmtRestore(NemesisBaseClass):
-    manager_operation = True
-    disruptive = True
-    kubernetes = True
-    xcloud = True
-    limited = True
-    supports_high_disk_utilization = False  # Snapshot/Restore operations consume disk space
-
-    def disrupt(self):
-        self.runner.disrupt_mgmt_restore()
-
-
-@target_data_nodes
-class MgmtRepair(NemesisBaseClass):
-    manager_operation = True
-    disruptive = False
-    kubernetes = True
-    limited = True
-
-    def disrupt(self):
-        self.runner.log.info("disrupt_mgmt_repair_cli Nemesis begin")
-        self.runner.disrupt_mgmt_repair_cli()
-        self.runner.log.info("disrupt_mgmt_repair_cli Nemesis end")
-        # For Manager APIs test, use: self.runner.disrupt_mgmt_repair_api()
-
-
-@target_data_nodes
-class MgmtCorruptThenRepair(NemesisBaseClass):
-    manager_operation = True
-    disruptive = True
-    kubernetes = True
-
-    def disrupt(self):
-        self.runner.disrupt_mgmt_corrupt_then_repair()
 
 
 class AbortRepairMonkey(NemesisBaseClass):

--- a/sdcm/nemesis/monkey/manager.py
+++ b/sdcm/nemesis/monkey/manager.py
@@ -1,0 +1,419 @@
+"""
+Module containing all Scylla Manager nemesis classes.
+
+Includes backup (rclone / native), restore, repair-via-manager, and
+corrupt-then-repair disruptions.  Module-level helper functions are shared
+across the monkey classes defined here.
+"""
+
+import datetime
+import logging
+from datetime import timedelta
+
+from sdcm import mgmt
+from sdcm.exceptions import UnsupportedNemesis
+from sdcm.mgmt.argus_report import report_manager_backup_results_to_argus
+from sdcm.mgmt.backup import run_manager_backup
+from sdcm.mgmt.common import TaskStatus, ObjectStorageUploadMode, get_persistent_snapshots
+from sdcm.mgmt.helpers import get_dc_name_from_ks_statement, get_schema_create_statements_from_snapshot
+from sdcm.nemesis import NemesisBaseClass, target_data_nodes
+from sdcm.nemesis.utils.common_ops import destroy_data_and_restart_scylla
+from sdcm.sct_events.group_common_events import (
+    decorate_with_context_if_issues_open,
+    ignore_take_snapshot_failing,
+    suppress_expected_unavailability_errors,
+)
+from sdcm.utils.cql_utils import cql_unquote_if_needed
+from sdcm.utils.decorators import latency_calculator_decorator
+from sdcm.utils.issues import SkipPerIssues
+
+LOGGER = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Module-level helper functions
+# ---------------------------------------------------------------------------
+
+
+def _get_manager_tool(tester):
+    """Return a ``ManagerTool`` instance from the first monitor node."""
+    return mgmt.get_scylla_manager_tool(manager_node=tester.monitors.nodes[0])
+
+
+def _run_manager_backup(runner, mgr_cluster, object_storage_upload_mode: ObjectStorageUploadMode, timeout: int):
+    """Execute a Manager backup, wrapped in an action-log scope.
+
+    Args:
+        runner: ``NemesisRunner`` instance.
+        mgr_cluster: Manager cluster object.
+        object_storage_upload_mode: Upload mode (RCLONE or NATIVE).
+        timeout: Timeout in seconds.
+
+    Returns:
+        ``BackupTask`` representing the completed backup.
+    """
+    with runner.action_log_scope("Scylla Manager backup"):
+        task = run_manager_backup(mgr_cluster, runner.tester.locations, object_storage_upload_mode, timeout)
+    return task
+
+
+def _manager_backup_and_report(runner, method: ObjectStorageUploadMode, label):
+    """Run a backup using Scylla Manager and report the result to Argus.
+
+    Args:
+        runner: ``NemesisRunner`` instance.
+        method: The transfer mode for object storage (e.g., RCLONE or NATIVE).
+        label: A label for reporting.
+
+    Returns:
+        ``BackupTask`` object representing the backup operation.
+    """
+    timeout = int(timedelta(hours=14).total_seconds())
+    manager_tool = _get_manager_tool(runner.tester)
+    mgr_cluster = runner.tester.ensure_and_get_cluster(manager_tool)
+    decorated = latency_calculator_decorator(legend="Scylla-Manager Backup", cycle_name=label)(_run_manager_backup)
+    task = decorated(runner, mgr_cluster, method, timeout)
+    report_manager_backup_results_to_argus(runner.tester.monitors, runner.tester.test_config, label, task, mgr_cluster)
+    return task
+
+
+def manager_backup(runner, object_storage_upload_mode: ObjectStorageUploadMode, label):
+    """Perform a Manager backup as a nemesis.  Deletes the snapshot at end.
+
+    This is the top-level entry-point used by ``ManagerRcloneBackup`` and
+    ``ManagerNativeBackup`` runner classes in ``runners.py``.
+
+    Args:
+        runner: ``NemesisRunner`` instance.
+        object_storage_upload_mode: The upload mode (e.g., RCLONE or NATIVE).
+        label: Label for reporting to Argus.
+    """
+    time_postfix = datetime.datetime.now().strftime("_%m%d_%H%M")
+    label_with_time = f"{label}{time_postfix}"
+    task = _manager_backup_and_report(runner, object_storage_upload_mode, label_with_time)
+    with runner.action_log_scope("Delete Manager backup snapshot"):
+        task.delete_backup_snapshot()
+
+
+def _delete_existing_backups(runner, mgr_cluster):
+    """Delete any in-progress or errored backup tasks before starting a new one."""
+    deleted_tasks = []
+    existing_backup_tasks = mgr_cluster.backup_task_list
+    for backup_task in existing_backup_tasks:
+        if backup_task.status in [TaskStatus.NEW, TaskStatus.RUNNING, TaskStatus.STARTING, TaskStatus.ERROR]:
+            deleted_tasks.append(backup_task.id)
+            mgr_cluster.delete_task(backup_task)
+    if deleted_tasks:
+        runner.log.warning("Deleted the following backup tasks before the nemesis starts: %s", ", ".join(deleted_tasks))
+
+
+@decorate_with_context_if_issues_open(
+    ignore_take_snapshot_failing, issue_refs=["https://github.com/scylladb/scylla-manager/issues/3389"]
+)
+def _mgmt_backup(runner, backup_specific_tables):
+    """Create and run a Manager backup task, optionally for specific keyspaces.
+
+    Args:
+        runner: ``NemesisRunner`` instance.
+        backup_specific_tables: If ``True``, back up only test keyspaces.
+    """
+    if not runner.cluster.params.get("use_mgmt") and not runner.cluster.params.get("use_cloud_manager"):
+        raise UnsupportedNemesis("Scylla-manager configuration is not defined!")
+    mgr_cluster = runner.cluster.get_cluster_manager()
+    if runner.cluster.params.get("use_cloud_manager"):
+        auto_backup_task = mgr_cluster.backup_task_list[0]
+        #  An example of the auto generated backup task of cloud manager is:
+        #  │ backup/8e40b8b4-5394-42d3-9884-a4ce8ab69687
+        #  │ --dc 'AWS_US_EAST_1' -L AWS_US_EAST_1:s3:scylla-cloud-backup-9952-10120-4q4w4d --retention 14
+        #  --rate-limit AWS_US_EAST_1:100 --snapshot-parallel '<nil>' --upload-parallel '<nil>'
+        #  │ 06 Jun 21 18:10:05 UTC (+1d)  │ NEW
+        location = auto_backup_task.get_task_info_dict()["location"]
+    else:
+        if not runner.cluster.params.get("backup_bucket_location"):
+            raise UnsupportedNemesis("backup bucket location configuration is not defined!")
+
+        backup_bucket_backend = runner.cluster.params.get("backup_bucket_backend")
+        region = next(iter(runner.cluster.params.region_names), "")
+        backup_bucket_location = runner.cluster.params.get("backup_bucket_location")[0].format(region=region)
+        location = f"{backup_bucket_backend}:{backup_bucket_location}"
+    _delete_existing_backups(runner, mgr_cluster)
+    if backup_specific_tables:
+        non_test_keyspaces = [cql_unquote_if_needed(ks) for ks in runner.cluster.get_test_keyspaces()]
+        runner.actions_log.info(f"Starting Scylla Manager backup task for keyspaces: {non_test_keyspaces}")
+        mgr_task = mgr_cluster.create_backup_task(
+            location_list=[
+                location,
+            ],
+            keyspace_list=non_test_keyspaces,
+        )
+    else:
+        runner.actions_log.info("Starting Scylla Manager backup task for all keyspaces")
+        mgr_task = mgr_cluster.create_backup_task(
+            location_list=[
+                location,
+            ]
+        )
+
+    assert mgr_task is not None, "Backup task wasn't created"
+
+    status = mgr_task.wait_and_get_final_status(timeout=54000, step=5, only_final=True)
+    runner.actions_log.info(f"Scylla Manager backup task finished with status: {status}")
+    if status == TaskStatus.DONE:
+        runner.log.info("Task: %s is done.", mgr_task.id)
+    elif status in (TaskStatus.ERROR, TaskStatus.ERROR_FINAL):
+        assert False, f"Backup task {mgr_task.id} failed"
+    else:
+        mgr_task.stop()
+        assert False, f"Backup task {mgr_task.id} timed out - while on status {status}"
+
+
+# ---------------------------------------------------------------------------
+# Monkey classes — Scylla Manager nemesis
+# ---------------------------------------------------------------------------
+
+
+@target_data_nodes
+class MgmtBackup(NemesisBaseClass):
+    """Run a full Scylla Manager backup of all keyspaces."""
+
+    manager_operation = True
+    disruptive = False
+    limited = True
+    supports_high_disk_utilization = False  # Snapshot/Restore operations consume disk space
+
+    def disrupt(self):
+        _mgmt_backup(self.runner, backup_specific_tables=False)
+
+
+@target_data_nodes
+class MgmtBackupSpecificKeyspaces(NemesisBaseClass):
+    """Run a Scylla Manager backup of test keyspaces only."""
+
+    manager_operation = True
+    disruptive = False
+    limited = True
+    supports_high_disk_utilization = False  # Snapshot/Restore operations consume disk space
+
+    def disrupt(self):
+        _mgmt_backup(self.runner, backup_specific_tables=True)
+
+
+@target_data_nodes
+class MgmtRestore(NemesisBaseClass):
+    """Restore a persistent Manager snapshot and validate the data."""
+
+    manager_operation = True
+    disruptive = True
+    kubernetes = True
+    xcloud = True
+    limited = True
+    supports_high_disk_utilization = False  # Snapshot/Restore operations consume disk space
+
+    def disrupt(self):  # noqa: PLR0914
+        self._disrupt_mgmt_restore()
+
+    def _disrupt_mgmt_restore(self):  # noqa: PLR0914
+        runner = self.runner
+
+        def get_total_scylla_partition_size():
+            result = runner.cluster.data_nodes[0].remoter.run("df -k | grep /var/lib/scylla")  # Size in KB
+            free_space_size = int(result.stdout.split()[1]) / 1024**2  # Converting to GB
+            return free_space_size
+
+        def choose_snapshot(snapshots_dict, region: str):
+            snapshot_groups_by_size = snapshots_dict["snapshots_sizes"]
+            total_partition_size = get_total_scylla_partition_size()
+            all_snapshot_sizes = sorted(list(snapshot_groups_by_size.keys()), reverse=True)
+            fitting_snapshot_sizes = [size for size in all_snapshot_sizes if total_partition_size / size >= 20]
+            if runner.tester.test_duration < 1000:
+                # Since verifying the restored data takes a long time, the nemesis limits the size of the restored
+                # backup based on the test duration
+                fitting_snapshot_sizes = [size for size in fitting_snapshot_sizes if size < 50]
+            # The restore should not take more than 5% of the space total space in /var/lib/scylla
+            assert fitting_snapshot_sizes, "There's not enough space for any snapshot restoration"
+
+            chosen_snapshot_size = runner.random.choice(fitting_snapshot_sizes)
+            all_snapshots_per_region = snapshot_groups_by_size[chosen_snapshot_size]["snapshots"][region]
+
+            if runner.cluster.nodes[0].is_enterprise:
+                snapshot_tag = runner.random.choice(list(all_snapshots_per_region.keys()))
+            else:
+                oss_snapshots = [
+                    snapshot_key
+                    for snapshot_key, snapshot_value in all_snapshots_per_region.items()
+                    if snapshot_value["scylla_product"] == "oss"
+                ]
+                snapshot_tag = runner.random.choice(oss_snapshots)
+
+            snapshot_info = all_snapshots_per_region[snapshot_tag]
+            snapshot_info.update(
+                {
+                    "expected_timeout": snapshot_groups_by_size[chosen_snapshot_size]["expected_timeout"],
+                    "number_of_rows": snapshot_groups_by_size[chosen_snapshot_size]["number_of_rows"],
+                }
+            )
+            return snapshot_tag, snapshot_info
+
+        def execute_data_validation_thread(command_template, keyspace_name, number_of_rows):
+            stress_queue = []
+            number_of_loaders = sum(runner.tester.params.get("n_loaders"))
+            rows_per_loader = int(number_of_rows / number_of_loaders)
+            for loader_index in range(number_of_loaders):
+                stress_command = command_template.format(
+                    num_of_rows=rows_per_loader,
+                    keyspace_name=keyspace_name,
+                    sequence_start=rows_per_loader * loader_index + 1,
+                    sequence_end=rows_per_loader * (loader_index + 1),
+                )
+                read_thread = runner.tester.run_stress_thread(
+                    stress_cmd=stress_command, round_robin=True, stop_test_on_failure=False
+                )
+                stress_queue.append(read_thread)
+            return stress_queue
+
+        def _restore_schema(locations: list, cluster_id: str, tag: str) -> None:
+            """Introduced to cover two flows:
+
+            - When a backup snapshot has different DC name than the current cluster's DC name -
+            restore schema out of the Manager applying CQL statements saved in schema.json file
+
+            - When backup snapshot has the same DC name as the current cluster's DC name -
+            restore schema using the Manager (sctool restore --restore-schema ...)
+            """
+            ks_statements, other_statements = get_schema_create_statements_from_snapshot(
+                bucket=locations[0].split(":")[-1],
+                mgr_cluster_id=cluster_id,
+                snapshot_tag=tag,
+            )
+
+            dc_under_test_name = next(iter(runner.cluster.get_nodetool_status()))
+            # Test is supposed to work with single DC setups only, so we can take the first DC name
+            dc_from_backup_name = get_dc_name_from_ks_statement(ks_statements[0])[0]
+            runner.log.debug("DC name from backup: %s, DC name under test: %s", dc_from_backup_name, dc_under_test_name)
+
+            if dc_under_test_name != dc_from_backup_name:
+                runner.log.info(
+                    "DC names mismatch - restoring the schema manually altering cql statements and "
+                    "applying them one by one"
+                )
+                # Alter the dc_name in keyspace cql statements to match the current cluster's dc_name
+                old_dc_block = f"'{dc_from_backup_name}':"  # Include quotes and colon to avoid unintended replacements
+                new_dc_block = f"'{dc_under_test_name}':"
+                ks_statements = [stmt.replace(old_dc_block, new_dc_block) for stmt in ks_statements]
+                # Apply cql statements one by one to restore schema
+                for cql_stmt in ks_statements + other_statements:
+                    runner.target_node.run_cqlsh(cql_stmt)
+            else:
+                runner.log.info("Restoring the schema using the Scylla Manager")
+                task = mgr_cluster.create_restore_task(restore_schema=True, location_list=locations, snapshot_tag=tag)
+                task.wait_and_get_final_status(step=10, timeout=6 * 60)  # 6 giving minutes to restore the schema
+                assert task.status == TaskStatus.DONE, f"Schema restoration failed: snapshot tag - {tag}"
+
+        skip_issues = [
+            "https://github.com/scylladb/scylla-manager/issues/3829",
+            "https://github.com/scylladb/scylla-manager/issues/4049",
+        ]
+        is_multi_dc = (
+            len(runner.cluster.params.region_names) > 1 or (runner.cluster.params.get("simulated_regions") or 0) > 1
+        )
+        if SkipPerIssues(skip_issues, params=runner.tester.params) and is_multi_dc:
+            raise UnsupportedNemesis("MultiDC cluster configuration is not supported by this nemesis")
+
+        if not (runner.cluster.params.get("use_mgmt") or runner.cluster.params.get("use_cloud_manager")):
+            raise UnsupportedNemesis("Scylla-manager configuration is not defined!")
+        if runner.cluster.params.get("cluster_backend") not in ("aws", "k8s-eks"):
+            raise UnsupportedNemesis("The restore test only supports 'AWS' and 'K8S-EKS' backends.")
+
+        mgr_cluster = runner.cluster.get_cluster_manager()
+        cluster_backend = runner.cluster.params.get("cluster_backend")
+        if cluster_backend == "k8s-eks":
+            cluster_backend = "aws"
+
+        persistent_manager_snapshots_dict = get_persistent_snapshots()
+        region = next(iter(runner.cluster.params.region_names), "")
+        target_bucket = persistent_manager_snapshots_dict[cluster_backend]["bucket"].format(region=region)
+        chosen_snapshot_tag, chosen_snapshot_info = choose_snapshot(
+            snapshots_dict=persistent_manager_snapshots_dict[cluster_backend], region=region
+        )
+
+        runner.log.info("Restoring the keyspace %s", chosen_snapshot_info["keyspace_name"])
+        location_list = [f"{runner.cluster.params.get('backup_bucket_backend')}:{target_bucket}"]
+        test_keyspaces = [cql_unquote_if_needed(keyspace) for keyspace in runner.cluster.get_test_keyspaces()]
+        # Keyspace names that start with a digit are surrounded by quotation marks in the output of a describe query
+        if chosen_snapshot_info["keyspace_name"] not in test_keyspaces:
+            runner.log.info("Restoring the schema of the keyspace '%s'", chosen_snapshot_info["keyspace_name"])
+            _restore_schema(
+                locations=location_list,
+                cluster_id=chosen_snapshot_info["cluster_id"],
+                tag=chosen_snapshot_tag,
+            )
+            with suppress_expected_unavailability_errors():
+                runner.cluster.restart_scylla()  # After schema restoration, you should restart the nodes
+
+            # TODO: Bring it back after the implementation of https://github.com/scylladb/scylla-manager/issues/4049
+            # which will unblock schema restore into a different DC. For now, we can restore schema only within one DC.
+            # According to https://github.com/scylladb/scylla-manager/issues/4041#issuecomment-2565489699, the step
+            # below is not needed if restoring the schema within one DC.
+            #
+            # self.tester.set_ks_strategy_to_network_and_rf_according_to_cluster(
+            #    keyspace=chosen_snapshot_info["keyspace_name"], repair_after_alter=False)
+        try:
+            restore_task = mgr_cluster.create_restore_task(
+                restore_data=True, location_list=location_list, snapshot_tag=chosen_snapshot_tag
+            )
+            restore_task.wait_and_get_final_status(step=30, timeout=chosen_snapshot_info["expected_timeout"])
+            assert restore_task.status == TaskStatus.DONE, f"Data restoration of {chosen_snapshot_tag} has failed!"
+
+            confirmation_stress_template = (persistent_manager_snapshots_dict)[cluster_backend][
+                "confirmation_stress_template"
+            ]
+            stress_queue = execute_data_validation_thread(
+                command_template=confirmation_stress_template,
+                keyspace_name=chosen_snapshot_info["keyspace_name"],
+                number_of_rows=chosen_snapshot_info["number_of_rows"],
+            )
+
+            for stress in stress_queue:
+                is_passed = runner.tester.verify_stress_thread(stress)
+                assert is_passed, (
+                    "Data verification stress command, triggered by the 'mgmt_restore' nemesis, has failed"
+                )
+        finally:
+            runner.log.info("Cleaning up restored keyspace '%s'", chosen_snapshot_info["keyspace_name"])
+            drop_ks_stmt = f'DROP KEYSPACE IF EXISTS "{chosen_snapshot_info["keyspace_name"]}";'
+            try:
+                runner.target_node.run_cqlsh(drop_ks_stmt)
+            except Exception as drop_err:  # noqa: BLE001
+                runner.log.warning("Failed to drop restored keyspace: %s", drop_err)
+
+
+@target_data_nodes
+class MgmtRepair(NemesisBaseClass):
+    """Run a repair via Scylla Manager CLI."""
+
+    manager_operation = True
+    disruptive = False
+    kubernetes = True
+    limited = True
+
+    def disrupt(self):
+        if not self.runner.cluster.params.get("use_mgmt") and not self.runner.cluster.params.get("use_cloud_manager"):
+            raise UnsupportedNemesis("Scylla-manager configuration is not defined!")
+        self.runner.log.info("MgmtRepair Nemesis begin")
+        self.runner.run_repair_manager()
+        self.runner.log.info("MgmtRepair Nemesis end")
+
+
+@target_data_nodes
+class MgmtCorruptThenRepair(NemesisBaseClass):
+    """Corrupt data by destroying SStables, then repair via Scylla Manager."""
+
+    manager_operation = True
+    disruptive = True
+    kubernetes = True
+
+    def disrupt(self):
+        if not self.runner.cluster.params.get("use_mgmt") and not self.runner.cluster.params.get("use_cloud_manager"):
+            raise UnsupportedNemesis("Scylla-manager configuration is not defined!")
+        destroy_data_and_restart_scylla(self.runner)
+        self.runner.run_repair_manager()

--- a/sdcm/nemesis/monkey/manager.py
+++ b/sdcm/nemesis/monkey/manager.py
@@ -35,7 +35,7 @@ LOGGER = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 
-def _get_manager_tool(tester):
+def get_manager_tool(tester):
     """Return a ``ManagerTool`` instance from the first monitor node."""
     return mgmt.get_scylla_manager_tool(manager_node=tester.monitors.nodes[0])
 
@@ -69,7 +69,7 @@ def _manager_backup_and_report(runner, method: ObjectStorageUploadMode, label):
         ``BackupTask`` object representing the backup operation.
     """
     timeout = int(timedelta(hours=14).total_seconds())
-    manager_tool = _get_manager_tool(runner.tester)
+    manager_tool = get_manager_tool(runner.tester)
     mgr_cluster = runner.tester.ensure_and_get_cluster(manager_tool)
     decorated = latency_calculator_decorator(legend="Scylla-Manager Backup", cycle_name=label)(_run_manager_backup)
     task = decorated(runner, mgr_cluster, method, timeout)
@@ -129,7 +129,7 @@ def _stop_unfinished_restore_task(runner, restore_task) -> None:
         )
 
 
-def _delete_existing_backups(runner, mgr_cluster):
+def delete_existing_backups(runner, mgr_cluster):
     """Delete any in-progress or errored backup tasks before starting a new one."""
     deleted_tasks = []
     existing_backup_tasks = mgr_cluster.backup_task_list
@@ -144,15 +144,13 @@ def _delete_existing_backups(runner, mgr_cluster):
 @decorate_with_context_if_issues_open(
     ignore_take_snapshot_failing, issue_refs=["https://github.com/scylladb/scylla-manager/issues/3389"]
 )
-def _mgmt_backup(runner, backup_specific_tables):
+def mgmt_backup(runner, backup_specific_tables):
     """Create and run a Manager backup task, optionally for specific keyspaces.
 
     Args:
         runner: ``NemesisRunner`` instance.
         backup_specific_tables: If ``True``, back up only test keyspaces.
     """
-    if not runner.cluster.params.get("use_mgmt") and not runner.cluster.params.get("use_cloud_manager"):
-        raise UnsupportedNemesis("Scylla-manager configuration is not defined!")
     mgr_cluster = runner.cluster.get_cluster_manager()
     if runner.cluster.params.get("use_cloud_manager"):
         auto_backup_task = mgr_cluster.backup_task_list[0]
@@ -170,7 +168,7 @@ def _mgmt_backup(runner, backup_specific_tables):
         region = next(iter(runner.cluster.params.region_names), "")
         backup_bucket_location = runner.cluster.params.get("backup_bucket_location")[0].format(region=region)
         location = f"{backup_bucket_backend}:{backup_bucket_location}"
-    _delete_existing_backups(runner, mgr_cluster)
+    delete_existing_backups(runner, mgr_cluster)
     if backup_specific_tables:
         non_test_keyspaces = [cql_unquote_if_needed(ks) for ks in runner.cluster.get_test_keyspaces()]
         runner.actions_log.info(f"Starting Scylla Manager backup task for keyspaces: {non_test_keyspaces}")
@@ -201,42 +199,148 @@ def _mgmt_backup(runner, backup_specific_tables):
         assert False, f"Backup task {mgr_task.id} timed out - while on status {status}"
 
 
+def get_total_scylla_partition_size(runner):
+    result = runner.cluster.data_nodes[0].remoter.run("df -k | grep /var/lib/scylla")  # Size in KB
+    free_space_size = int(result.stdout.split()[1]) / 1024**2  # Converting to GB
+    return free_space_size
+
+
+def choose_snapshot(runner, snapshots_dict, region: str):
+    snapshot_groups_by_size = snapshots_dict["snapshots_sizes"]
+    total_partition_size = get_total_scylla_partition_size(runner)
+    all_snapshot_sizes = sorted(list(snapshot_groups_by_size.keys()), reverse=True)
+    fitting_snapshot_sizes = [size for size in all_snapshot_sizes if total_partition_size / size >= 20]
+    if runner.tester.test_duration < 1000:
+        # Since verifying the restored data takes a long time, the nemesis limits the size of the restored
+        # backup based on the test duration
+        fitting_snapshot_sizes = [size for size in fitting_snapshot_sizes if size < 50]
+    # The restore should not take more than 5% of the space total space in /var/lib/scylla
+    assert fitting_snapshot_sizes, "There's not enough space for any snapshot restoration"
+
+    chosen_snapshot_size = runner.random.choice(fitting_snapshot_sizes)
+    all_snapshots_per_region = snapshot_groups_by_size[chosen_snapshot_size]["snapshots"][region]
+
+    if runner.cluster.nodes[0].is_enterprise:
+        snapshot_tag = runner.random.choice(list(all_snapshots_per_region.keys()))
+    else:
+        oss_snapshots = [
+            snapshot_key
+            for snapshot_key, snapshot_value in all_snapshots_per_region.items()
+            if snapshot_value["scylla_product"] == "oss"
+        ]
+        snapshot_tag = runner.random.choice(oss_snapshots)
+
+    snapshot_info = all_snapshots_per_region[snapshot_tag]
+    snapshot_info.update(
+        {
+            "expected_timeout": snapshot_groups_by_size[chosen_snapshot_size]["expected_timeout"],
+            "number_of_rows": snapshot_groups_by_size[chosen_snapshot_size]["number_of_rows"],
+        }
+    )
+    return snapshot_tag, snapshot_info
+
+
+def execute_data_validation_thread(runner, command_template, keyspace_name, number_of_rows):
+    stress_queue = []
+    number_of_loaders = sum(runner.tester.params.get("n_loaders"))
+    rows_per_loader = int(number_of_rows / number_of_loaders)
+    for loader_index in range(number_of_loaders):
+        stress_command = command_template.format(
+            num_of_rows=rows_per_loader,
+            keyspace_name=keyspace_name,
+            sequence_start=rows_per_loader * loader_index + 1,
+            sequence_end=rows_per_loader * (loader_index + 1),
+        )
+        read_thread = runner.tester.run_stress_thread(
+            stress_cmd=stress_command, round_robin=True, stop_test_on_failure=False
+        )
+        stress_queue.append(read_thread)
+    return stress_queue
+
+
+def restore_schema(runner, mgr_cluster, locations: list, cluster_id: str, tag: str) -> None:
+    """Introduced to cover two flows:
+
+    - When a backup snapshot has different DC name than the current cluster's DC name -
+    restore schema out of the Manager applying CQL statements saved in schema.json file
+
+    - When backup snapshot has the same DC name as the current cluster's DC name -
+    restore schema using the Manager (sctool restore --restore-schema ...)
+    """
+    ks_statements, other_statements = get_schema_create_statements_from_snapshot(
+        bucket=locations[0].split(":")[-1],
+        mgr_cluster_id=cluster_id,
+        snapshot_tag=tag,
+    )
+
+    dc_under_test_name = next(iter(runner.cluster.get_nodetool_status()))
+    # Test is supposed to work with single DC setups only, so we can take the first DC name
+    dc_from_backup_name = get_dc_name_from_ks_statement(ks_statements[0])[0]
+    runner.log.debug("DC name from backup: %s, DC name under test: %s", dc_from_backup_name, dc_under_test_name)
+
+    if dc_under_test_name != dc_from_backup_name:
+        runner.log.info(
+            "DC names mismatch - restoring the schema manually altering cql statements and applying them one by one"
+        )
+        # Alter the dc_name in keyspace cql statements to match the current cluster's dc_name
+        old_dc_block = f"'{dc_from_backup_name}':"  # Include quotes and colon to avoid unintended replacements
+        new_dc_block = f"'{dc_under_test_name}':"
+        ks_statements = [stmt.replace(old_dc_block, new_dc_block) for stmt in ks_statements]
+        # Apply cql statements one by one to restore schema
+        for cql_stmt in ks_statements + other_statements:
+            runner.target_node.run_cqlsh(cql_stmt)
+    else:
+        runner.log.info("Restoring the schema using the Scylla Manager")
+        task = mgr_cluster.create_restore_task(restore_schema=True, location_list=locations, snapshot_tag=tag)
+        task.wait_and_get_final_status(step=10, timeout=6 * 60)  # 6 giving minutes to restore the schema
+        assert task.status == TaskStatus.DONE, f"Schema restoration failed: snapshot tag - {tag}"
+
+
 # ---------------------------------------------------------------------------
 # Monkey classes — Scylla Manager nemesis
 # ---------------------------------------------------------------------------
 
 
+class ManagerMonkeyBase(NemesisBaseClass):
+    """Base class for the Scylla Manager nemesis with the shared manager-config precheck."""
+
+    manager_operation = True
+
+    def precheck(self, node) -> str | None:
+        params = self.runner.cluster.params
+        if not (params.get("use_mgmt") or params.get("use_cloud_manager")):
+            return "Scylla-manager configuration is not defined!"
+        return None
+
+
 @target_data_nodes
-class MgmtBackup(NemesisBaseClass):
+class MgmtBackup(ManagerMonkeyBase):
     """Run a full Scylla Manager backup of all keyspaces."""
 
-    manager_operation = True
     disruptive = False
     limited = True
     supports_high_disk_utilization = False  # Snapshot/Restore operations consume disk space
 
     def disrupt(self):
-        _mgmt_backup(self.runner, backup_specific_tables=False)
+        mgmt_backup(self.runner, backup_specific_tables=False)
 
 
 @target_data_nodes
-class MgmtBackupSpecificKeyspaces(NemesisBaseClass):
+class MgmtBackupSpecificKeyspaces(ManagerMonkeyBase):
     """Run a Scylla Manager backup of test keyspaces only."""
 
-    manager_operation = True
     disruptive = False
     limited = True
     supports_high_disk_utilization = False  # Snapshot/Restore operations consume disk space
 
     def disrupt(self):
-        _mgmt_backup(self.runner, backup_specific_tables=True)
+        mgmt_backup(self.runner, backup_specific_tables=True)
 
 
 @target_data_nodes
-class MgmtRestore(NemesisBaseClass):
+class MgmtRestore(ManagerMonkeyBase):
     """Restore a persistent Manager snapshot and validate the data."""
 
-    manager_operation = True
     disruptive = True
     kubernetes = True
     xcloud = True
@@ -244,104 +348,7 @@ class MgmtRestore(NemesisBaseClass):
     supports_high_disk_utilization = False  # Snapshot/Restore operations consume disk space
 
     def disrupt(self):  # noqa: PLR0914
-        self._disrupt_mgmt_restore()
-
-    def _disrupt_mgmt_restore(self):  # noqa: PLR0914
         runner = self.runner
-
-        def get_total_scylla_partition_size():
-            result = runner.cluster.data_nodes[0].remoter.run("df -k | grep /var/lib/scylla")  # Size in KB
-            free_space_size = int(result.stdout.split()[1]) / 1024**2  # Converting to GB
-            return free_space_size
-
-        def choose_snapshot(snapshots_dict, region: str):
-            snapshot_groups_by_size = snapshots_dict["snapshots_sizes"]
-            total_partition_size = get_total_scylla_partition_size()
-            all_snapshot_sizes = sorted(list(snapshot_groups_by_size.keys()), reverse=True)
-            fitting_snapshot_sizes = [size for size in all_snapshot_sizes if total_partition_size / size >= 20]
-            if runner.tester.test_duration < 1000:
-                # Since verifying the restored data takes a long time, the nemesis limits the size of the restored
-                # backup based on the test duration
-                fitting_snapshot_sizes = [size for size in fitting_snapshot_sizes if size < 50]
-            # The restore should not take more than 5% of the space total space in /var/lib/scylla
-            assert fitting_snapshot_sizes, "There's not enough space for any snapshot restoration"
-
-            chosen_snapshot_size = runner.random.choice(fitting_snapshot_sizes)
-            all_snapshots_per_region = snapshot_groups_by_size[chosen_snapshot_size]["snapshots"][region]
-
-            if runner.cluster.nodes[0].is_enterprise:
-                snapshot_tag = runner.random.choice(list(all_snapshots_per_region.keys()))
-            else:
-                oss_snapshots = [
-                    snapshot_key
-                    for snapshot_key, snapshot_value in all_snapshots_per_region.items()
-                    if snapshot_value["scylla_product"] == "oss"
-                ]
-                snapshot_tag = runner.random.choice(oss_snapshots)
-
-            snapshot_info = all_snapshots_per_region[snapshot_tag]
-            snapshot_info.update(
-                {
-                    "expected_timeout": snapshot_groups_by_size[chosen_snapshot_size]["expected_timeout"],
-                    "number_of_rows": snapshot_groups_by_size[chosen_snapshot_size]["number_of_rows"],
-                }
-            )
-            return snapshot_tag, snapshot_info
-
-        def execute_data_validation_thread(command_template, keyspace_name, number_of_rows):
-            stress_queue = []
-            number_of_loaders = sum(runner.tester.params.get("n_loaders"))
-            rows_per_loader = int(number_of_rows / number_of_loaders)
-            for loader_index in range(number_of_loaders):
-                stress_command = command_template.format(
-                    num_of_rows=rows_per_loader,
-                    keyspace_name=keyspace_name,
-                    sequence_start=rows_per_loader * loader_index + 1,
-                    sequence_end=rows_per_loader * (loader_index + 1),
-                )
-                read_thread = runner.tester.run_stress_thread(
-                    stress_cmd=stress_command, round_robin=True, stop_test_on_failure=False
-                )
-                stress_queue.append(read_thread)
-            return stress_queue
-
-        def _restore_schema(locations: list, cluster_id: str, tag: str) -> None:
-            """Introduced to cover two flows:
-
-            - When a backup snapshot has different DC name than the current cluster's DC name -
-            restore schema out of the Manager applying CQL statements saved in schema.json file
-
-            - When backup snapshot has the same DC name as the current cluster's DC name -
-            restore schema using the Manager (sctool restore --restore-schema ...)
-            """
-            ks_statements, other_statements = get_schema_create_statements_from_snapshot(
-                bucket=locations[0].split(":")[-1],
-                mgr_cluster_id=cluster_id,
-                snapshot_tag=tag,
-            )
-
-            dc_under_test_name = next(iter(runner.cluster.get_nodetool_status()))
-            # Test is supposed to work with single DC setups only, so we can take the first DC name
-            dc_from_backup_name = get_dc_name_from_ks_statement(ks_statements[0])[0]
-            runner.log.debug("DC name from backup: %s, DC name under test: %s", dc_from_backup_name, dc_under_test_name)
-
-            if dc_under_test_name != dc_from_backup_name:
-                runner.log.info(
-                    "DC names mismatch - restoring the schema manually altering cql statements and "
-                    "applying them one by one"
-                )
-                # Alter the dc_name in keyspace cql statements to match the current cluster's dc_name
-                old_dc_block = f"'{dc_from_backup_name}':"  # Include quotes and colon to avoid unintended replacements
-                new_dc_block = f"'{dc_under_test_name}':"
-                ks_statements = [stmt.replace(old_dc_block, new_dc_block) for stmt in ks_statements]
-                # Apply cql statements one by one to restore schema
-                for cql_stmt in ks_statements + other_statements:
-                    runner.target_node.run_cqlsh(cql_stmt)
-            else:
-                runner.log.info("Restoring the schema using the Scylla Manager")
-                task = mgr_cluster.create_restore_task(restore_schema=True, location_list=locations, snapshot_tag=tag)
-                task.wait_and_get_final_status(step=10, timeout=6 * 60)  # 6 giving minutes to restore the schema
-                assert task.status == TaskStatus.DONE, f"Schema restoration failed: snapshot tag - {tag}"
 
         skip_issues = [
             "https://github.com/scylladb/scylla-manager/issues/3829",
@@ -353,8 +360,6 @@ class MgmtRestore(NemesisBaseClass):
         if SkipPerIssues(skip_issues, params=runner.tester.params) and is_multi_dc:
             raise UnsupportedNemesis("MultiDC cluster configuration is not supported by this nemesis")
 
-        if not (runner.cluster.params.get("use_mgmt") or runner.cluster.params.get("use_cloud_manager")):
-            raise UnsupportedNemesis("Scylla-manager configuration is not defined!")
         if runner.cluster.params.get("cluster_backend") not in ("aws", "k8s-eks"):
             raise UnsupportedNemesis("The restore test only supports 'AWS' and 'K8S-EKS' backends.")
 
@@ -367,7 +372,7 @@ class MgmtRestore(NemesisBaseClass):
         region = next(iter(runner.cluster.params.region_names), "")
         target_bucket = persistent_manager_snapshots_dict[cluster_backend]["bucket"].format(region=region)
         chosen_snapshot_tag, chosen_snapshot_info = choose_snapshot(
-            snapshots_dict=persistent_manager_snapshots_dict[cluster_backend], region=region
+            runner, snapshots_dict=persistent_manager_snapshots_dict[cluster_backend], region=region
         )
 
         runner.log.info("Restoring the keyspace %s", chosen_snapshot_info["keyspace_name"])
@@ -376,7 +381,9 @@ class MgmtRestore(NemesisBaseClass):
         # Keyspace names that start with a digit are surrounded by quotation marks in the output of a describe query
         if chosen_snapshot_info["keyspace_name"] not in test_keyspaces:
             runner.log.info("Restoring the schema of the keyspace '%s'", chosen_snapshot_info["keyspace_name"])
-            _restore_schema(
+            restore_schema(
+                runner,
+                mgr_cluster,
                 locations=location_list,
                 cluster_id=chosen_snapshot_info["cluster_id"],
                 tag=chosen_snapshot_tag,
@@ -403,6 +410,7 @@ class MgmtRestore(NemesisBaseClass):
                 "confirmation_stress_template"
             ]
             stress_queue = execute_data_validation_thread(
+                runner,
                 command_template=confirmation_stress_template,
                 keyspace_name=chosen_snapshot_info["keyspace_name"],
                 number_of_rows=chosen_snapshot_info["number_of_rows"],
@@ -425,32 +433,26 @@ class MgmtRestore(NemesisBaseClass):
 
 
 @target_data_nodes
-class MgmtRepair(NemesisBaseClass):
+class MgmtRepair(ManagerMonkeyBase):
     """Run a repair via Scylla Manager CLI."""
 
-    manager_operation = True
     disruptive = False
     kubernetes = True
     limited = True
 
     def disrupt(self):
-        if not self.runner.cluster.params.get("use_mgmt") and not self.runner.cluster.params.get("use_cloud_manager"):
-            raise UnsupportedNemesis("Scylla-manager configuration is not defined!")
         self.runner.log.info("MgmtRepair Nemesis begin")
         self.runner.run_repair_manager()
         self.runner.log.info("MgmtRepair Nemesis end")
 
 
 @target_data_nodes
-class MgmtCorruptThenRepair(NemesisBaseClass):
+class MgmtCorruptThenRepair(ManagerMonkeyBase):
     """Corrupt data by destroying SStables, then repair via Scylla Manager."""
 
-    manager_operation = True
     disruptive = True
     kubernetes = True
 
     def disrupt(self):
-        if not self.runner.cluster.params.get("use_mgmt") and not self.runner.cluster.params.get("use_cloud_manager"):
-            raise UnsupportedNemesis("Scylla-manager configuration is not defined!")
         destroy_data_and_restart_scylla(self.runner)
         self.runner.run_repair_manager()

--- a/sdcm/nemesis/monkey/manager.py
+++ b/sdcm/nemesis/monkey/manager.py
@@ -1,0 +1,456 @@
+"""
+Module containing all Scylla Manager nemesis classes.
+
+Includes backup (rclone / native), restore, repair-via-manager, and
+corrupt-then-repair disruptions.  Module-level helper functions are shared
+across the monkey classes defined here.
+"""
+
+import datetime
+import logging
+from datetime import timedelta
+
+from sdcm import mgmt
+from sdcm.exceptions import UnsupportedNemesis, WaitForTimeoutError
+from sdcm.mgmt.argus_report import report_manager_backup_results_to_argus
+from sdcm.mgmt.backup import run_manager_backup
+from sdcm.mgmt.common import TaskStatus, TERMINAL_TASK_STATUSES, ObjectStorageUploadMode, get_persistent_snapshots
+from sdcm.mgmt.helpers import get_dc_name_from_ks_statement, get_schema_create_statements_from_snapshot
+from sdcm.nemesis import NemesisBaseClass, target_data_nodes
+from sdcm.nemesis.utils.common_ops import destroy_data_and_restart_scylla
+from sdcm.sct_events.group_common_events import (
+    decorate_with_context_if_issues_open,
+    ignore_take_snapshot_failing,
+    suppress_expected_unavailability_errors,
+)
+from sdcm.utils.cql_utils import cql_unquote_if_needed
+from sdcm.utils.decorators import latency_calculator_decorator
+from sdcm.utils.issues import SkipPerIssues
+
+LOGGER = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Module-level helper functions
+# ---------------------------------------------------------------------------
+
+
+def _get_manager_tool(tester):
+    """Return a ``ManagerTool`` instance from the first monitor node."""
+    return mgmt.get_scylla_manager_tool(manager_node=tester.monitors.nodes[0])
+
+
+def _run_manager_backup(runner, mgr_cluster, object_storage_upload_mode: ObjectStorageUploadMode, timeout: int):
+    """Execute a Manager backup, wrapped in an action-log scope.
+
+    Args:
+        runner: ``NemesisRunner`` instance.
+        mgr_cluster: Manager cluster object.
+        object_storage_upload_mode: Upload mode (RCLONE or NATIVE).
+        timeout: Timeout in seconds.
+
+    Returns:
+        ``BackupTask`` representing the completed backup.
+    """
+    with runner.action_log_scope("Scylla Manager backup"):
+        task = run_manager_backup(mgr_cluster, runner.tester.locations, object_storage_upload_mode, timeout)
+    return task
+
+
+def _manager_backup_and_report(runner, method: ObjectStorageUploadMode, label):
+    """Run a backup using Scylla Manager and report the result to Argus.
+
+    Args:
+        runner: ``NemesisRunner`` instance.
+        method: The transfer mode for object storage (e.g., RCLONE or NATIVE).
+        label: A label for reporting.
+
+    Returns:
+        ``BackupTask`` object representing the backup operation.
+    """
+    timeout = int(timedelta(hours=14).total_seconds())
+    manager_tool = _get_manager_tool(runner.tester)
+    mgr_cluster = runner.tester.ensure_and_get_cluster(manager_tool)
+    decorated = latency_calculator_decorator(legend="Scylla-Manager Backup", cycle_name=label)(_run_manager_backup)
+    task = decorated(runner, mgr_cluster, method, timeout)
+    report_manager_backup_results_to_argus(runner.tester.monitors, runner.tester.test_config, label, task, mgr_cluster)
+    return task
+
+
+def manager_backup(runner, object_storage_upload_mode: ObjectStorageUploadMode, label):
+    """Perform a Manager backup as a nemesis.  Deletes the snapshot at end.
+
+    This is the top-level entry-point used by ``ManagerRcloneBackup`` and
+    ``ManagerNativeBackup`` runner classes in ``runners.py``.
+
+    Args:
+        runner: ``NemesisRunner`` instance.
+        object_storage_upload_mode: The upload mode (e.g., RCLONE or NATIVE).
+        label: Label for reporting to Argus.
+    """
+    time_postfix = datetime.datetime.now().strftime("_%m%d_%H%M")
+    label_with_time = f"{label}{time_postfix}"
+    task = _manager_backup_and_report(runner, object_storage_upload_mode, label_with_time)
+    with runner.action_log_scope("Delete Manager backup snapshot"):
+        task.delete_backup_snapshot()
+
+
+def _stop_unfinished_restore_task(runner, restore_task) -> None:
+    """Stop a Manager restore task that hasn't reached a final status yet.
+
+    A WaitForTimeoutError from wait_and_get_final_status only means SCT gave up waiting; the
+    task may still be RUNNING. This function issues an sctool stop and waits for a terminal
+    status so the task is no longer touching the keyspace before the caller cleans it up.
+
+    Best effort only: every failure here is logged and swallowed rather than masking the
+    original error that brought us into the finally block.
+    """
+    if restore_task is None:
+        return
+    try:
+        status = restore_task.status
+        if status in TERMINAL_TASK_STATUSES:
+            return
+        runner.log.warning(
+            "Restore task %s is still in %s state - stopping it",
+            restore_task.id,
+            status,
+        )
+        try:
+            restore_task.stop()
+        except WaitForTimeoutError:
+            pass
+        restore_task.wait_for_status(list_status=TERMINAL_TASK_STATUSES, timeout=600, step=30)
+    except Exception as stop_err:  # noqa: BLE001
+        runner.log.warning(
+            "Failed to stop the restore task %s: %s",
+            restore_task.id,
+            stop_err,
+        )
+
+
+def _delete_existing_backups(runner, mgr_cluster):
+    """Delete any in-progress or errored backup tasks before starting a new one."""
+    deleted_tasks = []
+    existing_backup_tasks = mgr_cluster.backup_task_list
+    for backup_task in existing_backup_tasks:
+        if backup_task.status in [TaskStatus.NEW, TaskStatus.RUNNING, TaskStatus.STARTING, TaskStatus.ERROR]:
+            deleted_tasks.append(backup_task.id)
+            mgr_cluster.delete_task(backup_task)
+    if deleted_tasks:
+        runner.log.warning("Deleted the following backup tasks before the nemesis starts: %s", ", ".join(deleted_tasks))
+
+
+@decorate_with_context_if_issues_open(
+    ignore_take_snapshot_failing, issue_refs=["https://github.com/scylladb/scylla-manager/issues/3389"]
+)
+def _mgmt_backup(runner, backup_specific_tables):
+    """Create and run a Manager backup task, optionally for specific keyspaces.
+
+    Args:
+        runner: ``NemesisRunner`` instance.
+        backup_specific_tables: If ``True``, back up only test keyspaces.
+    """
+    if not runner.cluster.params.get("use_mgmt") and not runner.cluster.params.get("use_cloud_manager"):
+        raise UnsupportedNemesis("Scylla-manager configuration is not defined!")
+    mgr_cluster = runner.cluster.get_cluster_manager()
+    if runner.cluster.params.get("use_cloud_manager"):
+        auto_backup_task = mgr_cluster.backup_task_list[0]
+        #  An example of the auto generated backup task of cloud manager is:
+        #  │ backup/8e40b8b4-5394-42d3-9884-a4ce8ab69687
+        #  │ --dc 'AWS_US_EAST_1' -L AWS_US_EAST_1:s3:scylla-cloud-backup-9952-10120-4q4w4d --retention 14
+        #  --rate-limit AWS_US_EAST_1:100 --snapshot-parallel '<nil>' --upload-parallel '<nil>'
+        #  │ 06 Jun 21 18:10:05 UTC (+1d)  │ NEW
+        location = auto_backup_task.get_task_info_dict()["location"]
+    else:
+        if not runner.cluster.params.get("backup_bucket_location"):
+            raise UnsupportedNemesis("backup bucket location configuration is not defined!")
+
+        backup_bucket_backend = runner.cluster.params.get("backup_bucket_backend")
+        region = next(iter(runner.cluster.params.region_names), "")
+        backup_bucket_location = runner.cluster.params.get("backup_bucket_location")[0].format(region=region)
+        location = f"{backup_bucket_backend}:{backup_bucket_location}"
+    _delete_existing_backups(runner, mgr_cluster)
+    if backup_specific_tables:
+        non_test_keyspaces = [cql_unquote_if_needed(ks) for ks in runner.cluster.get_test_keyspaces()]
+        runner.actions_log.info(f"Starting Scylla Manager backup task for keyspaces: {non_test_keyspaces}")
+        mgr_task = mgr_cluster.create_backup_task(
+            location_list=[
+                location,
+            ],
+            keyspace_list=non_test_keyspaces,
+        )
+    else:
+        runner.actions_log.info("Starting Scylla Manager backup task for all keyspaces")
+        mgr_task = mgr_cluster.create_backup_task(
+            location_list=[
+                location,
+            ]
+        )
+
+    assert mgr_task is not None, "Backup task wasn't created"
+
+    status = mgr_task.wait_and_get_final_status(timeout=54000, step=5, only_final=True)
+    runner.actions_log.info(f"Scylla Manager backup task finished with status: {status}")
+    if status == TaskStatus.DONE:
+        runner.log.info("Task: %s is done.", mgr_task.id)
+    elif status in (TaskStatus.ERROR, TaskStatus.ERROR_FINAL):
+        assert False, f"Backup task {mgr_task.id} failed"
+    else:
+        mgr_task.stop()
+        assert False, f"Backup task {mgr_task.id} timed out - while on status {status}"
+
+
+# ---------------------------------------------------------------------------
+# Monkey classes — Scylla Manager nemesis
+# ---------------------------------------------------------------------------
+
+
+@target_data_nodes
+class MgmtBackup(NemesisBaseClass):
+    """Run a full Scylla Manager backup of all keyspaces."""
+
+    manager_operation = True
+    disruptive = False
+    limited = True
+    supports_high_disk_utilization = False  # Snapshot/Restore operations consume disk space
+
+    def disrupt(self):
+        _mgmt_backup(self.runner, backup_specific_tables=False)
+
+
+@target_data_nodes
+class MgmtBackupSpecificKeyspaces(NemesisBaseClass):
+    """Run a Scylla Manager backup of test keyspaces only."""
+
+    manager_operation = True
+    disruptive = False
+    limited = True
+    supports_high_disk_utilization = False  # Snapshot/Restore operations consume disk space
+
+    def disrupt(self):
+        _mgmt_backup(self.runner, backup_specific_tables=True)
+
+
+@target_data_nodes
+class MgmtRestore(NemesisBaseClass):
+    """Restore a persistent Manager snapshot and validate the data."""
+
+    manager_operation = True
+    disruptive = True
+    kubernetes = True
+    xcloud = True
+    limited = True
+    supports_high_disk_utilization = False  # Snapshot/Restore operations consume disk space
+
+    def disrupt(self):  # noqa: PLR0914
+        self._disrupt_mgmt_restore()
+
+    def _disrupt_mgmt_restore(self):  # noqa: PLR0914
+        runner = self.runner
+
+        def get_total_scylla_partition_size():
+            result = runner.cluster.data_nodes[0].remoter.run("df -k | grep /var/lib/scylla")  # Size in KB
+            free_space_size = int(result.stdout.split()[1]) / 1024**2  # Converting to GB
+            return free_space_size
+
+        def choose_snapshot(snapshots_dict, region: str):
+            snapshot_groups_by_size = snapshots_dict["snapshots_sizes"]
+            total_partition_size = get_total_scylla_partition_size()
+            all_snapshot_sizes = sorted(list(snapshot_groups_by_size.keys()), reverse=True)
+            fitting_snapshot_sizes = [size for size in all_snapshot_sizes if total_partition_size / size >= 20]
+            if runner.tester.test_duration < 1000:
+                # Since verifying the restored data takes a long time, the nemesis limits the size of the restored
+                # backup based on the test duration
+                fitting_snapshot_sizes = [size for size in fitting_snapshot_sizes if size < 50]
+            # The restore should not take more than 5% of the space total space in /var/lib/scylla
+            assert fitting_snapshot_sizes, "There's not enough space for any snapshot restoration"
+
+            chosen_snapshot_size = runner.random.choice(fitting_snapshot_sizes)
+            all_snapshots_per_region = snapshot_groups_by_size[chosen_snapshot_size]["snapshots"][region]
+
+            if runner.cluster.nodes[0].is_enterprise:
+                snapshot_tag = runner.random.choice(list(all_snapshots_per_region.keys()))
+            else:
+                oss_snapshots = [
+                    snapshot_key
+                    for snapshot_key, snapshot_value in all_snapshots_per_region.items()
+                    if snapshot_value["scylla_product"] == "oss"
+                ]
+                snapshot_tag = runner.random.choice(oss_snapshots)
+
+            snapshot_info = all_snapshots_per_region[snapshot_tag]
+            snapshot_info.update(
+                {
+                    "expected_timeout": snapshot_groups_by_size[chosen_snapshot_size]["expected_timeout"],
+                    "number_of_rows": snapshot_groups_by_size[chosen_snapshot_size]["number_of_rows"],
+                }
+            )
+            return snapshot_tag, snapshot_info
+
+        def execute_data_validation_thread(command_template, keyspace_name, number_of_rows):
+            stress_queue = []
+            number_of_loaders = sum(runner.tester.params.get("n_loaders"))
+            rows_per_loader = int(number_of_rows / number_of_loaders)
+            for loader_index in range(number_of_loaders):
+                stress_command = command_template.format(
+                    num_of_rows=rows_per_loader,
+                    keyspace_name=keyspace_name,
+                    sequence_start=rows_per_loader * loader_index + 1,
+                    sequence_end=rows_per_loader * (loader_index + 1),
+                )
+                read_thread = runner.tester.run_stress_thread(
+                    stress_cmd=stress_command, round_robin=True, stop_test_on_failure=False
+                )
+                stress_queue.append(read_thread)
+            return stress_queue
+
+        def _restore_schema(locations: list, cluster_id: str, tag: str) -> None:
+            """Introduced to cover two flows:
+
+            - When a backup snapshot has different DC name than the current cluster's DC name -
+            restore schema out of the Manager applying CQL statements saved in schema.json file
+
+            - When backup snapshot has the same DC name as the current cluster's DC name -
+            restore schema using the Manager (sctool restore --restore-schema ...)
+            """
+            ks_statements, other_statements = get_schema_create_statements_from_snapshot(
+                bucket=locations[0].split(":")[-1],
+                mgr_cluster_id=cluster_id,
+                snapshot_tag=tag,
+            )
+
+            dc_under_test_name = next(iter(runner.cluster.get_nodetool_status()))
+            # Test is supposed to work with single DC setups only, so we can take the first DC name
+            dc_from_backup_name = get_dc_name_from_ks_statement(ks_statements[0])[0]
+            runner.log.debug("DC name from backup: %s, DC name under test: %s", dc_from_backup_name, dc_under_test_name)
+
+            if dc_under_test_name != dc_from_backup_name:
+                runner.log.info(
+                    "DC names mismatch - restoring the schema manually altering cql statements and "
+                    "applying them one by one"
+                )
+                # Alter the dc_name in keyspace cql statements to match the current cluster's dc_name
+                old_dc_block = f"'{dc_from_backup_name}':"  # Include quotes and colon to avoid unintended replacements
+                new_dc_block = f"'{dc_under_test_name}':"
+                ks_statements = [stmt.replace(old_dc_block, new_dc_block) for stmt in ks_statements]
+                # Apply cql statements one by one to restore schema
+                for cql_stmt in ks_statements + other_statements:
+                    runner.target_node.run_cqlsh(cql_stmt)
+            else:
+                runner.log.info("Restoring the schema using the Scylla Manager")
+                task = mgr_cluster.create_restore_task(restore_schema=True, location_list=locations, snapshot_tag=tag)
+                task.wait_and_get_final_status(step=10, timeout=6 * 60)  # 6 giving minutes to restore the schema
+                assert task.status == TaskStatus.DONE, f"Schema restoration failed: snapshot tag - {tag}"
+
+        skip_issues = [
+            "https://github.com/scylladb/scylla-manager/issues/3829",
+            "https://github.com/scylladb/scylla-manager/issues/4049",
+        ]
+        is_multi_dc = (
+            len(runner.cluster.params.region_names) > 1 or (runner.cluster.params.get("simulated_regions") or 0) > 1
+        )
+        if SkipPerIssues(skip_issues, params=runner.tester.params) and is_multi_dc:
+            raise UnsupportedNemesis("MultiDC cluster configuration is not supported by this nemesis")
+
+        if not (runner.cluster.params.get("use_mgmt") or runner.cluster.params.get("use_cloud_manager")):
+            raise UnsupportedNemesis("Scylla-manager configuration is not defined!")
+        if runner.cluster.params.get("cluster_backend") not in ("aws", "k8s-eks"):
+            raise UnsupportedNemesis("The restore test only supports 'AWS' and 'K8S-EKS' backends.")
+
+        mgr_cluster = runner.cluster.get_cluster_manager()
+        cluster_backend = runner.cluster.params.get("cluster_backend")
+        if cluster_backend == "k8s-eks":
+            cluster_backend = "aws"
+
+        persistent_manager_snapshots_dict = get_persistent_snapshots()
+        region = next(iter(runner.cluster.params.region_names), "")
+        target_bucket = persistent_manager_snapshots_dict[cluster_backend]["bucket"].format(region=region)
+        chosen_snapshot_tag, chosen_snapshot_info = choose_snapshot(
+            snapshots_dict=persistent_manager_snapshots_dict[cluster_backend], region=region
+        )
+
+        runner.log.info("Restoring the keyspace %s", chosen_snapshot_info["keyspace_name"])
+        location_list = [f"{runner.cluster.params.get('backup_bucket_backend')}:{target_bucket}"]
+        test_keyspaces = [cql_unquote_if_needed(keyspace) for keyspace in runner.cluster.get_test_keyspaces()]
+        # Keyspace names that start with a digit are surrounded by quotation marks in the output of a describe query
+        if chosen_snapshot_info["keyspace_name"] not in test_keyspaces:
+            runner.log.info("Restoring the schema of the keyspace '%s'", chosen_snapshot_info["keyspace_name"])
+            _restore_schema(
+                locations=location_list,
+                cluster_id=chosen_snapshot_info["cluster_id"],
+                tag=chosen_snapshot_tag,
+            )
+            with suppress_expected_unavailability_errors():
+                runner.cluster.restart_scylla()  # After schema restoration, you should restart the nodes
+
+            # TODO: Bring it back after the implementation of https://github.com/scylladb/scylla-manager/issues/4049
+            # which will unblock schema restore into a different DC. For now, we can restore schema only within one DC.
+            # According to https://github.com/scylladb/scylla-manager/issues/4041#issuecomment-2565489699, the step
+            # below is not needed if restoring the schema within one DC.
+            #
+            # self.tester.set_ks_strategy_to_network_and_rf_according_to_cluster(
+            #    keyspace=chosen_snapshot_info["keyspace_name"], repair_after_alter=False)
+        restore_task = None
+        try:
+            restore_task = mgr_cluster.create_restore_task(
+                restore_data=True, location_list=location_list, snapshot_tag=chosen_snapshot_tag
+            )
+            restore_task.wait_and_get_final_status(step=30, timeout=chosen_snapshot_info["expected_timeout"])
+            assert restore_task.status == TaskStatus.DONE, f"Data restoration of {chosen_snapshot_tag} has failed!"
+
+            confirmation_stress_template = (persistent_manager_snapshots_dict)[cluster_backend][
+                "confirmation_stress_template"
+            ]
+            stress_queue = execute_data_validation_thread(
+                command_template=confirmation_stress_template,
+                keyspace_name=chosen_snapshot_info["keyspace_name"],
+                number_of_rows=chosen_snapshot_info["number_of_rows"],
+            )
+
+            for stress in stress_queue:
+                is_passed = runner.tester.verify_stress_thread(stress)
+                assert is_passed, (
+                    "Data verification stress command, triggered by the 'mgmt_restore' nemesis, has failed"
+                )
+        finally:
+            _stop_unfinished_restore_task(runner, restore_task)
+            keyspace_name = chosen_snapshot_info["keyspace_name"]
+            runner.log.info("Cleaning up restored keyspace '%s'", keyspace_name)
+            drop_ks_stmt = f'DROP KEYSPACE IF EXISTS "{keyspace_name}";'
+            try:
+                runner.target_node.run_cqlsh(drop_ks_stmt)
+            except Exception as drop_err:  # noqa: BLE001
+                runner.log.warning("Failed to drop restored keyspace: %s", drop_err)
+
+
+@target_data_nodes
+class MgmtRepair(NemesisBaseClass):
+    """Run a repair via Scylla Manager CLI."""
+
+    manager_operation = True
+    disruptive = False
+    kubernetes = True
+    limited = True
+
+    def disrupt(self):
+        if not self.runner.cluster.params.get("use_mgmt") and not self.runner.cluster.params.get("use_cloud_manager"):
+            raise UnsupportedNemesis("Scylla-manager configuration is not defined!")
+        self.runner.log.info("MgmtRepair Nemesis begin")
+        self.runner.run_repair_manager()
+        self.runner.log.info("MgmtRepair Nemesis end")
+
+
+@target_data_nodes
+class MgmtCorruptThenRepair(NemesisBaseClass):
+    """Corrupt data by destroying SStables, then repair via Scylla Manager."""
+
+    manager_operation = True
+    disruptive = True
+    kubernetes = True
+
+    def disrupt(self):
+        if not self.runner.cluster.params.get("use_mgmt") and not self.runner.cluster.params.get("use_cloud_manager"):
+            raise UnsupportedNemesis("Scylla-manager configuration is not defined!")
+        destroy_data_and_restart_scylla(self.runner)
+        self.runner.run_repair_manager()

--- a/sdcm/nemesis/monkey/runners.py
+++ b/sdcm/nemesis/monkey/runners.py
@@ -8,6 +8,7 @@ from typing import Callable, List, Set, Tuple
 
 from sdcm.mgmt.common import ObjectStorageUploadMode
 from sdcm.nemesis import NemesisRunner
+from sdcm.nemesis.monkey.manager import manager_backup
 
 
 class SisyphusMonkey(NemesisRunner):
@@ -120,7 +121,7 @@ class ManagerRcloneBackup(NemesisRunner):
     supports_high_disk_utilization = False
 
     def call_next_nemesis(self):
-        self.disrupt_manager_backup(object_storage_upload_mode=ObjectStorageUploadMode.RCLONE, label="rclone_backup")
+        manager_backup(self, object_storage_upload_mode=ObjectStorageUploadMode.RCLONE, label="rclone_backup")
 
 
 class ManagerNativeBackup(NemesisRunner):
@@ -129,7 +130,7 @@ class ManagerNativeBackup(NemesisRunner):
     supports_high_disk_utilization = False
 
     def call_next_nemesis(self):
-        self.disrupt_manager_backup(object_storage_upload_mode=ObjectStorageUploadMode.NATIVE, label="native_backup")
+        manager_backup(self, object_storage_upload_mode=ObjectStorageUploadMode.NATIVE, label="native_backup")
 
 
 class EnableDisableTableEncryptionAwsKmsProviderMonkey(NemesisRunner):

--- a/sdcm/nemesis/utils/common_ops.py
+++ b/sdcm/nemesis/utils/common_ops.py
@@ -1,0 +1,85 @@
+"""
+Cross-cutting utility functions shared by multiple nemesis groups.
+
+Functions here are stateless helpers that accept a ``NemesisRunner`` (or its
+constituent parts) and perform an operation.  They are imported by individual
+monkey modules so that the logic lives in one place.
+"""
+
+import random
+
+from sdcm.exceptions import FilesNotCorrupted, UnsupportedNemesis
+from sdcm.sct_events.group_common_events import (
+    decorate_with_context,
+    suppress_expected_unavailability_errors,
+)
+from sdcm.utils.context_managers import DbNodeLogger
+
+
+@decorate_with_context(suppress_expected_unavailability_errors)
+def destroy_data_and_restart_scylla(runner, keyspaces_for_destroy: list = None, sstables_to_destroy_perc: int = 50):
+    """Stop Scylla, randomly destroy a percentage of SStables, and restart.
+
+    This is a cross-group utility used by manager, data-destroy, and streaming
+    nemesis.  It was originally ``NemesisRunner._destroy_data_and_restart_scylla``.
+
+    Args:
+        runner: A ``NemesisRunner`` instance (provides ``cluster``,
+            ``target_node``, ``log``, ``actions_log``, ``action_log_scope``,
+            ``get_all_sstables``, and ``replace_full_file_name_to_prefix``).
+        keyspaces_for_destroy: Optional list of keyspaces to limit destruction.
+        sstables_to_destroy_perc: Percentage of SStables to remove (default 50).
+    """
+    tables = runner.cluster.get_non_system_ks_cf_list(
+        db_node=runner.target_node, filter_empty_tables=False, filter_by_keyspace=keyspaces_for_destroy
+    )
+    if not tables:
+        raise UnsupportedNemesis("Non-system keyspace and table are not found. The nemesis can't be run")
+
+    runner.log.debug("Chosen tables: %s", tables)
+
+    # Stop scylla service before deleting sstables to avoid partial deletion of files that are under compaction
+    with runner.action_log_scope(f"Stop Scylla on {runner.target_node.name}"):
+        runner.target_node.stop_scylla_server(verify_up=False, verify_down=True)
+
+    try:
+        # Remove data files
+        if not (all_files_to_destroy := runner.get_all_sstables(tables=tables, node=runner.target_node)):
+            raise UnsupportedNemesis("SStables for destroy are not found. The nemesis can't be run")
+
+        # How many SStables are going to be deleted
+        sstables_amount_to_destroy = int(len(all_files_to_destroy) * sstables_to_destroy_perc / 100)
+        runner.log.debug(
+            "SStables amount to destroy (%s percent of all SStables): %s",
+            sstables_to_destroy_perc,
+            sstables_amount_to_destroy,
+        )
+
+        destroyed_files = 0
+        while sstables_amount_to_destroy > 0:
+            file_for_destroy = random.choice(all_files_to_destroy)
+            if not (
+                file_group_for_destroy := runner.replace_full_file_name_to_prefix(
+                    one_file=file_for_destroy, ks_cf_for_destroy=tables
+                )
+            ):
+                continue
+
+            with DbNodeLogger(
+                runner.cluster.nodes,
+                "remove data",
+                target_node=runner.target_node,
+                additional_info=file_group_for_destroy,
+            ):
+                result = runner.target_node.remoter.sudo("rm -f %s" % file_group_for_destroy)
+            if result.stderr:
+                raise FilesNotCorrupted(f"Files were not removed. The nemesis can't be run. Error: {result}")
+            all_files_to_destroy.remove(file_for_destroy)
+            sstables_amount_to_destroy -= 1
+            destroyed_files += 1
+            runner.log.debug(f"Files {file_for_destroy} were destroyed")
+        runner.actions_log.info(f"removed {destroyed_files} files in tables: {tables} on {runner.target_node.name}")
+
+    finally:
+        with runner.action_log_scope(f"Start Scylla on {runner.target_node.name} node"):
+            runner.target_node.start_scylla_server(verify_up=True, verify_down=False)

--- a/unit_tests/unit/nemesis/monkey/test_manager.py
+++ b/unit_tests/unit/nemesis/monkey/test_manager.py
@@ -1,0 +1,554 @@
+"""Tests for sdcm.nemesis.monkey.manager module."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from sdcm.exceptions import FilesNotCorrupted, UnsupportedNemesis
+from sdcm.mgmt.common import ObjectStorageUploadMode, TaskStatus
+from sdcm.nemesis.monkey.manager import (
+    MgmtBackup,
+    MgmtBackupSpecificKeyspaces,
+    MgmtCorruptThenRepair,
+    MgmtRepair,
+    MgmtRestore,
+    _delete_existing_backups,
+    _get_manager_tool,
+    _mgmt_backup,
+    manager_backup,
+)
+from sdcm.nemesis.utils.common_ops import destroy_data_and_restart_scylla
+
+_MODULE = "sdcm.nemesis.monkey.manager"
+_COMMON_OPS_MODULE = "sdcm.nemesis.utils.common_ops"
+
+pytestmark = pytest.mark.usefixtures("events")
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def runner(base_runner):
+    """``base_runner`` extended with manager-nemesis-specific attributes."""
+    base_runner.cluster.params = MagicMock()
+    base_runner.cluster.params.get.return_value = False  # default: no manager configured
+    base_runner.cluster.params.region_names = ["us-east-1"]
+    base_runner.run_repair_manager = MagicMock()
+    base_runner.get_all_sstables = MagicMock(return_value=[])
+    base_runner.replace_full_file_name_to_prefix = MagicMock(return_value="")
+    base_runner.tester.monitors = MagicMock()
+    base_runner.tester.monitors.nodes = [MagicMock()]
+    base_runner.tester.test_config = MagicMock()
+    base_runner.tester.params = MagicMock(artifact_scylla_version="2025.3.0")
+    mock_tester_obj = MagicMock()
+    mock_tester_obj.params = base_runner.tester.params
+    with (
+        patch("sdcm.utils.issues.SkipPerIssues.get_issue_details", return_value=None),
+        patch("sdcm.sct_events.group_common_events.TestConfig") as mock_test_config,
+    ):
+        mock_test_config.return_value.tester_obj.return_value = mock_tester_obj
+        yield base_runner
+
+
+# ---------------------------------------------------------------------------
+# Monkey class flags
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "monkey_class, expected_flags",
+    [
+        pytest.param(
+            MgmtBackup,
+            {"manager_operation": True, "disruptive": False, "limited": True, "supports_high_disk_utilization": False},
+            id="MgmtBackup",
+        ),
+        pytest.param(
+            MgmtBackupSpecificKeyspaces,
+            {"manager_operation": True, "disruptive": False, "limited": True, "supports_high_disk_utilization": False},
+            id="MgmtBackupSpecificKeyspaces",
+        ),
+        pytest.param(
+            MgmtRestore,
+            {
+                "manager_operation": True,
+                "disruptive": True,
+                "kubernetes": True,
+                "xcloud": True,
+                "limited": True,
+                "supports_high_disk_utilization": False,
+            },
+            id="MgmtRestore",
+        ),
+        pytest.param(
+            MgmtRepair,
+            {"manager_operation": True, "disruptive": False, "kubernetes": True, "limited": True},
+            id="MgmtRepair",
+        ),
+        pytest.param(
+            MgmtCorruptThenRepair,
+            {"manager_operation": True, "disruptive": True, "kubernetes": True},
+            id="MgmtCorruptThenRepair",
+        ),
+    ],
+)
+def test_monkey_class_flags(monkey_class, expected_flags):
+    """Verify each manager monkey class has correct boolean flags for nemesis selection."""
+    for flag_name, expected_value in expected_flags.items():
+        assert getattr(monkey_class, flag_name) == expected_value, (
+            f"{monkey_class.__name__}.{flag_name} expected {expected_value}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# _get_manager_tool
+# ---------------------------------------------------------------------------
+
+
+@patch(f"{_MODULE}.mgmt")
+def test_get_manager_tool_delegates_to_mgmt(mock_mgmt):
+    """Verify _get_manager_tool calls mgmt.get_scylla_manager_tool with the first monitor node."""
+    tester = MagicMock()
+    monitor_node = MagicMock()
+    tester.monitors.nodes = [monitor_node]
+    _get_manager_tool(tester)
+    mock_mgmt.get_scylla_manager_tool.assert_called_once_with(manager_node=monitor_node)
+
+
+# ---------------------------------------------------------------------------
+# _delete_existing_backups
+# ---------------------------------------------------------------------------
+
+
+def test_delete_existing_backups_removes_actionable_tasks(runner):
+    """Verify _delete_existing_backups deletes tasks with NEW/RUNNING/STARTING/ERROR status."""
+    task_new = MagicMock(status=TaskStatus.NEW, id="task-1")
+    task_running = MagicMock(status=TaskStatus.RUNNING, id="task-2")
+    task_done = MagicMock(status=TaskStatus.DONE, id="task-3")
+    task_error = MagicMock(status=TaskStatus.ERROR, id="task-4")
+
+    mgr_cluster = MagicMock()
+    mgr_cluster.backup_task_list = [task_new, task_running, task_done, task_error]
+
+    _delete_existing_backups(runner, mgr_cluster)
+
+    # task_done should NOT be deleted
+    assert mgr_cluster.delete_task.call_count == 3
+    deleted_tasks = [call.args[0] for call in mgr_cluster.delete_task.call_args_list]
+    assert task_new in deleted_tasks
+    assert task_running in deleted_tasks
+    assert task_error in deleted_tasks
+    assert task_done not in deleted_tasks
+
+
+def test_delete_existing_backups_no_tasks(runner):
+    """Verify _delete_existing_backups does nothing when task list is empty."""
+    mgr_cluster = MagicMock()
+    mgr_cluster.backup_task_list = []
+    _delete_existing_backups(runner, mgr_cluster)
+    mgr_cluster.delete_task.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _mgmt_backup — UnsupportedNemesis guards
+# ---------------------------------------------------------------------------
+
+
+def test_mgmt_backup_raises_when_no_manager_configured(runner):
+    """Verify _mgmt_backup raises UnsupportedNemesis when neither use_mgmt nor use_cloud_manager is set."""
+    runner.cluster.params.get.return_value = False
+    with pytest.raises(UnsupportedNemesis, match="Scylla-manager configuration is not defined"):
+        _mgmt_backup(runner, backup_specific_tables=False)
+
+
+def test_mgmt_backup_raises_when_no_bucket_location(runner):
+    """Verify _mgmt_backup raises UnsupportedNemesis when backup_bucket_location is not configured."""
+
+    def params_get(key, *args, **kwargs):
+        return {
+            "use_mgmt": True,
+            "use_cloud_manager": False,
+            "backup_bucket_location": None,
+        }.get(key, None)
+
+    runner.cluster.params.get.side_effect = params_get
+    with pytest.raises(UnsupportedNemesis, match="backup bucket location"):
+        _mgmt_backup(runner, backup_specific_tables=False)
+
+
+# ---------------------------------------------------------------------------
+# manager_backup
+# ---------------------------------------------------------------------------
+
+
+@patch(f"{_MODULE}._manager_backup_and_report")
+def test_manager_backup_calls_report_and_deletes_snapshot(mock_report, runner):
+    """Verify manager_backup calls _manager_backup_and_report and then deletes the snapshot."""
+    mock_task = MagicMock()
+    mock_report.return_value = mock_task
+
+    manager_backup(runner, ObjectStorageUploadMode.RCLONE, "test_label")
+
+    mock_report.assert_called_once()
+    # Label should have a time postfix appended
+    call_label = mock_report.call_args.args[2]
+    assert call_label.startswith("test_label_")
+    mock_task.delete_backup_snapshot.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# UnsupportedNemesis guards — Monkey classes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "monkey_class",
+    [
+        pytest.param(MgmtBackup, id="MgmtBackup"),
+        pytest.param(MgmtBackupSpecificKeyspaces, id="MgmtBackupSpecificKeyspaces"),
+    ],
+)
+def test_backup_monkeys_raise_when_no_manager(runner, monkey_class):
+    """Verify backup monkey classes raise UnsupportedNemesis when manager is not configured."""
+    runner.cluster.params.get.return_value = False
+    with pytest.raises(UnsupportedNemesis, match="Scylla-manager configuration is not defined"):
+        monkey_class(runner).disrupt()
+
+
+@pytest.mark.parametrize(
+    "monkey_class",
+    [
+        pytest.param(MgmtRepair, id="MgmtRepair"),
+        pytest.param(MgmtCorruptThenRepair, id="MgmtCorruptThenRepair"),
+    ],
+)
+def test_repair_monkeys_raise_when_no_manager(runner, monkey_class):
+    """Verify repair monkey classes raise UnsupportedNemesis when manager is not configured."""
+    runner.cluster.params.get.return_value = False
+    with pytest.raises(UnsupportedNemesis, match="Scylla-manager configuration is not defined"):
+        monkey_class(runner).disrupt()
+
+
+def test_restore_raises_when_no_manager(runner):
+    """Verify MgmtRestore raises UnsupportedNemesis when manager is not configured."""
+
+    def params_get(key, *args, **kwargs):
+        return {"use_mgmt": False, "use_cloud_manager": False, "simulated_regions": 0}.get(key, False)
+
+    runner.cluster.params.get.side_effect = params_get
+    runner.cluster.params.region_names = ["us-east-1"]
+    with pytest.raises(UnsupportedNemesis, match="Scylla-manager configuration is not defined"):
+        MgmtRestore(runner).disrupt()
+
+
+def test_restore_raises_for_unsupported_backend(runner):
+    """Verify MgmtRestore raises UnsupportedNemesis for non-AWS/EKS backends."""
+
+    def params_get(key, *args, **kwargs):
+        return {
+            "use_mgmt": True,
+            "use_cloud_manager": False,
+            "cluster_backend": "gce",
+            "simulated_regions": 0,
+        }.get(key, False)
+
+    runner.cluster.params.get.side_effect = params_get
+    runner.cluster.params.region_names = ["us-east-1"]
+    with pytest.raises(UnsupportedNemesis, match="only supports 'AWS' and 'K8S-EKS'"):
+        MgmtRestore(runner).disrupt()
+
+
+# ---------------------------------------------------------------------------
+# MgmtRepair — happy path
+# ---------------------------------------------------------------------------
+
+
+def test_mgmt_repair_calls_run_repair_manager(runner):
+    """Verify MgmtRepair.disrupt() calls run_repair_manager when manager is configured."""
+
+    def params_get(key, *args, **kwargs):
+        return {"use_mgmt": True, "use_cloud_manager": False}.get(key, False)
+
+    runner.cluster.params.get.side_effect = params_get
+    MgmtRepair(runner).disrupt()
+    runner.run_repair_manager.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# MgmtCorruptThenRepair — happy path
+# ---------------------------------------------------------------------------
+
+
+@patch(f"{_MODULE}.destroy_data_and_restart_scylla")
+def test_mgmt_corrupt_then_repair_calls_destroy_and_repair(mock_destroy, runner):
+    """Verify MgmtCorruptThenRepair destroys data and then repairs."""
+
+    def params_get(key, *args, **kwargs):
+        return {"use_mgmt": True, "use_cloud_manager": False}.get(key, False)
+
+    runner.cluster.params.get.side_effect = params_get
+    MgmtCorruptThenRepair(runner).disrupt()
+    mock_destroy.assert_called_once_with(runner)
+    runner.run_repair_manager.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# destroy_data_and_restart_scylla (common_ops.py)
+# ---------------------------------------------------------------------------
+
+
+def test_destroy_data_raises_when_no_tables(runner):
+    """Verify destroy_data_and_restart_scylla raises UnsupportedNemesis when no tables are found."""
+    runner.cluster.get_non_system_ks_cf_list.return_value = []
+    with pytest.raises(UnsupportedNemesis, match="Non-system keyspace and table are not found"):
+        destroy_data_and_restart_scylla(runner)
+
+
+def test_destroy_data_raises_when_no_sstables(runner):
+    """Verify destroy_data_and_restart_scylla raises UnsupportedNemesis when no SStables are found."""
+    runner.cluster.get_non_system_ks_cf_list.return_value = ["ks1.table1"]
+    runner.get_all_sstables.return_value = []
+    with pytest.raises(UnsupportedNemesis, match="SStables for destroy are not found"):
+        destroy_data_and_restart_scylla(runner)
+    # Scylla should still be restarted even when UnsupportedNemesis is raised from sstable lookup
+    runner.target_node.start_scylla_server.assert_called_once_with(verify_up=True, verify_down=False)
+
+
+@patch(f"{_COMMON_OPS_MODULE}.random")
+@patch(f"{_COMMON_OPS_MODULE}.DbNodeLogger")
+def test_destroy_data_happy_path(mock_db_logger, mock_random, runner):
+    """Verify destroy_data_and_restart_scylla stops scylla, removes files, and restarts."""
+    mock_db_logger.return_value.__enter__ = MagicMock()
+    mock_db_logger.return_value.__exit__ = MagicMock(return_value=False)
+
+    runner.cluster.get_non_system_ks_cf_list.return_value = ["ks1.table1"]
+    sstables = ["/var/lib/scylla/data/ks1/table1/mc-1-big-Data.db"]
+    runner.get_all_sstables.return_value = list(sstables)
+    mock_random.choice.return_value = sstables[0]
+    runner.replace_full_file_name_to_prefix.return_value = "/var/lib/scylla/data/ks1/table1/mc-1-*"
+    runner.target_node.remoter.sudo.return_value = MagicMock(stderr="")
+
+    destroy_data_and_restart_scylla(runner, sstables_to_destroy_perc=100)
+
+    runner.target_node.stop_scylla_server.assert_called_once_with(verify_up=False, verify_down=True)
+    runner.target_node.remoter.sudo.assert_called_once()
+    runner.target_node.start_scylla_server.assert_called_once_with(verify_up=True, verify_down=False)
+
+
+@patch(f"{_COMMON_OPS_MODULE}.random")
+@patch(f"{_COMMON_OPS_MODULE}.DbNodeLogger")
+def test_destroy_data_restarts_scylla_on_file_removal_error(mock_db_logger, mock_random, runner):
+    """Verify Scylla is restarted even when file removal fails."""
+    mock_db_logger.return_value.__enter__ = MagicMock()
+    mock_db_logger.return_value.__exit__ = MagicMock(return_value=False)
+
+    runner.cluster.get_non_system_ks_cf_list.return_value = ["ks1.table1"]
+    sstables = ["/var/lib/scylla/data/ks1/table1/mc-1-big-Data.db"]
+    runner.get_all_sstables.return_value = list(sstables)
+    mock_random.choice.return_value = sstables[0]
+    runner.replace_full_file_name_to_prefix.return_value = "/var/lib/scylla/data/ks1/table1/mc-1-*"
+    runner.target_node.remoter.sudo.return_value = MagicMock(stderr="Permission denied")
+
+    with pytest.raises(FilesNotCorrupted):
+        destroy_data_and_restart_scylla(runner, sstables_to_destroy_perc=100)
+
+    # Scylla must be restarted regardless of the error
+    runner.target_node.start_scylla_server.assert_called_once_with(verify_up=True, verify_down=False)
+
+
+# ---------------------------------------------------------------------------
+# MgmtRestore — happy path
+# ---------------------------------------------------------------------------
+
+
+@patch(f"{_MODULE}.get_persistent_snapshots")
+@patch(f"{_MODULE}.get_schema_create_statements_from_snapshot")
+@patch(f"{_MODULE}.get_dc_name_from_ks_statement")
+def test_restore_happy_path_existing_keyspace(mock_get_dc, mock_get_schema, mock_get_snapshots, runner):
+    """Verify MgmtRestore happy path: restore data into an already-existing keyspace, validate, and clean up."""
+
+    def params_get(key, *args, **kwargs):
+        return {
+            "use_mgmt": True,
+            "use_cloud_manager": False,
+            "cluster_backend": "aws",
+            "backup_bucket_backend": "s3",
+            "simulated_regions": 0,
+        }.get(key, False)
+
+    runner.cluster.params.get.side_effect = params_get
+    runner.cluster.params.region_names = ["us-east-1"]
+    runner.tester.test_duration = 2000
+    runner.random.choice.side_effect = lambda seq: seq[0]
+
+    # Mock df output for partition size calculation (200 GB)
+    runner.cluster.data_nodes = [runner.target_node]
+    runner.target_node.remoter.run.return_value = MagicMock(
+        stdout="/dev/sda1 209715200 100000000 100000000 50% /var/lib/scylla"
+    )
+    runner.cluster.nodes = [runner.target_node]
+    runner.target_node.is_enterprise = True
+
+    # Mock persistent snapshots structure
+    mock_get_snapshots.return_value = {
+        "aws": {
+            "bucket": "backup-bucket-{region}",
+            "snapshots_sizes": {
+                5: {
+                    "expected_timeout": 3600,
+                    "number_of_rows": 1000,
+                    "snapshots": {
+                        "us-east-1": {
+                            "sm_20250101120000UTC": {
+                                "keyspace_name": "restored_ks",
+                                "cluster_id": "cluster-123",
+                                "scylla_product": "enterprise",
+                            }
+                        }
+                    },
+                }
+            },
+            "confirmation_stress_template": "cassandra-stress read n={num_of_rows} -schema 'keyspace={keyspace_name}' -pop 'seq={sequence_start}..{sequence_end}'",
+        }
+    }
+
+    # The keyspace already exists in the cluster — skip schema restoration
+    runner.cluster.get_test_keyspaces.return_value = ["restored_ks"]
+
+    # Mock manager cluster and restore task
+    mgr_cluster = MagicMock()
+    restore_task = MagicMock()
+    restore_task.status = TaskStatus.DONE
+    mgr_cluster.create_restore_task.return_value = restore_task
+    runner.cluster.get_cluster_manager.return_value = mgr_cluster
+
+    # Mock stress validation
+    runner.tester.params.get.return_value = [1]  # n_loaders
+    stress_thread = MagicMock()
+    runner.tester.run_stress_thread.return_value = stress_thread
+    runner.tester.verify_stress_thread.return_value = True
+
+    # Execute
+    MgmtRestore(runner).disrupt()
+
+    # Verify restore task was created with correct params
+    mgr_cluster.create_restore_task.assert_called_once_with(
+        restore_data=True,
+        location_list=["s3:backup-bucket-us-east-1"],
+        snapshot_tag="sm_20250101120000UTC",
+    )
+    restore_task.wait_and_get_final_status.assert_called_once()
+
+    # Verify data validation ran
+    runner.tester.run_stress_thread.assert_called_once()
+    runner.tester.verify_stress_thread.assert_called_once_with(stress_thread)
+
+    # Verify cleanup: keyspace dropped
+    runner.target_node.run_cqlsh.assert_called_once_with('DROP KEYSPACE IF EXISTS "restored_ks";')
+
+
+@patch(f"{_MODULE}.suppress_expected_unavailability_errors")
+@patch(f"{_MODULE}.get_persistent_snapshots")
+@patch(f"{_MODULE}.get_schema_create_statements_from_snapshot")
+@patch(f"{_MODULE}.get_dc_name_from_ks_statement")
+def test_restore_happy_path_with_schema_restoration(
+    mock_get_dc, mock_get_schema, mock_get_snapshots, mock_suppress, runner
+):
+    """Verify MgmtRestore restores schema when keyspace doesn't exist and DC names mismatch."""
+
+    def params_get(key, *args, **kwargs):
+        return {
+            "use_mgmt": True,
+            "use_cloud_manager": False,
+            "cluster_backend": "aws",
+            "backup_bucket_backend": "s3",
+            "simulated_regions": 0,
+        }.get(key, False)
+
+    runner.cluster.params.get.side_effect = params_get
+    runner.cluster.params.region_names = ["us-east-1"]
+    runner.tester.test_duration = 2000
+    runner.random.choice.side_effect = lambda seq: seq[0]
+
+    # Mock df output
+    runner.cluster.data_nodes = [runner.target_node]
+    runner.target_node.remoter.run.return_value = MagicMock(
+        stdout="/dev/sda1 209715200 100000000 100000000 50% /var/lib/scylla"
+    )
+    runner.cluster.nodes = [runner.target_node]
+    runner.target_node.is_enterprise = True
+
+    mock_get_snapshots.return_value = {
+        "aws": {
+            "bucket": "backup-bucket-{region}",
+            "snapshots_sizes": {
+                5: {
+                    "expected_timeout": 3600,
+                    "number_of_rows": 1000,
+                    "snapshots": {
+                        "us-east-1": {
+                            "sm_20250101120000UTC": {
+                                "keyspace_name": "new_ks",
+                                "cluster_id": "cluster-123",
+                                "scylla_product": "enterprise",
+                            }
+                        }
+                    },
+                }
+            },
+            "confirmation_stress_template": "cassandra-stress read n={num_of_rows} -schema 'keyspace={keyspace_name}'",
+        }
+    }
+
+    # Keyspace does NOT exist yet — triggers schema restoration
+    runner.cluster.get_test_keyspaces.return_value = ["other_ks"]
+
+    # DC name mismatch — triggers manual CQL application
+    runner.cluster.get_nodetool_status.return_value = {"dc_local": {}}
+    mock_get_schema.return_value = (
+        ["CREATE KEYSPACE new_ks WITH replication = {'class': 'NetworkTopologyStrategy', 'dc_backup': 3}"],
+        ["CREATE TABLE new_ks.t1 (id int PRIMARY KEY)"],
+    )
+    mock_get_dc.return_value = ("dc_backup",)
+
+    # Mock suppress context manager
+    mock_suppress.return_value.__enter__ = MagicMock()
+    mock_suppress.return_value.__exit__ = MagicMock(return_value=False)
+
+    # Mock manager cluster and restore task
+    mgr_cluster = MagicMock()
+    restore_task = MagicMock()
+    restore_task.status = TaskStatus.DONE
+    mgr_cluster.create_restore_task.return_value = restore_task
+    runner.cluster.get_cluster_manager.return_value = mgr_cluster
+
+    # Mock stress validation
+    runner.tester.params.get.return_value = [1]
+    stress_thread = MagicMock()
+    runner.tester.run_stress_thread.return_value = stress_thread
+    runner.tester.verify_stress_thread.return_value = True
+
+    # Execute
+    MgmtRestore(runner).disrupt()
+
+    # Verify schema was applied manually with DC name replacement
+    cqlsh_calls = runner.target_node.run_cqlsh.call_args_list
+    # First calls: schema restoration (ks statement with DC replaced + table statement)
+    assert any("dc_local" in str(call) for call in cqlsh_calls), "DC name should be replaced in CQL statements"
+    assert any("CREATE TABLE" in str(call) for call in cqlsh_calls), "Table creation CQL should be applied"
+
+    # Verify cluster was restarted after schema restoration
+    runner.cluster.restart_scylla.assert_called_once()
+
+    # Verify data restore task was created
+    mgr_cluster.create_restore_task.assert_called_once_with(
+        restore_data=True,
+        location_list=["s3:backup-bucket-us-east-1"],
+        snapshot_tag="sm_20250101120000UTC",
+    )
+
+    # Verify cleanup
+    assert any("DROP KEYSPACE" in str(call) for call in cqlsh_calls)

--- a/unit_tests/unit/nemesis/monkey/test_manager.py
+++ b/unit_tests/unit/nemesis/monkey/test_manager.py
@@ -1,0 +1,344 @@
+"""Tests for sdcm.nemesis.monkey.manager module."""
+
+from contextlib import nullcontext
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from sdcm.exceptions import FilesNotCorrupted, UnsupportedNemesis
+from sdcm.mgmt.common import ObjectStorageUploadMode, TaskStatus
+from sdcm.nemesis.monkey.manager import (
+    MgmtCorruptThenRepair,
+    MgmtRepair,
+    MgmtRestore,
+    delete_existing_backups,
+    get_manager_tool,
+    manager_backup,
+    mgmt_backup,
+)
+from sdcm.nemesis.utils.common_ops import destroy_data_and_restart_scylla
+
+_MODULE = "sdcm.nemesis.monkey.manager"
+_COMMON_OPS_MODULE = "sdcm.nemesis.utils.common_ops"
+
+pytestmark = pytest.mark.usefixtures("events")
+
+_SNAPSHOT_TAG = "sm_20250101120000UTC"
+_RESTORED_KS = "restored_ks"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _set_params(runner, **values):
+    """Point ``runner.cluster.params.get`` at ``values``, honouring the caller's default."""
+    runner.cluster.params.get.side_effect = lambda key, default=None, **kwargs: values.get(key, default)
+
+
+def _snapshot_catalog():
+    """A minimal ``get_persistent_snapshots()`` catalog: a single 5 GB AWS snapshot."""
+    return {
+        "aws": {
+            "bucket": "backup-bucket-{region}",
+            "snapshots_sizes": {
+                5: {
+                    "expected_timeout": 3600,
+                    "number_of_rows": 1000,
+                    "snapshots": {
+                        "us-east-1": {
+                            _SNAPSHOT_TAG: {
+                                "keyspace_name": _RESTORED_KS,
+                                "cluster_id": "cluster-123",
+                                "scylla_product": "enterprise",
+                            }
+                        }
+                    },
+                }
+            },
+            "confirmation_stress_template": (
+                "cassandra-stress read n={num_of_rows} -schema 'keyspace={keyspace_name}' "
+                "-pop 'seq={sequence_start}..{sequence_end}'"
+            ),
+        }
+    }
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def runner(base_runner):
+    """``base_runner`` extended with manager-nemesis-specific attributes."""
+    base_runner.cluster.params = MagicMock()
+    base_runner.cluster.params.get.return_value = False
+    base_runner.cluster.params.region_names = ["us-east-1"]
+    base_runner.run_repair_manager = MagicMock()
+    base_runner.get_all_sstables = MagicMock(return_value=[])
+    base_runner.replace_full_file_name_to_prefix = MagicMock(return_value="")
+    base_runner.tester.monitors = MagicMock()
+    base_runner.tester.monitors.nodes = [MagicMock()]
+    base_runner.tester.test_config = MagicMock()
+    base_runner.tester.params = MagicMock(artifact_scylla_version="2025.3.0")
+    mock_tester_obj = MagicMock()
+    mock_tester_obj.params = base_runner.tester.params
+    with (
+        patch("sdcm.utils.issues.SkipPerIssues.get_issue_details", return_value=None),
+        patch("sdcm.sct_events.group_common_events.TestConfig") as mock_test_config,
+    ):
+        mock_test_config.return_value.tester_obj.return_value = mock_tester_obj
+        yield base_runner
+
+
+@pytest.fixture(autouse=True)
+def _stub_common_ops():
+    """Stub the ``common_ops`` internals: DbNodeLogger opens SSH sessions to every
+    node, and the SStable pick has to be deterministic."""
+    with patch(f"{_COMMON_OPS_MODULE}.DbNodeLogger"), patch(f"{_COMMON_OPS_MODULE}.random") as mock_random:
+        mock_random.choice.side_effect = lambda seq: seq[0]
+        yield
+
+
+@pytest.fixture()
+def destroy_node_data_runner(runner):
+    """``runner`` wired for a successful ``destroy_data_and_restart_scylla`` run:
+    one table holding one SStable that ``rm`` removes without complaining."""
+    runner.cluster.get_non_system_ks_cf_list.return_value = ["ks1.table1"]
+    runner.get_all_sstables.return_value = ["/var/lib/scylla/data/ks1/table1/mc-1-big-Data.db"]
+    runner.replace_full_file_name_to_prefix.return_value = "/var/lib/scylla/data/ks1/table1/mc-1-*"
+    runner.target_node.remoter.sudo.return_value = MagicMock(stderr="")
+    return runner
+
+
+@pytest.fixture()
+def restore_snapshot_runner(runner):
+    """``runner`` wired for a successful ``MgmtRestore`` into an existing keyspace.
+
+    An AWS/S3 single-region cluster with a 200 GB ``/var/lib/scylla`` partition
+    (so the 5 GB snapshot of ``_snapshot_catalog()`` fits), a Manager restore
+    task that ends up DONE, and a single loader whose verification passes.  The
+    snapshot keyspace already exists in the cluster, so the schema-restoration
+    branch is not taken — ``restore_snapshot_with_schema_runner`` covers that one.
+    """
+    _set_params(runner, use_mgmt=True, cluster_backend="aws", backup_bucket_backend="s3")
+    runner.tester.test_duration = 2000
+    runner.cluster.nodes = runner.cluster.data_nodes = [runner.target_node]
+    runner.target_node.is_enterprise = True
+    runner.target_node.remoter.run.return_value = MagicMock(  # df -k output -> 200 GB partition
+        stdout="/dev/sda1 209715200 100000000 100000000 50% /var/lib/scylla"
+    )
+    runner.cluster.get_test_keyspaces.return_value = [_RESTORED_KS]
+    runner.cluster.get_cluster_manager.return_value.create_restore_task.return_value.status = TaskStatus.DONE
+    runner.tester.params.get.return_value = [1]  # n_loaders
+    runner.tester.verify_stress_thread.return_value = True
+    with patch(f"{_MODULE}.get_persistent_snapshots", return_value=_snapshot_catalog()):
+        yield runner
+
+
+@pytest.fixture()
+def restore_snapshot_with_schema_runner(restore_snapshot_runner):
+    """``restore_snapshot_runner`` steered into the schema-restoration branch.
+
+    The snapshot keyspace is absent from the cluster and the snapshot's DC name
+    differs from the cluster's, so the schema is applied CQL statement by CQL
+    statement with the DC name rewritten, rather than restored by the Manager.
+    """
+    restore_snapshot_runner.cluster.get_test_keyspaces.return_value = ["other_ks"]
+    restore_snapshot_runner.cluster.get_nodetool_status.return_value = {"dc_local": {}}
+    with (
+        patch(f"{_MODULE}.suppress_expected_unavailability_errors", return_value=nullcontext()),
+        patch(
+            f"{_MODULE}.get_schema_create_statements_from_snapshot",
+            return_value=(
+                [
+                    f"CREATE KEYSPACE {_RESTORED_KS} WITH replication = "
+                    "{'class': 'NetworkTopologyStrategy', 'dc_backup': 3}"
+                ],
+                [f"CREATE TABLE {_RESTORED_KS}.t1 (id int PRIMARY KEY)"],
+            ),
+        ),
+        patch(f"{_MODULE}.get_dc_name_from_ks_statement", return_value=("dc_backup",)),
+    ):
+        yield restore_snapshot_runner
+
+
+# ---------------------------------------------------------------------------
+# get_manager_tool
+# ---------------------------------------------------------------------------
+
+
+@patch(f"{_MODULE}.mgmt")
+def test_get_manager_tool_delegates_to_mgmt(mock_mgmt):
+    """get_manager_tool() asks mgmt for a tool bound to the first monitor node."""
+    tester = MagicMock()
+    monitor_node = MagicMock()
+    tester.monitors.nodes = [monitor_node]
+
+    get_manager_tool(tester)
+
+    mock_mgmt.get_scylla_manager_tool.assert_called_once_with(manager_node=monitor_node)
+
+
+# ---------------------------------------------------------------------------
+# delete_existing_backups
+# ---------------------------------------------------------------------------
+
+
+def test_delete_existing_backups_removes_actionable_tasks(runner):
+    """Only NEW/RUNNING/STARTING/ERROR tasks are deleted — a DONE task is left alone."""
+    actionable = (TaskStatus.NEW, TaskStatus.RUNNING, TaskStatus.STARTING, TaskStatus.ERROR)
+    tasks = {status: MagicMock(status=status, id=f"task-{status}") for status in (*actionable, TaskStatus.DONE)}
+    mgr_cluster = MagicMock(backup_task_list=list(tasks.values()))
+
+    delete_existing_backups(runner, mgr_cluster)
+
+    deleted = [call.args[0] for call in mgr_cluster.delete_task.call_args_list]
+    assert deleted == [tasks[status] for status in actionable]
+
+
+def test_delete_existing_backups_no_tasks(runner):
+    """Nothing is deleted when the cluster has no backup tasks at all."""
+    mgr_cluster = MagicMock(backup_task_list=[])
+
+    delete_existing_backups(runner, mgr_cluster)
+
+    mgr_cluster.delete_task.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# mgmt_backup
+# ---------------------------------------------------------------------------
+
+
+def test_mgmt_backup_raises_when_no_bucket_location(runner):
+    """mgmt_backup() still rejects a missing backup bucket location at run time."""
+    _set_params(runner, use_mgmt=True)
+
+    with pytest.raises(UnsupportedNemesis, match="backup bucket location"):
+        mgmt_backup(runner, backup_specific_tables=False)
+
+
+# ---------------------------------------------------------------------------
+# manager_backup
+# ---------------------------------------------------------------------------
+
+
+@patch(f"{_MODULE}._manager_backup_and_report")
+def test_manager_backup_calls_report_and_deletes_snapshot(mock_report, runner):
+    """manager_backup() reports the backup under a time-stamped label, then deletes the snapshot."""
+    manager_backup(runner, ObjectStorageUploadMode.RCLONE, "test_label")
+
+    assert mock_report.call_args.args[2].startswith("test_label_")
+    mock_report.return_value.delete_backup_snapshot.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# MgmtRepair / MgmtCorruptThenRepair
+# ---------------------------------------------------------------------------
+
+
+def test_mgmt_repair_calls_run_repair_manager(runner):
+    """MgmtRepair.disrupt() delegates straight to run_repair_manager()."""
+    MgmtRepair(runner).disrupt()
+
+    runner.run_repair_manager.assert_called_once()
+
+
+@patch(f"{_MODULE}.destroy_data_and_restart_scylla")
+def test_mgmt_corrupt_then_repair_calls_destroy_and_repair(mock_destroy, runner):
+    """MgmtCorruptThenRepair.disrupt() destroys data first and repairs afterwards."""
+    MgmtCorruptThenRepair(runner).disrupt()
+
+    mock_destroy.assert_called_once_with(runner)
+    runner.run_repair_manager.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# destroy_data_and_restart_scylla (common_ops.py)
+# ---------------------------------------------------------------------------
+
+
+def test_destroy_data_raises_when_no_tables(destroy_node_data_runner):
+    """No non-system table to corrupt — the nemesis cannot run."""
+    destroy_node_data_runner.cluster.get_non_system_ks_cf_list.return_value = []
+
+    with pytest.raises(UnsupportedNemesis, match="Non-system keyspace and table are not found"):
+        destroy_data_and_restart_scylla(destroy_node_data_runner)
+
+
+def test_destroy_data_raises_when_no_sstables(destroy_node_data_runner):
+    """No SStable to corrupt — the nemesis cannot run, but Scylla is brought back up."""
+    destroy_node_data_runner.get_all_sstables.return_value = []
+
+    with pytest.raises(UnsupportedNemesis, match="SStables for destroy are not found"):
+        destroy_data_and_restart_scylla(destroy_node_data_runner)
+
+    destroy_node_data_runner.target_node.start_scylla_server.assert_called_once_with(verify_up=True, verify_down=False)
+
+
+def test_destroy_data_happy_path(destroy_node_data_runner):
+    """The happy path stops Scylla, removes the SStable group, and restarts Scylla."""
+    destroy_data_and_restart_scylla(destroy_node_data_runner, sstables_to_destroy_perc=100)
+
+    destroy_node_data_runner.target_node.stop_scylla_server.assert_called_once_with(verify_up=False, verify_down=True)
+    destroy_node_data_runner.target_node.remoter.sudo.assert_called_once()
+    destroy_node_data_runner.target_node.start_scylla_server.assert_called_once_with(verify_up=True, verify_down=False)
+
+
+def test_destroy_data_restarts_scylla_on_file_removal_error(destroy_node_data_runner):
+    """Scylla is restarted even when ``rm`` fails and FilesNotCorrupted is raised."""
+    destroy_node_data_runner.target_node.remoter.sudo.return_value = MagicMock(stderr="Permission denied")
+
+    with pytest.raises(FilesNotCorrupted):
+        destroy_data_and_restart_scylla(destroy_node_data_runner, sstables_to_destroy_perc=100)
+
+    destroy_node_data_runner.target_node.start_scylla_server.assert_called_once_with(verify_up=True, verify_down=False)
+
+
+# ---------------------------------------------------------------------------
+# MgmtRestore
+# ---------------------------------------------------------------------------
+
+
+def test_restore_raises_for_unsupported_backend(runner):
+    """MgmtRestore.disrupt() still rejects backends other than AWS / K8S-EKS."""
+    _set_params(runner, use_mgmt=True, cluster_backend="gce")
+
+    with pytest.raises(UnsupportedNemesis, match="only supports 'AWS' and 'K8S-EKS'"):
+        MgmtRestore(runner).disrupt()
+
+
+def test_restore_happy_path_existing_keyspace(restore_snapshot_runner):
+    """The keyspace already exists: restore the data, validate it, then drop the keyspace."""
+    MgmtRestore(restore_snapshot_runner).disrupt()
+
+    mgr_cluster = restore_snapshot_runner.cluster.get_cluster_manager.return_value
+    mgr_cluster.create_restore_task.assert_called_once_with(
+        restore_data=True, location_list=["s3:backup-bucket-us-east-1"], snapshot_tag=_SNAPSHOT_TAG
+    )
+    mgr_cluster.create_restore_task.return_value.wait_and_get_final_status.assert_called_once()
+    restore_snapshot_runner.cluster.restart_scylla.assert_not_called()  # no schema restoration
+    restore_snapshot_runner.tester.run_stress_thread.assert_called_once()
+    restore_snapshot_runner.tester.verify_stress_thread.assert_called_once_with(
+        restore_snapshot_runner.tester.run_stress_thread.return_value
+    )
+    restore_snapshot_runner.target_node.run_cqlsh.assert_called_once_with(f'DROP KEYSPACE IF EXISTS "{_RESTORED_KS}";')
+
+
+def test_restore_happy_path_with_schema_restoration(restore_snapshot_with_schema_runner):
+    """The keyspace is missing and the DC names mismatch: apply the schema CQL with the
+    DC name rewritten, restart the cluster, then restore the data as usual."""
+    MgmtRestore(restore_snapshot_with_schema_runner).disrupt()
+
+    statements = [str(call) for call in restore_snapshot_with_schema_runner.target_node.run_cqlsh.call_args_list]
+    assert any("dc_local" in stmt for stmt in statements), "DC name should be rewritten in the keyspace statement"
+    assert any("CREATE TABLE" in stmt for stmt in statements), "Table creation CQL should be applied"
+    assert any("DROP KEYSPACE" in stmt for stmt in statements), "Restored keyspace should be cleaned up"
+    restore_snapshot_with_schema_runner.cluster.restart_scylla.assert_called_once()
+    mgr_cluster = restore_snapshot_with_schema_runner.cluster.get_cluster_manager.return_value
+    mgr_cluster.create_restore_task.assert_called_once_with(
+        restore_data=True, location_list=["s3:backup-bucket-us-east-1"], snapshot_tag=_SNAPSHOT_TAG
+    )


### PR DESCRIPTION
Task: https://scylladb.atlassian.net/browse/SCT-210

**Extract Scylla Manager nemesis into monkey/manager.py**
Extract Manager-related disrupt_* methods and their Monkey classes into monkey/manager.py. Includes: backup, restore, repair CLI, corrupt-then-repair. Add destroy_data_and_restart_scylla to utils/common_ops.py.

Per [nemesis-extraction.md](https://github.com/scylladb/scylla-cluster-tests/blob/master/docs/plans/nemesis/nemesis-extraction.md) Phase 4 (~385 lines).

The new Manager unit-tests passed ok.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x]  [Manager nemesis refactor test](https://argus.scylladb.com/tests/scylla-cluster-tests/3cb9dfb1-b236-4e31-921e-7818f62409b6)
- [x] Unit test

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
