### PR TITLE
fix(raft): select topology coordinator via group0 leader host

### DIFF
--- a/sdcm/rest/raft_api.py
+++ b/sdcm/rest/raft_api.py
@@ -25,3 +25,16 @@ class RaftApi(RemoteCurlClient):
     def read_barrier(self, group_id: str) -> str:
         path = f"read_barrier?group_id={group_id}"
         return self.run_remoter_curl(method="POST", path=path, params={}, timeout=30).stdout.strip()
+
+    def get_group0_leader_host_id(self) -> str:
+        """Return the current group0 Raft leader host id (the live topology coordinator).
+
+        No group_id param is passed, so the endpoint defaults to group0. The response is a
+        JSON-quoted UUID string (e.g. '"<uuid>"'); when no leader is known during an
+        election/stepdown, the response contains the nil UUID
+        ('"00000000-0000-0000-0000-000000000000"'), not an empty string, because Scylla
+        serializes current_leader() via server_id::to_sstring(). The raw stdout is returned
+        unparsed - the caller must parse it and handle that transient sentinel.
+        """
+        path = "leader_host"
+        return self.run_remoter_curl(method="GET", path=path, params={}, timeout=30).stdout.strip()

--- a/sdcm/utils/raft/common.py
+++ b/sdcm/utils/raft/common.py
@@ -2,7 +2,6 @@ import logging
 import contextlib
 import time
 import traceback
-import re
 
 from typing import Iterable, Callable
 from functools import partial
@@ -18,12 +17,17 @@ from sdcm.utils.parallel_object import ParallelObject
 from sdcm.utils.raft import get_node_status_from_system_by, NodeState
 from sdcm.cluster import BaseMonitorSet, NodeSetupFailed, BaseScyllaCluster, BaseNode
 from sdcm.exceptions import RaftTopologyCoordinatorNotFound
+from sdcm.rest.raft_api import RaftApi
 from sdcm.rest.storage_service_client import StorageServiceClient
 from sdcm.utils.decorators import retrying
 
 
 LOGGER = logging.getLogger(__name__)
-UUID_REGEX = re.compile(r"([0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12})")
+
+# Scylla's GET /raft/leader_host serializes current_leader() via server_id::to_sstring(). When no
+# leader is known (election/stepdown in progress) current_leader() is a null server_id, which is
+# serialized as this nil UUID rather than an empty string. See scylladb api/raft.cc.
+NULL_LEADER_HOST_ID = "00000000-0000-0000-0000-000000000000"
 
 
 class RaftException(Exception):
@@ -56,24 +60,26 @@ def validate_raft_on_nodes(nodes: list[BaseNode]) -> None:
     n=3, allowed_exceptions=(RaftTopologyCoordinatorNotFound,), message="Waiting topology coordinator election ..."
 )
 def get_topology_coordinator_node(node: BaseNode) -> BaseNode:
+    """Return the node that is the current topology coordinator.
+
+    The topology coordinator fiber runs only on the group0 Raft leader, so the current topology
+    coordinator is the current group0 leader - a live fact exposed by the /raft/leader_host REST
+    endpoint. This avoids depending on system.group0_history retention, which is short-lived
+    (see scylladb PR #30395: group0_history GC shortened from 1 week to 1 hour).
+    """
     active_nodes: list[BaseNode] = node.parent_cluster.get_nodes_up_and_normal(node)
-    stm = "select description from system.group0_history where key = 'history' and \
-            description LIKE 'Starting new topology coordinator%' ALLOW FILTERING;"
-    with node.parent_cluster.cql_connection_patient(node) as session:
-        result = list(session.execute(stm))
-    coordinators_ids = []
-    for row in result:
-        if match := UUID_REGEX.search(row.description):
-            coordinators_ids.append(match.group(1))
-    if not coordinators_ids:
-        raise RaftTopologyCoordinatorNotFound("No host ids were found in raft group0 history")
-    LOGGER.debug("All coordinators history ids: %s", coordinators_ids)
+    # query any healthy up node: /raft/leader_host fans out internally, so it is safe even when
+    # the coordinator node itself is being restarted.
+    leader_host_id = loads(RaftApi(node).get_group0_leader_host_id() or '""')
+    if not leader_host_id or leader_host_id == NULL_LEADER_HOST_ID:
+        raise RaftTopologyCoordinatorNotFound("Group0 leader host id is unknown (election/stepdown in progress)")
+    LOGGER.debug("Group0 leader host id: %s", leader_host_id)
     for active_node in active_nodes:
         node_hostid = loads(StorageServiceClient(active_node).get_local_hostid().stdout)
         LOGGER.debug("Node %s host id is %s", active_node.name, node_hostid)
-        if node_hostid == coordinators_ids[0]:
+        if node_hostid == leader_host_id:
             return active_node
-    raise RaftTopologyCoordinatorNotFound(f"The node with host id {coordinators_ids[0]} was not found")
+    raise RaftTopologyCoordinatorNotFound(f"Leader host {leader_host_id} not found among active nodes")
 
 
 class NodeBootstrapAbortManager:

