### PR TITLE
fix(tests): drive base-version tests off live supported versions, drop EOL hardcoding

### DIFF
--- a/unit_tests/integration/test_base_version.py
+++ b/unit_tests/integration/test_base_version.py
@@ -10,18 +10,41 @@
 # See LICENSE for more details.
 #
 # Copyright (c) 2021 ScyllaDB
+import logging
 from unittest.mock import patch
 
 import pytest
+import requests
+from botocore.exceptions import BotoCoreError, ClientError
 
+from sdcm.utils.decorators import retrying
+from sdcm.utils.parallel_object import ParallelObjectException
 from sdcm.utils.version_utils import ComparableScyllaVersion
-from utils.get_supported_scylla_base_versions import UpgradeBaseVersion
+from utils.get_supported_scylla_base_versions import (
+    UpgradeBaseVersion,
+    fetch_official_supported_versions,
+)
 
 pytestmark = pytest.mark.integration
+
+LOGGER = logging.getLogger(__name__)
 
 """
 This module contains tests for the UpgradeBaseVersion class, which is used to determine
 the supported Scylla versions for upgrades based on the provided repository, backend, and Linux distribution.
+
+The version-specific coverage is driven off the list of *currently supported* (live) ScyllaDB
+releases published by the ScyllaDB docs homepage (see fetch_official_supported_versions). This keeps
+the tests correct as versions roll: they never hardcode EOL versions (which point at repositories that
+have since been removed and cause the tests to fail), and they assert invariants instead of exact
+version sets that would churn over time.
+
+The download S3 buckets (downloads.scylladb.com) are cleaned up regularly: EOL releases and old
+timestamped artifacts get removed. Tests must therefore NOT hardcode values (timestamps or specific
+release versions) - those rot the moment the buckets are cleaned and cause spurious CI failures. That
+is why versions are derived dynamically from the docs-homepage source of truth and repo URLs use the
+``latest`` branch path instead of a pinned timestamp (the URL is only parsed for its version string,
+never fetched, so ``latest`` is sufficient and never goes stale).
 """
 
 
