### PR TITLE
fix(trigger-matrix): stop --region overwriting multi-region jobs

### DIFF
--- a/configurations/triggers/perf-regression.yaml
+++ b/configurations/triggers/perf-regression.yaml
@@ -57,83 +57,84 @@ jobs:
 
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-i8g-vnodes"
     backend: "aws"
-    region: "eu-west-2"
     include_versions: ["master"]
     labels: ["master-monthly"]
     job_throttle_category: "SCT-perf-eu-west-2-i8g"
     params:
+      region: "eu-west-2"
       sub_tests: '["test_read_gradual_increase_load", "test_mixed_gradual_increase_load", "test_write_gradual_increase_load", "test_read_disk_only_gradual_increase_load"]'
 
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-i8g-vnodes"
     backend: "aws"
-    region: "eu-west-2"
     exclude_versions: ["2025.2", "2025.1", "2024.2", "2024.1", "master"]
     labels: []
     job_throttle_category: "SCT-perf-eu-west-2-i8g"
     params:
+      region: "eu-west-2"
       sub_tests: '["test_mixed_gradual_increase_load"]'
 
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-with-nemesis-i8g-vnodes"
     backend: "aws"
-    region: "eu-north-1"
     include_versions: ["master"]
     labels: ["master-monthly"]
     job_throttle_category: "SCT-perf-eu-north-1-i8g"
     params:
+      region: "eu-north-1"
       sub_tests: '["test_latency_mixed_with_nemesis", "test_latency_read_with_nemesis", "test_latency_write_with_nemesis"]'
 
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-with-nemesis-i8g-vnodes"
     backend: "aws"
-    region: "eu-west-1"
     exclude_versions: ["2025.2", "2025.1", "2024.2", "2024.1", "master"]
     labels: []
     job_throttle_category: "SCT-perf-eu-west-1-i8g"
     params:
+      region: "eu-west-1"
       sub_tests: '["test_latency_mixed_with_nemesis"]'
 
   # === x86 vnodes (non-master only) ===
 
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-vnodes"
     backend: "aws"
-    region: "us-east-1"
     include_versions: ["2025.2", "2025.1", "2024.2", "2024.1"]
     labels: []
     params:
+      region: "us-east-1"
       sub_tests: '["test_read_gradual_increase_load", "test_mixed_gradual_increase_load", "test_read_disk_only_gradual_increase_load"]'
 
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-write-vnodes"
     backend: "aws"
-    region: "us-east-1"
     include_versions: ["2025.2", "2025.1", "2024.2", "2024.1"]
     labels: []
     params:
+      region: "us-east-1"
       sub_tests: '["test_write_gradual_increase_load"]'
 
   # === Latency with rolling upgrade (all versions) ===
 
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-during-rolling-upgrade"
     backend: "aws"
-    region: "eu-west-1"
     disabled: true
     labels: []
     params:
+      region: "eu-west-1"
       rolling_upgrade_test: "true"
 
   # === Latency with nemesis x86 (non-master only) ===
 
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-with-nemesis"
     backend: "aws"
-    region: "eu-west-2"
     include_versions: ["2025.2", "2025.1", "2024.2", "2024.1"]
     labels: []
     params:
+      region: "eu-west-2"
       sub_tests: '["test_latency_mixed_with_nemesis"]'
 
   # === Latency with nemesis rbno-disabled (all versions) ===
 
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-with-nemesis-rbno-disabled"
     backend: "aws"
-    region: "eu-west-3"
+    params:
+      region: "eu-west-3"
     disabled: true
     labels: []
 
@@ -141,37 +142,36 @@ jobs:
 
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-simple-query-weekly-microbenchmark_arm64"
     backend: "aws"
-    region: "us-east-1"
     labels: ["master-weekly"]
     params:
+      region: "us-east-1"
       microbenchmark: "true"
 
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-simple-query-weekly-microbenchmark_arm64-write"
     backend: "aws"
-    region: "us-east-1"
     labels: ["master-weekly"]
     params:
+      region: "us-east-1"
       microbenchmark: "true"
 
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-simple-query-weekly-microbenchmark_x86_64"
     backend: "aws"
-    region: "us-east-1"
     labels: ["master-weekly"]
     params:
+      region: "us-east-1"
       microbenchmark: "true"
 
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-simple-query-weekly-microbenchmark_x86_64-write"
     backend: "aws"
-    region: "us-east-1"
     labels: ["master-weekly"]
     params:
+      region: "us-east-1"
       microbenchmark: "true"
 
   # === Daily sanity perf (master-only) ===
 
   - job_name: "/scylla-master/perf-regression/perf-regression-predefined-throughput-steps-sanity-vnodes"
     backend: "aws"
-    region: ""
     disabled: true
     labels: ["master-daily"]
 
@@ -179,78 +179,78 @@ jobs:
 
   - job_name: "/scylla-master/perf-regression/scylla-release-perf-regression-alternator"
     backend: "aws"
-    region: "eu-north-1"
     include_versions: ["master"]
     labels: ["alternator-weekly"]
     params:
+      region: "eu-north-1"
       sub_tests: '["test_full"]'
 
   # === GCE custom monthly latte ===
 
   - job_name: "/scylla-master/perf-regression/latte-perf-regression-latency-steady-state-custom-d1-workload1-vnodes"
     backend: "gce"
-    region: "us-east1"
     exclude_versions: ["2024.1", "2024.2"]
     pre_release: ["rc1", "rc3"]
     labels: ["gce-custom-monthly"]
     params:
+      region: "us-east1"
       sub_tests: '["test_latency_steady_state"]'
 
   - job_name: "/scylla-master/perf-regression/latte-perf-regression-latency-steady-state-custom-d1-workload1-tablets"
     backend: "gce"
-    region: "us-east1"
     exclude_versions: ["2024.1", "2024.2"]
     pre_release: ["rc1", "rc3"]
     labels: ["gce-custom-monthly"]
     params:
+      region: "us-east1"
       sub_tests: '["test_latency_steady_state"]'
 
   # === i8g tablets (aarch64) — weekly ===
 
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-i8g-tablets"
     backend: "aws"
-    region: "us-east-1"
     include_versions: ["master"]
     labels: ["master-weekly"]
     job_throttle_category: "SCT-perf-us-east-1-i8g"
     params:
+      region: "us-east-1"
       sub_tests: '["test_read_gradual_increase_load", "test_mixed_gradual_increase_load", "test_write_gradual_increase_load", "test_read_disk_only_gradual_increase_load"]'
 
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-i8g-tablets"
     backend: "aws"
-    region: "us-west-2"
     exclude_versions: ["2025.2", "2025.1", "2024.1", "2024.2", "master"]
     labels: []
     job_throttle_category: "SCT-perf-us-west-2-i8g"
     params:
+      region: "us-west-2"
       sub_tests: '["test_read_gradual_increase_load", "test_mixed_gradual_increase_load", "test_write_gradual_increase_load", "test_read_disk_only_gradual_increase_load"]'
 
   # === x86 tablets (non-master only) ===
 
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-tablets"
     backend: "aws"
-    region: "us-east-1"
     include_versions: ["2025.2", "2025.1"]
     labels: []
     params:
+      region: "us-east-1"
       sub_tests: '["test_read_gradual_increase_load", "test_mixed_gradual_increase_load", "test_read_disk_only_gradual_increase_load"]'
 
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-write-tablets"
     backend: "aws"
-    region: "us-east-1"
     include_versions: ["2025.2", "2025.1"]
     labels: []
     params:
+      region: "us-east-1"
       sub_tests: '["test_write_gradual_increase_load"]'
 
   # === Tablets latency — rolling upgrade (non-master) ===
 
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-during-rolling-upgrade-tablets"
     backend: "aws"
-    region: "eu-west-2"
     include_versions: ["2025.2", "2025.1"]
     labels: []
     params:
+      region: "eu-west-2"
       sub_tests: '["test_latency_mixed_with_upgrade"]'
       rolling_upgrade_test: "true"
 
@@ -258,31 +258,31 @@ jobs:
 
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-with-nemesis-tablets"
     backend: "aws"
-    region: "eu-west-3"
     include_versions: ["2025.2", "2025.1"]
     labels: []
     params:
+      region: "eu-west-3"
       sub_tests: '["test_latency_read_with_nemesis", "test_latency_mixed_with_nemesis"]'
 
   # === i8g tablets latency — rolling upgrade (3-weekly) ===
 
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-during-rolling-upgrade-i8g-tablets"
     backend: "aws"
-    region: "us-east-2"
     include_versions: ["master"]
     labels: ["master-3weeks"]
     job_throttle_category: "SCT-perf-us-east-2-i8g"
     params:
+      region: "us-east-2"
       sub_tests: '["test_latency_mixed_with_upgrade"]'
       rolling_upgrade_test: "true"
 
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-during-rolling-upgrade-i8g-tablets"
     backend: "aws"
-    region: "eu-west-2"
     exclude_versions: ["2025.2", "2025.1", "2024.2", "2024.1", "master"]
     labels: []
     job_throttle_category: "SCT-perf-eu-west-2-i8g"
     params:
+      region: "eu-west-2"
       sub_tests: '["test_latency_mixed_with_upgrade"]'
       rolling_upgrade_test: "true"
 
@@ -290,36 +290,36 @@ jobs:
 
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-with-nemesis-i8g-tablets"
     backend: "aws"
-    region: "eu-north-1"
     include_versions: ["master"]
     labels: ["master-3weeks"]
     job_throttle_category: "SCT-perf-eu-north-1-i8g"
     params:
+      region: "eu-north-1"
       sub_tests: '["test_latency_mixed_with_nemesis"]'
 
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-with-nemesis-i8g-tablets"
     backend: "aws"
