### PR TITLE
fix(oci): shorten user_prefix for OCI to fit X.509 CN 64-char limit

### DIFF
--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -3151,6 +3151,9 @@ class SCTConfiguration(BaseModel):
         if self.get("cluster_backend") == "azure":
             # for Azure need to shorten it more due longer region names
             prefix_max_len -= 2
+        if self.get("cluster_backend") == "oci":
+            # OCI node names include region (up to 14 chars) and must fit X.509 CN 64-char limit
+            prefix_max_len -= 10
         if (self.get("simulated_regions") or 0) > 1:
             # another shortening for simulated regions due added simulated dc suffix
             prefix_max_len -= 3

--- a/unit_tests/integration/test_config.py
+++ b/unit_tests/integration/test_config.py
@@ -75,6 +75,24 @@ def test_10_longevity(monkeypatch):
 
 
 @pytest.mark.integration
+def test_10_oci_user_prefix_fits_x509_cn_limit(monkeypatch):
+    """OCI node names include region; user_prefix must be short enough for the full name to fit X.509 CN 64-char limit."""
+    user_prefix = "longevity-5gb-1h-ToggleAuditRulesNemesisSyslog"
+    monkeypatch.setenv("SCT_CLUSTER_BACKEND", "oci")
+    monkeypatch.setenv("SCT_CONFIG_FILES", "unit_tests/test_configs/minimal_test_case.yaml")
+    monkeypatch.setenv("SCT_USER_PREFIX", user_prefix)
+    monkeypatch.setenv("SCT_OCI_IMAGE_DB", "ocid1.image.oc1.iad.fake")
+    monkeypatch.setenv("SCT_OCI_IMAGE_USERNAME", "ubuntu")
+    monkeypatch.setenv("SCT_OCI_INSTANCE_TYPE_DB", "VM.DenseIO.E5.Flex:8")
+    monkeypatch.setenv("SCT_OCI_INSTANCE_TYPE_LOADER", "VM.Standard.E4.Flex:2")
+    monkeypatch.setenv("SCT_OCI_INSTANCE_TYPE_MONITOR", "VM.Standard.E4.Flex:2")
+    monkeypatch.setenv("SCT_OCI_REGION_NAME", "eu-frankfurt-1")
+    conf = sct_config.SCTConfiguration()
+    conf.verify_configuration()
+    assert conf.user_prefix == user_prefix[:25]  # 35 - 10
+
+
+@pytest.mark.integration
 def test_10_mananger_regression(monkeypatch):
     monkeypatch.setenv("SCT_CLUSTER_BACKEND", "aws")
     monkeypatch.setenv("SCT_AMI_ID_DB_SCYLLA", "ami-dummy ami-dummy2")


### PR DESCRIPTION
OCI node names include the region (up to 14 chars, i.e. eu-frankfurt-1) in the format {user_prefix}-loader-node-{shortid}-{region}-{index}. With the default prefix_max_len of 35, node names could reach 71 chars, exceeding the X.509 Common Name 64-character limit and causing certificate creation to fail with ValueError during node setup.

Reduce prefix_max_len by 10 for OCI backend (similar to existing Azure shortening), ensuring the longest possible node name stays within 64 characters.

Fixes: #SCT-688

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