@@ -40,13 +63,61 @@ def general_test(scylla_repo="", linux_distro="", cloud_provider=None, base_vers
 download_url_base = "http://downloads.scylladb.com"
 url_base = f"{download_url_base}/unstable/scylla"
 
+# Errors raised by the network paths these tests exercise: boto3/S3 listing (botocore) during
+# ``UpgradeBaseVersion`` construction, and requests/ParallelObject while reading repositories. They
+# are retried, never swallowed: if the operation keeps failing the exception is re-raised and the
+# test reds, so a genuine regression (including one wrapped in ``ParallelObjectException``) is still
+# reported instead of being silently skipped.
+RETRIABLE_REPO_ERRORS = (BotoCoreError, ClientError, requests.RequestException, ParallelObjectException)
+
+
+def _build_target_repo(version: str, linux_distro: str) -> str:
+    """Build an unstable target repo URL for the given release and distro.
+
+    The ``latest`` path is used on purpose: the URL is only parsed for its version string (never
+    fetched), so there is no need for a concrete timestamp - and a pinned timestamp would rot once the
+    download S3 buckets get their regular cleanup.
+    """
+    if linux_distro.split("-")[0] in ("centos", "rocky", "rhel"):
+        return f"{url_base}/branch-{version}/rpm/centos/latest/scylla.repo"
+    return f"{url_base}/branch-{version}/deb/unified/latest/scylladb-{version}/scylla.list"
+
+
+@retrying(n=3, sleep_time=5, allowed_exceptions=RETRIABLE_REPO_ERRORS, message="Retrying repository access")
+def get_base_versions(scylla_repo: str, linux_distro: str) -> tuple[UpgradeBaseVersion, list[str]]:
+    """Resolve the base-version list for a target repo, retrying transient repository/S3 failures.
+
+    ``UpgradeBaseVersion`` construction reaches S3 (``boto3.list_objects``) and ``get_version_list``
+    reads the repositories over HTTP, so both are covered by the retry. Once the retries are
+    exhausted the original exception propagates and the test fails - nothing is skipped.
+    """
+    version_detector = UpgradeBaseVersion(scylla_repo, linux_distro, None)
+    version_detector.set_start_support_version(None)
+    _, version_list = version_detector.get_version_list()
+    return version_detector, version_list
+
+
+@pytest.fixture(scope="session")
+def live_supported_versions():
+    """Session-scoped list of currently-supported (live) ScyllaDB versions.
+
+    Fetched at execution time (never at import/collection) so that test collection stays identical
+    across xdist workers regardless of the network outcome, and so nothing runs when the integration
+    marker is deselected. ``fetch_official_supported_versions`` already retries transient HTTP
+    failures internally (it uses ``create_retry_session``); anything it still raises is propagated,
+    and an empty result is an error - the test must fail rather than run over an empty list.
+    """
+    versions = fetch_official_supported_versions()
+    assert versions, "no officially supported ScyllaDB versions were returned - cannot verify base versions"
+    return versions
+
 
 def test_master_rpm():
     """
     Test that master branch select on specific version for upgrade.
     (not hardcoding the version, since it keep changing)
     """
-    scylla_repo = url_base + "/master/rpm/centos/2021-08-29T00:58:58Z/scylla.repo"
+    scylla_repo = url_base + "/master/rpm/centos/latest/scylla.repo"
     linux_distro = "centos"
     version_list = general_test(scylla_repo, linux_distro)
     assert len(version_list) == 1
@@ -58,92 +129,53 @@ def test_master_deb():
     Test that master branch select on specific version for upgrade.
     (not hardcoding the version, since it keep changing)
     """
-    scylla_repo = url_base + "/master/deb/unified/2025-02-16T22:46:42Z/scylladb-2025.1/scylla.list"
+    scylla_repo = url_base + "/master/deb/unified/latest/scylladb-master/scylla.list"
     linux_distro = "ubuntu-jammy"
     version_list = general_test(scylla_repo, linux_distro)
     assert len(version_list) == 1
     assert ComparableScyllaVersion(version_list[0]) >= "2025.1"
 
 
-def test_2024_1_with_centos9():
-    """Test that development branch of 2024.1 with centos9 is returned correct versions"""
-    scylla_repo = url_base + "-enterprise/enterprise-2024.1/rpm/centos/latest/scylla.repo"
-    linux_distro = "centos-9"
-    version_list = general_test(scylla_repo, linux_distro)
-    assert set(version_list) == {"5.4", "2024.1"}
+@pytest.mark.parametrize("linux_distro", ["centos-9", "ubuntu-focal"])
+def test_live_supported_version_base_versions(linux_distro, live_supported_versions):
+    """Base-version detection for every currently-supported (live) ScyllaDB release.
 
+    Instead of hardcoding version sets (which go EOL and point at removed repositories), this test is
+    driven off ``fetch_official_supported_versions()`` (obtained via a session-scoped fixture, not at
+    import time) and asserts invariants that stay true as versions roll, for each live version:
 
-def test_2024_1():
-    """Test that development branch of 2024.1 is returned correct versions"""
-    scylla_repo = url_base + "-enterprise/enterprise-2024.1/rpm/centos/latest/scylla.repo"
-    linux_distro = "centos"
-    version_list = general_test(scylla_repo, linux_distro)
-    assert set(version_list) == {"5.4", "2023.1", "2024.1"}
+    - a non-empty base-version list is returned;
+    - every returned version has a real repository in the S3 repo mapping;
+    - every returned version is <= the target (live) version;
+    - the target live version itself is included (it is released, so its repo exists).
 
+    Transient repository/network outages are retried (see ``get_base_versions``); a failure that
+    survives the retries reds the test rather than skipping it.
+    """
+    for live_version in live_supported_versions:
+        scylla_repo = _build_target_repo(live_version, linux_distro)
+        version_detector, version_list = get_base_versions(scylla_repo, linux_distro)
 
-def test_2024_2():
-    """Test that development branch of 2024.2 is returned correct versions"""
-    scylla_repo = url_base + "-enterprise/enterprise-2024.2/rpm/centos/latest/scylla.repo"
-    linux_distro = "centos-9"
-    version_list = general_test(scylla_repo, linux_distro)
-    assert set(version_list) == {"6.0", "2024.1", "2024.2"}
+        assert version_list, f"no base versions returned for live version {live_version} on {linux_distro}"
 
+        # every returned version must be backed by a real repository in the S3 mapping
+        for version in version_list:
+            assert version in version_detector.repo_maps, (
+                f"base version {version!r} has no repository in the S3 mapping "
+                f"(target {live_version}, distro {linux_distro})"
+            )
 
-def test_2024_2_ubuntu():
-    """Test that development branch of 2024.2 on ubuntu is returned correct versions"""
-    scylla_repo = url_base + "-enterprise/enterprise-2024.2/deb/unified/latest/scylladb-2024.2/scylla.list"
-    linux_distro = "ubuntu-focal"
-    version_list = general_test(scylla_repo, linux_distro)
-    assert set(version_list) == {"6.0", "2024.1", "2024.2"}
+        # no returned base version may be newer than the target version
+        for version in version_list:
+            assert ComparableScyllaVersion(version) <= live_version, (
+                f"base version {version!r} is newer than target {live_version} (distro {linux_distro})"
+            )
 
-
-def test_2025_1_dev():
-    """Test that development branch of 2025.1 is returned correct versions"""
-    scylla_repo = url_base + "/master/rpm/centos/2025-01-15T09:25:01Z/scylla.repo"
-    linux_distro = "centos"
-    version_list = general_test(scylla_repo, linux_distro)
-    assert len(version_list) == 1
-    assert ComparableScyllaVersion(version_list[0]) >= "2025.1"
-
-
-def test_2025_1_release_ubuntu():
-    """Test that 2025.1 release on Ubuntu returns correct versions"""
-    scylla_repo = url_base + "/branch-2025.1/deb/unified/2025-02-16T22:46:42Z/scylladb-2025.1/scylla.list"
-    linux_distro = "ubuntu-focal"
-    version_list = general_test(scylla_repo, linux_distro)
-    assert {"6.2", "2024.1", "2024.2"}.issubset(set(version_list))
-
-
-def test_2025_4_release_rocky():
-    """Test that 2025.4 release on centos is returned correct versions"""
-    scylla_repo = url_base + "/branch-2025.4/rpm/centos/2025-02-23T16:19:08Z/scylla.repo"
-    linux_distro = "rocky-10"
-    version_list = general_test(scylla_repo, linux_distro)
-    assert {"2025.3", "2025.4"} == set(version_list)
-
-
-def test_2025_1_release_centos():
-    """Test that 2025.1 release on centos is returned correct versions"""
-    scylla_repo = url_base + "/branch-2025.1/rpm/centos/2025-02-23T16:19:08Z/scylla.repo"
-    linux_distro = "centos-9"
-    version_list = general_test(scylla_repo, linux_distro)
-    assert {"6.2", "2024.1", "2024.2"}.issubset(set(version_list))
-
-
-def test_2025_3_release_ubuntu():
-    """Test that 2025.3 release on Ubuntu returns correct versions"""
-    scylla_repo = url_base + "/branch-2025.3/deb/unified/2026-02-16T22:46:42Z/scylladb-2025.3/scylla.list"
-    linux_distro = "ubuntu-focal"
-    version_list = general_test(scylla_repo, linux_distro)
-    assert {"2025.1", "2025.2", "2025.3"}.issubset(set(version_list))
-
-
-def test_2025_3_release_centos():
-    """Test that 2025.3 release on centos returns correct versions"""
-    scylla_repo = url_base + "/branch-2025.3/rpm/centos/2025-02-23T16:19:08Z/scylla.repo"
-    linux_distro = "centos-9"
-    version_list = general_test(scylla_repo, linux_distro)
-    assert {"2025.1", "2025.2", "2025.3"}.issubset(set(version_list))
+        # the live target version itself is released, so it must be part of the returned list
+        assert live_version in version_list, (
+            f"live version {live_version} is missing from its own base-version list {version_list} "
+            f"(distro {linux_distro})"
+        )
 
 
 @pytest.mark.parametrize(
@@ -232,9 +264,7 @@ def test_upgrade_matrix_stages(test_case):
     expected_version_set = test_case["expected_version_set"]
     base_version_all_sts_versions = test_case.get("base_version_all_sts_versions", False)
 
-    scylla_repo = (
-        url_base + f"/branch-{target_branch}/deb/unified/2026-02-16T22:46:42Z/scylladb-{target_branch}/scylla.list"
-    )
+    scylla_repo = url_base + f"/branch-{target_branch}/deb/unified/latest/scylladb-{target_branch}/scylla.list"
     linux_distro = "ubuntu-focal"
     # Mock get_all_versions and get_s3_scylla_repos_mapping to simulate available versions
 
@@ -256,7 +286,7 @@ def test_upgrade_matrix_stages(test_case):
 
 def test_master_all_sts_versions():
     """Test master branch returns both last LTS and last STS when base_version_all_sts_versions is True."""
-    scylla_repo = url_base + "/master/rpm/centos/2025-08-01T00:00:00Z/scylla.repo"
+    scylla_repo = url_base + "/master/rpm/centos/latest/scylla.repo"
     linux_distro = "centos"
     # Provide a repo map with multiple enterprise versions including LTS and STS
     mock_supported_versions = [


### PR DESCRIPTION
## Motivation / Why

The download S3 buckets (`downloads.scylladb.com` / the S3 repos) get **cleaned up regularly** — EOL releases and old timestamped artifacts are removed. Because of that, any test that **actually reads from S3 / the download buckets** (i.e. the integration/network tests) must **not hardcode values (timestamps or specific release versions)**: hardcoded timestamps and EOL releases rot the moment the buckets are cleaned, causing spurious CI failures. Such tests must derive versions dynamically (from the docs-homepage supported-versions source of truth) and use `latest` branch paths instead of pinned timestamps.

Pure mocked unit tests never reach the buckets being cleaned, so they are unaffected and may keep fixed values.

## Problem

The ScyllaDB base-version integration tests in `unit_tests/integration/test_base_version.py` hardcoded EOL enterprise versions (`2024.1`, `2024.2`, `2025.3`, `2025.4`) and asserted exact version sets against them.

Those repositories have since been removed, so the tests now point at dead repo URLs and fail — e.g. `test_2024_2_ubuntu` already reds with `AssertionError` because the `enterprise-2024.2` unstable repo no longer exists. More generally the flow raises `ValueError: The following repository URL '...scylladb-2024.2...' is incorrect` for removed repos.

On `master` these tests are marked `pytest.mark.integration` (so excluded from unit CI), but they are still broken and would fail if run. On older release branches the **same file runs in the unit suite** and reds it whenever a hardcoded version goes EOL.

## Fix

Drive the version-specific coverage off `utils.get_supported_scylla_base_versions.fetch_official_supported_versions()` — the ScyllaDB docs-homepage `supported_versions.json`, the source of truth for currently-supported (live) versions. A single test `test_live_supported_version_base_versions`, parametrized by distro only, iterates each live version × rpm/deb distro and asserts **invariants** that stay correct as versions roll, instead of exact version sets that churn:

- a non-empty base-version list is returned;
- every returned version is backed by a real repository in the S3 repo mapping;
- every returned version is `<=` the target (live) version;
- the target live version itself is included (it is released, so its repo exists).

All repo URLs (including `test_master_rpm`/`test_master_deb`) now use `latest` paths instead of pinned timestamps — the URL is only parsed for its version string, never fetched, so `latest` is sufficient and never goes stale.

### Review feedback addressed

- **Deterministic collection under xdist** (`-n4`): the live-version list is fetched at **execution time** via a session-scoped fixture, never at import/collection. Collection is now identical across workers regardless of network outcome (only distro is parametrized), and nothing runs when the integration marker is deselected.
- **Retry, never skip**: the test no longer calls `pytest.skip()` anywhere. The whole network path (`UpgradeBaseVersion(...)` construction, which reaches S3 via `boto3.list_objects`, plus `get_version_list()`) is wrapped in a `get_base_versions()` helper decorated with `sdcm.utils.decorators.retrying(n=3, sleep_time=5, ...)` over `BotoCoreError`, `ClientError`, `requests.RequestException` and `ParallelObjectException`. Transient outages are retried; once the retries are exhausted the original exception propagates and the test **reds**.
- **`ParallelObjectException` is no longer a skip trigger**: it is only in the *retriable* tuple. A genuine regression wrapped in it (parsing error, malformed metadata, `ValueError`, …) is not helped by retries and is re-raised with its original traceback, so nothing is masked.
- **Never runs empty**: the fixture no longer returns `[]` on failure. `fetch_official_supported_versions()` (which already retries transient HTTP internally via `create_retry_session`) propagates its errors, and an empty result is an assertion failure — the test cannot pass by iterating over nothing.
- **Cosmetics**: `test_master_deb` no longer carries a stale `scylladb-2025.1` sub-path under `master/` (it is never parsed, but it was misleading) — now `scylladb-master`.

The genuinely version-agnostic tests are kept: `test_master_rpm`, `test_master_deb`, the fully-mocked `test_upgrade_matrix_stages`, and `test_master_all_sts_versions`. `pytestmark = pytest.mark.integration` is preserved.

## Verification

`uv run pytest unit_tests/integration/test_base_version.py -v` against live network: **13 passed** (live versions resolved to `2026.2`, `2026.1`, `2025.1`). Stable under `-n4`: 13 collected, **13 passed**. Pre-commit (ruff/ruff-format) clean.

## Follow-up

Backports are needed to the release branches where this file still runs in the **unit** suite (`branch-2026.2` / `branch-2026.1` / `branch-2025.1` / `perf-v17`), so those branches stop reding as versions go EOL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