-    region: "eu-west-2"
     exclude_versions: ["2025.2", "2025.1", "2024.2", "2024.1", "master"]
     labels: []
     job_throttle_category: "SCT-perf-eu-west-2-i8g"
     params:
+      region: "eu-west-2"
       sub_tests: '["test_latency_read_with_nemesis", "test_latency_mixed_with_nemesis"]'
 
   # === Elasticity (monthly) ===
 
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-2.5tb-i8g-elasticity"
     backend: "aws"
-    region: "eu-north-1"
     exclude_versions: ["2024.1", "2024.2", "2025.1", "2025.4", "master"]
     labels: []
     params:
+      region: "eu-north-1"
       sub_tests: '["test_latency_mixed_with_nemesis"]'
 
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-2.5tb-i8g-elasticity"
     backend: "aws"
-    region: "eu-north-1"
     include_versions: ["master"]
     labels: ["master-monthly"]
     params:
+      region: "eu-north-1"
       sub_tests: '["test_latency_mixed_with_nemesis"]'

--- a/configurations/triggers/pgo-offline-installer.yaml
+++ b/configurations/triggers/pgo-offline-installer.yaml
@@ -24,45 +24,45 @@ jobs:
   # --- x86_64 microbenchmarks ---
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-simple-query-weekly-microbenchmark_x86_64"
     backend: "aws"
-    region: "us-east-1"
     wait: false
     labels:
       - "pgo-x86"
     exclude_versions: []
     params:
+      region: "us-east-1"
       unified_package: "{unified_package}"
       nonroot_offline_install: "false"
 
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-simple-query-weekly-microbenchmark_x86_64-write"
     backend: "aws"
-    region: "us-east-1"
     wait: false
     labels:
       - "pgo-x86"
     exclude_versions: []
     params:
+      region: "us-east-1"
       unified_package: "{unified_package}"
       nonroot_offline_install: "false"
 
   # --- ARM64 microbenchmarks ---
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-simple-query-weekly-microbenchmark_arm64"
     backend: "aws"
-    region: "us-east-1"
     wait: false
     labels:
       - "pgo-arm"
     exclude_versions: []
     params:
+      region: "us-east-1"
       unified_package: "{unified_package}"
       nonroot_offline_install: "false"
 
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-simple-query-weekly-microbenchmark_arm64-write"
     backend: "aws"
-    region: "us-east-1"
     wait: false
     labels:
       - "pgo-arm"
     exclude_versions: []
     params:
+      region: "us-east-1"
       unified_package: "{unified_package}"
       nonroot_offline_install: "false"

--- a/configurations/triggers/rolling-upgrade.yaml
+++ b/configurations/triggers/rolling-upgrade.yaml
@@ -35,12 +35,12 @@ jobs:
 
   - job_name: "rolling-upgrade/rolling-upgrade-rocky10-test"
     backend: "gce"
-    region: "us-central1"
     labels:
       - "weekly"
       - "rpm"
     exclude_versions: []
     params:
+      region: "us-central1"
       new_scylla_repo: "http://downloads.scylladb.com/unstable/scylla/{branch}/rpm/centos/latest/scylla.repo"
 
   # ===========================================================================
@@ -49,32 +49,32 @@ jobs:
 
   - job_name: "rolling-upgrade/rolling-upgrade-debian13-test"
     backend: "gce"
-    region: "us-central1"
     labels:
       - "weekly"
       - "deb"
     exclude_versions: []
     params:
+      region: "us-central1"
       new_scylla_repo: "http://downloads.scylladb.com.s3.amazonaws.com/unstable/scylla/{branch}/deb/unified/latest/scylladb-{branch}/scylla.list"
 
   - job_name: "rolling-upgrade/rolling-upgrade-ubuntu2404-test"
     backend: "gce"
-    region: "us-central1"
     labels:
       - "weekly"
       - "deb"
     exclude_versions: []
     params:
+      region: "us-central1"
       new_scylla_repo: "http://downloads.scylladb.com.s3.amazonaws.com/unstable/scylla/{branch}/deb/unified/latest/scylladb-{branch}/scylla.list"
 
   - job_name: "rolling-upgrade/rolling-upgrade-ubuntu2604-test"
     backend: "gce"
-    region: "us-central1"
     labels:
       - "weekly"
       - "deb"
     exclude_versions: []
     params:
+      region: "us-central1"
       new_scylla_repo: "http://downloads.scylladb.com.s3.amazonaws.com/unstable/scylla/{branch}/deb/unified/latest/scylladb-{branch}/scylla.list"
 
   # ===========================================================================
@@ -83,18 +83,17 @@ jobs:
 
   - job_name: "rolling-upgrade/rolling-upgrade-ami-test"
     backend: "aws"
-    region: "eu-west-1"
     labels:
       - "weekly"
       - "image"
       - "ami"
     exclude_versions: []
     params:
+      region: "eu-west-1"
       new_scylla_repo: "http://downloads.scylladb.com.s3.amazonaws.com/unstable/scylla/{branch}/deb/unified/latest/scylladb-{branch}/scylla.list"
 
   - job_name: "rolling-upgrade/rolling-upgrade-ami-arm-test"
     backend: "aws"
-    region: "eu-west-1"
     arch: "aarch64"
     labels:
       - "weekly"
@@ -102,28 +101,29 @@ jobs:
       - "ami"
     exclude_versions: []
     params:
+      region: "eu-west-1"
       new_scylla_repo: "http://downloads.scylladb.com.s3.amazonaws.com/unstable/scylla/{branch}/deb/unified/latest/scylladb-{branch}/scylla.list"
 
   - job_name: "rolling-upgrade/rolling-upgrade-gce-image-test"
     backend: "gce"
-    region: "us-central1"
     labels:
       - "weekly"
       - "image"
       - "gce"
     exclude_versions: []
     params:
+      region: "us-central1"
       new_scylla_repo: "http://downloads.scylladb.com.s3.amazonaws.com/unstable/scylla/{branch}/deb/unified/latest/scylladb-{branch}/scylla.list"
 
   - job_name: "rolling-upgrade/rolling-upgrade-azure-image-test"
     backend: "azure"
-    region: "eastus"
     labels:
       - "weekly"
       - "image"
       - "azure"
     exclude_versions: []
     params:
+      region: "eastus"
       new_scylla_repo: "http://downloads.scylladb.com.s3.amazonaws.com/unstable/scylla/{branch}/deb/unified/latest/scylladb-{branch}/scylla.list"
 
   # ===========================================================================
@@ -132,83 +132,83 @@ jobs:
 
   - job_name: "rolling-upgrade/rolling-upgrade-alternator-test"
     backend: "gce"
-    region: "us-east1"
     labels:
       - "weekly"
       - "deb"
     exclude_versions: []
     params:
+      region: "us-east1"
       new_scylla_repo: "http://downloads.scylladb.com.s3.amazonaws.com/unstable/scylla/{branch}/deb/unified/latest/scylladb-{branch}/scylla.list"
 
   # --- Non-weekly jobs (triggered by scylla-pkg on release only) ---
 
   - job_name: "rolling-upgrade/rolling-upgrade-multidc-test"
     backend: "aws"
-    region: "eu-west-1"
     labels:
       - "release"
       - "deb"
     exclude_versions: []
     params:
+      region: "eu-west-1"
       new_scylla_repo: "http://downloads.scylladb.com.s3.amazonaws.com/unstable/scylla/{branch}/deb/unified/latest/scylladb-{branch}/scylla.list"
 
   - job_name: "rolling-upgrade/rolling-upgrade-with-sla-test"
     backend: "gce"
-    region: "us-east1"
     labels:
       - "release"
       - "deb"
     exclude_versions: []
     params:
+      region: "us-east1"
       new_scylla_repo: "http://downloads.scylladb.com.s3.amazonaws.com/unstable/scylla/{branch}/deb/unified/latest/scylladb-{branch}/scylla.list"
 
   - job_name: "rolling-upgrade/rolling-upgrade-with-sla-no-shares-test"
     backend: "gce"
-    region: "us-east1"
     labels:
       - "release"
       - "deb"
     exclude_versions: []
     params:
+      region: "us-east1"
       new_scylla_repo: "http://downloads.scylladb.com.s3.amazonaws.com/unstable/scylla/{branch}/deb/unified/latest/scylladb-{branch}/scylla.list"
 
   - job_name: "rolling-upgrade/rolling-upgrade-with-null-inserts-test"
     backend: "gce"
-    region: "us-east1"
     labels:
       - "release"
       - "deb"
     exclude_versions: []
     params:
+      region: "us-east1"
       new_scylla_repo: "http://downloads.scylladb.com.s3.amazonaws.com/unstable/scylla/{branch}/deb/unified/latest/scylladb-{branch}/scylla.list"
 
   - job_name: "rolling-upgrade/rolling-upgrade-with-enable-tablets-test"
     backend: "gce"
-    region: "us-east1"
     labels:
       - "release"
       - "image"
       - "gce"
     exclude_versions: []
     params:
+      region: "us-east1"
       new_scylla_repo: "http://downloads.scylladb.com.s3.amazonaws.com/unstable/scylla/{branch}/deb/unified/latest/scylladb-{branch}/scylla.list"
 
   - job_name: "rolling-upgrade/rolling-upgrade-debian11-test"
     backend: "gce"
-    region: "us-central1"
     labels:
       - "release"
       - "deb"
     exclude_versions: []
     params:
+      region: "us-central1"
       new_scylla_repo: "http://downloads.scylladb.com.s3.amazonaws.com/unstable/scylla/{branch}/deb/unified/latest/scylladb-{branch}/scylla.list"
 
   - job_name: "rolling-upgrade/rolling-upgrade-ubuntu22.04-ldap-authorization-test"
     backend: "gce"
-    region: "us-east1"
     labels:
       - "release"
       - "deb"
     exclude_versions: []
     params:
