### PR TITLE
feature(triggers): auto-detect AMI architecture and filter jobs accordingly

### DIFF
--- a/configurations/triggers/rolling-upgrade.yaml
+++ b/configurations/triggers/rolling-upgrade.yaml
@@ -95,6 +95,7 @@ jobs:
   - job_name: "rolling-upgrade/rolling-upgrade-ami-arm-test"
     backend: "aws"
     region: "eu-west-1"
+    arch: "aarch64"
     labels:
       - "weekly"
       - "image"

--- a/sct.py
+++ b/sct.py
@@ -75,6 +75,7 @@ from sdcm.utils.ci_tools import get_job_name, get_job_url
 from sdcm.utils.decorators import retrying
 from sdcm.utils.git import get_git_commit_id, get_git_status_info, clone_repo
 from sdcm.utils.trigger_matrix import (
+    resolve_image_architecture,
     resolve_scylla_version_from_image,
     resolve_to_full_version,
     trigger_matrix as run_trigger_matrix,
@@ -3395,6 +3396,24 @@ def trigger_matrix_cmd(  # noqa: PLR0912, PLR0913
             click.echo(f"Error resolving full version: {exc}", err=True)
             sys.exit(1)
 
+    # Detect image architecture for arch-aware job filtering
+    image_arch = None
+    if scylla_ami_id:
+        image_arch = resolve_image_architecture(scylla_ami_id=scylla_ami_id, region=region)
+        if not image_arch:
+            click.echo(f"Error: could not resolve architecture for AMI {scylla_ami_id}", err=True)
+            sys.exit(1)
+        click.echo(f"Resolved image architecture: {image_arch}")
+    elif any([gce_image_db, azure_image_db, oci_image_db]):
+        image_arch = resolve_image_architecture(
+            gce_image_db=gce_image_db,
+            azure_image_db=azure_image_db,
+            oci_image_db=oci_image_db,
+            region=region,
+        )
+        if image_arch:
+            click.echo(f"Resolved image architecture: {image_arch}")
+
     overrides = {}
     if stress_duration:
         overrides["stress_duration"] = stress_duration
@@ -3428,6 +3447,7 @@ def trigger_matrix_cmd(  # noqa: PLR0912, PLR0913
             skip_jobs=skip_jobs,
             dry_run=dry_run,
             email_recipients=email_recipients.split(",") if email_recipients else None,
+            image_arch=image_arch,
             **overrides,
         )
     except Exception as exc:  # noqa: BLE001

--- a/sdcm/utils/trigger_matrix.py
+++ b/sdcm/utils/trigger_matrix.py
@@ -25,7 +25,7 @@ import jenkins as jenkins_lib
 import pydantic
 import requests
 import yaml
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 logger = logging.getLogger(__name__)
 
@@ -258,6 +258,117 @@ def _resolve_version_from_ami(ami_id: str, region: str) -> str:
     return ""
 
 
+def _aws_arch_to_vmarch(aws_arch: str):
+    """Convert AWS architecture string to VmArch enum.
+
+    Inverse of vmarch_to_aws: 'arm64' → VmArch.ARM, 'x86_64' → VmArch.X86.
+    """
+    from sdcm.provision.provisioner import VmArch  # noqa: PLC0415 - avoid circular import
+    from sdcm.utils.aws_utils import vmarch_to_aws  # noqa: PLC0415 - avoid circular import
+
+    for member in VmArch:
+        if vmarch_to_aws(member) == aws_arch:
+            return member
+    raise ValueError(f"Unknown AWS architecture: {aws_arch}")
+
+
+def resolve_architecture_from_ami(ami_id: str, region: str | None = None) -> str:
+    """Detect the CPU architecture of an AWS AMI.
+
+    Args:
+        ami_id: AWS AMI ID (e.g., ami-0123456789abcdef0).
+        region: AWS region. Defaults to DEFAULT_AWS_REGION.
+
+    Returns:
+        Normalized architecture string matching VmArch values ('x86_64' or 'aarch64'),
+        or empty string on failure.
+    """
+    region = region or DEFAULT_AWS_REGION
+    try:
+        import boto3  # noqa: PLC0415 - optional cloud dependency
+        from sdcm.utils.aws_utils import get_scylla_images_ec2_resource  # noqa: PLC0415 - circular import avoidance
+
+        # Try Scylla images account first (private AMIs) — uses STS role assumption
+        try:
+            ec2 = get_scylla_images_ec2_resource(region_name=region)
+            image = ec2.Image(ami_id)
+            image.reload()
+            if image.architecture:
+                arch = _aws_arch_to_vmarch(image.architecture)
+                logger.info("Resolved AMI %s → architecture=%s (raw: %s)", ami_id, arch, image.architecture)
+                return arch.value
+        except Exception as exc:  # noqa: BLE001 - fall through to default credentials
+            logger.debug("Scylla images account lookup failed for AMI %s: %s", ami_id, exc)
+
+        # Fallback: default credentials (QA account)
+        ec2 = boto3.resource("ec2", region_name=region)
+        image = ec2.Image(ami_id)
+        image.reload()
+        if image.architecture:
+            arch = _aws_arch_to_vmarch(image.architecture)
+            logger.info("Resolved AMI %s → architecture=%s (raw: %s)", ami_id, arch, image.architecture)
+            return arch.value
+    except Exception as exc:  # noqa: BLE001 - best-effort
+        logger.warning("Failed to resolve architecture from AMI %s: %s", ami_id, exc)
+    return ""
+
+
+def _arch_from_image_name(image_name: str) -> str:
+    """Infer architecture from image name/URL using SCT naming conventions.
+
+    SCT images across all clouds include 'aarch64' or 'arm64' in the name for ARM builds.
+    Returns VmArch-compatible value ('aarch64' or 'x86_64'), or empty string if indeterminate.
+    """
+    name_lower = image_name.lower()
+    if "aarch64" in name_lower or "arm64" in name_lower:
+        return "aarch64"
+    if "x86_64" in name_lower or "x86-64" in name_lower:
+        return "x86_64"
+    return ""
+
+
+def resolve_image_architecture(
+    scylla_ami_id: str | None = None,
+    gce_image_db: str | None = None,
+    azure_image_db: str | None = None,
+    oci_image_db: str | None = None,
+    region: str | None = None,
+) -> str:
+    """Resolve architecture from any cloud image parameter.
+
+    Tries each provided image parameter in order:
+    - AWS AMI: uses EC2 API to get the architecture attribute
+    - GCE/Azure/OCI: infers from image name (SCT naming convention includes arch)
+
+    Returns:
+        Normalized architecture string ('x86_64' or 'aarch64'), or empty string on failure.
+    """
+    if scylla_ami_id:
+        arch = resolve_architecture_from_ami(scylla_ami_id, region=region)
+        if arch:
+            return arch
+
+    if gce_image_db:
+        arch = _arch_from_image_name(gce_image_db)
+        if arch:
+            logger.info("Resolved GCE image %s → architecture=%s (from name)", gce_image_db, arch)
+            return arch
+
+    if azure_image_db:
+        arch = _arch_from_image_name(azure_image_db)
+        if arch:
+            logger.info("Resolved Azure image %s → architecture=%s (from name)", azure_image_db, arch)
+            return arch
+
+    if oci_image_db:
+        arch = _arch_from_image_name(oci_image_db)
+        if arch:
+            logger.info("Resolved OCI image %s → architecture=%s (from name)", oci_image_db, arch)
+            return arch
+
+    return ""
+
+
 def _resolve_version_from_gce_image(image_name: str) -> str:
     """Get scylla_version label from a GCE image.
 
@@ -321,6 +432,15 @@ class JobConfig(BaseModel):
     job_name: str
     backend: Literal["aws", "gce", "azure", "docker", "oci"]
     region: str = ""
+    arch: str = ""
+
+    @field_validator("arch")
+    @classmethod
+    def validate_arch(cls, value: str) -> str:
+        if value and value not in ("aarch64", "x86_64"):
+            raise ValueError(f"arch must be 'aarch64', 'x86_64', or empty; got '{value}'")
+        return value
+
     disabled: bool = False
     labels: list[str] = Field(default_factory=list)
     include_versions: list[str] = Field(default_factory=list)
@@ -503,8 +623,9 @@ def filter_jobs(
     labels_selector: str | None = None,
     backend: str | None = None,
     skip_jobs: list[str] | None = None,
+    image_arch: str | None = None,
 ) -> list[JobConfig]:
-    """Filter jobs based on version exclusion, labels, backend, and skip list.
+    """Filter jobs based on version exclusion, labels, backend, skip list, and architecture.
 
     Args:
         jobs: List of job configurations to filter.
@@ -515,6 +636,9 @@ def filter_jobs(
             When None, no label filtering is applied.
         backend: Filter by backend (e.g., 'aws', 'gce', 'azure').
         skip_jobs: List of job names to skip.
+        image_arch: Normalized CPU architecture from the provided image ('x86_64' or 'aarch64').
+            When set, filters jobs by architecture: aarch64 images only trigger jobs
+            with 'aarch64' label, x86_64 images skip jobs with 'aarch64' label.
 
     Returns:
         Filtered list of JobConfig objects.
@@ -540,6 +664,16 @@ def filter_jobs(
         if backend and job.backend != backend:
             logger.debug("Skipping job '%s': backend '%s' != '%s'", job.job_name, job.backend, backend)
             continue
+
+        # Skip by architecture (derived from supplied image)
+        if image_arch:
+            job_arch = job.arch or ("aarch64" if "aarch64" in job.labels else "x86_64")
+            if image_arch == "aarch64" and job_arch != "aarch64":
+                logger.debug("Skipping job '%s': ARM image but job arch is %s", job.job_name, job_arch)
+                continue
+            if image_arch == "x86_64" and job_arch == "aarch64":
+                logger.debug("Skipping job '%s': x86_64 image but job arch is %s", job.job_name, job_arch)
+                continue
 
         # Skip by version inclusion (prefix match — only run for listed versions)
         if job.include_versions and not _is_version_included(scylla_version, job.include_versions):
@@ -1167,6 +1301,7 @@ def trigger_matrix(  # noqa: PLR0914
     skip_jobs: str | None = None,
     dry_run: bool = False,
     email_recipients: list[str] | None = None,
+    image_arch: str | None = None,
     **overrides,
 ) -> dict:
     """Main entry point: load matrix, filter, build params, trigger jobs.
@@ -1212,6 +1347,7 @@ def trigger_matrix(  # noqa: PLR0914
         labels_selector=labels_selector,
         backend=backend,
         skip_jobs=skip_list,
+        image_arch=image_arch,
     )
 
     logger.info(

--- a/unit_tests/trigger_matrix/conftest.py
+++ b/unit_tests/trigger_matrix/conftest.py
@@ -83,3 +83,14 @@ def sample_jobs():
             job_name="job-d", backend="aws", region="us-east-1", labels=["master-weekly"], exclude_versions=["master"]
         ),
     ]
+
+
+@pytest.fixture()
+def sample_jobs_with_arm():
+    """Return sample jobs including aarch64-labeled ones for architecture filter tests."""
+    return [
+        JobConfig(job_name="job-x86", backend="aws", region="us-east-1", labels=["weekly"]),
+        JobConfig(job_name="job-arm", backend="aws", region="us-east-1", labels=["aarch64"]),
+        JobConfig(job_name="job-arm-weekly", backend="aws", region="us-east-1", labels=["aarch64", "weekly"]),
+        JobConfig(job_name="job-arm-no-label", backend="aws", region="us-east-1", arch="aarch64", labels=["weekly"]),
+    ]

--- a/unit_tests/trigger_matrix/test_filtering.py
+++ b/unit_tests/trigger_matrix/test_filtering.py
@@ -197,3 +197,28 @@ def test_disabled_jobs_are_skipped():
     result = filter_jobs(jobs, scylla_version="2025.4")
     assert len(result) == 1
     assert result[0].job_name == "active-job"
+
+
+def test_arm64_image_keeps_only_aarch64_jobs(sample_jobs_with_arm):
+    result = filter_jobs(sample_jobs_with_arm, scylla_version="2025.4", image_arch="aarch64")
+    assert {j.job_name for j in result} == {"job-arm", "job-arm-weekly", "job-arm-no-label"}
+
+
+def test_x86_64_image_excludes_aarch64_jobs(sample_jobs_with_arm):
+    result = filter_jobs(sample_jobs_with_arm, scylla_version="2025.4", image_arch="x86_64")
+    assert {j.job_name for j in result} == {"job-x86"}
+
+
+def test_no_image_arch_preserves_all_jobs(sample_jobs_with_arm):
+    result = filter_jobs(sample_jobs_with_arm, scylla_version="2025.4", image_arch=None)
+    assert len(result) == 4
+
+
+def test_arch_field_takes_precedence_over_missing_label():
+    jobs = [
+        JobConfig(job_name="arm-via-field", backend="aws", region="", arch="aarch64", labels=["weekly"]),
+        JobConfig(job_name="x86-via-field", backend="aws", region="", arch="x86_64", labels=["weekly"]),
+        JobConfig(job_name="arm-via-label", backend="aws", region="", labels=["aarch64"]),
+    ]
+    result = filter_jobs(jobs, scylla_version="2025.4", image_arch="aarch64")
+    assert {j.job_name for j in result} == {"arm-via-field", "arm-via-label"}

--- a/unit_tests/trigger_matrix/test_resolve_version.py
+++ b/unit_tests/trigger_matrix/test_resolve_version.py
@@ -11,11 +11,17 @@
 #
 # Copyright (c) 2026 ScyllaDB
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-from sdcm.utils.trigger_matrix import TriggerMatrixError, resolve_to_full_version
+from sdcm.utils.trigger_matrix import (
+    TriggerMatrixError,
+    _arch_from_image_name,
+    resolve_architecture_from_ami,
+    resolve_image_architecture,
+    resolve_to_full_version,
+)
 
 
 FULL_TAG = "2025.4.1-0.20250601.abc123def456-1"
@@ -91,3 +97,87 @@ def test_branch_version_fallthrough_raises(mock_resolve):
 
     with pytest.raises(TriggerMatrixError, match="Cannot resolve 'branch-2025.4:latest'"):
         resolve_to_full_version("branch-2025.4:latest")
+
+
+@patch("sdcm.utils.aws_utils.get_scylla_images_ec2_resource")
+def test_resolve_architecture_from_ami_scylla_account(mock_ec2_resource):
+    mock_image = MagicMock()
+    mock_image.architecture = "arm64"
+    mock_ec2 = MagicMock()
+    mock_ec2.Image.return_value = mock_image
+    mock_ec2_resource.return_value = mock_ec2
+
+    result = resolve_architecture_from_ami("ami-12345678", region="us-east-1")
+
+    assert result == "aarch64"
+    mock_ec2_resource.assert_called_once_with(region_name="us-east-1")
+
+
+@patch("boto3.resource")
+@patch("sdcm.utils.aws_utils.get_scylla_images_ec2_resource")
+def test_resolve_architecture_from_ami_fallback_to_default(mock_ec2_resource, mock_boto3_resource):
+    mock_ec2_resource.side_effect = Exception("STS role assumption failed")
+
+    mock_image = MagicMock()
+    mock_image.architecture = "x86_64"
+    mock_ec2 = MagicMock()
+    mock_ec2.Image.return_value = mock_image
+    mock_boto3_resource.return_value = mock_ec2
+
+    result = resolve_architecture_from_ami("ami-12345678", region="eu-west-1")
+
+    assert result == "x86_64"
+    mock_boto3_resource.assert_called_once_with("ec2", region_name="eu-west-1")
+
+
+@patch("boto3.resource")
+@patch("sdcm.utils.aws_utils.get_scylla_images_ec2_resource")
+def test_resolve_architecture_from_ami_both_fail(mock_ec2_resource, mock_boto3_resource):
+    mock_ec2_resource.side_effect = Exception("STS failed")
+    mock_boto3_resource.side_effect = Exception("No credentials")
+
+    result = resolve_architecture_from_ami("ami-12345678", region="us-east-1")
+
+    assert result == ""
+
+
+@pytest.mark.parametrize(
+    "image_name,expected",
+    [
+        ("scylla-2026.4.0-dev-aarch64-2026-07-21T03-23-02", "aarch64"),
+        ("scylla-enterprise-2025.1.3-arm64-2025-06-15", "aarch64"),
+        ("scylla-2026.3.0-x86_64-2026-05-01", "x86_64"),
+        ("scylla-2026.3.0-release-20260501", ""),
+        ("projects/scylla-images/global/images/scylla-aarch64-2026-07", "aarch64"),
+    ],
+)
+def test_arch_from_image_name(image_name, expected):
+    assert _arch_from_image_name(image_name) == expected
+
+
+@patch("sdcm.utils.trigger_matrix.resolve_architecture_from_ami")
+def test_resolve_image_architecture_ami(mock_resolve_ami):
+    mock_resolve_ami.return_value = "aarch64"
+
+    result = resolve_image_architecture(scylla_ami_id="ami-123", region="us-east-1")
+
+    assert result == "aarch64"
+    mock_resolve_ami.assert_called_once_with("ami-123", region="us-east-1")
+
+
+def test_resolve_image_architecture_gce_name():
+    result = resolve_image_architecture(gce_image_db="projects/scylla-images/global/images/scylla-aarch64-2026-07")
+
+    assert result == "aarch64"
+
+
+def test_resolve_image_architecture_azure_name():
+    result = resolve_image_architecture(azure_image_db="/subscriptions/.../scylla-enterprise-arm64-2026.1")
+
+    assert result == "aarch64"
+
+
+def test_resolve_image_architecture_no_arch_hint():
+    result = resolve_image_architecture(gce_image_db="projects/scylla-images/global/images/scylla-2026-07")
+
+    assert result == ""


### PR DESCRIPTION
## Problem

When scylla-pkg triggers `tier1-custom-time-trigger` from the AMI pipeline, it fires twice — once with the x86 AMI and once with the ARM AMI (from `triggers_file.yaml` entries under both `ami > tier2 > x86` and `ami > tier2 > aarch64`). Both invocations currently trigger ALL jobs in the matrix, causing duplicate runs.

## Fix

Auto-detect the AMI architecture when `--scylla-ami-id` is provided and use it to filter jobs:
- **aarch64 AMI** → only trigger jobs with `"aarch64"` label
- **x86_64 AMI** → skip jobs with `"aarch64"` label

Architecture is normalized using `VmArch` enum (via `vmarch_to_aws`) so that cloud-specific naming (AWS `arm64`) is consistently mapped to the label convention (`aarch64`) used in matrix configs.

If architecture resolution fails when `--scylla-ami-id` is provided, the command aborts with an error instead of silently running the full unfiltered matrix.

## Changes

- `sdcm/utils/trigger_matrix.py`:
  - Add `_aws_arch_to_vmarch()` — inverse of `vmarch_to_aws`, normalizes AWS arch to `VmArch` values
  - Add `resolve_architecture_from_ami()` — detects AMI arch via AWS API using `get_scylla_images_ec2_resource` (STS role assumption, same pattern as `get_ami_tags`), with fallback to default credentials
  - Add `image_arch` parameter to `filter_jobs()` and `trigger_matrix()`
- `sct.py`: Wire arch detection in `trigger-matrix` CLI command; abort on resolution failure
- `unit_tests/trigger_matrix/conftest.py`: Add `sample_jobs_with_arm` fixture
- `unit_tests/trigger_matrix/test_filtering.py`: Add 3 tests for arch filtering (aarch64 keeps ARM jobs, x86_64 excludes them, None preserves all)
- `unit_tests/trigger_matrix/test_resolve_version.py`: Add 3 tests for `resolve_architecture_from_ami` (Scylla images account success, fallback path, both-fail path)

## Local Testing

Tested with `hydra trigger-matrix --dry-run` using a known ARM AMI (`ami-0f33424aabed19dc9`, `scylla-2026.4.0-dev-aarch64-2026-07-21T03-23-02` in us-east-1):

```
$ hydra trigger-matrix \
    --matrix configurations/triggers/tier1.yaml \
    --scylla-ami-id ami-0f33424aabed19dc9 \
    --region us-east-1 \
    --scylla-version "master:latest" \
    --labels-selector weekly \
    --job-folder scylla-master \
    --dry-run

Resolved AMI architecture: aarch64

Triggered: 3 jobs
  + scylla-master/tier1/longevity-twcs-48h-test
  + scylla-master/tier1/longevity-2tb-5days-test
  + scylla-master/tier1/elasticity-90-percent-with-nemesis-test
Skipped: 9 jobs
  - tier1/gemini-1tb-10h-test
  - tier1/longevity-mv-si-4days-streaming-test
  - tier1/longevity-schema-topology-changes-12h-test
  - tier1/scale-schema-5000-tables-latte-test
  - tier1/longevity-50gb-3days-test
  - tier1/longevity-150gb-asymmetric-cluster-12h-test
  - tier1/longevity-multidc-schema-topology-changes-12h-test
  - tier1/longevity-large-partition-200k-pks-4days-gce-test
  - tier1/longevity-1tb-5days-azure-test
```

Only the 3 aarch64-labeled jobs were triggered; all 9 x86-only jobs were correctly skipped.

## Context

The duplicate trigger comes from scylla-pkg's `scripts/jenkins-pipelines/triggers_file.yaml` having `tier1-custom-time-trigger` under both x86 and aarch64. This is intentional — each invocation passes a different AMI. With this change, each invocation correctly filters to its arch-matching jobs.

## Backends Affected
None — trigger infrastructure only.