### PR TITLE
fix(zeus): remove default from cassandra oracle version

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -373,7 +373,7 @@ vector_store_version: ''
 docker_image_cassandra: 'cassandra'
 cassandra_version: '4.1'
 cassandra_num_tokens: 16
-cassandra_oracle_version: '4.1'
+cassandra_oracle_version: ''
 download_from_s3: []
 # The object-storage method options in Scylla-Manager are: native/rclone/auto.
 # An empty value here, means Scylla-Manager will use its default value.

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -3059,7 +3059,7 @@ num_tokens value to configure in cassandra.yaml.
 
 Cassandra version for the oracle cluster, i.e. '4.1' or '5.0'
 
-**default:** 4.1
+**default:** N/A
 
 **type:** str (appendable)
 


### PR DESCRIPTION
It makes Zeus to hallucinate that it uses cassandra as oracle in Gemini tests. This started to happen after changing this variable.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