+      region: "us-east1"
       new_scylla_repo: "http://downloads.scylladb.com.s3.amazonaws.com/unstable/scylla/{branch}/deb/unified/latest/scylladb-{branch}/scylla.list"

--- a/configurations/triggers/sanity.yaml
+++ b/configurations/triggers/sanity.yaml
@@ -19,61 +19,70 @@ jobs:
   # --- Sanity jobs (from sanity-*-trigger.jenkinsfile) ---
   - job_name: "longevity/longevity-100gb-4h-test"
     backend: "aws"
-    region: "eu-west-1"
+    params:
+      region: "eu-west-1"
     labels: []
     exclude_versions: []
 
   - job_name: "longevity/longevity-10gb-3h-azure-test"
     backend: "azure"
-    region: "eastus"
+    params:
+      region: "eastus"
     labels: []
     exclude_versions: []
 
   - job_name: "longevity/longevity-10gb-3h-gce-test"
     backend: "gce"
-    region: "us-east1"
+    params:
+      region: "us-east1"
     labels: []
     exclude_versions: []
 
   # --- Additional AWS jobs (from additional-aws-trigger.jenkinsfile) ---
   - job_name: "longevity/longevity-10gb-3h-test"
     backend: "aws"
-    region: "eu-west-1"
+    params:
+      region: "eu-west-1"
     labels:
       - "additional"
     exclude_versions: []
 
   - job_name: "no_tablets/longevity-lwt-3h-no-tablets-test"
     backend: "aws"
-    region: "eu-west-1"
+    params:
+      region: "eu-west-1"
     labels:
       - "additional"
     exclude_versions: []
 
   - job_name: "longevity/longevity-twcs-3h-test"
     backend: "aws"
-    region: "eu-west-1"
+    params:
+      region: "eu-west-1"
     labels:
       - "additional"
     exclude_versions: []
 
   - job_name: "alternator/longevity-alternator-3h-test"
     backend: "aws"
-    region: "eu-west-1"
+    params:
+      region: "eu-west-1"
     labels:
       - "additional"
     exclude_versions: []
 
   - job_name: "no_tablets/longevity-cdc-100gb-4h-no-tablets-test"
     backend: "aws"
-    region: "eu-west-1"
+    params:
+      region: "eu-west-1"
     labels:
       - "additional"
     exclude_versions: []
 
   - job_name: "longevity/longevity-large-partition-asymmetric-cluster-3h-test"
     backend: "aws"
-    region: "eu-west-1"
+    params:
+      region: "eu-west-1"
     labels:
       - "additional"
     exclude_versions: []

--- a/configurations/triggers/scylla-doctor-gating.yaml
+++ b/configurations/triggers/scylla-doctor-gating.yaml
@@ -20,7 +20,6 @@ defaults:
 jobs:
   - job_name: "/scylla-doctor/oss/artifacts/artifacts-ami-test"
     backend: "aws"
-    region: "eu-west-1"
     wait: true
     wait_timeout: 7200
     fail_on_error: true
@@ -29,11 +28,11 @@ jobs:
     labels:
       - "gating"
     params:
+      region: "eu-west-1"
       scylla_doctor_edition: "full"
 
   - job_name: "/scylla-doctor/oss/artifacts/artifacts-ami-arm-test"
     backend: "aws"
-    region: "eu-west-1"
     wait: true
     wait_timeout: 7200
     fail_on_error: true
@@ -42,11 +41,11 @@ jobs:
     labels:
       - "gating"
     params:
+      region: "eu-west-1"
       scylla_doctor_edition: "full"
 
   - job_name: "/scylla-doctor/oss/artifacts/artifacts-docker-test"
     backend: "aws"
-    region: "eu-west-1"
     wait: true
     wait_timeout: 3600
     fail_on_error: true
@@ -55,6 +54,7 @@ jobs:
     labels:
       - "gating"
     params:
+      region: "eu-west-1"
       scylla_doctor_edition: "full"
 
 email_recipients: "qa@scylladb.com"

--- a/configurations/triggers/tier1.yaml
+++ b/configurations/triggers/tier1.yaml
@@ -35,60 +35,68 @@ jobs:
 
   - job_name: "tier1/gemini-1tb-10h-test"
     backend: "aws"
-    region: "eu-west-1"
+    params:
+      region: "eu-west-1"
     labels:
       - "weekly"
     exclude_versions: ["2024.1", "2025.1", "2025.4", "2026.1"]
 
   - job_name: "tier1/longevity-mv-si-4days-streaming-test"
     backend: "aws"
-    region: "eu-west-1"
+    params:
+      region: "eu-west-1"
     labels:
       - "weekly"
 
   - job_name: "tier1/longevity-schema-topology-changes-12h-test"
     backend: "aws"
-    region: "eu-west-1"
+    params:
+      region: "eu-west-1"
     labels:
       - "weekly"
 
   - job_name: "tier1/scale-schema-5000-tables-latte-test"
     backend: "aws"
-    region: "eu-west-1"
+    params:
+      region: "eu-west-1"
     labels:
       - "weekly"
     exclude_versions: ["2024.1", "2025.1", "2025.4", "2026.1"]
 
   - job_name: "tier1/longevity-twcs-48h-test"
     backend: "aws"
-    region: "us-east-1"
+    params:
+      region: "us-east-1"
     labels:
       - "weekly"
 
   - job_name: "tier1/longevity-50gb-3days-test"
     backend: "aws"
-    region: "eu-west-1"
+    params:
+      region: "eu-west-1"
     labels:
       - "weekly"
     include_versions: ["2024.1", "2025.1", "2025.4", "2026.1"]
 
   - job_name: "tier1/longevity-150gb-asymmetric-cluster-12h-test"
     backend: "aws"
-    region: "us-east-1"
+    params:
+      region: "us-east-1"
     labels:
       - "weekly"
 
   - job_name: "tier1/elasticity-90-percent-with-nemesis-test"
     backend: "aws"
-    region: "us-east-1"
+    params:
+      region: "us-east-1"
     labels:
       - "weekly"
     exclude_versions: ["2024.1", "2025.1", "2025.4", "2026.1"]
 
   - job_name: "tier1/longevity-multidc-schema-topology-changes-12h-test"
     backend: "aws"
-    region: '["eu-west-1", "eu-west-2"]'
     params:
+      region: '["eu-west-1", "eu-west-2"]'
       availability_zone: "a,b,c"
     labels:
       - "weekly"
@@ -97,7 +105,8 @@ jobs:
 
   - job_name: "tier1/longevity-twcs-48h-test"
     backend: "aws"
-    region: "us-east-1"
+    params:
+      region: "us-east-1"
     labels:
       - "weekly"
       - "aarch64"
@@ -105,7 +114,8 @@ jobs:
 
   - job_name: "tier1/longevity-2tb-5days-test"
     backend: "aws"
-    region: "eu-west-1"
+    params:
+      region: "eu-west-1"
     labels:
       - "weekly"
       - "aarch64"
@@ -113,7 +123,8 @@ jobs:
 
   - job_name: "tier1/elasticity-90-percent-with-nemesis-test"
     backend: "aws"
-    region: "us-east-1"
+    params:
+      region: "us-east-1"
     labels:
       - "weekly"
       - "aarch64"
@@ -123,8 +134,8 @@ jobs:
 
   - job_name: "tier1/longevity-large-partition-200k-pks-4days-gce-test"
     backend: "gce"
-    region: "us-east1"
     params:
+      region: "us-east1"
       availability_zone: ""
     labels:
       - "weekly"
@@ -133,8 +144,8 @@ jobs:
 
   - job_name: "tier1/longevity-1tb-5days-azure-test"
     backend: "azure"
-    region: "eastus"
     params:
+      region: "eastus"
       availability_zone: ""
     labels:
       - "weekly"

--- a/docs/testing/trigger-matrix.md
+++ b/docs/testing/trigger-matrix.md
@@ -2,6 +2,70 @@
 
 Manual testing procedures for the `sct.py trigger-matrix` command and the YAML trigger matrix system.
 
+## Matrix YAML Layout
+
+A job entry has two kinds of keys, and putting one in the other's place is rejected at load time.
+
+**Job-level keys** decide *whether and how* the job is triggered — they are consumed by the trigger itself:
+
+`job_name`, `backend`, `arch`, `disabled`, `labels`, `include_versions`, `exclude_versions`, `pre_release`,
+`job_throttle_category`, `params`, `wait`, `wait_timeout`, `fail_on_error`, `collect_results`
+
+One exception: `job_throttle_category` is *also* forwarded to Jenkins as a build parameter of the same
+name (via `setdefault`, so a `params:` entry of the same name wins). Every other job-level key stops at
+the trigger.
+
+**Everything else is a Jenkins job parameter and belongs under `params:`** — including `region` and
+`availability_zone`, which used to sit at job level.
+
+```yaml
+jobs:
+  - job_name: "tier1/longevity-multidc-schema-topology-changes-12h-test"
+    backend: "aws"
+    params:
+      region: '["eu-west-1", "eu-west-2"]'   # multi-region: a JSON *string*, not a YAML list
+      availability_zone: "a,b,c"
+    labels:
+      - "weekly"
+```
+
+### Migrating an existing matrix
+
+`region` and `availability_zone` used to be job-level keys. Moving them under `params:` is a breaking
+layout change — a matrix still using the old form fails to load. To migrate:
+
+1. Move every job-level `region:` / `availability_zone:` line under that job's `params:`, creating the
+   `params:` block if the job doesn't have one.
+2. Drop empty ones (`region: ""`). They were a no-op before, and keeping them would start passing an
+   empty region to Jenkins.
+3. Quote multi-valued parameters as JSON *strings* — a YAML list is rejected.
+4. Validate: `uv run python -c "from sdcm.utils.trigger_matrix import load_matrix_config; load_matrix_config('<matrix>.yaml')"`
+
+```yaml
+# before                                    # after
+- job_name: "tier1/multidc-test"            - job_name: "tier1/multidc-test"
+  backend: "aws"                              backend: "aws"
+  region: '["eu-west-1", "eu-west-2"]'        params:
+  params:                                       region: '["eu-west-1", "eu-west-2"]'
+    availability_zone: "a,b,c"                  availability_zone: "a,b,c"
+  labels:                                     labels:
+    - "weekly"                                  - "weekly"
+```
+
+`load_matrix_config()` validates the layout and reports every problem at once, naming the offending job:
+
+- unknown job-level key → `job 'tier1/foo' (jobs[3]): unknown job-level key 'region' — Jenkins job parameters belong under 'params:'`
+- job-level key nested under `params:` → `'labels' is a job-level key and must not be nested under 'params:'`
+- near-miss key names get a `did you mean 'labels'?` hint
+- non-scalar values in `params`/`defaults`/`cron_triggers[].params` → every Jenkins parameter is a string,
+  so multi-valued ones (multi-region, `sub_tests`) must be quoted JSON strings
+
+Check a file after editing it:
+
+```bash
+uv run python -c "from sdcm.utils.trigger_matrix import load_matrix_config; load_matrix_config('configurations/triggers/tier1.yaml')"
+```
+
 ## Prerequisites
 
 - SCT environment set up (`uv sync`)
