### PR TITLE
fix(aws): use instance ResourceType for spot fleet launch spec tags

### DIFF
--- a/sdcm/ec2_client.py
+++ b/sdcm/ec2_client.py
@@ -374,7 +374,10 @@ class EC2ClientWrapper:
 
         assert tag_specifications, "Tag specifications is a must for all instances creation api"
 
-        tag_specifications[0]["ResourceType"] = "spot-fleet-request"  # Ensure tags are applied to correct resource type
+        # Tags here live inside the fleet's LaunchSpecifications[].TagSpecifications, where AWS only accepts
+        # ResourceType="instance". "spot-fleet-request" is only valid at the top level of the fleet request config
+        # and causes InvalidSpotFleetRequestConfig here.
+        tag_specifications[0]["ResourceType"] = "instance"
 
         request_id = self._request_spot_fleet(
             instance_type,


### PR DESCRIPTION
## Summary
- Fix `InvalidSpotFleetRequestConfig ... 'spot-fleet-request' is not a valid taggable resource type` failure that occurs during `add_nodes` when `instance_provision=spot_fleet`.
- The legacy spot-fleet path (`sdcm/ec2_client.py`) set `ResourceType="spot-fleet-request"` on the tag spec that is embedded inside the fleet's `LaunchSpecifications[].TagSpecifications`. AWS only accepts `ResourceType="instance"` there; `"spot-fleet-request"` is valid only at the top level of the fleet request config.

## Background
There are two provisioning code paths:
- **Initial cluster provision** uses the new provisioner (`sdcm/provision/aws/provisioner.py`), which already tags with `ResourceType="instance"` — so it was never affected.
- **add_nodes** uses the legacy path (`sdcm/cluster_aws.py` -> `sdcm/ec2_client.py`), which used the invalid `"spot-fleet-request"` value.

This is why the initial provision succeeded but `add_nodes` failed with `spot_fleet`. This aligns the legacy path with the correct value used by the new provisioner.

## Testing
- `pre-commit run --files sdcm/ec2_client.py` — all checks pass.

## Fixes
Fixing the failure in: https://argus.scylladb.com/tests/scylla-cluster-tests/718be971-200e-4d6f-a2bf-3cf89602a183
(No JIRA issue).