### PR TITLE
ci(pr-pipeline): abort previous build on force-push

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -116,6 +116,7 @@ pipeline {
     }
     options {
         timestamps()
+        disableConcurrentBuilds(abortPrevious: true)
         buildDiscarder(logRotator(numToKeepStr: '10'))
     }
     stages {


### PR DESCRIPTION
## Problem

When a PR is force-pushed while a Jenkins build is still running, the later
pipeline stages (integration-tests, provision-test) do a fresh `checkout scm`
that fetches only the **current** PR head ref. The old commit that triggered
the build no longer exists in the fetched refs, causing:

```
fatal: reference is not a tree: df2e2dfff02e2865c836d713ba17b93c85821e81
ERROR: Checkout failed
hudson.plugins.git.GitException: Could not checkout df2e2dfff...
```

This results in confusing `jenkins/integration-tests` failures that are
unrelated to the PR's code changes.

**Observed in:** PR-15518 build #2

## Fix

Add `disableConcurrentBuilds(abortPrevious: true)` to the pipeline options.
This automatically aborts the stale build when a new push triggers a fresh one.

In a multibranch pipeline this applies **per-branch**, so different PRs still
run in parallel — only multiple builds of the **same** PR are deduplicated.

## Testing

- [x] Verified this is a single-line declarative option with no side effects on other PRs
- [x] Confirmed multibranch semantics: concurrency is per-branch, not global

### PR pre-checks (self review)
- [x] I didn't leave commented-out/debugging code
