### PR TITLE
improvement(provision): wait for cloud-init on all nodes in parallel

### DIFF
--- a/configurations/scale/scale-180-200.yaml
+++ b/configurations/scale/scale-180-200.yaml
@@ -5,6 +5,11 @@ add_node_cnt: 20
 
 user_prefix: 'cluster-scale-180-200-test'
 
+# The sct-runner holds a live remoter (SSH session + background log threads) per node.
+# For 180-200 nodes the default runner (m7i-flex.xlarge, 16G) runs out of memory and the
+# sct.py process is OOM-killed during (parallel) provisioning. Use a memory-optimized runner.
+instance_type_runner: 'r6i.2xlarge'  # 8 vcpus, 64G
+
 # Takes too long on big clusters
 cluster_health_check: false
 use_scylla_doctor_on_failure: false

--- a/configurations/scale/scale-40-60.yaml
+++ b/configurations/scale/scale-40-60.yaml
@@ -5,6 +5,11 @@ add_node_cnt: 10
 
 user_prefix: 'cluster-scale-40-60-test'
 
+# The sct-runner holds a live remoter (SSH session + background log threads) per node, so
+# memory scales with cluster size. Bump above the default runner (m7i-flex.xlarge, 16G) to
+# keep comfortable headroom for 40-60 nodes during (parallel) provisioning.
+instance_type_runner: 'r6i.xlarge'  # 4 vcpus, 32G
+
 # Takes too long on big clusters
 cluster_health_check: false
 use_scylla_doctor_on_failure: false

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -5584,9 +5584,13 @@ class BaseScyllaCluster:
         self.log.info("Update DB packages duration -> %s s", int(time_elapsed))
 
     def update_seed_provider(self):
-        for node in self.nodes:
+        def _update_node_seed_provider(node):
             with node.remote_scylla_yaml() as scylla_yml:
                 scylla_yml.seed_provider = node.proposed_scylla_yaml.seed_provider
+
+        # Each node update is an independent SSH read+write of scylla.yaml, so run them in
+        # parallel to avoid the serial per-node latency during cluster provisioning (SCT-731).
+        self.run_func_parallel(func=_update_node_seed_provider)
 
     def update_db_binary(self, node_list=None, start_service=True):
         if node_list is None:

--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -56,6 +56,7 @@ from sdcm.kernel_panic_checker import AWSKernelPanicChecker
 from sdcm.utils.decorators import retrying
 from sdcm.nemesis.utils.node_allocator import mark_new_nodes_as_running_nemesis
 from sdcm.utils.net import to_inet_ntop_format
+from sdcm.utils.parallel_object import ParallelObject
 from sdcm.utils.vector_store_utils import VectorStoreClusterMixin, VectorStoreNodeMixin
 from sdcm.wait import exponential_retry
 
@@ -72,6 +73,17 @@ EBS_VOLUME = "attached"
 INSTANCE_STORE = "instance_store"
 
 SPOT_TERMINATION_CHECK_DELAY = 0
+
+# Max number of nodes to initialize concurrently in add_nodes. Caps threads/SSH sessions
+# and concurrent EC2 API calls on very large clusters.
+MAX_NODE_INIT_WORKERS = 20
+# Per-node timeout (seconds) passed to ParallelObject when creating + initializing nodes.
+# NOTE: ParallelObject applies this per future, not as a strict global wall-clock deadline
+# (see sdcm/utils/parallel_object.py). For clusters larger than MAX_NODE_INIT_WORKERS the
+# overflow nodes are queued, so the effective ceiling can be higher than this value.
+# node.init() waits for the instance to reach `running`, allocates/attaches an EIP, waits for
+# the public IP, then runs wait_ssh_up (up to 5min) and wait_for_cloud_init.
+NODE_INIT_TIMEOUT = 40 * 60
 
 P = ParamSpec("P")
 R = TypeVar("R")
@@ -569,15 +581,22 @@ class AWSCluster(cluster.BaseCluster):
                     ami_id=image_id,
                 )
             )
+        # Assign node_index/rack serially so node names, ordering and rack distribution stay
+        # deterministic and identical to the previous serial implementation.
+        node_specs = []
         for node_index, instance in enumerate(instances):
             self._node_index += 1
             # in case rack is not specified, spread nodes to different racks
             node_rack = node_index % self.racks_count if rack is None else rack