@@ -97,7 +161,16 @@ uv run sct.py trigger-matrix \
 
 **Expected**: Each `[DRY-RUN]` log line shows the overridden parameters in the parameter output.
 
-Note: `--region` overrides all job-specific regions. If a job has `region: eu-west-1` in YAML and you pass `--region us-west-2`, the job runs in `us-west-2`.
+Note: **`--region` and `--availability-zone` do not override jobs that pin their own value.** They are location parameters — a job that declares `region:` under its `params:` owns it, and the CLI value only fills in for jobs that don't. Everything else (`--provision-type`, `--stress-duration`, `--new-scylla-repo`, ...) overrides per-job values as usual.
+
+Precedence, highest first:
+
+| Parameter | Precedence |
+|-----------|------------|
+| `region`, `availability_zone` | job `params` → CLI flag → matrix `defaults` |
+| everything else | CLI flag → job `params` → matrix `defaults` |
+
+This is what keeps a multi-DC job configured with `region: '["eu-west-1", "eu-west-2"]'` from collapsing into a single region when a trigger run passes `--region us-east-1` (SCT-693).
 
 ### Job Folder Resolution
 

--- a/sct.py
+++ b/sct.py
@@ -3263,8 +3263,19 @@ def hdr_investigate(
 )
 @click.option("--skip-jobs", default=None, type=str, help="Comma-separated job names to skip")
 @click.option("--stress-duration", default=None, type=str, help="Override stress_duration parameter")
-@click.option("--region", default=None, type=str, help="Override region for all jobs")
-@click.option("--availability-zone", default=None, type=str, help="Override availability zone for all jobs")
+@click.option(
+    "--region",
+    default=None,
+    type=str,
+    help="Region for jobs that don't set one in the matrix. Jobs with their own 'region' param keep it",
+)
+@click.option(
+    "--availability-zone",
+    default=None,
+    type=str,
+    help="Availability zone for jobs that don't set one in the matrix. "
+    "Jobs with their own 'availability_zone' param keep it",
+)
 @click.option(
     "--provision-type",
     default=None,

--- a/sdcm/utils/trigger_matrix.py
+++ b/sdcm/utils/trigger_matrix.py
@@ -11,6 +11,7 @@
 #
 # Copyright (c) 2026 ScyllaDB
 
+import difflib
 import fnmatch
 import json
 import logging
@@ -25,7 +26,7 @@ import jenkins as jenkins_lib
 import pydantic
 import requests
 import yaml
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 logger = logging.getLogger(__name__)
 
@@ -99,6 +100,12 @@ DEFAULT_AWS_REGION = "eu-west-1"
 WAIT_POLL_INTERVAL = 30
 WAIT_TIMEOUT = 14400
 DEFAULT_EMAIL_RECIPIENTS = ["qa@scylladb.com"]
+
+# Parameters that describe *where* a job runs. They are per-job by nature: a job that
+# declares them in its `params` owns them, and a global CLI value only fills in for the
+# jobs that don't. Without this, `--region us-east-1` would silently collapse a multi-DC
+# job configured with region: '["eu-west-1", "eu-west-2"]' into a single region (SCT-693).
+PER_JOB_LOCATION_PARAMS = ("region", "availability_zone")
 
 
 def is_full_version_tag(version: str) -> bool:
@@ -424,16 +431,33 @@ def _resolve_version_from_azure_image(image_id: str) -> str:
 class CronTriggerConfig(BaseModel):
     """Configuration for a cron-based trigger schedule."""
 
+    model_config = ConfigDict(extra="forbid")
+
     schedule: str
     params: dict = Field(default_factory=dict)
 
 
+class JenkinsfileEntry(BaseModel):
+    """A Jenkinsfile generated from this matrix by generate_trigger_jenkinsfiles.py."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    path: str
+    labels_selector: str = ""
+
+
 class JobConfig(BaseModel):
-    """Configuration for a single Jenkins job in the trigger matrix."""
+    """Configuration for a single Jenkins job in the trigger matrix.
+
+    The fields here are *structural* — they decide whether and how the job is triggered.
+    Everything the Jenkins job itself receives (region, availability_zone,
+    instance types, sub_tests, ...) belongs under `params`.
+    """
+
+    model_config = ConfigDict(extra="forbid")
 
     job_name: str
     backend: Literal["aws", "gce", "azure", "docker", "oci"]
-    region: str = ""
     arch: str = ""
 
     @field_validator("arch")
@@ -459,11 +483,20 @@ class JobConfig(BaseModel):
 class MatrixConfig(BaseModel):
     """Full trigger matrix configuration loaded from YAML."""
 
+    model_config = ConfigDict(extra="forbid")
+
     jobs: list[JobConfig]
     defaults: dict = Field(default_factory=dict)
     default_scylla_version: str = ""
     cron_triggers: list[CronTriggerConfig] = Field(default_factory=list)
     email_recipients: list[str] = Field(default_factory=list)
+    jenkinsfiles: list[JenkinsfileEntry] = Field(default_factory=list)
+
+
+# Keys allowed directly on a job entry — anything else is a Jenkins parameter and
+# must live under `params`.
+JOB_LEVEL_KEYS = frozenset(JobConfig.model_fields)
+MATRIX_LEVEL_KEYS = frozenset(MatrixConfig.model_fields)
 
 
 class TriggerMatrixError(Exception):
@@ -517,6 +550,90 @@ def get_parameterized_cron(path: str | Path) -> str:
     return "\n".join(lines)
 
 
+def _did_you_mean(key: str, candidates: frozenset[str]) -> str:
+    """Return a ' — did you mean ...' hint when `key` looks like a typo of a known key."""
+    close = difflib.get_close_matches(key, sorted(candidates), n=1, cutoff=0.8)
+    return f" — did you mean '{close[0]}'?" if close else ""
+
+
+def _validate_params_block(params: object, where: str, errors: list[str]) -> None:
+    """Validate a `params`/`defaults` mapping: no job-level keys, scalar values only.
+
+    Every entry ends up as a Jenkins StringParameterValue, so nested lists/mappings
+    are always a mistake — multi-valued parameters are passed as JSON strings.
+    """
+    if not isinstance(params, dict):
+        errors.append(f"{where}: must be a mapping of Jenkins parameters, got {type(params).__name__}")
+        return
+
+    for key, value in params.items():
+        if key in JOB_LEVEL_KEYS:
+            errors.append(
+                f"{where}: '{key}' is a job-level key and must not be nested under 'params:' — "
+                f"move it up, next to 'job_name:'"
+            )
+        if isinstance(value, (list, dict)):
+            hint = (
+                f' (for a multi-region job use a JSON string: {key}: \'["eu-west-1", "eu-west-2"]\')'
+                if key == "region"
+                else " (pass multi-valued parameters as a JSON string)"
+            )
+            errors.append(
+                f"{where}: '{key}' must be a scalar — Jenkins parameters are strings, got {type(value).__name__}{hint}"
+            )
+
+
+def _validate_job_entry(index: int, job: object, errors: list[str]) -> None:
+    """Validate a single raw job entry before pydantic parsing, for locatable errors."""
+    if not isinstance(job, dict):
+        errors.append(f"jobs[{index}]: must be a mapping, got {type(job).__name__}")
+        return
+
+    where = f"job '{job.get('job_name', '<missing job_name>')}' (jobs[{index}])"
+    for key in job:
+        if key not in JOB_LEVEL_KEYS:
+            errors.append(
+                f"{where}: unknown job-level key '{key}' — Jenkins job parameters belong under 'params:'"
+                f"{_did_you_mean(key, JOB_LEVEL_KEYS)}"
+            )
+
+    if "params" in job:
+        _validate_params_block(job["params"], f"{where}: params", errors)
+
+
+def validate_matrix_layout(raw: dict) -> None:
+    """Check that every key in a raw matrix mapping sits where it belongs.
+
+    Pydantic already rejects unknown keys, but its errors don't say *where* a key
+    should have gone. This pass collects all misplacements at once so a YAML with
+    several mistakes reports them in one go.
+
+    Raises:
+        MatrixValidationError: If any key is unknown or in the wrong section.
+    """
+    errors: list[str] = []
+
+    for key in raw:
+        if key not in MATRIX_LEVEL_KEYS:
+            errors.append(
+                f"unknown top-level key '{key}' — expected one of: {', '.join(sorted(MATRIX_LEVEL_KEYS))}"
+                f"{_did_you_mean(key, MATRIX_LEVEL_KEYS)}"
+            )
+
+    if "defaults" in raw:
+        _validate_params_block(raw["defaults"], "defaults", errors)
+
+    for index, cron in enumerate(raw.get("cron_triggers") or []):
+        if isinstance(cron, dict) and "params" in cron:
+            _validate_params_block(cron["params"], f"cron_triggers[{index}]: params", errors)
+
+    for index, job in enumerate(raw.get("jobs") or []):
+        _validate_job_entry(index, job, errors)
+
+    if errors:
+        raise MatrixValidationError("Invalid trigger matrix layout:\n  - " + "\n  - ".join(errors))
+
+
 def load_matrix_config(path: str | Path) -> MatrixConfig:
     """Load and validate a trigger matrix YAML file.
 
@@ -551,10 +668,12 @@ def load_matrix_config(path: str | Path) -> MatrixConfig:
     if isinstance(raw_email, str):
         raw["email_recipients"] = [e.strip() for e in raw_email.split(",") if e.strip()]
 
+    validate_matrix_layout(raw)
+
     try:
         return MatrixConfig.model_validate(raw)
     except pydantic.ValidationError as exc:
-        raise MatrixValidationError(str(exc)) from exc
+        raise MatrixValidationError(f"Invalid trigger matrix {path}:\n{exc}") from exc
 
 
 def determine_job_folder(scylla_version: str, job_folder: str | None = None) -> str:
@@ -808,7 +927,12 @@ def build_job_parameters(
 ) -> dict:
     """Build final parameter dict for a Jenkins job.
 
-    Priority: cli_overrides > job.params > defaults.
+    Priority: cli_overrides > job.params > defaults, except for the location
+    parameters in PER_JOB_LOCATION_PARAMS (region, availability_zone), where a
+    job's own value wins over the CLI: cli_overrides > job.params is inverted to
+    job.params > cli_overrides > defaults. A global `--region` must not collapse a
+    multi-DC job into a single region (SCT-693).
+
     Always includes scylla_version. Downstream jobs resolve their
     own backend-specific images from the version.
 
@@ -828,15 +952,19 @@ def build_job_parameters(
     Returns:
         Merged parameter dictionary.
     """
-    params = dict(defaults)
-    params.update(job.params)
-    params.update({k: v for k, v in cli_overrides.items() if v is not None})
+    overrides = {k: v for k, v in cli_overrides.items() if v is not None}
+    # Location overrides are applied *under* the job's own params — they fill in for
+    # jobs that don't pin a region/AZ instead of overwriting the ones that do.
+    location_overrides = {k: overrides.pop(k) for k in PER_JOB_LOCATION_PARAMS if k in overrides}
 
-    # Always set scylla_version (if provided) and region
+    params = dict(defaults)
+    params.update(location_overrides)
+    params.update(job.params)
+    params.update(overrides)
+
+    # Always set scylla_version (if provided)
     if scylla_version:
         params["scylla_version"] = scylla_version
-    if job.region:
-        params.setdefault("region", job.region)
     if job.job_throttle_category:
         params.setdefault("job_throttle_category", job.job_throttle_category)
 

--- a/unit_tests/trigger_matrix/conftest.py
+++ b/unit_tests/trigger_matrix/conftest.py
@@ -32,32 +32,30 @@ def sample_matrix_yaml(tmp_path):
             {
                 "job_name": "tier1/longevity-50gb-3days-test",
                 "backend": "aws",
-                "region": "eu-west-1",
                 "labels": ["weekly"],
                 "exclude_versions": [],
-                "params": {"stress_duration": "4320"},
+                "params": {"region": "eu-west-1", "stress_duration": "4320"},
             },
             {
                 "job_name": "tier1/longevity-1tb-5days-azure-test",
                 "backend": "azure",
-                "region": "eastus",
                 "labels": ["weekly"],
                 "exclude_versions": ["2024.1"],
+                "params": {"region": "eastus"},
             },
             {
                 "job_name": "longevity/longevity-10gb-3h-gce-test",
                 "backend": "gce",
-                "region": "us-east1",
                 "labels": [],
                 "exclude_versions": [],
+                "params": {"region": "us-east1"},
             },
             {
                 "job_name": "/scylla-enterprise/perf-regression/perf-test",
                 "backend": "aws",
-                "region": "us-east-1",
                 "labels": ["master-weekly", "additional"],
                 "exclude_versions": ["master"],
-                "params": {"sub_tests": '["test_read"]'},
+                "params": {"region": "us-east-1", "sub_tests": '["test_read"]'},
             },
         ],
     }
