### PR TITLE
fix(longevity-twcs): add -random-data to avoid single-partition materialized views

### DIFF
--- a/test-cases/longevity/longevity-twcs-3h.yaml
+++ b/test-cases/longevity/longevity-twcs-3h.yaml
@@ -1,6 +1,6 @@
 test_duration: 210
 
-stress_cmd: ["scylla-bench -workload=timeseries -mode=write -replication-factor=3 -partition-count=4000 -clustering-row-count=10000 -clustering-row-size=200 -concurrency=100 -rows-per-request=1 -start-timestamp=SET_WRITE_TIMESTAMP -connection-count 100 -max-rate 30000 --timeout 120s -retry-number=30 -retry-interval=80ms,1s -duration=170m"]
+stress_cmd: ["scylla-bench -workload=timeseries -mode=write -random-data -replication-factor=3 -partition-count=4000 -clustering-row-count=10000 -clustering-row-size=200 -concurrency=100 -rows-per-request=1 -start-timestamp=SET_WRITE_TIMESTAMP -connection-count 100 -max-rate 30000 --timeout 120s -retry-number=30 -retry-interval=80ms,1s -duration=170m"]
 # write-rate with timeseries workload for read mode
 # calculated from timeseries workload for write mode by formula:
 # write-rate = -max-rate / -concurrency = 30000 / 150 = 200

--- a/test-cases/longevity/longevity-twcs-48h.yaml
+++ b/test-cases/longevity/longevity-twcs-48h.yaml
@@ -26,7 +26,7 @@
 test_duration: 3000
 
 stress_cmd: [
-    "scylla-bench -workload=timeseries -mode=write -replication-factor=3 -partition-count=200000 -clustering-row-count=100000 -clustering-row-size=2000 -concurrency=150 -rows-per-request=1 -start-timestamp=SET_WRITE_TIMESTAMP -connection-count 100 -max-rate 90000 -timeout=120s -retry-number=30 -retry-interval=80ms,1s -duration=2880m"
+    "scylla-bench -workload=timeseries -mode=write -random-data -replication-factor=3 -partition-count=200000 -clustering-row-count=100000 -clustering-row-size=2000 -concurrency=150 -rows-per-request=1 -start-timestamp=SET_WRITE_TIMESTAMP -connection-count 100 -max-rate 90000 -timeout=120s -retry-number=30 -retry-interval=80ms,1s -duration=2880m"
 ]
 # write-rate with timeseries workload for read mode
 # calculated from timeseries workload for write mode by formula:


### PR DESCRIPTION
## Problem

The twcs longevity write commands use a fixed `-clustering-row-size` with scylla-bench's default zero-filled value blob, so **every row's value column is byte-identical**. When an MV nemesis (`KillMVBuildingCoordinator`, `AddRemoveMvNemesis`) creates a materialized view keyed on that column via `create_materialized_view_for_random_column`, all view rows share a single partition key → the whole view lands on one shard per replica and overloads it during view building: `view_update_sl:default` semaphore saturation, `OVERSIZED_ALLOCATION`, and commitlog segments that never free.

Observed in longevity-twcs-3h run `db341140-52f3-42cd-b8e6-8d5d162c27a3` (Scylla 2025.4.7). Related: SCYLLADB-2876, SCT-353.

## Fix

Add `-random-data` to the write `stress_cmd` in both twcs configs. scylla-bench then fills the value blob with high-entropy data **distinct per `(pk, ck)`**, so a view keyed on that column distributes across the cluster normally.

For **longevity-twcs-48h** this fixes a second problem: it uses `ZstdWithDictsCompressor` and its stated purpose is to validate ZSTD dictionary compression stability. All-zero blobs are perfectly compressible, so that measurement was meaningless on degenerate data — real per-row data makes it representative.

Only the write commands need the flag; the read commands don't validate, so they read the data back unchanged.

## Dependency

Requires a scylla-bench build that includes the `-random-data` flag: scylladb/scylla-bench#313. **Merge/roll out that scylla-bench release first** — otherwise the write command fails with `flag provided but not defined: -random-data`.

## Note

The root anti-pattern (an MV keyed on a low-cardinality column) can't be fixed generically in `create_materialized_view_for_random_column`: scylla-bench's default table has only `pk, ck, v`, so excluding `v` would leave nothing to key the view on. Making `v` high-cardinality at ingestion is the correct layer.