### PR TITLE
fix(config): disable simulated racks for longevity-1-rf-test-12h

### DIFF
--- a/test-cases/longevity/longevity-1-rf-test-12h.yaml
+++ b/test-cases/longevity/longevity-1-rf-test-12h.yaml
@@ -22,6 +22,10 @@ n_db_nodes: 3
 n_loaders: 2
 round_robin: true
 
+# Disable simulated racks for RF=1 — rack simulation is meaningless with a single replica.
+# See: https://scylladb.atlassian.net/browse/SCYLLADB-2896
+simulated_racks: 0
+
 instance_type_db: 'i4i.xlarge'
 instance_type_loader: 'c6i.4xlarge'
 


### PR DESCRIPTION
Follow-up to #15252, which only covered the `rf1-non-disruptive` configuration fragment.

`test-cases/longevity/longevity-1-rf-test-12h.yaml` also runs everything with `replication-factor=1`, so rack simulation there is equally meaningless — there is a single replica and no benefit from rack-aware placement.

**Changes:**
- `test-cases/longevity/longevity-1-rf-test-12h.yaml`: Added `simulated_racks: 0` with a comment linking to the Jira issue

Verified with `sct.py conf` that the rendered config reports `simulated_racks: 0`.

Fixes: [SCYLLADB-2896](https://scylladb.atlassian.net/browse/SCYLLADB-2896)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SCYLLADB-2896]: https://scylladb.atlassian.net/browse/SCYLLADB-2896?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