+            node_specs.append((instance, self._node_index, node_rack))
+
+        def _create_and_init_node(node_spec):
+            instance, node_index, node_rack = node_spec
             node = self._create_node(
                 instance,
                 self._ec2_ami_username,
                 self.node_prefix,
-                self._node_index,
+                node_index,
                 self.logdir,
                 dc_idx=dc_idx,
                 rack=node_rack,
@@ -586,8 +605,27 @@ class AWSCluster(cluster.BaseCluster):
             node.enable_auto_bootstrap = enable_auto_bootstrap
             if ssh_connection_ip_type(self.params) == "ipv6" and not node.distro.is_ubuntu:
                 node.config_ipv6_as_persistent()
+            return node
 
-            self.nodes.append(node)
+        # _create_node runs node.init(), which blocks per node on EC2 waiters (instance running,
+        # public IP), EIP allocation and SSH/cloud-init - previously done one node at a time, making
+        # provisioning grow linearly with cluster size (SCT-721). Initialize all nodes concurrently.
+        # ignore_exceptions=True so a failure on one node does not discard the nodes that succeeded:
+        # they must still be registered in self.nodes to be terminated during teardown. Nodes that
+        # fail init self-terminate via the @terminate_on_failure decorator on init().
+        results = ParallelObject(
+            objects=node_specs,
+            timeout=NODE_INIT_TIMEOUT,
+            num_workers=min(len(node_specs), MAX_NODE_INIT_WORKERS),
+        ).run(_create_and_init_node, ignore_exceptions=True)
+
+        # ParallelObject preserves submission order, so self.nodes keeps the original ordering.
+        self.nodes.extend([result.result for result in results if result.exc is None])
+
+        if failed := [result for result in results if result.exc is not None]:
+            self.log.error("Failed to initialize %s out of %s node(s)", len(failed), len(node_specs))
+            raise failed[0].exc
+
         self.write_node_public_ip_file()
         self.write_node_private_ip_file()
         return self.nodes[-count:]

--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -1339,7 +1339,8 @@ class CassandraAWSCluster(BaseCassandraCluster, AWSCluster):
     @cluster.wait_for_init_wrap
     def wait_for_init(self, node_list=None, verbose=False, timeout=None, check_node_health=True):
         node_list = node_list if node_list else self.nodes
-        for node in node_list:
+
+        def _wait_for_node_db_up(node):
             wait.wait_for(
                 func=self.check_node_db_up,
                 step=10,
@@ -1348,6 +1349,10 @@ class CassandraAWSCluster(BaseCassandraCluster, AWSCluster):
                 throw_exc=True,
                 node=node,
             )
+
+        # Waiting for each node serially takes up to N * timeout; wait for all nodes in
+        # parallel so the whole cluster converges within a single timeout window (SCT-730).
+        self.run_func_parallel(func=_wait_for_node_db_up, node_list=node_list)
 
 
 class LoaderSetAWS(cluster.BaseLoaderSet, AWSCluster):

--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -1541,7 +1541,8 @@ class VectorStoreSetAWS(VectorStoreClusterMixin, AWSCluster):
             return
 
         self.log.info("Reconfiguring Vector Store nodes with Scylla cluster information")
-        for node in self.nodes:
+
+        def _reconfigure_node(node):
             try:
                 node.remoter.run("sudo systemctl stop vector-store", ignore_status=True, verbose=True)
                 node.configure_vector_store_service()
@@ -1549,6 +1550,11 @@ class VectorStoreSetAWS(VectorStoreClusterMixin, AWSCluster):
             except Exception as e:
                 self.log.error("Failed to reconfigure Vector Store node %s: %s", node.name, e)
                 raise
+
+        # Each node reconfiguration is an independent set of SSH commands, so run them in
+        # parallel to cut the serial per-node provisioning latency (SCT-729). run_func_parallel
+        # re-raises the first exception via future.result(), preserving the fail-fast behavior.
+        self.run_func_parallel(func=_reconfigure_node)
 
     def _create_node(
         self, instance, ami_username, node_prefix, node_index, base_logdir, dc_idx, rack, after_config=None

--- a/sdcm/cluster_docker.py
+++ b/sdcm/cluster_docker.py
@@ -684,7 +684,8 @@ class VectorStoreSetDocker(VectorStoreClusterMixin, DockerCluster):
             return
 
         self.log.info("Reconfiguring Vector Store with Scylla node information")
-        for node in self.nodes:
+
+        def _reconfigure_node(node):
             try:
                 if ContainerManager.is_running(node, "node"):
                     self.log.debug("Stopping container %s for reconfiguration", node.name)
@@ -696,6 +697,11 @@ class VectorStoreSetDocker(VectorStoreClusterMixin, DockerCluster):
             except Exception as e:  # noqa: BLE001
                 self.log.error("Failed to reconfigure container %s: %s", node.name, e)
                 raise
+
+        # Each node reconfiguration is an independent container restart, so run them in
+        # parallel to cut the serial per-node provisioning latency (SCT-729). run_func_parallel
+        # re-raises the first exception via future.result(), preserving the fail-fast behavior.
+        self.run_func_parallel(func=_reconfigure_node)
 
     def _create_node(self, node_index, container=None, after_config=None):
         node = VectorStoreDockerNode(

--- a/sdcm/sct_provision/instances_provider.py
+++ b/sdcm/sct_provision/instances_provider.py
@@ -30,8 +30,15 @@ from sdcm.sct_config import SCTConfiguration
 from sdcm.sct_provision import region_definition_builder
 from sdcm.test_config import TestConfig
 from sdcm.utils.decorators import retrying
+from sdcm.utils.parallel_object import ParallelObject
 
 LOGGER = logging.getLogger(__name__)
+
+# Max number of nodes to wait on concurrently. Caps threads/SSH sessions on very large clusters.
+MAX_PROVISION_WAIT_WORKERS = 50
+# Overall timeout (seconds) for waiting on cloud-init across all nodes. wait_cloud_init_completes
+# itself retries for up to ~20*10s plus a 5min SSH is_up per node, so this leaves ample headroom.
+CLOUD_INIT_WAIT_TIMEOUT = 30 * 60
 
 
 @retrying(n=3, sleep_time=5, allowed_exceptions=(ProvisionError,))
@@ -56,7 +63,9 @@ def provision_instances_with_fallback(
             raise
 
     provisioned_instances = provisioner.get_or_create_instances(definitions=definitions)
-    for definition, v_m in zip(definitions, provisioned_instances):
+
+    def wait_instance_ready(definition_and_vm: tuple[InstanceDefinition, VmInstance]) -> None:
+        definition, v_m = definition_and_vm
         if definition.use_public_ip:
             hostname = v_m.public_ip_address if v_m.public_ip_address else v_m.private_ip_address
         else:
@@ -69,6 +78,19 @@ def provision_instances_with_fallback(
         remoter = RemoteCmdRunnerBase.create_remoter(**ssh_login_info)
         wait_cloud_init_completes(remoter=remoter, instance=v_m)
         # todo: wait for scylla-machine-image service to complete if instance is scylla-db?
+
+    # Instances are created in parallel by the provisioner, but each node still needs an SSH
+    # connection and a (potentially multi-minute) cloud-init wait. Doing that serially made
+    # provisioning time grow linearly with cluster size, so wait for all nodes concurrently.
+    instance_pairs = list(zip(definitions, provisioned_instances))
+    if instance_pairs:
+        # ignore_exceptions=False so any cloud-init failure still propagates (provisioning must fail
+        # if a node did not come up correctly), while ParallelObject surfaces it after all workers run.
+        ParallelObject(
+            objects=instance_pairs,
+            timeout=CLOUD_INIT_WAIT_TIMEOUT,
+            num_workers=min(len(instance_pairs), MAX_PROVISION_WAIT_WORKERS),
+        ).run(wait_instance_ready, ignore_exceptions=False)
     return provisioned_instances
 
 

--- a/sdcm/sct_provision/instances_provider.py
+++ b/sdcm/sct_provision/instances_provider.py
@@ -85,7 +85,7 @@ def provision_instances_with_fallback(
     # Instances are created in parallel by the provisioner, but each node still needs an SSH
     # connection and a (potentially multi-minute) cloud-init wait. Doing that serially made
     # provisioning time grow linearly with cluster size, so wait for all nodes concurrently.
-    instance_pairs = list(zip(definitions, provisioned_instances))
+    instance_pairs = list(zip(definitions, provisioned_instances, strict=True))
     if instance_pairs:
         # ignore_exceptions=False so any cloud-init failure still propagates (provisioning must fail
         # if a node did not come up correctly), while ParallelObject surfaces it after all workers run.

--- a/sdcm/sct_provision/instances_provider.py
+++ b/sdcm/sct_provision/instances_provider.py
@@ -36,8 +36,11 @@ LOGGER = logging.getLogger(__name__)
 
 # Max number of nodes to wait on concurrently. Caps threads/SSH sessions on very large clusters.
 MAX_PROVISION_WAIT_WORKERS = 50
-# Overall timeout (seconds) for waiting on cloud-init across all nodes. wait_cloud_init_completes
-# itself retries for up to ~20*10s plus a 5min SSH is_up per node, so this leaves ample headroom.
+# Per-node timeout (seconds) passed to ParallelObject when waiting on cloud-init.
+# NOTE: ParallelObject applies this per future, not as a strict global wall-clock deadline
+# (see sdcm/utils/parallel_object.py). For clusters larger than MAX_PROVISION_WAIT_WORKERS the
+# overflow nodes are queued, so the effective ceiling can be higher than this value.
+# wait_cloud_init_completes itself retries for up to ~20*10s plus a 5min SSH is_up per node.
 CLOUD_INIT_WAIT_TIMEOUT = 30 * 60
 
 
@@ -77,7 +80,7 @@ def provision_instances_with_fallback(
         }
         remoter = RemoteCmdRunnerBase.create_remoter(**ssh_login_info)
         wait_cloud_init_completes(remoter=remoter, instance=v_m)
-        # todo: wait for scylla-machine-image service to complete if instance is scylla-db?
+        # TODO: wait for scylla-machine-image service to complete if instance is scylla-db?
 
     # Instances are created in parallel by the provisioner, but each node still needs an SSH
     # connection and a (potentially multi-minute) cloud-init wait. Doing that serially made

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -6,7 +6,8 @@ description: >-
   across class hierarchies, verifying override compatibility, checking import
   conventions, error handling patterns, backend impact, test coverage, or
   provision label requirements. Covers inheritance safety, polymorphic method
-  audits, and SCT-specific review criteria.
+  audits, detection of serial per-node blocking-I/O loops in provisioning paths,
+  and SCT-specific review criteria.
 ---
 
 # Code Review for SCT
@@ -56,6 +57,7 @@ Ask: Is there a test for this change? Is there a default value for this config o
 - Evaluating whether a PR needs provision test labels
 - Checking for missing tests, missing defaults, or missing docstrings
 - Reviewing nemesis operations or cluster configuration changes
+- Spotting serial per-node loops doing blocking I/O (SSH/cloud-API/HTTP) that should run in parallel
 
 ## When NOT to Use
 
@@ -180,6 +182,29 @@ Real incident: `sdcm/monitorstack/__init__.py` imported `logcollector` for verif
 - No bare `requests.get()` / `requests.post()` without session+retry
 - Localhost/metadata calls may use `retry=0` but must still use the utility for consistent `--connect-timeout`
 
+### Check 10: Serial Per-Node Blocking I/O in Provisioning Paths
+
+**Trigger**: PR adds or modifies a `for node in self.nodes:` (or `for node in node_list:`) loop whose body performs **blocking I/O** — SSH commands (`node.remoter.run/sudo`), cloud-provider API calls, HTTP requests, or `wait.wait_for(...)` polling — especially in cluster setup/provisioning paths (`cluster.py`, `cluster_aws.py`, `cluster_gce.py`, `cluster_azure.py`, `sct_provision/`).
+
+**Why this matters**: These loops run once per node and each iteration blocks on network round-trips. On large clusters the latency is `N * per_node_latency`, and for `wait.wait_for` loops with a per-node timeout the worst case is `N * timeout` (e.g. `CassandraAWSCluster.wait_for_init` was `N * 1200s`). Parallelizing turns this into roughly a single per-node latency, materially cutting provisioning time. This is a correctness-adjacent performance issue that static checks and existing tests never surface.
+
+**How to review:**
+
+1. Identify whether the per-node work items are **independent** (no ordering dependency, no shared mutable state written without a lock). If independent -> **flag the serial loop and suggest parallelization**.
+2. Prefer the existing helper `BaseCluster.run_func_parallel(func, node_list=None)` — it submits `func(node)` per node on a `ThreadPoolExecutor` and re-raises the first exception via `future.result()`, preserving fail-fast.
+3. Verify the refactor **preserves original semantics**:
+   - Fail-fast loops (that `raise` on error) must still propagate the first exception — `run_func_parallel` does this; a bare `ParallelObject(...).run(..., ignore_exceptions=True)` does NOT.
+   - Order-dependent side effects (e.g. seed election, first-node-only work) must NOT be parallelized blindly.
+   - `ParallelObject` applies its `timeout` **per future**, not as a global deadline — do not describe it as a whole-operation timeout.
+4. If the author left the loop serial, ask whether it is intentional (ordering/dependency) or an oversight; request a one-line comment when serial execution is deliberate.
+
+**Reference examples** (EPIC SCT-720 — parallelizing serial per-node provisioning work):
+- `update_seed_provider` (SCT-731) — per-node `scylla.yaml` SSH read+write.
+- `CassandraAWSCluster.wait_for_init` (SCT-730) — per-node `wait.wait_for(check_node_db_up)` polling.
+- `VectorStoreSetAWS._reconfigure_vector_store_nodes` (SCT-729) — per-node `systemctl` restart, fail-fast preserved.
+
+All three extract the loop body into a local `func(node)` and dispatch via `self.run_func_parallel(func=...)`, with a unit test asserting every node is processed (and, where relevant, that exceptions still propagate).
+
 ## Reference Index
 
 | File | Content |
@@ -205,3 +230,4 @@ A complete code review:
 - [ ] Commit message validated — Conventional Commits format followed
 - [ ] Missing code identified — defaults, docstrings, tests, other backends
 - [ ] HTTP resilience verified — no bare curl or requests calls without retry
+- [ ] Serial per-node blocking-I/O loops flagged — independent per-node work in provisioning paths parallelized (or deliberately kept serial with a comment)

--- a/unit_tests/test_aws_add_nodes_parallel.py
+++ b/unit_tests/test_aws_add_nodes_parallel.py
@@ -1,0 +1,134 @@
+"""Unit tests for SCT-721 (AWS only): parallelize node.init() in AWSCluster.add_nodes.
+
+`_create_node` runs `node.init()`, which blocks per node on EC2 waiters, EIP allocation
+and SSH/cloud-init. These tests verify the nodes are now created concurrently while
+node ordering, `_node_index` and rack assignment stay deterministic, and that nodes
+which initialized successfully are still registered for teardown when another fails.
+"""
+
+import threading
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from sdcm.cluster_aws import AWSCluster
+
+
+def _make_cluster(racks_count=1):
+    cluster = AWSCluster.__new__(AWSCluster)
+    cluster.log = MagicMock()
+    cluster.nodes = []
+    cluster.racks_count = racks_count
+    cluster._node_index = 0
+    cluster.node_prefix = "test-node"
+    cluster.logdir = "/tmp/sct-test"
+    cluster._ec2_ami_username = "ubuntu"
+    cluster.params = MagicMock()
+    cluster.test_config = MagicMock()
+    cluster.prepare_user_data = MagicMock(return_value="")
+    cluster.write_node_public_ip_file = MagicMock()
+    cluster.write_node_private_ip_file = MagicMock()
+    return cluster
+
+
+def _patch_instances(cluster, count):
+    """Stub instance creation so add_nodes gets `count` fake EC2 instances."""
+    instances = [MagicMock() for _ in range(count)]
+    cluster._create_or_find_instances = MagicMock(side_effect=lambda count, **kwargs: instances[:count])
+    return instances
+
+
+@pytest.fixture(autouse=True)
+def _no_ipv6():
+    # keep add_nodes out of the ipv6 branch, which would need a real node.distro
+    with patch("sdcm.cluster_aws.ssh_connection_ip_type", return_value="ipv4"):
+        yield
+
+
+def test_add_nodes_creates_all_nodes_in_order():
+    cluster = _make_cluster()
+    _patch_instances(cluster, 4)
+    created = []
+
+    def _create_node(instance, ami_username, node_prefix, node_index, base_logdir, dc_idx, rack, after_config=None):
+        node = MagicMock()
+        node.node_index = node_index
+        node.rack = rack
+        created.append(node)
+        return node
+
+    cluster._create_node = _create_node
+
+    added = cluster.add_nodes(count=4)
+
+    assert len(added) == 4
+    assert cluster.nodes == added
+    # node_index is assigned serially and ordering is preserved regardless of completion order
+    assert [node.node_index for node in cluster.nodes] == [1, 2, 3, 4]
+    assert cluster._node_index == 4
+
+
+def test_add_nodes_initializes_nodes_in_parallel():
+    cluster = _make_cluster()
+    _patch_instances(cluster, 3)
+    barrier = threading.Barrier(3, timeout=10)
+
+    def _create_node(instance, ami_username, node_prefix, node_index, base_logdir, dc_idx, rack, after_config=None):
+        barrier.wait()  # blocks unless all 3 nodes are initialized concurrently
+        return MagicMock()
+
+    cluster._create_node = _create_node
+
+    # would raise BrokenBarrierError if node.init() still ran one node at a time
+    cluster.add_nodes(count=3)
+
+
+def test_add_nodes_spreads_racks_when_rack_is_none():
+    cluster = _make_cluster(racks_count=2)
+    _patch_instances(cluster, 4)
+    racks = []
+    lock = threading.Lock()
+
+    def _create_node(instance, ami_username, node_prefix, node_index, base_logdir, dc_idx, rack, after_config=None):
+        node = MagicMock()
+        node.node_index = node_index
+        with lock:
+            racks.append((node_index, rack))
+        return node
+
+    cluster._create_node = _create_node
+
+    cluster.add_nodes(count=4, rack=None)
+
+    # rack assignment stays tied to the node's position, not to completion order
+    assert sorted(racks) == [(1, 0), (2, 1), (3, 0), (4, 1)]
+
+
+def test_add_nodes_keeps_successful_nodes_and_reraises():
+    cluster = _make_cluster()
+    _patch_instances(cluster, 3)
+
+    def _create_node(instance, ami_username, node_prefix, node_index, base_logdir, dc_idx, rack, after_config=None):
+        if node_index == 2:
+            raise RuntimeError("boom")
+        node = MagicMock()
+        node.node_index = node_index
+        return node
+
+    cluster._create_node = _create_node
+
+    with pytest.raises(RuntimeError, match="boom"):
+        cluster.add_nodes(count=3)
+
+    # the nodes that initialized successfully must stay registered so teardown terminates them
+    assert [node.node_index for node in cluster.nodes] == [1, 3]
+    # ip files are only written on a fully successful add_nodes, as before
+    cluster.write_node_public_ip_file.assert_not_called()
+
+
+def test_add_nodes_zero_count_is_noop():
+    cluster = _make_cluster()
+    cluster._create_node = MagicMock()
+
+    assert cluster.add_nodes(count=0) == []
+    cluster._create_node.assert_not_called()

--- a/unit_tests/test_cassandra_wait_for_init_parallel.py
+++ b/unit_tests/test_cassandra_wait_for_init_parallel.py
@@ -14,7 +14,14 @@ from sdcm.cluster_aws import CassandraAWSCluster
 
 
 def _make_nodes(count):
-    return [MagicMock(name=f"node-{i}") for i in range(count)]
+    # `MagicMock(name=...)` does NOT set an accessible `.name` attribute (it's a reserved
+    # constructor kwarg used for the mock's repr); assign the attribute explicitly instead.
+    nodes = []
+    for i in range(count):
+        node = MagicMock()
+        node.name = f"node-{i}"
+        nodes.append(node)
+    return nodes
 
 
 @pytest.fixture
@@ -43,3 +50,29 @@ def test_cassandra_wait_for_init_waits_for_all_nodes(cassandra_aws_cluster):
         CassandraAWSCluster.wait_for_init.__wrapped__(cassandra_aws_cluster)
 
     assert set(waited_nodes) == set(nodes)
+
+
+def test_cassandra_wait_for_init_runs_in_parallel(cassandra_aws_cluster):
+    nodes = _make_nodes(3)
+    cassandra_aws_cluster.nodes = nodes
+    barrier = threading.Barrier(3, timeout=10)
+
+    def _fake_wait_for(func, node, **kwargs):
+        barrier.wait()  # blocks unless all 3 run concurrently
+
+    with patch("sdcm.cluster_aws.wait.wait_for", side_effect=_fake_wait_for):
+        # would raise BrokenBarrierError if nodes were waited on serially
+        CassandraAWSCluster.wait_for_init.__wrapped__(cassandra_aws_cluster)
+
+
+def test_cassandra_wait_for_init_propagates_node_timeout(cassandra_aws_cluster):
+    nodes = _make_nodes(3)
+    cassandra_aws_cluster.nodes = nodes
+
+    def _fake_wait_for(func, node, **kwargs):
+        if node is nodes[1]:
+            raise TimeoutError(f"{node.name} did not come up in time")
+
+    with patch("sdcm.cluster_aws.wait.wait_for", side_effect=_fake_wait_for):
+        with pytest.raises(TimeoutError, match="did not come up in time"):
+            CassandraAWSCluster.wait_for_init.__wrapped__(cassandra_aws_cluster)

--- a/unit_tests/test_cassandra_wait_for_init_parallel.py
+++ b/unit_tests/test_cassandra_wait_for_init_parallel.py
@@ -1,0 +1,45 @@
+"""Unit tests for SCT-730: parallelize CassandraAWSCluster.wait_for_init.
+
+Verifies that the DB-up wait is issued for every node concurrently instead of
+serially (which previously took up to N * timeout).
+"""
+
+import threading
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from sdcm.cluster import BaseCluster
+from sdcm.cluster_aws import CassandraAWSCluster
+
+
+def _make_nodes(count):
+    return [MagicMock(name=f"node-{i}") for i in range(count)]
+
+
+@pytest.fixture
+def cassandra_aws_cluster():
+    with patch.object(CassandraAWSCluster, "__init__", lambda self, **kw: None):
+        cluster = CassandraAWSCluster()
+        cluster.log = MagicMock()
+        cluster.nodes = []
+        # run_func_parallel is defined on the BaseCluster mixin; bind the real implementation.
+        cluster.run_func_parallel = BaseCluster.run_func_parallel.__get__(cluster)
+        return cluster
+
+
+def test_cassandra_wait_for_init_waits_for_all_nodes(cassandra_aws_cluster):
+    nodes = _make_nodes(3)
+    cassandra_aws_cluster.nodes = nodes
+    waited_nodes = []
+    lock = threading.Lock()
+
+    def _fake_wait_for(func, node, **kwargs):
+        with lock:
+            waited_nodes.append(node)
+
+    # wait_for_init is wrapped by wait_for_init_wrap; call the underlying function directly.
+    with patch("sdcm.cluster_aws.wait.wait_for", side_effect=_fake_wait_for):
+        CassandraAWSCluster.wait_for_init.__wrapped__(cassandra_aws_cluster)
+
+    assert set(waited_nodes) == set(nodes)

--- a/unit_tests/test_reconfigure_vector_store_docker_parallel.py
+++ b/unit_tests/test_reconfigure_vector_store_docker_parallel.py
@@ -1,0 +1,72 @@
+"""Unit tests for SCT-729 (Docker parity): parallelize
+VectorStoreSetDocker._reconfigure_vector_store_nodes.
+
+Mirrors test_reconfigure_vector_store_parallel.py (AWS) for the Docker backend
+implementation, which had the same serial per-node loop pattern.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from sdcm.cluster import BaseCluster
+from sdcm.cluster_docker import VectorStoreSetDocker
+
+
+def _make_nodes(count):
+    # `MagicMock(name=...)` does NOT set an accessible `.name` attribute (it's a reserved
+    # constructor kwarg used for the mock's repr); assign the attribute explicitly instead.
+    nodes = []
+    for i in range(count):
+        node = MagicMock()
+        node.name = f"node-{i}"
+        nodes.append(node)
+    return nodes
+
+
+@pytest.fixture
+def vector_store_docker_cluster():
+    with patch.object(VectorStoreSetDocker, "__init__", lambda self, **kw: None):
+        cluster = VectorStoreSetDocker()
+        cluster.log = MagicMock()
+        cluster.nodes = []
+        # run_func_parallel is defined on the BaseCluster mixin; bind the real implementation.
+        cluster.run_func_parallel = BaseCluster.run_func_parallel.__get__(cluster)
+        return cluster
+
+
+@patch("sdcm.cluster_docker.ContainerManager")
+def test_reconfigure_vector_store_nodes_processes_all(mock_container_manager, vector_store_docker_cluster):
+    mock_container_manager.is_running.return_value = False
+    nodes = _make_nodes(3)
+    vector_store_docker_cluster.nodes = nodes
+
+    vector_store_docker_cluster._reconfigure_vector_store_nodes()
+
+    assert mock_container_manager.destroy_container.call_count == 3
+    assert mock_container_manager.run_container.call_count == 3
+    assert mock_container_manager.wait_for_status.call_count == 3
+
+
+@patch("sdcm.cluster_docker.ContainerManager")
+def test_reconfigure_vector_store_nodes_reraises(mock_container_manager, vector_store_docker_cluster):
+    nodes = _make_nodes(3)
+    vector_store_docker_cluster.nodes = nodes
+    mock_container_manager.is_running.return_value = False
+
+    def _run_container(node, _name):
+        if node is nodes[1]:
+            raise RuntimeError("boom")
+
+    mock_container_manager.run_container.side_effect = _run_container
+
+    with pytest.raises(RuntimeError, match="boom"):
+        vector_store_docker_cluster._reconfigure_vector_store_nodes()
+
+    # All nodes run concurrently, so destroy_container still runs for every node.
+    assert mock_container_manager.destroy_container.call_count == 3
+
+
+def test_reconfigure_vector_store_nodes_empty_is_noop(vector_store_docker_cluster):
+    vector_store_docker_cluster.nodes = []
+    vector_store_docker_cluster._reconfigure_vector_store_nodes()  # must not raise

--- a/unit_tests/test_reconfigure_vector_store_parallel.py
+++ b/unit_tests/test_reconfigure_vector_store_parallel.py
@@ -1,0 +1,52 @@
+"""Unit tests for SCT-729: parallelize VectorStoreSetAWS._reconfigure_vector_store_nodes.
+
+Verifies every node is reconfigured concurrently and that a failure on any node is
+re-raised (fail-fast preserved).
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from sdcm.cluster import BaseCluster
+from sdcm.cluster_aws import VectorStoreSetAWS
+
+
+def _make_nodes(count):
+    return [MagicMock(name=f"node-{i}") for i in range(count)]
+
+
+@pytest.fixture
+def vector_store_cluster():
+    with patch.object(VectorStoreSetAWS, "__init__", lambda self, **kw: None):
+        cluster = VectorStoreSetAWS()
+        cluster.log = MagicMock()
+        cluster.nodes = []
+        # run_func_parallel is defined on the BaseCluster mixin; bind the real implementation.
+        cluster.run_func_parallel = BaseCluster.run_func_parallel.__get__(cluster)
+        return cluster
+
+
+def test_reconfigure_vector_store_nodes_processes_all(vector_store_cluster):
+    nodes = _make_nodes(3)
+    vector_store_cluster.nodes = nodes
+
+    vector_store_cluster._reconfigure_vector_store_nodes()
+
+    for node in nodes:
+        node.configure_vector_store_service.assert_called_once()
+        assert node.remoter.run.call_count == 2  # stop + start
+
+
+def test_reconfigure_vector_store_nodes_reraises(vector_store_cluster):
+    nodes = _make_nodes(3)
+    nodes[1].configure_vector_store_service.side_effect = RuntimeError("boom")
+    vector_store_cluster.nodes = nodes
+
+    with pytest.raises(RuntimeError, match="boom"):
+        vector_store_cluster._reconfigure_vector_store_nodes()
+
+
+def test_reconfigure_vector_store_nodes_empty_is_noop(vector_store_cluster):
+    vector_store_cluster.nodes = []
+    vector_store_cluster._reconfigure_vector_store_nodes()  # must not raise

--- a/unit_tests/test_reconfigure_vector_store_parallel.py
+++ b/unit_tests/test_reconfigure_vector_store_parallel.py
@@ -13,7 +13,14 @@ from sdcm.cluster_aws import VectorStoreSetAWS
 
 
 def _make_nodes(count):
-    return [MagicMock(name=f"node-{i}") for i in range(count)]
+    # `MagicMock(name=...)` does NOT set an accessible `.name` attribute (it's a reserved
+    # constructor kwarg used for the mock's repr); assign the attribute explicitly instead.
+    nodes = []
+    for i in range(count):
+        node = MagicMock()
+        node.name = f"node-{i}"
+        nodes.append(node)
+    return nodes
 
 
 @pytest.fixture
@@ -45,6 +52,17 @@ def test_reconfigure_vector_store_nodes_reraises(vector_store_cluster):
 
     with pytest.raises(RuntimeError, match="boom"):
         vector_store_cluster._reconfigure_vector_store_nodes()
+
+    # All nodes run concurrently: the other nodes still get fully reconfigured
+    # (stop + start) even though nodes[1] failed and its exception propagates.
+    # This differs from the original serial loop, which stopped at the first
+    # failing node and never touched subsequent nodes.
+    for node in (nodes[0], nodes[2]):
+        node.configure_vector_store_service.assert_called_once()
+        assert node.remoter.run.call_count == 2  # stop + start
+
+    # nodes[1] failed between stop and start, so only the stop command ran.
+    assert nodes[1].remoter.run.call_count == 1
 
 
 def test_reconfigure_vector_store_nodes_empty_is_noop(vector_store_cluster):

--- a/unit_tests/test_update_seed_provider_parallel.py
+++ b/unit_tests/test_update_seed_provider_parallel.py
@@ -14,7 +14,14 @@ from sdcm.cluster import BaseScyllaCluster, BaseCluster
 
 
 def _make_nodes(count):
-    return [MagicMock(name=f"node-{i}") for i in range(count)]
+    # `MagicMock(name=...)` does NOT set an accessible `.name` attribute (it's a reserved
+    # constructor kwarg used for the mock's repr); assign the attribute explicitly instead.
+    nodes = []
+    for i in range(count):
+        node = MagicMock()
+        node.name = f"node-{i}"
+        nodes.append(node)
+    return nodes
 
 
 def _attach_run_func_parallel(cluster):

--- a/unit_tests/test_update_seed_provider_parallel.py
+++ b/unit_tests/test_update_seed_provider_parallel.py
@@ -1,0 +1,70 @@
+"""Unit tests for SCT-731: parallelize BaseScyllaCluster.update_seed_provider.
+
+Verifies every node's scylla.yaml seed_provider is updated and that the per-node
+updates run concurrently rather than serially.
+"""
+
+import threading
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from sdcm.cluster import BaseScyllaCluster, BaseCluster
+
+
+def _make_nodes(count):
+    return [MagicMock(name=f"node-{i}") for i in range(count)]
+
+
+def _attach_run_func_parallel(cluster):
+    # run_func_parallel is defined on the BaseCluster mixin; concrete cluster classes combine
+    # BaseScyllaCluster with BaseCluster. In these isolated unit tests we instantiate a single
+    # mixin, so bind the real implementation onto the instance.
+    cluster.run_func_parallel = BaseCluster.run_func_parallel.__get__(cluster)
+
+
+@pytest.fixture
+def scylla_cluster():
+    with patch.object(BaseScyllaCluster, "__init__", lambda self, **kw: None):
+        cluster = BaseScyllaCluster()
+        cluster.log = MagicMock()
+        cluster.nodes = []
+        _attach_run_func_parallel(cluster)
+        return cluster
+
+
+def test_update_seed_provider_processes_all_nodes(scylla_cluster):
+    nodes = _make_nodes(4)
+    for node in nodes:
+        yaml_obj = MagicMock()
+
+        @contextmanager
+        def _cm(_yaml_obj=yaml_obj):
+            yield _yaml_obj
+
+        node.remote_scylla_yaml.side_effect = _cm
+        node._yaml_obj = yaml_obj
+    scylla_cluster.nodes = nodes
+
+    scylla_cluster.update_seed_provider()
+
+    for node in nodes:
+        node.remote_scylla_yaml.assert_called_once()
+        assert node._yaml_obj.seed_provider == node.proposed_scylla_yaml.seed_provider
+
+
+def test_update_seed_provider_runs_in_parallel(scylla_cluster):
+    barrier = threading.Barrier(3, timeout=10)
+    nodes = _make_nodes(3)
+    for node in nodes:
+
+        @contextmanager
+        def _cm(_node=node):
+            barrier.wait()  # blocks unless all 3 run concurrently
+            yield MagicMock()
+
+        node.remote_scylla_yaml.side_effect = _cm
+    scylla_cluster.nodes = nodes
+
+    scylla_cluster.update_seed_provider()  # would raise BrokenBarrierError if serial


### PR DESCRIPTION
## Summary

`provision_instances_with_fallback()` already creates VMs in parallel (the provisioner's `get_or_create_instances` does this internally), but it then waited for **cloud-init to complete on each node serially**. Each `wait_cloud_init_completes()` call opens an SSH connection and can block for several minutes (`is_up` waits up to 5 min, plus up to 20×10s retries and `cloud-init status --wait`). On large clusters this serial pass made provisioning time grow **linearly** with the node count.

This change waits for all nodes concurrently.

## Details

- Extracted the per-node remoter creation + cloud-init wait into a `wait_instance_ready()` helper and run it across all `(definition, vm)` pairs in parallel via `ParallelObject`.
- Worker count capped at `min(len(pairs), MAX_PROVISION_WAIT_WORKERS=50)` to avoid spawning an unbounded number of threads/SSH sessions on very large clusters.
- 30 min overall timeout, comfortably above the per-node internal retry budget so a slow node does not trigger a false timeout.
- `ignore_exceptions=False` is kept so a cloud-init failure on any node still fails provisioning (raised after all workers complete) — preserving the original fail-fast semantics.

Provisioning wait time is now bounded by the slowest node rather than the sum of all nodes.

## Testing

- `pre-commit` (ruff / ruff-format) passes on the changed file.
- Existing provisioner unit tests pass: `unit_tests/unit/provisioner/test_provision_sct_resources.py` (2 passed).