### PR TITLE
fix(triggers): exclude 2026.2 from longevity-2tb-5days-test trigger

### DIFF
--- a/configurations/triggers/tier1.yaml
+++ b/configurations/triggers/tier1.yaml
@@ -40,13 +40,6 @@ jobs:
       - "weekly"
     exclude_versions: ["2024.1", "2025.1", "2025.4", "2026.1"]
 
-  - job_name: "tier1/longevity-2tb-5days-test"
-    backend: "aws"
-    region: "eu-west-1"
-    labels:
-      - "weekly"
-    exclude_versions: ["2024.1", "2025.1", "2025.4", "2026.1"]
-
   - job_name: "tier1/longevity-mv-si-4days-streaming-test"
     backend: "aws"
     region: "eu-west-1"
@@ -116,7 +109,7 @@ jobs:
     labels:
       - "weekly"
       - "aarch64"
-    exclude_versions: ["2024.1", "2025.1", "2025.4", "2026.1"]
+    exclude_versions: ["2024.1", "2025.1", "2025.4", "2026.1", "2026.2"]
 
   - job_name: "tier1/elasticity-90-percent-with-nemesis-test"
     backend: "aws"


### PR DESCRIPTION
branch-2026.2 does not have `longevity-2tb-5days.jenkinsfile` (it still uses `longevity-1tb-5days-azure`). The tier1 trigger matrix was missing `"2026.2"` in `exclude_versions` for both x86 and aarch64 entries of `longevity-2tb-5days-test`, causing pipeline validation to fail:

```
Failed: 2 jobs
  ! scylla-2026.2/tier1/longevity-2tb-5days-test
  ! scylla-2026.2/tier1/longevity-2tb-5days-test
```

**Fix:** Add `"2026.2"` to `exclude_versions` for both `longevity-2tb-5days-test` entries (x86 and aarch64) in `configurations/triggers/tier1.yaml`.