@@ -70,17 +68,23 @@ def sample_matrix_yaml(tmp_path):
 def sample_jobs():
     """Return a list of sample JobConfig objects for filter tests."""
     return [
-        JobConfig(job_name="job-a", backend="aws", region="eu-west-1", labels=["weekly"], exclude_versions=[]),
+        JobConfig(
+            job_name="job-a", backend="aws", labels=["weekly"], exclude_versions=[], params={"region": "eu-west-1"}
+        ),
         JobConfig(
             job_name="job-b",
             backend="azure",
-            region="eastus",
             labels=["weekly", "additional"],
             exclude_versions=["2024.1"],
+            params={"region": "eastus"},
         ),
-        JobConfig(job_name="job-c", backend="gce", region="us-east1", labels=[], exclude_versions=[]),
+        JobConfig(job_name="job-c", backend="gce", labels=[], exclude_versions=[], params={"region": "us-east1"}),
         JobConfig(
-            job_name="job-d", backend="aws", region="us-east-1", labels=["master-weekly"], exclude_versions=["master"]
+            job_name="job-d",
+            backend="aws",
+            labels=["master-weekly"],
+            exclude_versions=["master"],
+            params={"region": "us-east-1"},
         ),
     ]
 
@@ -89,8 +93,16 @@ def sample_jobs():
 def sample_jobs_with_arm():
     """Return sample jobs including aarch64-labeled ones for architecture filter tests."""
     return [
-        JobConfig(job_name="job-x86", backend="aws", region="us-east-1", labels=["weekly"]),
-        JobConfig(job_name="job-arm", backend="aws", region="us-east-1", labels=["aarch64"]),
-        JobConfig(job_name="job-arm-weekly", backend="aws", region="us-east-1", labels=["aarch64", "weekly"]),
-        JobConfig(job_name="job-arm-no-label", backend="aws", region="us-east-1", arch="aarch64", labels=["weekly"]),
+        JobConfig(job_name="job-x86", backend="aws", labels=["weekly"], params={"region": "us-east-1"}),
+        JobConfig(job_name="job-arm", backend="aws", labels=["aarch64"], params={"region": "us-east-1"}),
+        JobConfig(
+            job_name="job-arm-weekly", backend="aws", labels=["aarch64", "weekly"], params={"region": "us-east-1"}
+        ),
+        JobConfig(
+            job_name="job-arm-no-label",
+            backend="aws",
+            arch="aarch64",
+            labels=["weekly"],
+            params={"region": "us-east-1"},
+        ),
     ]

--- a/unit_tests/trigger_matrix/test_build_parameters.py
+++ b/unit_tests/trigger_matrix/test_build_parameters.py
@@ -15,7 +15,7 @@ from sdcm.utils.trigger_matrix import JobConfig, build_job_parameters
 
 
 def test_defaults_applied():
-    job = JobConfig(job_name="test", backend="aws", region="eu-west-1")
+    job = JobConfig(job_name="test", backend="aws", params={"region": "eu-west-1"})
     defaults = {"provision_type": "spot", "post_behavior_db_nodes": "destroy"}
     params = build_job_parameters(job, defaults, "master:latest", {})
 
@@ -25,7 +25,7 @@ def test_defaults_applied():
 
 
 def test_job_params_override_defaults():
-    job = JobConfig(job_name="test", backend="aws", region="eu-west-1", params={"provision_type": "on_demand"})
+    job = JobConfig(job_name="test", backend="aws", params={"region": "eu-west-1", "provision_type": "on_demand"})
     defaults = {"provision_type": "spot"}
     params = build_job_parameters(job, defaults, "master:latest", {})
 
@@ -33,7 +33,7 @@ def test_job_params_override_defaults():
 
 
 def test_cli_overrides_take_precedence():
-    job = JobConfig(job_name="test", backend="aws", region="eu-west-1", params={"provision_type": "on_demand"})
+    job = JobConfig(job_name="test", backend="aws", params={"region": "eu-west-1", "provision_type": "on_demand"})
     defaults = {"provision_type": "spot"}
     overrides = {"provision_type": "spot_fleet", "stress_duration": "120"}
     params = build_job_parameters(job, defaults, "2025.4", overrides)
@@ -44,14 +44,44 @@ def test_cli_overrides_take_precedence():
 
 
 def test_version_always_included():
-    job = JobConfig(job_name="test", backend="aws", region="")
+    job = JobConfig(job_name="test", backend="aws")
     params = build_job_parameters(job, {}, "2024.2.5-0.20250221.cb9e2a54ae6d-1", {})
     assert params["scylla_version"] == "2024.2.5-0.20250221.cb9e2a54ae6d-1"
 
 
 def test_none_overrides_ignored():
-    job = JobConfig(job_name="test", backend="aws", region="eu-west-1")
+    job = JobConfig(job_name="test", backend="aws", params={"region": "eu-west-1"})
     defaults = {"provision_type": "spot"}
     overrides = {"provision_type": None, "region": None}
     params = build_job_parameters(job, defaults, "master:latest", overrides)
     assert params["provision_type"] == "spot"
