### PR TITLE
fix(trigger-matrix): handle RC version format in job folder resolution

### DIFF
--- a/sdcm/utils/trigger_matrix.py
+++ b/sdcm/utils/trigger_matrix.py
@@ -72,9 +72,11 @@ def _get_jenkins_client() -> tuple[jenkins_lib.Jenkins, str]:
 # Regex for full version tags like:
 #   2024.2.5-0.20250221.cb9e2a54ae6d-1 (release)
 #   2026.2.0~dev-0.20260322.f51126483167 (dev/nightly)
+#   2026.3.0.rc0.0.20260719.a64da1e635f3 (release candidate)
 FULL_VERSION_TAG_RE = re.compile(
     r"^(?P<major>\d{4})\.(?P<minor>\d+)\.(?P<patch>\d+)"
-    r"[~-][a-zA-Z0-9._~]+-?\d*\.\d{8}\.[0-9a-f]+(?:-\d+)?$"
+    r"(?:[~-][a-zA-Z0-9._~]+-?\d*\.\d{8}\.[0-9a-f]+(?:-\d+)?"
+    r"|\.rc\d+\.\d+\.\d{8}\.[0-9a-f]+(?:\.\d+)?)$"
 )
 
 # Regex for release version strings like: 2026.1.8, 2025.4.1 (three-part, specific release)

--- a/unit_tests/trigger_matrix/test_job_folder.py
+++ b/unit_tests/trigger_matrix/test_job_folder.py
@@ -27,6 +27,11 @@ from sdcm.utils.trigger_matrix import TriggerMatrixError, determine_job_folder, 
         pytest.param("5.2.1", "scylla-5.2", id="oss_version"),
         pytest.param("2024.2.5-0.20250221.cb9e2a54ae6d-1", "scylla-2024.2", id="full_tag"),
         pytest.param("2025.1.3-0.20260101.abcdef1234-1", "scylla-2025.1", id="full_tag_2025"),
+        pytest.param("2026.3.0.rc0.0.20260719.a64da1e635f3", "scylla-2026.3", id="rc_dot_separator"),
+        pytest.param("2026.3.0~rc0.0.20260719.a64da1e635f3", "scylla-2026.3", id="rc_tilde_separator"),
+        pytest.param("2026.3.0-rc0.0.20260719.a64da1e635f3", "scylla-2026.3", id="rc_dash_separator"),
+        pytest.param("2026.1.0.rc1.0.20260501.abcdef123456", "scylla-2026.1", id="rc1_dot_separator"),
+        pytest.param("2024.1.0.rc2.0.20231218.a063c2c16185.1", "scylla-2024.1", id="rc_with_revision"),
     ],
 )
 def test_version_to_folder(version, expected):


### PR DESCRIPTION
## Problem

The `trigger-matrix` command fails when the resolved version from a GCE image is a release candidate with dot separators:

```
Error: Cannot determine job folder from version '2026.3.0.rc0.0.20260719.a64da1e635f3'. Provide an explicit --job-folder.
```

Observed in: https://jenkins.scylladb.com/job/scylla-master/job/sct_triggers/job/tier1-custom-time-trigger/30/console

## Root Cause

`FULL_VERSION_TAG_RE` only accepted `~` or `-` as separators after the patch number. The RC version format uses `.` as separator (`2026.3.0.rc0.0.20260719.a64da1e635f3`), which didn't match any of the patterns.

## Fix

Added an alternation to `FULL_VERSION_TAG_RE` to also accept the `.rcN.BUILD.DATE.HASH` format:

| Format | Separator | Status |
|--------|-----------|--------|
| `2026.3.0.rc0.0.20260719.a64da1e635f3` | `.` (dot) | **Fixed** |
| `2026.3.0~rc0.0.20260719.a64da1e635f3` | `~` (tilde) | Already worked |
| `2026.3.0-rc0.0.20260719.a64da1e635f3` | `-` (dash) | Already worked |

## Testing

Added parametrized test cases for all three RC separator variants. All 19 tests pass.