### PR TITLE
fix(adaptive_timeouts): add contention factor to tablets decommission timeouts

### DIFF
--- a/sdcm/utils/adaptive_timeouts/__init__.py
+++ b/sdcm/utils/adaptive_timeouts/__init__.py
@@ -33,6 +33,9 @@ def _get_operation_timeout_factor(params, operation: "Operations") -> float:
 TABLETS_SOFT_TIMEOUT = 1 * 60 * 60
 TABLETS_HARD_TIMEOUT = 3 * 60 * 60
 _STREAMING_OVERHEAD = 600  # add 10 minutes overhead for operations other than streaming
+# Extra headroom to account for reduced effective throughput under concurrent foreground load.
+# See: https://scylladb.atlassian.net/browse/SCT-681
+TIMEOUT_CONTENTION_FACTOR = 1.3
 
 
 def _get_decommission_timeout(
@@ -45,8 +48,8 @@ def _get_decommission_timeout(
         if tablets_enabled:
             node_info["tablets_enabled"] = True
             estimated = int(node_info_service.node_data_size_mb / node_info_service.expected_throughput)
-            soft_timeout = estimated * 2 + _STREAMING_OVERHEAD
-            hard_timeout = estimated * 4 + _STREAMING_OVERHEAD
+            soft_timeout = int((estimated * 2 + _STREAMING_OVERHEAD) * TIMEOUT_CONTENTION_FACTOR)
+            hard_timeout = int((estimated * 4 + _STREAMING_OVERHEAD) * TIMEOUT_CONTENTION_FACTOR)
             return (soft_timeout, hard_timeout), node_info
         else:
             # For non-tablet cases, calculate based on data size

--- a/unit_tests/unit/test_adaptive_timeouts.py
+++ b/unit_tests/unit/test_adaptive_timeouts.py
@@ -35,6 +35,7 @@ from sdcm.utils.adaptive_timeouts import (
     Operations,
     adaptive_timeout,
     TABLETS_HARD_TIMEOUT,
+    TIMEOUT_CONTENTION_FACTOR,
 )
 from unit_tests.lib.fake_cluster import DummyDbCluster
 
@@ -209,16 +210,54 @@ def test_tablets_decommission_timeout_is_calculated_from_data_size(
         operation=Operations.DECOMMISSION, node=fake_node, stats_storage=adaptive_timeout_store
     ) as timeout:
         # node_data_size_mb=102400, expected_throughput=69/2*3=103.5 → estimated≈989.4s
-        # hard = int(estimated) * 4 + 600 (10-minute overhead) = 4556
+        # hard = int((estimated * 4 + 600) * 1.3 contention factor)
         throughput = _I4I_LARGE_BASELINE_THROUGHPUT_MB_PER_SEC / _I4I_LARGE_SHARD_COUNT * 3
         estimated = int(102400 / throughput)
-        expected_hard = estimated * 4 + _STREAMING_OVERHEAD
+        expected_hard = int((estimated * 4 + _STREAMING_OVERHEAD) * TIMEOUT_CONTENTION_FACTOR)
         assert timeout == expected_hard
 
     soft_timeout_mock.assert_not_called()
     hard_timeout_mock.assert_not_called()
     metrics = adaptive_timeout_store.get(operation=Operations.DECOMMISSION.name)
     assert metrics[0].get("tablets_enabled") is True
+
+
+@mock.patch("sdcm.sct_events.system.SoftTimeoutEvent.publish_or_dump")
+@mock.patch("sdcm.sct_events.system.HardTimeoutEvent.publish_or_dump")
+def test_tablets_decommission_timeout_applies_contention_factor(
+    hard_timeout_mock, soft_timeout_mock, fake_node, adaptive_timeout_store, mock_tablets_feature
+):
+    """The soft and hard timeouts both include a contention factor to account for reduced
+    effective throughput under concurrent foreground load. Applying the same factor to both
+    keeps the hard timeout above the soft timeout at any data size.
+    See: https://scylladb.atlassian.net/browse/SCT-681
+    """
+    mock_tablets_feature.return_value = True
+    # Mock small data size (~3GB) to simulate a freshly bootstrapped node (SCT-681 scenario)
+    with mock.patch("sdcm.utils.adaptive_timeouts.TimeoutMonitor") as timeout_monitor_mock:
+        with mock.patch.object(
+            NodeLoadInfoService, "node_data_size_mb", new_callable=mock.PropertyMock, return_value=3000
+        ):
+            with adaptive_timeout(
+                operation=Operations.DECOMMISSION, node=fake_node, stats_storage=adaptive_timeout_store
+            ) as timeout:
+                # node_data_size_mb=3000, expected_throughput=69/2*3=103.5 → estimated≈28
+                throughput = _I4I_LARGE_BASELINE_THROUGHPUT_MB_PER_SEC / _I4I_LARGE_SHARD_COUNT * 3
+                estimated = int(3000 / throughput)
+                expected_soft = int((estimated * 2 + _STREAMING_OVERHEAD) * TIMEOUT_CONTENTION_FACTOR)
+                expected_hard = int((estimated * 4 + _STREAMING_OVERHEAD) * TIMEOUT_CONTENTION_FACTOR)
+                assert timeout == expected_hard
+                assert expected_hard > expected_soft
+        # Verify TimeoutMonitor receives both contention-factored soft and hard values
+        timeout_monitor_mock.assert_called_once_with(
+            Operations.DECOMMISSION.name,
+            expected_soft,
+            expected_hard,
+            start_time=mock.ANY,
+        )
+
+    soft_timeout_mock.assert_not_called()
+    hard_timeout_mock.assert_not_called()
 
 
 @mock.patch("sdcm.sct_events.system.SoftTimeoutEvent.publish_or_dump")


### PR DESCRIPTION
Apply a 1.3x contention factor (TIMEOUT_CONTENTION_FACTOR) to both the soft and
hard decommission timeouts to account for reduced effective streaming throughput
under concurrent foreground load.

Under heavy load (e.g. multiple large-partition loaders driving near-100% reactor
utilization), the formula-based hard timeout (estimated * 4 + 600s overhead) was
too tight: for a freshly bootstrapped node with ~3GB of data it produced ~716s,
while the operation actually took 720.8s, failing the test with a CRITICAL
HardTimeoutEvent.

Applying the same factor to both soft and hard keeps the hard timeout above the
soft timeout at any data size, and the config multiplier still scales both
symmetrically.


Fixes: SCT-681

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- https://jenkins.scylladb.com/job/scylla-master/job/reproducers/job/longevity-large-partition-200k-pks-4days-gce-extend-timeout/2/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