+    assert params["region"] == "eu-west-1"
+
+
+def test_cli_region_does_not_override_job_region():
+    """SCT-693: --region must not collapse a multi-DC job into a single region."""
+    job = JobConfig(job_name="test", backend="aws", params={"region": '["eu-west-1", "eu-west-2"]'})
+    params = build_job_parameters(job, {}, "master:latest", {"region": "us-east-1"})
+
+    assert params["region"] == '["eu-west-1", "eu-west-2"]'
+
+
+def test_cli_region_fills_in_for_jobs_without_one():
+    job = JobConfig(job_name="test", backend="aws")
+    params = build_job_parameters(job, {}, "master:latest", {"region": "us-east-1"})
+
+    assert params["region"] == "us-east-1"
+
+
+def test_cli_region_overrides_matrix_defaults():
+    job = JobConfig(job_name="test", backend="aws")
+    params = build_job_parameters(job, {"region": "eu-west-1"}, "master:latest", {"region": "us-east-1"})
+
+    assert params["region"] == "us-east-1"
+
+
+def test_cli_availability_zone_does_not_override_job_value():
+    job = JobConfig(job_name="test", backend="aws", params={"availability_zone": "a,b,c"})
+    params = build_job_parameters(job, {"availability_zone": "c"}, "master:latest", {"availability_zone": "b"})
+
+    assert params["availability_zone"] == "a,b,c"

--- a/unit_tests/trigger_matrix/test_filtering.py
+++ b/unit_tests/trigger_matrix/test_filtering.py
@@ -80,79 +80,79 @@ def test_combined_filters(sample_jobs):
 
 
 def test_include_versions_passes_matching_prefix():
-    jobs = [JobConfig(job_name="job-a", backend="aws", region="", include_versions=["master"])]
+    jobs = [JobConfig(job_name="job-a", backend="aws", include_versions=["master"])]
     result = filter_jobs(jobs, scylla_version="master:latest")
     assert len(result) == 1
 
 
 def test_include_versions_blocks_non_matching():
-    jobs = [JobConfig(job_name="job-a", backend="aws", region="", include_versions=["master"])]
+    jobs = [JobConfig(job_name="job-a", backend="aws", include_versions=["master"])]
     result = filter_jobs(jobs, scylla_version="2025.1:latest")
     assert len(result) == 0
 
 
 def test_include_versions_prefix_match():
-    jobs = [JobConfig(job_name="job-a", backend="aws", region="", include_versions=["2025.1"])]
+    jobs = [JobConfig(job_name="job-a", backend="aws", include_versions=["2025.1"])]
     result = filter_jobs(jobs, scylla_version="2025.1.3:latest")
     assert len(result) == 1
 
 
 def test_include_versions_multiple():
-    jobs = [JobConfig(job_name="job-a", backend="aws", region="", include_versions=["master", "2025.1"])]
+    jobs = [JobConfig(job_name="job-a", backend="aws", include_versions=["master", "2025.1"])]
     assert len(filter_jobs(jobs, scylla_version="master:latest")) == 1
     assert len(filter_jobs(jobs, scylla_version="2025.1:latest")) == 1
     assert len(filter_jobs(jobs, scylla_version="2024.2:latest")) == 0
 
 
 def test_empty_include_versions_allows_all():
-    jobs = [JobConfig(job_name="job-a", backend="aws", region="", include_versions=[])]
+    jobs = [JobConfig(job_name="job-a", backend="aws", include_versions=[])]
     assert len(filter_jobs(jobs, scylla_version="anything")) == 1
 
 
 def test_include_versions_uses_original_not_resolved():
-    jobs = [JobConfig(job_name="job-a", backend="aws", region="", include_versions=["master"])]
+    jobs = [JobConfig(job_name="job-a", backend="aws", include_versions=["master"])]
     result = filter_jobs(jobs, scylla_version="master:latest", resolved_version="2026.3.0~dev-0.20260525.abc")
     assert len(result) == 1
 
 
 def test_pre_release_master_always_passes():
-    jobs = [JobConfig(job_name="job-a", backend="aws", region="", pre_release=["rc1", "rc3"])]
+    jobs = [JobConfig(job_name="job-a", backend="aws", pre_release=["rc1", "rc3"])]
     result = filter_jobs(jobs, scylla_version="master:latest", resolved_version="2026.3.0~dev-0.20260525.abc")
     assert len(result) == 1
 
 
 def test_pre_release_rc1_in_resolved_passes():
-    jobs = [JobConfig(job_name="job-a", backend="aws", region="", pre_release=["rc1", "rc3"])]
+    jobs = [JobConfig(job_name="job-a", backend="aws", pre_release=["rc1", "rc3"])]
     result = filter_jobs(jobs, scylla_version="2025.1:latest", resolved_version="2025.1.3-rc1-0.20250525.abc")
     assert len(result) == 1
 
 
 def test_pre_release_rc3_in_resolved_passes():
-    jobs = [JobConfig(job_name="job-a", backend="aws", region="", pre_release=["rc1", "rc3"])]
+    jobs = [JobConfig(job_name="job-a", backend="aws", pre_release=["rc1", "rc3"])]
     result = filter_jobs(jobs, scylla_version="2025.1:latest", resolved_version="2025.1.3-rc3-0.20250525.abc")
     assert len(result) == 1
 
 
 def test_pre_release_non_rc_blocked():
-    jobs = [JobConfig(job_name="job-a", backend="aws", region="", pre_release=["rc1", "rc3"])]
+    jobs = [JobConfig(job_name="job-a", backend="aws", pre_release=["rc1", "rc3"])]
     result = filter_jobs(jobs, scylla_version="2025.1:latest", resolved_version="2025.1.3-0.20250525.abc")
     assert len(result) == 0
 
 
 def test_pre_release_rc2_not_in_list_blocked():
-    jobs = [JobConfig(job_name="job-a", backend="aws", region="", pre_release=["rc1", "rc3"])]
+    jobs = [JobConfig(job_name="job-a", backend="aws", pre_release=["rc1", "rc3"])]
     result = filter_jobs(jobs, scylla_version="2025.1:latest", resolved_version="2025.1.3-rc2-0.20250525.abc")
     assert len(result) == 0
 
 
 def test_pre_release_empty_allows_all():
-    jobs = [JobConfig(job_name="job-a", backend="aws", region="", pre_release=[])]
+    jobs = [JobConfig(job_name="job-a", backend="aws", pre_release=[])]
     result = filter_jobs(jobs, scylla_version="2025.1:latest", resolved_version="2025.1.3-0.20250525.abc")
     assert len(result) == 1
 
 
 def test_pre_release_fallback_to_scylla_version():
-    jobs = [JobConfig(job_name="job-a", backend="aws", region="", pre_release=["rc1"])]
+    jobs = [JobConfig(job_name="job-a", backend="aws", pre_release=["rc1"])]
     result = filter_jobs(jobs, scylla_version="2025.1.3-rc1-0.20250525.abc")
     assert len(result) == 1
 
@@ -162,7 +162,6 @@ def test_pre_release_with_include_versions_combined():
         JobConfig(
             job_name="job-a",
             backend="aws",
-            region="",
             include_versions=["master"],
             pre_release=["rc1", "rc3"],
         ),
@@ -173,8 +172,8 @@ def test_pre_release_with_include_versions_combined():
 
 def test_include_versions_checks_original_exclude_checks_original():
     jobs = [
-        JobConfig(job_name="included", backend="aws", region="", include_versions=["master"]),
-        JobConfig(job_name="excluded", backend="aws", region="", exclude_versions=["master"]),
+        JobConfig(job_name="included", backend="aws", include_versions=["master"]),
+        JobConfig(job_name="excluded", backend="aws", exclude_versions=["master"]),
     ]
     result = filter_jobs(jobs, scylla_version="master:latest", resolved_version="2026.3.0~dev-abc")
     assert len(result) == 1
@@ -182,7 +181,7 @@ def test_include_versions_checks_original_exclude_checks_original():
 
 
 def test_pre_release_checks_resolved_version():
-    jobs = [JobConfig(job_name="job-a", backend="aws", region="", pre_release=["rc1"])]
+    jobs = [JobConfig(job_name="job-a", backend="aws", pre_release=["rc1"])]
     result = filter_jobs(jobs, scylla_version="2025.1:latest", resolved_version="2025.1.3-rc1-0.abc")
     assert len(result) == 1
     result = filter_jobs(jobs, scylla_version="2025.1:latest", resolved_version="2025.1.3-0.abc")
@@ -191,8 +190,8 @@ def test_pre_release_checks_resolved_version():
 
 def test_disabled_jobs_are_skipped():
     jobs = [
-        JobConfig(job_name="active-job", backend="aws", region=""),
-        JobConfig(job_name="disabled-job", backend="aws", region="", disabled=True),
+        JobConfig(job_name="active-job", backend="aws"),
+        JobConfig(job_name="disabled-job", backend="aws", disabled=True),
     ]
     result = filter_jobs(jobs, scylla_version="2025.4")
     assert len(result) == 1
@@ -216,9 +215,9 @@ def test_no_image_arch_preserves_all_jobs(sample_jobs_with_arm):
 
 def test_arch_field_takes_precedence_over_missing_label():
     jobs = [
-        JobConfig(job_name="arm-via-field", backend="aws", region="", arch="aarch64", labels=["weekly"]),
-        JobConfig(job_name="x86-via-field", backend="aws", region="", arch="x86_64", labels=["weekly"]),
-        JobConfig(job_name="arm-via-label", backend="aws", region="", labels=["aarch64"]),
+        JobConfig(job_name="arm-via-field", backend="aws", arch="aarch64", labels=["weekly"]),
+        JobConfig(job_name="x86-via-field", backend="aws", arch="x86_64", labels=["weekly"]),
+        JobConfig(job_name="arm-via-label", backend="aws", labels=["aarch64"]),
     ]
     result = filter_jobs(jobs, scylla_version="2025.4", image_arch="aarch64")
     assert {j.job_name for j in result} == {"arm-via-field", "arm-via-label"}