--- a/unit_tests/unit/test_raft_common.py
+++ b/unit_tests/unit/test_raft_common.py
@@ -1,0 +1,113 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2026 ScyllaDB
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from sdcm.exceptions import RaftTopologyCoordinatorNotFound
+from sdcm.utils.raft import common
+
+LEADER_HOST_ID = "11111111-1111-1111-1111-111111111111"
+OTHER_HOST_ID = "22222222-2222-2222-2222-222222222222"
+NULL_HOST_ID = "00000000-0000-0000-0000-000000000000"
+
+
+def _make_node(name: str, host_id: str) -> MagicMock:
+    node = MagicMock()
+    node.name = name
+    node.host_id = host_id
+    return node
+
+
+def _make_verification_node(active_nodes: list[MagicMock]) -> MagicMock:
+    node = MagicMock()
+    node.name = "verification-node"
+    node.parent_cluster.get_nodes_up_and_normal.return_value = active_nodes
+    return node
+
+
+@pytest.fixture(autouse=True)
+def _no_retry_sleep(monkeypatch):
+    # Speed up retrying(n=3) failures.
+    monkeypatch.setattr("sdcm.utils.decorators.time.sleep", lambda *_, **__: None)
+
+
+@pytest.fixture
+def storage_service_client_mock(monkeypatch):
+    """Patch StorageServiceClient to return each node's host id as JSON-quoted stdout."""
+
+    def _factory(active_node):
+        client = MagicMock()
+        client.get_local_hostid.return_value.stdout = f'"{active_node.host_id}"'
+        return client
+
+    mock_cls = MagicMock(side_effect=_factory)
+    monkeypatch.setattr(common, "StorageServiceClient", mock_cls)
+    return mock_cls
+
+
+@pytest.fixture
+def raft_leader_host_mock(monkeypatch):
+    """Patch RaftApi and return get_group0_leader_host_id mock for setup/assertions."""
+    raft_api_cls = MagicMock()
+    monkeypatch.setattr(common, "RaftApi", raft_api_cls)
+    return raft_api_cls.return_value.get_group0_leader_host_id
+
+
+def test_returns_node_matching_group0_leader(raft_leader_host_mock, storage_service_client_mock):
+    leader_node = _make_node("node-1", LEADER_HOST_ID)
+    other_node = _make_node("node-2", OTHER_HOST_ID)
+    verification_node = _make_verification_node([other_node, leader_node])
+    raft_leader_host_mock.return_value = f'"{LEADER_HOST_ID}"'
+
+    result = common.get_topology_coordinator_node(verification_node)
+
+    assert result is leader_node, (
+        f"Expected the node whose host id matches the group0 leader ({LEADER_HOST_ID}), got {result}"
+    )
+    raft_leader_host_mock.assert_called_once_with()
+    verification_node.parent_cluster.get_nodes_up_and_normal.assert_called_once_with(verification_node)
+    assert storage_service_client_mock.call_count == 2, (
+        f"Expected host id to be resolved for both active nodes, got {storage_service_client_mock.call_count} call(s)"
+    )
+
+
+@pytest.mark.parametrize(
+    ("leader_host_id", "error_match"),
+    [
+        # Scylla serializes an unknown leader (election/stepdown) as the nil UUID, not "".
+        pytest.param(f'"{NULL_HOST_ID}"', "unknown", id="nil-uuid-leader-host"),
+        pytest.param('""', "unknown", id="empty-leader-host"),
+        pytest.param(f'"{LEADER_HOST_ID}"', "not found among active nodes", id="leader-not-in-active-nodes"),
+    ],
+)
+def test_raises_when_leader_unusable_or_missing_in_active_nodes(
+    raft_leader_host_mock,
+    storage_service_client_mock,
+    leader_host_id,
+    error_match,
+):
+    verification_node = _make_verification_node([_make_node("node-1", OTHER_HOST_ID)])
+    raft_leader_host_mock.return_value = leader_host_id
+
+    with pytest.raises(RaftTopologyCoordinatorNotFound, match=error_match):
+        common.get_topology_coordinator_node(verification_node)
+
+    # Retry wrapper re-runs three times for RaftTopologyCoordinatorNotFound.
+    assert raft_leader_host_mock.call_count == 3, (
+        f"Expected the @retrying(n=3) wrapper to query the leader host 3 times, "
+        f"got {raft_leader_host_mock.call_count} call(s)"
+    )
+    # Validate we no longer use the old CQL history lookup code path.
+    verification_node.parent_cluster.cql_connection_patient.assert_not_called()


### PR DESCRIPTION
Replace group0_history-based coordinator lookup with Raft leader_host API and cover success/retry/failure paths in unit tests.

Fixes: SCT-697

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [Job passed ](https://jenkins.scylladb.com/job/scylla-staging/job/aleksbykov/job/longevities/job/longevity-100gb-4h-test/20/)
- [job passed](https://argus.scylladb.com/tests/scylla-cluster-tests/9e22668f-4f3c-4b88-8258-6d85d1ec7202)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
