### PR TITLE
fix(triggers): use scylla- prefix instead of branch- for job folder names

### DIFF
--- a/sdcm/utils/trigger_matrix.py
+++ b/sdcm/utils/trigger_matrix.py
@@ -443,7 +443,7 @@ def determine_job_folder(scylla_version: str, job_folder: str | None = None) -> 
         job_folder: Explicit override — returned as-is if provided.
 
     Returns:
-        Jenkins job folder name (e.g., 'scylla-master', 'branch-2025.4').
+        Jenkins job folder name (e.g., 'scylla-master', 'scylla-2025.4').
 
     Examples:
         >>> determine_job_folder("master:latest")
@@ -451,11 +451,11 @@ def determine_job_folder(scylla_version: str, job_folder: str | None = None) -> 
         >>> determine_job_folder("master")
         'scylla-master'
         >>> determine_job_folder("2025.4")
-        'branch-2025.4'
+        'scylla-2025.4'
         >>> determine_job_folder("2025.4.1")
-        'branch-2025.4'
+        'scylla-2025.4'
         >>> determine_job_folder("2024.2.5-0.20250221.cb9e2a54ae6d-1")
-        'branch-2024.2'
+        'scylla-2024.2'
         >>> determine_job_folder("master:latest", job_folder="my-folder")
         'my-folder'
     """
@@ -471,21 +471,21 @@ def determine_job_folder(scylla_version: str, job_folder: str | None = None) -> 
     branch_match = BRANCH_VERSION_RE.match(scylla_version)
     if branch_match:
         branch = branch_match.group("branch")
-        return "scylla-master" if branch == "master" else f"branch-{branch}"
+        return "scylla-master" if branch == "master" else f"scylla-{branch}"
 
     # Handle full version tags (e.g., "2024.2.5-0.20250221.cb9e2a54ae6d-1")
     full_match = FULL_VERSION_TAG_RE.match(scylla_version)
     if full_match:
         major = full_match.group("major")
         minor = full_match.group("minor")
-        return f"branch-{major}.{minor}"
+        return f"scylla-{major}.{minor}"
 
     # Handle simple version strings (e.g., "2025.4", "2025.4.0")
     simple_match = SIMPLE_VERSION_RE.match(scylla_version)
     if simple_match:
         major = simple_match.group("major")
         minor = simple_match.group("minor")
-        return f"branch-{major}.{minor}"
+        return f"scylla-{major}.{minor}"
 
     # Handle bare "master"
     if scylla_version.strip().lower() == "master":

--- a/unit_tests/trigger_matrix/test_job_folder.py
+++ b/unit_tests/trigger_matrix/test_job_folder.py
@@ -22,11 +22,11 @@ from sdcm.utils.trigger_matrix import TriggerMatrixError, determine_job_folder, 
         pytest.param("master:latest", "scylla-master", id="master_latest"),
         pytest.param("master:all", "scylla-master", id="master_all"),
         pytest.param("master", "scylla-master", id="bare_master"),
-        pytest.param("2025.4", "branch-2025.4", id="two_part_version"),
-        pytest.param("2025.4.0", "branch-2025.4", id="three_part_version"),
-        pytest.param("5.2.1", "branch-5.2", id="oss_version"),
-        pytest.param("2024.2.5-0.20250221.cb9e2a54ae6d-1", "branch-2024.2", id="full_tag"),
-        pytest.param("2025.1.3-0.20260101.abcdef1234-1", "branch-2025.1", id="full_tag_2025"),
+        pytest.param("2025.4", "scylla-2025.4", id="two_part_version"),
+        pytest.param("2025.4.0", "scylla-2025.4", id="three_part_version"),
+        pytest.param("5.2.1", "scylla-5.2", id="oss_version"),
+        pytest.param("2024.2.5-0.20250221.cb9e2a54ae6d-1", "scylla-2024.2", id="full_tag"),
+        pytest.param("2025.1.3-0.20260101.abcdef1234-1", "scylla-2025.1", id="full_tag_2025"),
     ],
 )
 def test_version_to_folder(version, expected):
@@ -38,7 +38,7 @@ def test_explicit_override():
 
 
 def test_branch_qualifier():
-    assert determine_job_folder("branch-2019.1:all") == "branch-branch-2019.1"
+    assert determine_job_folder("branch-2019.1:all") == "scylla-branch-2019.1"
 
 
 def test_invalid_version_raises():


### PR DESCRIPTION
## Problem

`determine_job_folder()` in trigger-matrix generates `branch-X.Y` folder names, but Jenkins job folders have been renamed to `scylla-X.Y`. This causes all trigger-matrix runs to fail with:

```
ERROR: Job not found: branch-2026.3/tier1/gemini-1tb-10h-test
```

**Failed build**: https://jenkins.scylladb.com/job/scylla-master/job/sct_triggers/job/tier1-custom-time-trigger/28/console

## Fix

Replace `branch-` prefix with `scylla-` in all three code paths of `determine_job_folder()`:
- branch:qualifier format (e.g. `branch-2025.4:latest`)
- full version tags (e.g. `2024.2.5-0.20250221.cb9e2a54ae6d-1`)
- simple versions (e.g. `2025.4`, `2025.4.0`)

Unit test expectations updated accordingly.

## Backends Affected
None — this is trigger infrastructure only.