--- a/unit_tests/trigger_matrix/test_layout_validation.py
+++ b/unit_tests/trigger_matrix/test_layout_validation.py
@@ -1,0 +1,156 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2026 ScyllaDB
+
+"""Tests for the layout validation that keeps Jenkins parameters under `params:`."""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from sdcm.utils.trigger_matrix import JOB_LEVEL_KEYS, MatrixValidationError, load_matrix_config
+
+TRIGGERS_DIR = Path(__file__).parent.parent.parent / "configurations" / "triggers"
+
+
+def write_matrix(tmp_path, data) -> Path:
+    path = tmp_path / "matrix.yaml"
+    path.write_text(yaml.dump(data))
+    return path
+
+
+def test_job_level_region_rejected(tmp_path):
+    """`region` at job level is the pre-SCT-693 layout — it must point at `params:`."""
+    path = write_matrix(tmp_path, {"jobs": [{"job_name": "test", "backend": "aws", "region": "eu-west-1"}]})
+    with pytest.raises(MatrixValidationError, match=r"unknown job-level key 'region'.*under 'params:'"):
+        load_matrix_config(path)
+
+
+def test_unknown_job_level_key_rejected(tmp_path):
+    path = write_matrix(tmp_path, {"jobs": [{"job_name": "test", "backend": "aws", "instance_type_db": "i4i.4xlarge"}]})
+    with pytest.raises(MatrixValidationError, match=r"unknown job-level key 'instance_type_db'"):
+        load_matrix_config(path)
+
+
+def test_typo_in_job_level_key_suggests_correction(tmp_path):
+    path = write_matrix(tmp_path, {"jobs": [{"job_name": "test", "backend": "aws", "label": ["weekly"]}]})
+    with pytest.raises(MatrixValidationError, match=r"did you mean 'labels'\?"):
+        load_matrix_config(path)
+
+
+def test_error_names_the_offending_job(tmp_path):
+    path = write_matrix(
+        tmp_path,
+        {
+            "jobs": [
+                {"job_name": "good", "backend": "aws"},
+                {"job_name": "tier1/bad-job", "backend": "aws", "region": "eu-west-1"},
+            ]
+        },
+    )
+    with pytest.raises(MatrixValidationError, match=r"job 'tier1/bad-job' \(jobs\[1\]\)"):
+        load_matrix_config(path)
+
+
+def test_all_layout_errors_reported_at_once(tmp_path):
+    path = write_matrix(
+        tmp_path,
+        {
+            "jobs": [
+                {"job_name": "job-a", "backend": "aws", "region": "eu-west-1"},
+                {"job_name": "job-b", "backend": "aws", "availability_zone": "a"},
+            ]
+        },
+    )
+    with pytest.raises(MatrixValidationError) as exc_info:
+        load_matrix_config(path)
+    assert "job-a" in str(exc_info.value)
+    assert "job-b" in str(exc_info.value)
+
+
+@pytest.mark.parametrize("key", sorted(JOB_LEVEL_KEYS - {"params"}))
+def test_job_level_key_nested_under_params_rejected(tmp_path, key):
+    path = write_matrix(tmp_path, {"jobs": [{"job_name": "test", "backend": "aws", "params": {key: "x"}}]})
+    with pytest.raises(MatrixValidationError, match=rf"'{key}' is a job-level key"):
+        load_matrix_config(path)
+
+
+def test_list_valued_param_rejected(tmp_path):
+    path = write_matrix(tmp_path, {"jobs": [{"job_name": "test", "backend": "aws", "params": {"sub_tests": ["a"]}}]})
+    with pytest.raises(MatrixValidationError, match=r"'sub_tests' must be a scalar"):
+        load_matrix_config(path)
+
+
+def test_list_valued_region_suggests_json_string(tmp_path):
+    path = write_matrix(
+        tmp_path,
+        {"jobs": [{"job_name": "test", "backend": "aws", "params": {"region": ["eu-west-1", "eu-west-2"]}}]},
+    )
+    with pytest.raises(MatrixValidationError, match=r"use a JSON string"):
+        load_matrix_config(path)
+
+
+def test_multi_region_json_string_accepted(tmp_path):
+    path = write_matrix(
+        tmp_path,
+        {"jobs": [{"job_name": "test", "backend": "aws", "params": {"region": '["eu-west-1", "eu-west-2"]'}}]},
+    )
+    config = load_matrix_config(path)
+    assert config.jobs[0].params["region"] == '["eu-west-1", "eu-west-2"]'
+
+
+def test_params_not_a_mapping_rejected(tmp_path):
+    path = write_matrix(tmp_path, {"jobs": [{"job_name": "test", "backend": "aws", "params": ["region=eu-west-1"]}]})
+    with pytest.raises(MatrixValidationError, match=r"must be a mapping of Jenkins parameters"):
+        load_matrix_config(path)
+
+
+def test_unknown_top_level_key_rejected(tmp_path):
+    path = write_matrix(tmp_path, {"jobs": [], "job": []})
+    with pytest.raises(MatrixValidationError, match=r"unknown top-level key 'job'"):
+        load_matrix_config(path)
+
+
+def test_job_level_key_in_defaults_rejected(tmp_path):
+    path = write_matrix(tmp_path, {"defaults": {"labels": ["weekly"]}, "jobs": []})
+    with pytest.raises(MatrixValidationError, match=r"defaults: 'labels' is a job-level key"):
+        load_matrix_config(path)
+
+
+def test_list_valued_default_rejected(tmp_path):
+    path = write_matrix(tmp_path, {"defaults": {"post_behavior_db_nodes": ["destroy"]}, "jobs": []})
+    with pytest.raises(MatrixValidationError, match=r"defaults: 'post_behavior_db_nodes' must be a scalar"):
+        load_matrix_config(path)
+
+
+def test_list_valued_cron_param_rejected(tmp_path):
+    path = write_matrix(
+        tmp_path,
+        {"cron_triggers": [{"schedule": "0 6 * * 6", "params": {"labels_selector": ["weekly"]}}], "jobs": []},
+    )
+    with pytest.raises(MatrixValidationError, match=r"cron_triggers\[0\]: params: 'labels_selector' must be a scalar"):
+        load_matrix_config(path)
+
+
+@pytest.mark.parametrize("filename", sorted(p.name for p in TRIGGERS_DIR.glob("*.yaml")))
+def test_production_matrices_pass_layout_validation(filename):
+    """Every shipped trigger matrix must keep its Jenkins parameters under `params:`."""
+    config = load_matrix_config(TRIGGERS_DIR / filename)
+    assert config.jobs
+
+
+@pytest.mark.parametrize("filename", sorted(p.name for p in TRIGGERS_DIR.glob("*.yaml")))
+def test_production_matrices_have_no_job_level_region(filename):
+    raw = yaml.safe_load((TRIGGERS_DIR / filename).read_text(encoding="utf-8"))
+    offenders = [job["job_name"] for job in raw["jobs"] if "region" in job]
+    assert not offenders, f"{filename}: region must live under 'params:' for {offenders}"

--- a/unit_tests/trigger_matrix/test_load_config.py
+++ b/unit_tests/trigger_matrix/test_load_config.py
@@ -24,9 +24,8 @@ def test_load_valid_yaml(sample_matrix_yaml):
     assert len(config.jobs) == 4
     assert config.jobs[0].job_name == "tier1/longevity-50gb-3days-test"
     assert config.jobs[0].backend == "aws"
-    assert config.jobs[0].region == "eu-west-1"
     assert config.jobs[0].labels == ["weekly"]
-    assert config.jobs[0].params == {"stress_duration": "4320"}
+    assert config.jobs[0].params == {"region": "eu-west-1", "stress_duration": "4320"}
 
 
 def test_load_defaults(sample_matrix_yaml):
@@ -93,7 +92,6 @@ def test_load_minimal_job(tmp_path):
     path = tmp_path / "minimal.yaml"
     path.write_text(yaml.dump({"jobs": [{"job_name": "test", "backend": "aws"}]}))
     config = load_matrix_config(path)
-    assert config.jobs[0].region == ""
     assert config.jobs[0].labels == []
     assert config.jobs[0].exclude_versions == []
     assert config.jobs[0].params == {}

--- a/unit_tests/trigger_matrix/test_rolling_upgrade.py
+++ b/unit_tests/trigger_matrix/test_rolling_upgrade.py
@@ -46,7 +46,6 @@ def test_branch_template_resolved_in_params():
     job = JobConfig(
         job_name="rolling-upgrade/test",
         backend="gce",
-        region="us-central1",
         params={
             "rolling_upgrade_test": "true",
             "new_scylla_repo": "http://downloads.scylladb.com/unstable/scylla/{branch}/rpm/centos/latest/scylla.repo",
@@ -63,7 +62,6 @@ def test_branch_template_from_simple_version():
     job = JobConfig(
         job_name="rolling-upgrade/test",
         backend="gce",
-        region="us-central1",
         params={
             "rolling_upgrade_test": "true",
             "new_scylla_repo": "http://repo/{branch}/deb/scylla.list",
@@ -77,7 +75,6 @@ def test_branch_template_from_full_version_tag():
     job = JobConfig(
         job_name="rolling-upgrade/test",
         backend="aws",
-        region="eu-west-1",
         params={
             "rolling_upgrade_test": "true",
             "new_scylla_repo": "http://repo/{branch}/rpm/scylla.repo",
@@ -91,7 +88,6 @@ def test_no_template_no_change():
     job = JobConfig(
         job_name="rolling-upgrade/test",
         backend="aws",
-        region="eu-west-1",
         params={
             "rolling_upgrade_test": "true",
             "new_scylla_repo": "http://explicit-repo/scylla.repo",
@@ -105,7 +101,6 @@ def test_cli_override_wins_over_template():
     job = JobConfig(
         job_name="rolling-upgrade/test",
         backend="gce",
-        region="us-central1",
         params={
             "rolling_upgrade_test": "true",
             "new_scylla_repo": "http://downloads/{branch}/rpm/scylla.repo",
@@ -119,7 +114,6 @@ def test_empty_version_no_resolution():
     job = JobConfig(
         job_name="rolling-upgrade/test",
         backend="gce",
-        region="us-central1",
         params={
             "rolling_upgrade_test": "true",
             "new_scylla_repo": "http://downloads/{branch}/rpm/scylla.repo",
@@ -152,7 +146,6 @@ def test_branch_source_version_overrides_resolved_version():
     job = JobConfig(
         job_name="rolling-upgrade/test",
         backend="gce",
-        region="us-central1",
         params={
             "rolling_upgrade_test": "true",
             "new_scylla_repo": "http://downloads.scylladb.com.s3.amazonaws.com/unstable/scylla/{branch}/deb/unified/latest/scylladb-{branch}/scylla.list",
@@ -172,7 +165,6 @@ def test_branch_source_version_none_falls_back_to_scylla_version():
     job = JobConfig(
         job_name="rolling-upgrade/test",
         backend="gce",
-        region="us-central1",
         params={
             "rolling_upgrade_test": "true",
             "new_scylla_repo": "http://repo/{branch}/rpm/scylla.repo",
@@ -187,7 +179,6 @@ def test_rolling_upgrade_test_clears_scylla_version():
     job = JobConfig(
         job_name="perf-regression/rolling-upgrade-test",
         backend="aws",
-        region="eu-west-1",
         params={
             "rolling_upgrade_test": "true",
             "new_scylla_repo": "http://downloads/{branch}/deb/scylla.list",
@@ -206,7 +197,6 @@ def test_rolling_upgrade_test_keeps_base_versions_from_override():
     job = JobConfig(
         job_name="perf-regression/rolling-upgrade-test",
         backend="aws",
-        region="eu-west-1",
         params={
             "rolling_upgrade_test": "true",
             "new_scylla_repo": "http://downloads/{branch}/deb/scylla.list",
@@ -223,7 +213,6 @@ def test_non_rolling_upgrade_keeps_scylla_version():
     job = JobConfig(
         job_name="perf-regression/throughput-test",
         backend="aws",
-        region="us-east-1",
         params={"sub_tests": '["test_read"]'},
     )
     params = build_job_parameters(job, {}, "2026.3.0~dev-0.20260710.9cda315bbab0", {})
@@ -235,7 +224,6 @@ def test_non_rolling_upgrade_strips_new_scylla_repo_from_overrides():
     job = JobConfig(
         job_name="perf-regression/throughput-test",
         backend="aws",
-        region="us-east-1",
         params={"sub_tests": '["test_read"]'},
     )
     overrides = {"new_scylla_repo": "http://downloads/master/rpm/scylla.repo"}
@@ -249,7 +237,6 @@ def test_non_rolling_upgrade_strips_new_scylla_repo_from_defaults():
     job = JobConfig(
         job_name="perf-regression/latency-test",
         backend="aws",
-        region="eu-west-1",
         params={},
     )
     defaults = {"new_scylla_repo": "http://downloads/master/rpm/scylla.repo"}

--- a/unit_tests/trigger_matrix/test_trigger.py
+++ b/unit_tests/trigger_matrix/test_trigger.py
@@ -195,7 +195,6 @@ def test_default_scylla_version_used_when_empty(tmp_path):
             {
                 "job_name": "/scylla-enterprise/perf-regression/perf-test",
                 "backend": "aws",
-                "region": "us-east-1",
                 "labels": [],
                 "exclude_versions": [],
                 "params": {"unified_package": "https://example.com/scylla-unified.tar.gz"},
@@ -221,19 +220,16 @@ def test_duplicate_job_names_deduplicated(tmp_path):
             {
                 "job_name": "tier1/longevity-twcs-48h-test",
                 "backend": "aws",
-                "region": "us-east-1",
                 "labels": ["weekly"],
             },
             {
                 "job_name": "tier1/longevity-twcs-48h-test",
                 "backend": "aws",
-                "region": "us-east-1",
                 "labels": ["weekly", "aarch64"],
             },
             {
                 "job_name": "tier1/longevity-2tb-5days-test",
                 "backend": "aws",
-                "region": "eu-west-1",
                 "labels": ["weekly"],
             },
         ],

--- a/unit_tests/trigger_matrix/test_wait_mode.py
+++ b/unit_tests/trigger_matrix/test_wait_mode.py
@@ -20,7 +20,7 @@ from sdcm.utils.trigger_matrix import JobConfig, JenkinsTriggerError, load_matri
 
 
 def test_job_config_wait_defaults_false():
-    job = JobConfig(job_name="test", backend="aws", region="eu-west-1")
+    job = JobConfig(job_name="test", backend="aws")
     assert job.wait is False
     assert job.fail_on_error is False
     assert job.collect_results == []
@@ -32,7 +32,6 @@ def test_load_yaml_with_wait_fields(tmp_path):
             {
                 "job_name": "artifacts/artifacts-ami",
                 "backend": "aws",
-                "region": "eu-west-1",
                 "wait": True,
                 "fail_on_error": True,
                 "collect_results": ["scylla_doctor_*_analysis.json"],
@@ -53,7 +52,6 @@ def test_dry_run_wait_mode(tmp_path, caplog):
             {
                 "job_name": "artifacts/artifacts-ami",
                 "backend": "aws",
-                "region": "eu-west-1",
                 "wait": True,
                 "fail_on_error": True,
                 "collect_results": ["*.json"],
@@ -79,14 +77,12 @@ def test_fail_on_error_aborts_remaining(tmp_path, monkeypatch):
             {
                 "job_name": "/gating/job-1",
                 "backend": "aws",
-                "region": "eu-west-1",
                 "wait": True,
                 "fail_on_error": True,
             },
             {
                 "job_name": "/gating/job-2",
                 "backend": "aws",
-                "region": "eu-west-1",
                 "wait": False,
             },
         ],

--- a/vars/triggerMatrixPipeline.groovy
+++ b/vars/triggerMatrixPipeline.groovy
@@ -54,9 +54,9 @@ def call(Map pipelineParams = [:]) {
             string(name: 'stress_duration', defaultValue: '',
                    description: 'Override stress duration for all jobs')
             string(name: 'region', defaultValue: '',
-                   description: 'Override region for all jobs')
+                   description: 'Region for jobs that do not set one in the matrix. Jobs with their own "region" param (including multi-region ones) keep it.')
             string(name: 'availability_zone', defaultValue: '',
-                   description: 'Override availability zone for all jobs')
+                   description: 'Availability zone for jobs that do not set one in the matrix. Jobs with their own "availability_zone" param keep it.')
             string(name: 'provision_type', defaultValue: '',
                    description: 'spot | on_demand | spot_fleet')
             string(name: 'scylla_ami_id', defaultValue: '',


### PR DESCRIPTION
### Problem

A tier1 trigger run passing `--region us-east-1` collapsed `longevity-multidc-schema-topology-changes-12h-test` — configured with `region: '["eu-west-1", "eu-west-2"]'` — into a single region, and [the job failed](https://jenkins.scylladb.com/job/scylla-2026.3/job/tier1/job/longevity-multidc-schema-topology-changes-12h-test/3/).

`build_job_parameters` applied CLI overrides last, so the global `--region` clobbered the job's own value. `job.region` was then applied with `setdefault`, which is a no-op once the CLI value is already in place.

### Fix

`region` and `availability_zone` describe *where* a job runs, so they are per-job by nature. They are now applied as fallbacks — under `job.params` instead of over it:

| Parameter | Precedence (highest first) |
|---|---|
| `region`, `availability_zone` | job `params` → CLI flag → matrix `defaults` |
| everything else | CLI flag → job `params` → matrix `defaults` |

Scoped deliberately rather than making all job params win: `--new-scylla-repo` is documented as overriding per-job template values, and `rolling-upgrade.yaml` relies on that.

### All regions under `params`

Dropped `JobConfig.region` and moved `region:` into `params:` across all six trigger matrices, so a job entry holds only structural keys (whether/how to trigger) and `params:` holds everything Jenkins receives.

One no-op `region: ""` (on a disabled perf job) was removed rather than migrated — it was falsy before, so migrating it would have started passing an empty region to Jenkins.

### Layout validation

`load_matrix_config` now runs `validate_matrix_layout` before pydantic parsing, collecting *all* problems in one message with the offending job named:

- unknown job-level key → `job 'tier1/foo' (jobs[3]): unknown job-level key 'region' — Jenkins job parameters belong under 'params:'`
- job-level key nested under `params:` → `'labels' is a job-level key and must not be nested under 'params:'`
- near-miss key names → `did you mean 'labels'?`
- non-scalar values in `params` / `defaults` / `cron_triggers[].params` — every Jenkins parameter is a string, so a YAML-list `region` is pointed at the JSON-string form
- `extra="forbid"` on all models; `jenkinsfiles` added to `MatrixConfig` (it was an undeclared top-level key)

### Testing

- 180 tests pass in `unit_tests/trigger_matrix/`, including a new `test_layout_validation.py` and regression tests for both precedence rules
- Dry-run of the exact SCT-693 command keeps `region=["eu-west-1", "eu-west-2"]` and `availability_zone=a,b,c`
- pre-commit clean; `generate_trigger_jenkinsfiles.py` reports no drift

Fixes: https://scylladb.atlassian.net/browse/SCT-693

🤖 Generated with [Claude Code](https://claude.com/claude-code)