### PR TITLE
improvement(keystore): default keystore_backend to secretsmanager

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -261,8 +261,9 @@ Critical environment variables:
 - `SCT_REUSE_CLUSTER` - Test ID to reuse existing cluster
 - `SCT_ENABLE_ARGUS` - Enable/disable Argus reporting
 - `SCT_IP_SSH_CONNECTIONS` - Use 'public' for local development
-- `SCT_KEYSTORE_BACKEND` - Credential storage backend: `s3` (default) or `secretsmanager`
+- `SCT_KEYSTORE_BACKEND` - Credential storage backend: `secretsmanager` (default) or `s3` (legacy)
 - `SCT_KEYSTORE_SM_PREFIX` - Secrets Manager secret name prefix (default: `sct/`)
+- `SCT_KEYSTORE_SM_REGION` - Region holding the Secrets Manager secrets (default: `us-east-1`)
 - `AWS_PROFILE` - AWS profile for authentication (if using OKTA)
 
 ## Common Issues and Solutions

--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -395,7 +395,7 @@ cs_extra_jvm_opts: ''
 test_metadata: null
 
 # KeyStore backend for credential retrieval.
+#   secretsmanager - Default: read from AWS Secrets Manager under the configured prefix.
 #   s3             - Legacy: fetch from the scylla-qa-keystore S3 bucket.
-#   secretsmanager - Read from AWS Secrets Manager under the configured prefix.
-keystore_backend: 's3'
+keystore_backend: 'secretsmanager'
 keystore_sm_prefix: 'sct/'

--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -399,3 +399,4 @@ test_metadata: null
 #   s3             - Legacy: fetch from the scylla-qa-keystore S3 bucket.
 keystore_backend: 'secretsmanager'
 keystore_sm_prefix: 'sct/'
+keystore_sm_region: 'us-east-1'

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -4803,9 +4803,9 @@ Structured metadata for test documentation and labeling. Validated by pydantic m
 
 ## **keystore_backend** / SCT_KEYSTORE_BACKEND
 
-Credential storage backend for KeyStore: 's3' (default) or 'secretsmanager'
+Credential storage backend for KeyStore: 'secretsmanager' (default) or 's3' (legacy)
 
-**default:** s3
+**default:** secretsmanager
 
 **type:** Literal['s3', 'secretsmanager']
 

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -4817,3 +4817,12 @@ AWS Secrets Manager secret name prefix when keystore_backend=secretsmanager (def
 **default:** sct/
 
 **type:** str (appendable)
+
+
+## **keystore_sm_region** / SCT_KEYSTORE_SM_REGION
+
+AWS region holding the KeyStore secrets when keystore_backend=secretsmanager (default: 'us-east-1')
+
+**default:** us-east-1
+
+**type:** str (appendable)

--- a/docs/gcp_create_new_project.md
+++ b/docs/gcp_create_new_project.md
@@ -128,6 +128,11 @@ aws secretsmanager create-secret --region us-east-1 \
 shred -u "/tmp/${NEW_PROJECT_ID}.json"
 ```
 
+> `shred` overwrites before unlinking, which only means something on a real
+> block device. On a tmpfs `/tmp` (common in containers and on CI runners) the
+> overwrite is a no-op and `-u` merely deletes the file — which is fine here,
+> because nothing reached persistent storage to begin with.
+
 ---
 
 ## Step 4: Assign IAM Roles to Service Account

--- a/docs/gcp_create_new_project.md
+++ b/docs/gcp_create_new_project.md
@@ -118,7 +118,7 @@ legacy backend — upload to **both** (see
 aws s3 cp "/tmp/${NEW_PROJECT_ID}.json" "s3://scylla-qa-keystore/${NEW_PROJECT_ID}.json"
 
 # Mirror into Secrets Manager (the default backend)
-aws secretsmanager create-secret --region us-east-1 \
+aws secretsmanager create-secret --region "${SCT_KEYSTORE_SM_REGION:-us-east-1}" \
     --name "sct/${NEW_PROJECT_ID}.json" \
     --description "GCP service account: ${NEW_PROJECT_ID}" \
     --secret-string "file:///tmp/${NEW_PROJECT_ID}.json" \
@@ -247,7 +247,7 @@ aws s3 cp "/tmp/${NEW_PROJECT_ID}_service_accounts.json" \
     "s3://scylla-qa-keystore/${NEW_PROJECT_ID}_service_accounts.json"
 
 # Mirror into Secrets Manager (the default backend)
-aws secretsmanager create-secret --region us-east-1 \
+aws secretsmanager create-secret --region "${SCT_KEYSTORE_SM_REGION:-us-east-1}" \
     --name "sct/${NEW_PROJECT_ID}_service_accounts.json" \
     --secret-string "file:///tmp/${NEW_PROJECT_ID}_service_accounts.json" \
     --tags Key=team,Value=sct Key=secret_type,Value=config

--- a/docs/gcp_create_new_project.md
+++ b/docs/gcp_create_new_project.md
@@ -107,14 +107,25 @@ gcloud iam service-accounts keys create "/tmp/${NEW_PROJECT_ID}.json" \
     --project="$NEW_PROJECT_ID"
 ```
 
-### Upload Credentials to S3 Keystore
+### Upload Credentials to the Keystore
+
+The keystore reads from AWS Secrets Manager by default, with S3 as the
+legacy backend — upload to **both** (see
+[keystore-secrets-manager.md](keystore-secrets-manager.md)).
 
 ```bash
-# Upload the service account key to the SCT keystore
+# Upload the service account key to the SCT keystore (S3)
 aws s3 cp "/tmp/${NEW_PROJECT_ID}.json" "s3://scylla-qa-keystore/${NEW_PROJECT_ID}.json"
 
+# Mirror into Secrets Manager (the default backend)
+aws secretsmanager create-secret --region us-east-1 \
+    --name "sct/${NEW_PROJECT_ID}.json" \
+    --description "GCP service account: ${NEW_PROJECT_ID}" \
+    --secret-string "file:///tmp/${NEW_PROJECT_ID}.json" \
+    --tags Key=team,Value=sct Key=secret_type,Value=cloud_creds Key=rotation_tier,Value=tier2
+
 # Clean up local key
-rm "/tmp/${NEW_PROJECT_ID}.json"
+shred -u "/tmp/${NEW_PROJECT_ID}.json"
 ```
 
 ---
@@ -226,9 +237,15 @@ cat > "/tmp/${NEW_PROJECT_ID}_service_accounts.json" << 'EOF'
 ]
 EOF
 
-# Upload to keystore
+# Upload to keystore (S3)
 aws s3 cp "/tmp/${NEW_PROJECT_ID}_service_accounts.json" \
     "s3://scylla-qa-keystore/${NEW_PROJECT_ID}_service_accounts.json"
+
+# Mirror into Secrets Manager (the default backend)
+aws secretsmanager create-secret --region us-east-1 \
+    --name "sct/${NEW_PROJECT_ID}_service_accounts.json" \
+    --secret-string "file:///tmp/${NEW_PROJECT_ID}_service_accounts.json" \
+    --tags Key=team,Value=sct Key=secret_type,Value=config
 ```
 
 > **Note:** The `https://www.googleapis.com/auth/cloud-platform` scope is automatically appended
@@ -523,8 +540,8 @@ hydra run-test longevity_test.LongevityTest.test_custom_time --backend gce --con
 
 - [ ] Project created and billing linked
 - [ ] All required APIs enabled
-- [ ] Main service account created with key uploaded to S3 keystore
-- [ ] Service accounts scopes JSON uploaded to S3 keystore
+- [ ] Main service account created with key uploaded to S3 keystore **and** mirrored to `sct/<project-id>.json` in Secrets Manager
+- [ ] Service accounts scopes JSON uploaded to S3 keystore **and** mirrored to `sct/<project-id>_service_accounts.json` in Secrets Manager
 - [ ] IAM roles assigned (especially `roles/storage.admin` for object retention)
 - [ ] `qa-vpc` network created
 - [ ] Firewall rules configured (or let SCT auto-create on first run)
@@ -554,12 +571,18 @@ gcloud projects add-iam-policy-binding "$NEW_PROJECT_ID" \
 
 ### Credential File Not Found
 
-Ensure the service account key is uploaded to S3 with the correct filename:
-- Main credentials: `s3://scylla-qa-keystore/<project-id>.json`
-- Service account scopes: `s3://scylla-qa-keystore/<project-id>_service_accounts.json`
+Ensure the service account key is uploaded with the correct name to **both** backends:
+
+| | Secrets Manager (default) | S3 (legacy) |
+|---|---|---|
+| Main credentials | `sct/<project-id>.json` | `s3://scylla-qa-keystore/<project-id>.json` |
+| Service account scopes | `sct/<project-id>_service_accounts.json` | `s3://scylla-qa-keystore/<project-id>_service_accounts.json` |
 
 The `KeyStore.get_gcp_credentials()` method in `sdcm/keystore.py` resolves the filename from
 `SCT_GCE_PROJECT` environment variable (defaults to `gcp-sct-project-1`).
+A `ResourceNotFoundException` for `sct/<project-id>.json` means the entry exists in S3 but was
+never mirrored into Secrets Manager — see
+[keystore-secrets-manager.md](keystore-secrets-manager.md#gcp-projects).
 
 ### Quota Issues
 

--- a/docs/keystore-secrets-manager.md
+++ b/docs/keystore-secrets-manager.md
@@ -62,19 +62,20 @@ is set. `KeyStore` therefore always passes `region_name`, defaulting to
 
 ## Optional entries
 
-Some keys are resolved from a runtime value, so which ones are needed depends on
-what a job is pointed at. A missing entry here does **not** fail loudly, which
-makes it the easiest kind of gap to miss:
+Some keys are resolved from a runtime value, so the name isn't visible at the call
+site and a gap only shows up on the job that happens to need it. All of these are
+mirrored today; the "on a miss" column is what to expect if a *new* value gets
+introduced without mirroring it.
 
 | Key pattern | Resolved from | Consumers | On a miss |
 |---|---|---|---|
-| `argus_rest_credentials_sct_{provider}.json` | detected cloud provider | `KeyStore.get_argus_rest_credentials_per_provider()` | falls back to `argus_rest_credentials.json`, logged at debug. Only `aws` is mirrored today. |
-| `scylla_cloud_sct_api_creds_{env}.json` | `xcloud_env` | `xcloud` runs, `utils/cloud_cleanup/xcloud/clean_xcloud.py`, `sdcm/utils/cloud_monitor/resources/xcloud.py` | **hard failure** for a run: `cloud_env_credentials` is read from `SCTConfiguration.__init__` via the release-tag lookup. Cleanup and cloud-monitor instead catch it, warn and skip that environment — leaked clusters. Every xcloud pipeline here uses `xcloud_env: 'staging'`. |
-| `{s3_baremetal_config}.json` | `s3_baremetal_config` | baremetal provisioning + log collection | hard failure at provisioning, via `get_cluster_baremetal()`. Values in use: `baremetal_config_example`, `baremetal_credentials`, `oci_baremetal_config`. |
+| `argus_rest_credentials_sct_{provider}.json` | detected cloud provider | `KeyStore.get_argus_rest_credentials_per_provider()` | falls back to `argus_rest_credentials.json`, logged at debug. Only `aws` has a dedicated entry; every other provider takes the fallback by design. |
+| `scylla_cloud_sct_api_creds_{env}.json` | `xcloud_env` | `xcloud` runs, `utils/cloud_cleanup/xcloud/clean_xcloud.py`, `sdcm/utils/cloud_monitor/resources/xcloud.py` | **hard failure** for a run: `cloud_env_credentials` is read from `SCTConfiguration.__init__` via the release-tag lookup. Cleanup and cloud-monitor instead catch it, warn and skip that environment — leaked clusters. Mirrored: `lab`, `staging`, `prod`. |
+| `{s3_baremetal_config}.json` | `s3_baremetal_config` | baremetal provisioning + log collection | hard failure at provisioning, via `get_cluster_baremetal()`. Mirrored: `baremetal_config_example`, `baremetal_credentials`, `oci_baremetal_config`. |
 
-Mirror the entry for any environment/provider/config a job actually uses before
-pointing it at the `secretsmanager` backend. Run the [validation](#validation)
-snippet below to see which are still missing.
+When adding an environment, provider or baremetal config, mirror its entry in the
+same change — nothing in CI enforces this. Run the [validation](#validation)
+snippet to check the current state.
 
 ## Not mirrored: bulk data caches
 
@@ -131,7 +132,13 @@ id to `SUPPORTED_PROJECTS`.
 
 ## Adding or updating credentials
 
-Always update **both** S3 and Secrets Manager.
+Always update **both** S3 and Secrets Manager. Secrets Manager is regional, so
+pass `--region` explicitly rather than relying on the ambient one — writing to the
+wrong region creates a secret SCT will never read.
+
+Stage the file on RAM-backed tmpfs (`/dev/shm`) under `umask 077` so the plaintext
+never reaches persistent storage; see the note on `shred` in
+[gcp_create_new_project.md](gcp_create_new_project.md).
 
 ### JSON credential
 
@@ -141,12 +148,13 @@ aws s3 cp /path/to/new_cred.json s3://scylla-qa-keystore/new_cred.json
 
 # 2. Upload to Secrets Manager (create or update)
 #    First time:
-aws secretsmanager create-secret \
+aws secretsmanager create-secret --region "${SCT_KEYSTORE_SM_REGION:-us-east-1}" \
     --name sct/new_cred.json \
+    --description "SCT keystore entry migrated from s3://scylla-qa-keystore/new_cred.json" \
     --secret-string file:///path/to/new_cred.json \
-    --tags Key=team,Value=sct
+    --tags Key=team,Value=sct Key=secret_type,Value=config
 #    Update existing:
-aws secretsmanager put-secret-value \
+aws secretsmanager put-secret-value --region "${SCT_KEYSTORE_SM_REGION:-us-east-1}" \
     --secret-id sct/new_cred.json \
     --secret-string file:///path/to/new_cred.json
 
@@ -161,12 +169,24 @@ shred -u /path/to/new_cred.json
 aws s3 cp /path/to/key s3://scylla-qa-keystore/scylla_test_id_ed25519
 
 # 2. Upload to Secrets Manager
-aws secretsmanager put-secret-value \
+aws secretsmanager put-secret-value --region "${SCT_KEYSTORE_SM_REGION:-us-east-1}" \
     --secret-id sct/scylla_test_id_ed25519 \
     --secret-binary fileb:///path/to/key
 
 # 3. Clean up
 shred -u /path/to/key
+```
+
+To verify a mirror landed intact without printing the material, compare byte
+counts:
+
+```bash
+name=new_cred.json
+aws s3api head-object --bucket scylla-qa-keystore --key "$name" \
+    --query ContentLength --output text
+aws secretsmanager get-secret-value --secret-id "sct/$name" \
+    --region "${SCT_KEYSTORE_SM_REGION:-us-east-1}" \
+    --query 'length(SecretString)' --output text
 ```
 
 SCT detects rotation via ETag (S3) or VersionId sidecar (SM) and
@@ -176,15 +196,15 @@ re-downloads automatically on the next run.
 
 ```bash
 # From Secrets Manager (JSON)
-aws secretsmanager get-secret-value \
+aws secretsmanager get-secret-value --region "${SCT_KEYSTORE_SM_REGION:-us-east-1}" \
     --secret-id sct/email_config.json \
     --query SecretString --output text | jq .
 
-# From Secrets Manager (binary)
-aws secretsmanager get-secret-value \
+# From Secrets Manager (binary) -- /dev/shm is tmpfs, so the key stays in RAM
+(umask 077 && aws secretsmanager get-secret-value \
+    --region "${SCT_KEYSTORE_SM_REGION:-us-east-1}" \
     --secret-id sct/scylla_test_id_ed25519 \
-    --query SecretBinary --output text | base64 -d > /tmp/key
-chmod 600 /tmp/key
+    --query SecretBinary --output text | base64 -d > /dev/shm/key)
 
 # From S3
 aws s3 cp s3://scylla-qa-keystore/email_config.json -
@@ -211,7 +231,9 @@ required="scylla_test_id_ed25519 scylla_test_id_ed25519.pub
           github_access.json jenkins.json scylla_doctor_full.json
           CA.pem SCYLLADB.pem hytrust-kmip-cacert.pem hytrust-kmip-scylla.pem"
 
-# Needed only by the jobs that use them -- see "Optional entries" above.
+# Needed only by the jobs that use them -- see "Optional entries" above.  The
+# per-provider argus tokens are the exception: only `aws` has one, and the others
+# are meant to fall back to the shared token, so a GAP there is expected.
 optional="argus_rest_credentials_sct_aws.json
           argus_rest_credentials_sct_gce.json
           argus_rest_credentials_sct_azure.json
@@ -236,6 +258,9 @@ check() {
 check MISS "$required"   # any MISS breaks runs on the secretsmanager backend
 check GAP  "$optional"   # a GAP only breaks the jobs that need that entry
 ```
+
+As of the `secretsmanager` default switch this reports `OK` for everything except
+`argus_rest_credentials_sct_{gce,azure}.json`, which are intentionally absent.
 
 The `issues/` cache is intentionally absent from both lists — see
 [Not mirrored: bulk data caches](#not-mirrored-bulk-data-caches).

--- a/docs/keystore-secrets-manager.md
+++ b/docs/keystore-secrets-manager.md
@@ -69,11 +69,12 @@ makes it the easiest kind of gap to miss:
 | Key pattern | Resolved from | Consumers | On a miss |
 |---|---|---|---|
 | `argus_rest_credentials_sct_{provider}.json` | detected cloud provider | `KeyStore.get_argus_rest_credentials_per_provider()` | falls back to `argus_rest_credentials.json`, logged at debug. Only `aws` is mirrored today. |
-| `scylla_cloud_sct_api_creds_{env}.json` | `xcloud_env` | `xcloud` runs, `utils/cloud_cleanup/xcloud/clean_xcloud.py`, `sdcm/utils/cloud_monitor/resources/xcloud.py` | both cleanup and cloud-monitor catch it, log a warning and **skip that environment** — leaked clusters, no hard failure. `lab` is mirrored; `staging` and `prod` are **not**. |
-| `{s3_baremetal_config}.json` | `s3_baremetal_config` | baremetal provisioning + log collection | hard failure at provisioning. Not mirrored (`baremetal_config_example.json`, `baremetal_credentials.json`, `oci_baremetal_config.json` exist in S3 only) — baremetal jobs must set `keystore_backend: 's3'` until they are. |
+| `scylla_cloud_sct_api_creds_{env}.json` | `xcloud_env` | `xcloud` runs, `utils/cloud_cleanup/xcloud/clean_xcloud.py`, `sdcm/utils/cloud_monitor/resources/xcloud.py` | **hard failure** for a run: `cloud_env_credentials` is read from `SCTConfiguration.__init__` via the release-tag lookup. Cleanup and cloud-monitor instead catch it, warn and skip that environment — leaked clusters. Every xcloud pipeline here uses `xcloud_env: 'staging'`. |
+| `{s3_baremetal_config}.json` | `s3_baremetal_config` | baremetal provisioning + log collection | hard failure at provisioning, via `get_cluster_baremetal()`. Values in use: `baremetal_config_example`, `baremetal_credentials`, `oci_baremetal_config`. |
 
 Mirror the entry for any environment/provider/config a job actually uses before
-pointing it at the `secretsmanager` backend.
+pointing it at the `secretsmanager` backend. Run the [validation](#validation)
+snippet below to see which are still missing.
 
 ## Not mirrored: bulk data caches
 
@@ -216,12 +217,16 @@ optional="argus_rest_credentials_sct_aws.json
           argus_rest_credentials_sct_azure.json
           scylla_cloud_sct_api_creds_lab.json
           scylla_cloud_sct_api_creds_staging.json
-          scylla_cloud_sct_api_creds_prod.json"
+          scylla_cloud_sct_api_creds_prod.json
+          baremetal_config_example.json
+          baremetal_credentials.json
+          oci_baremetal_config.json"
 
 check() {
     for name in $2; do
         if aws secretsmanager describe-secret --secret-id "sct/$name" \
-             --region us-east-1 --output text --query Name >/dev/null 2>&1; then
+             --region "${SCT_KEYSTORE_SM_REGION:-us-east-1}" \
+             --output text --query Name >/dev/null 2>&1; then
             echo "OK   sct/$name"
         else
             echo "$1 sct/$name"

--- a/docs/keystore-secrets-manager.md
+++ b/docs/keystore-secrets-manager.md
@@ -46,6 +46,10 @@ is set. `KeyStore` therefore always passes `region_name`, defaulting to
 | `scylladb_upload.json` | json | Upload API token |
 | `qa_users.json` | json | QA user roster |
 | `bucket-users.json` | json | ACL grantees |
+| `aws_images_role.json` | json | AWS role for image copying |
+| `github_access.json` | json | GitHub API token |
+| `jenkins.json` | json | Jenkins API credentials |
+| `scylla_doctor_full.json` | json | scylla-doctor credentials |
 
 ## Adding or updating credentials
 
@@ -120,9 +124,10 @@ for name in scylla_test_id_ed25519 scylla_test_id_ed25519.pub \
             housekeeping-db.json backup_azure_blob.json \
             azure_kms_config.json gcp_kms_config.json \
             scylladb_upload.json qa_users.json bucket-users.json \
-            gcp-scylladbaaslab.json; do
+            gcp-scylladbaaslab.json aws_images_role.json \
+            github_access.json jenkins.json scylla_doctor_full.json; do
     if aws secretsmanager get-secret-value --secret-id "sct/$name" \
-         --output text --query Name >/dev/null 2>&1; then
+         --region us-east-1 --output text --query Name >/dev/null 2>&1; then
         echo "OK   sct/$name"
     else
         echo "MISS sct/$name"

--- a/docs/keystore-secrets-manager.md
+++ b/docs/keystore-secrets-manager.md
@@ -40,8 +40,14 @@ is set. `KeyStore` therefore always passes `region_name`, defaulting to
 | `docker.json` | json | Docker Hub credentials |
 | `email_config.json` | json | SMTP config |
 | `ldap_ms_ad.json` | json | LDAP / AD config |
-| `argus_rest_credentials.json` | json | Argus API token |
+| `argus_rest_credentials.json` | json | Argus API token (shared fallback) |
+| `argus_rest_credentials_sct_{provider}.json` | json | Argus API token per cloud provider; optional, falls back to the shared one (see [optional entries](#optional-entries)) |
+| `scylla_cloud_sct_api_creds_{env}.json` | json | Scylla Cloud REST API creds per `xcloud_env` (see [optional entries](#optional-entries)) |
 | `scylladb_jira.json` | json | Jira API token |
+| `CA.pem` | binary | Encryption-at-rest CA cert |
+| `SCYLLADB.pem` | binary | Encryption-at-rest cert |
+| `hytrust-kmip-cacert.pem` | binary | HyTrust KMIP CA cert |
+| `hytrust-kmip-scylla.pem` | binary | HyTrust KMIP client cert |
 | `housekeeping-db.json` | json | Internal DB credentials |
 | `backup_azure_blob.json` | json | Azure Blob backup credentials |
 | `azure_kms_config.json` | json | Azure KMS config |
@@ -53,6 +59,39 @@ is set. `KeyStore` therefore always passes `region_name`, defaulting to
 | `github_access.json` | json | GitHub API token |
 | `jenkins.json` | json | Jenkins API credentials |
 | `scylla_doctor_full.json` | json | scylla-doctor credentials |
+
+## Optional entries
+
+Some keys are resolved from a runtime value, so which ones are needed depends on
+what a job is pointed at. A missing entry here does **not** fail loudly, which
+makes it the easiest kind of gap to miss:
+
+| Key pattern | Resolved from | Consumers | On a miss |
+|---|---|---|---|
+| `argus_rest_credentials_sct_{provider}.json` | detected cloud provider | `KeyStore.get_argus_rest_credentials_per_provider()` | falls back to `argus_rest_credentials.json`, logged at debug. Only `aws` is mirrored today. |
+| `scylla_cloud_sct_api_creds_{env}.json` | `xcloud_env` | `xcloud` runs, `utils/cloud_cleanup/xcloud/clean_xcloud.py`, `sdcm/utils/cloud_monitor/resources/xcloud.py` | both cleanup and cloud-monitor catch it, log a warning and **skip that environment** — leaked clusters, no hard failure. `lab` is mirrored; `staging` and `prod` are **not**. |
+| `{s3_baremetal_config}.json` | `s3_baremetal_config` | baremetal provisioning + log collection | hard failure at provisioning. Not mirrored (`baremetal_config_example.json`, `baremetal_credentials.json`, `oci_baremetal_config.json` exist in S3 only) — baremetal jobs must set `keystore_backend: 's3'` until they are. |
+
+Mirror the entry for any environment/provider/config a job actually uses before
+pointing it at the `secretsmanager` backend.
+
+## Not mirrored: bulk data caches
+
+The `issues/` prefix in `scylla-qa-keystore` holds the Jira/GitHub issue caches
+that `sdcm/utils/issues.py` reads. These are **not** credentials and are
+deliberately **not** mirrored:
+
+- they exceed the 64 KB Secrets Manager secret limit (largest is >1 MB);
+- they are rewritten every 6 hours by `.github/workflows/cache-issues.yaml` and
+  `cache-jira-issues.yaml`, which upload to S3 only.
+
+`CachedJiraIssues` and `CachedGitHubIssues` therefore construct
+`KeyStore(backend="s3")` explicitly and ignore `keystore_backend`. Without that
+pin, every issue lookup misses the cache and falls back to the live API — the
+GitHub rate limit the cache exists to avoid — while only emitting a warning.
+
+Use `KeyStore(backend="s3")` for any future non-credential bulk data; do not try
+to mirror it.
 
 ## GCP projects
 
@@ -152,28 +191,49 @@ aws s3 cp s3://scylla-qa-keystore/email_config.json -
 
 ## Validation
 
-Quick check that all entries are readable in Secrets Manager:
+Quick check that all entries are readable in Secrets Manager. `describe-secret`
+is enough to prove existence and — unlike `get-secret-value` — never pulls the
+secret material onto the machine running the check:
 
 ```bash
-for name in scylla_test_id_ed25519 scylla_test_id_ed25519.pub \
-            gcp-sct-project-1.json gcp-sct-project-1_service_accounts.json \
-            gcp-local-ssd-latency.json gcp-local-ssd-latency_service_accounts.json \
-            azure.json oci.json docker.json \
-            email_config.json ldap_ms_ad.json \
-            argus_rest_credentials.json scylladb_jira.json \
-            housekeeping-db.json backup_azure_blob.json \
-            azure_kms_config.json gcp_kms_config.json \
-            scylladb_upload.json qa_users.json bucket-users.json \
-            gcp-scylladbaaslab.json aws_images_role.json \
-            github_access.json jenkins.json scylla_doctor_full.json; do
-    if aws secretsmanager get-secret-value --secret-id "sct/$name" \
-         --region us-east-1 --output text --query Name >/dev/null 2>&1; then
-        echo "OK   sct/$name"
-    else
-        echo "MISS sct/$name"
-    fi
-done
+# Required for every run.
+required="scylla_test_id_ed25519 scylla_test_id_ed25519.pub
+          gcp-sct-project-1.json gcp-sct-project-1_service_accounts.json
+          gcp-local-ssd-latency.json gcp-local-ssd-latency_service_accounts.json
+          azure.json oci.json docker.json
+          email_config.json ldap_ms_ad.json
+          argus_rest_credentials.json scylladb_jira.json
+          housekeeping-db.json backup_azure_blob.json
+          azure_kms_config.json gcp_kms_config.json
+          scylladb_upload.json qa_users.json bucket-users.json
+          gcp-scylladbaaslab.json aws_images_role.json
+          github_access.json jenkins.json scylla_doctor_full.json
+          CA.pem SCYLLADB.pem hytrust-kmip-cacert.pem hytrust-kmip-scylla.pem"
+
+# Needed only by the jobs that use them -- see "Optional entries" above.
+optional="argus_rest_credentials_sct_aws.json
+          argus_rest_credentials_sct_gce.json
+          argus_rest_credentials_sct_azure.json
+          scylla_cloud_sct_api_creds_lab.json
+          scylla_cloud_sct_api_creds_staging.json
+          scylla_cloud_sct_api_creds_prod.json"
+
+check() {
+    for name in $2; do
+        if aws secretsmanager describe-secret --secret-id "sct/$name" \
+             --region us-east-1 --output text --query Name >/dev/null 2>&1; then
+            echo "OK   sct/$name"
+        else
+            echo "$1 sct/$name"
+        fi
+    done
+}
+check MISS "$required"   # any MISS breaks runs on the secretsmanager backend
+check GAP  "$optional"   # a GAP only breaks the jobs that need that entry
 ```
+
+The `issues/` cache is intentionally absent from both lists — see
+[Not mirrored: bulk data caches](#not-mirrored-bulk-data-caches).
 
 ## Access policy
 

--- a/docs/keystore-secrets-manager.md
+++ b/docs/keystore-secrets-manager.md
@@ -9,8 +9,8 @@ S3 fallback stays in sync.
 
 | Source | Key | Value |
 |---|---|---|
-| Environment variable | `SCT_KEYSTORE_BACKEND` | `s3` (default) or `secretsmanager` |
-| SCT config file | `keystore_backend` | `s3` or `secretsmanager` |
+| Environment variable | `SCT_KEYSTORE_BACKEND` | `secretsmanager` (default) or `s3` |
+| SCT config file | `keystore_backend` | `secretsmanager` (default) or `s3` |
 | Environment variable | `SCT_KEYSTORE_SM_PREFIX` | default: `sct/` |
 | SCT config file | `keystore_sm_prefix` | default: `sct/` |
 

--- a/docs/keystore-secrets-manager.md
+++ b/docs/keystore-secrets-manager.md
@@ -30,7 +30,10 @@ is set. `KeyStore` therefore always passes `region_name`, defaulting to
 |---|---|---|
 | `scylla_test_id_ed25519` | binary | SSH private key |
 | `scylla_test_id_ed25519.pub` | binary | SSH public key |
-| `gcp-sct-project-1.json` | json | GCP service account |
+| `gcp-sct-project-1.json` | json | GCP service account (see [GCP projects](#gcp-projects)) |
+| `gcp-sct-project-1_service_accounts.json` | json | GCP instance service accounts |
+| `gcp-local-ssd-latency.json` | json | GCP service account (see [GCP projects](#gcp-projects)) |
+| `gcp-local-ssd-latency_service_accounts.json` | json | GCP instance service accounts |
 | `gcp-scylladbaaslab.json` | json | GCP service account (DBaaS lab) |
 | `azure.json` | json | Azure credentials |
 | `oci.json` | json | OCI credentials |
@@ -50,6 +53,41 @@ is set. `KeyStore` therefore always passes `region_name`, defaulting to
 | `github_access.json` | json | GitHub API token |
 | `jenkins.json` | json | Jenkins API credentials |
 | `scylla_doctor_full.json` | json | scylla-doctor credentials |
+
+## GCP projects
+
+GCP credentials are keyed by project id, not by a fixed name.
+`KeyStore.get_gcp_credentials()` and `KeyStore.get_gcp_service_accounts()`
+resolve the project from `SCT_GCE_PROJECT` (defaulting to
+`gcp-sct-project-1`) and fetch:
+
+- `{project}.json` — the service-account key used to authenticate to GCP
+- `{project}_service_accounts.json` — the service accounts attached to
+  provisioned instances
+
+The set of project ids SCT may be pointed at is
+`SUPPORTED_PROJECTS` in `sdcm/utils/gce_utils.py`. **Every project in
+`SUPPORTED_PROJECTS` needs both entries present in Secrets Manager**, or
+any run / cleanup / cloud-monitor pass that iterates the project set
+fails with `ResourceNotFoundException` for the missing one. Current set:
+
+| Project id | Required secrets |
+|---|---|
+| `gcp-sct-project-1` | `sct/gcp-sct-project-1.json`, `sct/gcp-sct-project-1_service_accounts.json` |
+| `gcp-local-ssd-latency` | `sct/gcp-local-ssd-latency.json`, `sct/gcp-local-ssd-latency_service_accounts.json` |
+
+When adding a project (see [gcp_create_new_project.md](gcp_create_new_project.md)),
+mirror both entries into Secrets Manager in the same change that adds the
+id to `SUPPORTED_PROJECTS`.
+
+> **Backporting note.** The Secrets Manager mirror only holds the
+> projects listed above. Release branches that still carry extra project
+> ids in `SUPPORTED_PROJECTS` — the legacy `gcp` project is present on
+> `branch-2022.2` through `branch-2024.2` — must have those ids dropped
+> as part of backporting the `secretsmanager` default, otherwise
+> `sct.py`/cleanup will look up `sct/gcp.json`, which does not exist.
+> Branches `branch-2025.1` and newer, plus `branch-perf-v17`, already
+> carry exactly the two projects above and need no adjustment.
 
 ## Adding or updating credentials
 
@@ -118,7 +156,9 @@ Quick check that all entries are readable in Secrets Manager:
 
 ```bash
 for name in scylla_test_id_ed25519 scylla_test_id_ed25519.pub \
-            gcp-sct-project-1.json azure.json oci.json docker.json \
+            gcp-sct-project-1.json gcp-sct-project-1_service_accounts.json \
+            gcp-local-ssd-latency.json gcp-local-ssd-latency_service_accounts.json \
+            azure.json oci.json docker.json \
             email_config.json ldap_ms_ad.json \
             argus_rest_credentials.json scylladb_jira.json \
             housekeeping-db.json backup_azure_blob.json \

--- a/docs/keystore-secrets-manager.md
+++ b/docs/keystore-secrets-manager.md
@@ -13,8 +13,16 @@ S3 fallback stays in sync.
 | SCT config file | `keystore_backend` | `secretsmanager` (default) or `s3` |
 | Environment variable | `SCT_KEYSTORE_SM_PREFIX` | default: `sct/` |
 | SCT config file | `keystore_sm_prefix` | default: `sct/` |
+| Environment variable | `SCT_KEYSTORE_SM_REGION` | default: `us-east-1` |
+| SCT config file | `keystore_sm_region` | default: `us-east-1` |
 
 The environment variable takes precedence.
+
+The region must be pinned explicitly: S3 has a global endpoint so boto3 falls
+back to `us-east-1` on its own, but Secrets Manager is strictly regional and
+raises `NoRegionError` when neither `AWS_DEFAULT_REGION` nor an explicit region
+is set. `KeyStore` therefore always passes `region_name`, defaulting to
+`us-east-1` where the `sct/*` secrets live.
 
 ## Managed credentials
 

--- a/sdcm/keystore.py
+++ b/sdcm/keystore.py
@@ -87,12 +87,18 @@ class KeyStore:
     environment variable (``secretsmanager`` by default, ``s3`` for the
     legacy scylla-qa-keystore bucket).  ``SCT_KEYSTORE_SM_REGION``
     overrides the region the secrets are read from.
+
+    Args:
+        backend: Pin this instance to a backend, ignoring
+            ``SCT_KEYSTORE_BACKEND``.  Needed for entries that only exist
+            in S3 and cannot be mirrored -- see the ``issues/`` bulk cache
+            in :mod:`sdcm.utils.issues`.  Leave unset for credentials.
     """
 
-    def __init__(self):
+    def __init__(self, backend: str | None = None):
         self._cache: dict[str, bytes] = {}
         self._cache_lock = threading.Lock()
-        self._backend = os.environ.get("SCT_KEYSTORE_BACKEND") or "secretsmanager"
+        self._backend = backend or os.environ.get("SCT_KEYSTORE_BACKEND") or "secretsmanager"
         self._sm_prefix = os.environ.get("SCT_KEYSTORE_SM_PREFIX") or "sct/"
         self._sm_region = os.environ.get("SCT_KEYSTORE_SM_REGION") or KEYSTORE_SM_REGION
 
@@ -337,9 +343,16 @@ class KeyStore:
                 return self.get_json(f"argus_rest_credentials_sct_{cloud_provider}.json")
             except ClientError as e:
                 # Per-provider credentials are optional; fall through to the shared
-                # ones when this provider has no dedicated entry.
+                # ones when this provider has no dedicated entry.  Only `aws` is
+                # currently mirrored, so this is the normal path for every other
+                # provider -- log it so a *deleted* entry is still traceable.
                 if not is_not_found_error(e):
                     raise
+                LOGGER.debug(
+                    "no argus_rest_credentials_sct_%s.json in %s backend, using shared argus_rest_credentials.json",
+                    cloud_provider,
+                    self._backend,
+                )
 
         return self.get_json("argus_rest_credentials.json")
 

--- a/sdcm/keystore.py
+++ b/sdcm/keystore.py
@@ -62,6 +62,20 @@ def _is_transient_error(exception):
     return code in _TRANSIENT_S3_ERROR_CODES or code in _TRANSIENT_SM_ERROR_CODES
 
 
+# "Key/secret does not exist" is reported with a different code per backend:
+# S3 says NoSuchKey, Secrets Manager says ResourceNotFoundException.  Callers
+# that treat a missing entry as a soft miss must accept both, otherwise their
+# fallback silently stops working when the backend changes.
+_NOT_FOUND_ERROR_CODES = frozenset({"NoSuchKey", "404", "ResourceNotFoundException"})
+
+
+def is_not_found_error(exception) -> bool:
+    """Return True if the exception means the requested key/secret does not exist."""
+    if not isinstance(exception, ClientError):
+        return False
+    return exception.response.get("Error", {}).get("Code") in _NOT_FOUND_ERROR_CODES
+
+
 class KeyStore:
     """Credential store backed by AWS Secrets Manager or S3.
 
@@ -322,7 +336,9 @@ class KeyStore:
             try:
                 return self.get_json(f"argus_rest_credentials_sct_{cloud_provider}.json")
             except ClientError as e:
-                if not e.response["Error"]["Code"] == "NoSuchKey":
+                # Per-provider credentials are optional; fall through to the shared
+                # ones when this provider has no dedicated entry.
+                if not is_not_found_error(e):
                     raise
 
         return self.get_json("argus_rest_credentials.json")

--- a/sdcm/keystore.py
+++ b/sdcm/keystore.py
@@ -37,6 +37,12 @@ LOGGER = logging.getLogger(__name__)
 
 KEYSTORE_S3_BUCKET = "scylla-qa-keystore"
 
+# Region holding the mirrored `sct/*` secrets.  Unlike S3 (whose global
+# endpoint lets boto3 fall back to us-east-1), Secrets Manager is strictly
+# regional and raises NoRegionError when no region is configured, so the
+# client must always be pinned explicitly.
+KEYSTORE_SM_REGION = "us-east-1"
+
 SSHKey = namedtuple("SSHKey", ["name", "public_key", "private_key"])
 
 BOTO3_CLIENT_CREATION_LOCK = threading.Lock()
@@ -65,7 +71,8 @@ class KeyStore:
 
     Backend selection is controlled by the ``SCT_KEYSTORE_BACKEND``
     environment variable (``secretsmanager`` by default, ``s3`` for the
-    legacy scylla-qa-keystore bucket).
+    legacy scylla-qa-keystore bucket).  ``SCT_KEYSTORE_SM_REGION``
+    overrides the region the secrets are read from.
     """
 
     def __init__(self):
@@ -73,6 +80,7 @@ class KeyStore:
         self._cache_lock = threading.Lock()
         self._backend = os.environ.get("SCT_KEYSTORE_BACKEND") or "secretsmanager"
         self._sm_prefix = os.environ.get("SCT_KEYSTORE_SM_PREFIX") or "sct/"
+        self._sm_region = os.environ.get("SCT_KEYSTORE_SM_REGION") or KEYSTORE_SM_REGION
 
     @property
     def s3(self) -> S3ServiceResource:
@@ -82,6 +90,11 @@ class KeyStore:
     def s3_client(self) -> S3Client:
         with BOTO3_CLIENT_CREATION_LOCK:
             return boto3.client("s3")
+
+    @property
+    def sm_client(self):
+        with BOTO3_CLIENT_CREATION_LOCK:
+            return boto3.client("secretsmanager", region_name=self._sm_region)
 
     @tenacity.retry(
         retry=tenacity.retry_if_exception(_is_transient_error),
@@ -102,8 +115,7 @@ class KeyStore:
     )
     def _fetch_from_secrets_manager(self, file_name):
         """Fetch a secret from AWS Secrets Manager with automatic retry."""
-        with BOTO3_CLIENT_CREATION_LOCK:
-            sm = boto3.client("secretsmanager")
+        sm = self.sm_client
         secret_name = f"{self._sm_prefix}{file_name}"
         resp = sm.get_secret_value(SecretId=secret_name)
         if "SecretBinary" in resp:
@@ -413,8 +425,7 @@ class KeyStore:
     )
     def get_sm_version_id(self, key):
         """Return the current VersionId of a Secrets Manager secret."""
-        with BOTO3_CLIENT_CREATION_LOCK:
-            sm = boto3.client("secretsmanager")
+        sm = self.sm_client
         secret_name = f"{self._sm_prefix}{key}"
         resp = sm.describe_secret(SecretId=secret_name)
         for version_id, stages in resp.get("VersionIdsToStages", {}).items():

--- a/sdcm/keystore.py
+++ b/sdcm/keystore.py
@@ -57,21 +57,21 @@ def _is_transient_error(exception):
 
 
 class KeyStore:
-    """Credential store backed by S3 or AWS Secrets Manager.
+    """Credential store backed by AWS Secrets Manager or S3.
 
     Fetches credentials (JSON configs, SSH keys, API tokens) from a
     configurable backend.  Results are cached in a thread-safe dict for
     the lifetime of the instance.
 
     Backend selection is controlled by the ``SCT_KEYSTORE_BACKEND``
-    environment variable (``s3`` by default, ``secretsmanager`` for
-    AWS Secrets Manager).
+    environment variable (``secretsmanager`` by default, ``s3`` for the
+    legacy scylla-qa-keystore bucket).
     """
 
     def __init__(self):
         self._cache: dict[str, bytes] = {}
         self._cache_lock = threading.Lock()
-        self._backend = os.environ.get("SCT_KEYSTORE_BACKEND") or "s3"
+        self._backend = os.environ.get("SCT_KEYSTORE_BACKEND") or "secretsmanager"
         self._sm_prefix = os.environ.get("SCT_KEYSTORE_SM_PREFIX") or "sct/"
 
     @property

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -2416,7 +2416,7 @@ class SCTConfiguration(BaseModel):
         ),
     )
     keystore_backend: Literal["s3", "secretsmanager"] = SctField(
-        description="Credential storage backend for KeyStore: 's3' (default) or 'secretsmanager'",
+        description="Credential storage backend for KeyStore: 'secretsmanager' (default) or 's3' (legacy)",
     )
     keystore_sm_prefix: String = SctField(
         description="AWS Secrets Manager secret name prefix when keystore_backend=secretsmanager (default: 'sct/')",

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -2795,6 +2795,10 @@ class SCTConfiguration(BaseModel):
         self._resolve_instance_sizes(env)
         merge_dicts_append_strings(self, env)
 
+        # All keystore sources are now merged, so export them before any of the
+        # resolution below can construct a KeyStore (xcloud's release tag lookup does).
+        self._propagate_keystore_env()
+
         if not self.get("billing_project"):
             if job_name := os.environ.get("JOB_NAME"):
                 release_folder = job_name.split("/")[0]
@@ -3316,18 +3320,35 @@ class SCTConfiguration(BaseModel):
             self["c_s_driver_version"] = random.choice(["4", "3"])
             self.log.debug("Using random cassandra-stress driver version: %s", self["c_s_driver_version"])
 
-        # Propagate keystore settings to env vars so KeyStore instances created
-        # later (including from utility code that doesn't hold an SCTConfiguration
-        # reference) pick up the config-file / CLI-overridden values.  A value we
-        # exported ourselves is refreshed, but an env var the user actually set is
-        # never overwritten -- otherwise the first instance's value would leak and
-        # outrank the config file of every later instance in the same process.
-        for _param in ("keystore_backend", "keystore_sm_prefix", "keystore_sm_region"):
-            _env_name = f"SCT_{_param.upper()}"
-            _value = self.get(_param)
-            if _value and (_env_name not in os.environ or _is_self_exported_keystore_env(_env_name)):
-                os.environ[_env_name] = str(_value)
-                _KEYSTORE_ENV_EXPORTED[_env_name] = str(_value)
+    def _propagate_keystore_env(self):
+        """Export the resolved keystore settings so bare ``KeyStore()`` callers agree.
+
+        KeyStore reads ``SCT_KEYSTORE_*`` from the environment, so utility code that
+        doesn't hold an SCTConfiguration reference needs the config-file / CLI values
+        mirrored there.  A value we exported ourselves is refreshed, but an env var
+        the user actually set is never overwritten -- otherwise the first instance's
+        value would leak and outrank the config file of every later instance in the
+        same process.
+
+        Must run as soon as the config sources are merged and *before* anything in
+        ``__init__`` can construct a KeyStore: xcloud's ``release:latest`` path
+        reaches ``cloud_env_credentials`` -> ``KeyStore()`` from inside __init__, so
+        exporting at the end of __init__ left that fetch on the wrong backend and
+        made the documented ``keystore_backend: 's3'`` opt-out a no-op for it.
+        """
+        for param in ("keystore_backend", "keystore_sm_prefix", "keystore_sm_region"):
+            env_name = f"SCT_{param.upper()}"
+            value = self.get(param)
+            if not value:
+                continue
+            if env_name not in os.environ or _is_self_exported_keystore_env(env_name):
+                os.environ[env_name] = str(value)
+                _KEYSTORE_ENV_EXPORTED[env_name] = str(value)
+            else:
+                # A user override we must not touch.  Drop our marker so that
+                # setting the env var back to the value we once exported still
+                # reads as a real override rather than as our own leak.
+                _KEYSTORE_ENV_EXPORTED.pop(env_name, None)
 
     def load_docker_images_defaults(self):
         stress_image = _load_docker_images_defaults_cached()

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -100,6 +100,11 @@ from sdcm.utils.cloud_catalog.instance_matcher import NoMatchingInstanceError, s
 
 _SIZING_RESOLUTION_CACHE: dict[tuple, str] = {}
 
+# SCT_KEYSTORE_* env var names this process exported itself (see the keystore
+# propagation in verify_configuration).  Tracked so a later SCTConfiguration can
+# refresh them without mistaking them for a user-supplied override.
+_KEYSTORE_ENV_EXPORTED: set[str] = set()
+
 
 class IgnoredType:
     pass
@@ -2421,6 +2426,9 @@ class SCTConfiguration(BaseModel):
     keystore_sm_prefix: String = SctField(
         description="AWS Secrets Manager secret name prefix when keystore_backend=secretsmanager (default: 'sct/')",
     )
+    keystore_sm_region: String = SctField(
+        description="AWS region holding the KeyStore secrets when keystore_backend=secretsmanager (default: 'us-east-1')",
+    )
 
     required_params: Annotated[list, IgnoredType] = [
         "cluster_backend",
@@ -3301,13 +3309,16 @@ class SCTConfiguration(BaseModel):
 
         # Propagate keystore settings to env vars so KeyStore instances created
         # later (including from utility code that doesn't hold an SCTConfiguration
-        # reference) pick up the config-file / CLI-overridden values.  An
-        # explicit SCT_KEYSTORE_* env var always wins since we don't overwrite.
-        for _param in ("keystore_backend", "keystore_sm_prefix"):
+        # reference) pick up the config-file / CLI-overridden values.  A value we
+        # exported ourselves is refreshed, but an env var the user actually set is
+        # never overwritten -- otherwise the first instance's value would leak and
+        # outrank the config file of every later instance in the same process.
+        for _param in ("keystore_backend", "keystore_sm_prefix", "keystore_sm_region"):
             _env_name = f"SCT_{_param.upper()}"
             _value = self.get(_param)
-            if _value and _env_name not in os.environ:
+            if _value and (_env_name not in os.environ or _env_name in _KEYSTORE_ENV_EXPORTED):
                 os.environ[_env_name] = str(_value)
+                _KEYSTORE_ENV_EXPORTED.add(_env_name)
 
     def load_docker_images_defaults(self):
         stress_image = _load_docker_images_defaults_cached()

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -100,10 +100,19 @@ from sdcm.utils.cloud_catalog.instance_matcher import NoMatchingInstanceError, s
 
 _SIZING_RESOLUTION_CACHE: dict[tuple, str] = {}
 
-# SCT_KEYSTORE_* env var names this process exported itself (see the keystore
-# propagation in verify_configuration).  Tracked so a later SCTConfiguration can
-# refresh them without mistaking them for a user-supplied override.
-_KEYSTORE_ENV_EXPORTED: set[str] = set()
+# SCT_KEYSTORE_* env vars this process exported itself (see the keystore
+# propagation at the end of SCTConfiguration.__init__), mapped to the value we
+# wrote.  The value matters, not just the name: environment variables outrank
+# config files, so a value this process leaked into os.environ would otherwise
+# beat a later config file asking for a different backend.  Comparing against
+# the tracked value lets `_load_environment_variables` ignore our own export
+# while still honouring a value the user changed behind our back.
+_KEYSTORE_ENV_EXPORTED: dict[str, str] = {}
+
+
+def _is_self_exported_keystore_env(env_name: str) -> bool:
+    """True if os.environ[env_name] is still the value this process exported."""
+    return env_name in _KEYSTORE_ENV_EXPORTED and os.environ.get(env_name) == _KEYSTORE_ENV_EXPORTED[env_name]
 
 
 class IgnoredType:
@@ -3316,9 +3325,9 @@ class SCTConfiguration(BaseModel):
         for _param in ("keystore_backend", "keystore_sm_prefix", "keystore_sm_region"):
             _env_name = f"SCT_{_param.upper()}"
             _value = self.get(_param)
-            if _value and (_env_name not in os.environ or _env_name in _KEYSTORE_ENV_EXPORTED):
+            if _value and (_env_name not in os.environ or _is_self_exported_keystore_env(_env_name)):
                 os.environ[_env_name] = str(_value)
-                _KEYSTORE_ENV_EXPORTED.add(_env_name)
+                _KEYSTORE_ENV_EXPORTED[_env_name] = str(_value)
 
     def load_docker_images_defaults(self):
         stress_image = _load_docker_images_defaults_cached()
@@ -3547,6 +3556,13 @@ class SCTConfiguration(BaseModel):
                 continue
 
             field_env = f"SCT_{field_name.upper()}"
+
+            # Env vars this process exported itself are not user input, so they must
+            # not be given environment-variable precedence over a config file.  Only
+            # skip them while they still hold the value we wrote -- a value the user
+            # changed since is a genuine override.
+            if _is_self_exported_keystore_env(field_env):
+                continue
 
             def no_op(x):
                 return x

--- a/sdcm/utils/issues.py
+++ b/sdcm/utils/issues.py
@@ -108,10 +108,16 @@ class CachedJiraIssues:
     This class provides a cache for issue data retrieved from an S3 bucket
 
     The cache is automatically populated by the `.github/workflows/cache-jira-issues.yaml` workflow every 6 hours.
+
+    The KeyStore is pinned to `s3` regardless of `keystore_backend`: these CSVs are
+    bulk data rather than credentials, they exceed the 64 KB Secrets Manager secret
+    limit (the largest is >1 MB), and only the workflow above writes them -- to S3.
+    Reading them through Secrets Manager can only ever miss, which silently degrades
+    every issue lookup to a live API call.
     """
 
     def __init__(self):
-        self.storage = KeyStore()
+        self.storage = KeyStore(backend="s3")
 
     @lru_cache
     def get_project(self, project: str) -> dict[str, Issue]:
@@ -176,10 +182,15 @@ class CachedGitHubIssues:
     every 6 hours.
 
     it's main goal is to make sure we don't reach the rate limit of the github api
+
+    Pinned to the `s3` backend for the same reason as :class:`CachedJiraIssues`:
+    bulk CSVs, too large for Secrets Manager, written to S3 only.  A cache miss
+    here falls back to the live GitHub API, i.e. straight into the rate limit
+    this cache exists to avoid.
     """
 
     def __init__(self):
-        self.storage = KeyStore()
+        self.storage = KeyStore(backend="s3")
 
     @lru_cache
     def get_repo(self, owner: str, repo: str) -> dict[int, Issue]:

--- a/unit_tests/unit/test_config.py
+++ b/unit_tests/unit/test_config.py
@@ -1012,3 +1012,66 @@ def test_verify_emr_spark_mode_native_release_label(monkeypatch, release_label, 
     else:
         with pytest.raises(ValueError, match=expected_error):
             conf.verify_configuration()
+
+
+@pytest.fixture(name="clean_keystore_exports")
+def fixture_clean_keystore_exports(monkeypatch):
+    """Isolate the process-wide record of keystore env vars SCT exported itself.
+
+    Constructing SCTConfiguration writes SCT_KEYSTORE_* into os.environ, and
+    monkeypatch cannot roll back a variable that did not exist beforehand, so the
+    teardown clears whatever the test left behind.
+    """
+    keystore_envs = ("SCT_KEYSTORE_BACKEND", "SCT_KEYSTORE_SM_PREFIX", "SCT_KEYSTORE_SM_REGION")
+    monkeypatch.setattr(sct_config, "_KEYSTORE_ENV_EXPORTED", {})
+    for env_name in keystore_envs:
+        monkeypatch.delenv(env_name, raising=False)
+    monkeypatch.setenv("SCT_CLUSTER_BACKEND", "docker")
+    yield
+    for env_name in keystore_envs:
+        os.environ.pop(env_name, None)
+
+
+def _write_keystore_conf(tmp_path, backend):
+    conf_file = tmp_path / f"keystore_{backend}.yaml"
+    conf_file.write_text(f"keystore_backend: '{backend}'\n", encoding="utf-8")
+    return str(conf_file)
+
+
+def test_keystore_export_does_not_outrank_a_later_config_file(monkeypatch, tmp_path, clean_keystore_exports):  # noqa: ARG001
+    """A keystore value this process exported must not win over a later config file.
+
+    SCTConfiguration writes the resolved keystore settings into os.environ so bare
+    KeyStore() callers pick them up.  Environment variables outrank config files, so
+    without the self-export bookkeeping the first instance's default would silently
+    beat every later instance's config file in the same process.
+    """
+    first = sct_config.SCTConfiguration()
+    assert first.get("keystore_backend") == "secretsmanager"
+    assert os.environ["SCT_KEYSTORE_BACKEND"] == "secretsmanager"
+
+    monkeypatch.setenv("SCT_CONFIG_FILES", _write_keystore_conf(tmp_path, "s3"))
+    second = sct_config.SCTConfiguration()
+    assert second.get("keystore_backend") == "s3"
+    # and the export is refreshed so KeyStore() agrees with the config file
+    assert os.environ["SCT_KEYSTORE_BACKEND"] == "s3"
+
+
+def test_keystore_user_env_var_still_beats_config_file(monkeypatch, tmp_path, clean_keystore_exports):  # noqa: ARG001
+    """An env var the user set is a real override: it outranks the config file and is never rewritten."""
+    monkeypatch.setenv("SCT_KEYSTORE_BACKEND", "s3")
+    monkeypatch.setenv("SCT_CONFIG_FILES", _write_keystore_conf(tmp_path, "secretsmanager"))
+
+    conf = sct_config.SCTConfiguration()
+    assert conf.get("keystore_backend") == "s3"
+    assert os.environ["SCT_KEYSTORE_BACKEND"] == "s3"
+    assert "SCT_KEYSTORE_BACKEND" not in sct_config._KEYSTORE_ENV_EXPORTED
+
+
+def test_keystore_env_changed_after_export_is_a_user_override(monkeypatch, clean_keystore_exports):  # noqa: ARG001
+    """Only the exact value we exported is ignored; a value changed since is honoured."""
+    sct_config.SCTConfiguration()
+    assert sct_config._KEYSTORE_ENV_EXPORTED["SCT_KEYSTORE_BACKEND"] == "secretsmanager"
+
+    monkeypatch.setenv("SCT_KEYSTORE_BACKEND", "s3")
+    assert sct_config.SCTConfiguration().get("keystore_backend") == "s3"

--- a/unit_tests/unit/test_config.py
+++ b/unit_tests/unit/test_config.py
@@ -21,6 +21,7 @@ import pytest
 import yaml
 
 from sdcm import sct_config
+from sdcm.keystore import KeyStore
 from sdcm.provision.aws.capacity_errors import RegionAMINotFoundError
 from sdcm.test_config import TestConfig
 from sdcm.utils.common import get_latest_scylla_release
@@ -1112,3 +1113,57 @@ def test_keystore_env_changed_after_export_is_a_user_override(
 
     monkeypatch.setenv(env_name, other_value)
     assert sct_config.SCTConfiguration().get(param) == other_value
+
+
+@pytest.mark.parametrize("param, default_value, other_value", KEYSTORE_PARAM_CASES)
+def test_keystore_marker_is_dropped_once_the_user_overrides(
+    monkeypatch,
+    tmp_path,
+    clean_keystore_exports,  # noqa: ARG001
+    param,
+    default_value,
+    other_value,
+):
+    """A user override must not be re-armed as a self-export by matching the old value.
+
+    Without dropping the marker, setting the env var back to the value SCT once
+    exported would make it look like our own leak again, so a config file would
+    silently win over what the user explicitly asked for.
+    """
+    env_name = f"SCT_{param.upper()}"
+    sct_config.SCTConfiguration()
+    assert sct_config._KEYSTORE_ENV_EXPORTED[env_name] == default_value
+
+    # The user takes over, then happens to set it back to the exported value.
+    monkeypatch.setenv(env_name, other_value)
+    sct_config.SCTConfiguration()
+    assert env_name not in sct_config._KEYSTORE_ENV_EXPORTED
+
+    monkeypatch.setenv(env_name, default_value)
+    monkeypatch.setenv("SCT_CONFIG_FILES", _write_keystore_conf(tmp_path, param, other_value))
+    assert sct_config.SCTConfiguration().get(param) == default_value
+
+
+def test_keystore_env_is_exported_before_init_resolves_xcloud_version(monkeypatch, tmp_path, clean_keystore_exports):  # noqa: ARG001
+    """A config-file `keystore_backend` must apply to KeyStore calls made *during* __init__.
+
+    `_resolve_xcloud_version_tag` reaches `cloud_env_credentials` -> bare `KeyStore()`
+    from inside __init__.  While the export ran at the end of __init__, that fetch
+    still saw the default backend, so the documented `keystore_backend: 's3'` opt-out
+    was a no-op for exactly the path that needs it most.
+    """
+    monkeypatch.setenv("SCT_CLUSTER_BACKEND", "xcloud")
+    monkeypatch.setenv("SCT_XCLOUD_PROVIDER", "aws")
+    monkeypatch.setenv("SCT_SCYLLA_VERSION", "release:latest")
+    monkeypatch.setenv("SCT_CONFIG_FILES", _write_keystore_conf(tmp_path, "keystore_backend", "s3"))
+
+    seen = []
+    monkeypatch.setattr(
+        sct_config.SCTConfiguration,
+        "_resolve_xcloud_version_tag",
+        lambda self, version_tag: seen.append(KeyStore()._backend),
+    )
+
+    sct_config.SCTConfiguration()
+
+    assert seen == ["s3"], f"KeyStore built during __init__ saw {seen}, config file asked for s3"

--- a/unit_tests/unit/test_config.py
+++ b/unit_tests/unit/test_config.py
@@ -1032,13 +1032,31 @@ def fixture_clean_keystore_exports(monkeypatch):
         os.environ.pop(env_name, None)
 
 
-def _write_keystore_conf(tmp_path, backend):
-    conf_file = tmp_path / f"keystore_{backend}.yaml"
-    conf_file.write_text(f"keystore_backend: '{backend}'\n", encoding="utf-8")
+def _write_keystore_conf(tmp_path, param, value):
+    conf_file = tmp_path / f"keystore_{param}_{value.replace('/', '')}.yaml"
+    conf_file.write_text(f"{param}: '{value}'\n", encoding="utf-8")
     return str(conf_file)
 
 
-def test_keystore_export_does_not_outrank_a_later_config_file(monkeypatch, tmp_path, clean_keystore_exports):  # noqa: ARG001
+# All three keystore params share one propagation loop, so each case exercises the
+# same code path -- but only `keystore_backend` was covered while the other two
+# (both new) went through it untested.
+KEYSTORE_PARAM_CASES = [
+    pytest.param("keystore_backend", "secretsmanager", "s3", id="backend"),
+    pytest.param("keystore_sm_prefix", "sct/", "other/", id="sm_prefix"),
+    pytest.param("keystore_sm_region", "us-east-1", "eu-west-1", id="sm_region"),
+]
+
+
+@pytest.mark.parametrize("param, default_value, other_value", KEYSTORE_PARAM_CASES)
+def test_keystore_export_does_not_outrank_a_later_config_file(
+    monkeypatch,
+    tmp_path,
+    clean_keystore_exports,  # noqa: ARG001
+    param,
+    default_value,
+    other_value,
+):
     """A keystore value this process exported must not win over a later config file.
 
     SCTConfiguration writes the resolved keystore settings into os.environ so bare
@@ -1046,32 +1064,51 @@ def test_keystore_export_does_not_outrank_a_later_config_file(monkeypatch, tmp_p
     without the self-export bookkeeping the first instance's default would silently
     beat every later instance's config file in the same process.
     """
+    env_name = f"SCT_{param.upper()}"
+
     first = sct_config.SCTConfiguration()
-    assert first.get("keystore_backend") == "secretsmanager"
-    assert os.environ["SCT_KEYSTORE_BACKEND"] == "secretsmanager"
+    assert first.get(param) == default_value
+    assert os.environ[env_name] == default_value
 
-    monkeypatch.setenv("SCT_CONFIG_FILES", _write_keystore_conf(tmp_path, "s3"))
+    monkeypatch.setenv("SCT_CONFIG_FILES", _write_keystore_conf(tmp_path, param, other_value))
     second = sct_config.SCTConfiguration()
-    assert second.get("keystore_backend") == "s3"
+    assert second.get(param) == other_value
     # and the export is refreshed so KeyStore() agrees with the config file
-    assert os.environ["SCT_KEYSTORE_BACKEND"] == "s3"
+    assert os.environ[env_name] == other_value
 
 
-def test_keystore_user_env_var_still_beats_config_file(monkeypatch, tmp_path, clean_keystore_exports):  # noqa: ARG001
+@pytest.mark.parametrize("param, default_value, other_value", KEYSTORE_PARAM_CASES)
+def test_keystore_user_env_var_still_beats_config_file(
+    monkeypatch,
+    tmp_path,
+    clean_keystore_exports,  # noqa: ARG001
+    param,
+    default_value,  # noqa: ARG001
+    other_value,
+):
     """An env var the user set is a real override: it outranks the config file and is never rewritten."""
-    monkeypatch.setenv("SCT_KEYSTORE_BACKEND", "s3")
-    monkeypatch.setenv("SCT_CONFIG_FILES", _write_keystore_conf(tmp_path, "secretsmanager"))
+    env_name = f"SCT_{param.upper()}"
+    monkeypatch.setenv(env_name, other_value)
+    monkeypatch.setenv("SCT_CONFIG_FILES", _write_keystore_conf(tmp_path, param, default_value))
 
     conf = sct_config.SCTConfiguration()
-    assert conf.get("keystore_backend") == "s3"
-    assert os.environ["SCT_KEYSTORE_BACKEND"] == "s3"
-    assert "SCT_KEYSTORE_BACKEND" not in sct_config._KEYSTORE_ENV_EXPORTED
+    assert conf.get(param) == other_value
+    assert os.environ[env_name] == other_value
+    assert env_name not in sct_config._KEYSTORE_ENV_EXPORTED
 
 
-def test_keystore_env_changed_after_export_is_a_user_override(monkeypatch, clean_keystore_exports):  # noqa: ARG001
+@pytest.mark.parametrize("param, default_value, other_value", KEYSTORE_PARAM_CASES)
+def test_keystore_env_changed_after_export_is_a_user_override(
+    monkeypatch,
+    clean_keystore_exports,  # noqa: ARG001
+    param,
+    default_value,
+    other_value,
+):
     """Only the exact value we exported is ignored; a value changed since is honoured."""
+    env_name = f"SCT_{param.upper()}"
     sct_config.SCTConfiguration()
-    assert sct_config._KEYSTORE_ENV_EXPORTED["SCT_KEYSTORE_BACKEND"] == "secretsmanager"
+    assert sct_config._KEYSTORE_ENV_EXPORTED[env_name] == default_value
 
-    monkeypatch.setenv("SCT_KEYSTORE_BACKEND", "s3")
-    assert sct_config.SCTConfiguration().get("keystore_backend") == "s3"
+    monkeypatch.setenv(env_name, other_value)
+    assert sct_config.SCTConfiguration().get(param) == other_value

--- a/unit_tests/unit/test_issues_cache_backend.py
+++ b/unit_tests/unit/test_issues_cache_backend.py
@@ -1,0 +1,45 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2026 ScyllaDB
+
+"""The issue caches must keep reading from S3 whatever `keystore_backend` says.
+
+`issues/*.csv` are bulk data, not credentials: the largest is over 1 MB (the
+Secrets Manager limit is 64 KB) and they are rewritten every 6 hours by
+`.github/workflows/cache-issues.yaml` / `cache-jira-issues.yaml`, which upload
+to S3 only.  Reading them through Secrets Manager can only ever miss, and both
+retrievers swallow a cache miss and fall back to the live API -- so the
+regression is silent, and shows up as GitHub rate limiting instead.
+"""
+
+import pytest
+
+from sdcm.utils.issues import CachedGitHubIssues, CachedJiraIssues
+
+
+@pytest.fixture(name="sm_backend_env")
+def fixture_sm_backend_env(monkeypatch):
+    """Put the process on the secretsmanager backend, as a real run would be."""
+    monkeypatch.delenv("SCT_KEYSTORE_BACKEND", raising=False)
+    yield
+
+
+@pytest.mark.parametrize("cache_class", [CachedJiraIssues, CachedGitHubIssues], ids=["jira", "github"])
+def test_issue_cache_is_pinned_to_s3(cache_class, sm_backend_env):  # noqa: ARG001
+    assert cache_class().storage._backend == "s3"
+
+
+@pytest.mark.parametrize("cache_class", [CachedJiraIssues, CachedGitHubIssues], ids=["jira", "github"])
+def test_issue_cache_ignores_explicit_sm_backend(cache_class, monkeypatch):
+    """Even an explicit opt-in to secretsmanager must not redirect the bulk cache."""
+    monkeypatch.setenv("SCT_KEYSTORE_BACKEND", "secretsmanager")
+    assert cache_class().storage._backend == "s3"

--- a/unit_tests/unit/test_keystore.py
+++ b/unit_tests/unit/test_keystore.py
@@ -920,6 +920,29 @@ class TestSecretsManagerBackend:
         ks = KeyStore()
         assert ks._backend == "s3"
 
+    @pytest.mark.parametrize("env_backend", ["secretsmanager", "s3", None])
+    def test_constructor_backend_wins_over_env(self, mocked_s3, monkeypatch, env_backend):
+        """A constructor-pinned backend ignores SCT_KEYSTORE_BACKEND entirely.
+
+        The `issues/` bulk cache exists in S3 only -- it is too large for a
+        Secrets Manager secret and is written by a workflow that uploads to S3
+        -- so its readers pin `backend="s3"` and must not follow the config.
+        """
+        if env_backend is None:
+            monkeypatch.delenv("SCT_KEYSTORE_BACKEND", raising=False)
+        else:
+            monkeypatch.setenv("SCT_KEYSTORE_BACKEND", env_backend)
+        assert KeyStore(backend="s3")._backend == "s3"
+
+    def test_s3_pinned_instance_reads_from_s3_under_sm_default(self, mocked_s3, monkeypatch):
+        """The pin has to change where bytes actually come from, not just `_backend`."""
+        monkeypatch.delenv("SCT_KEYSTORE_BACKEND", raising=False)
+        boto3.client("s3").put_object(
+            Bucket=KEYSTORE_S3_BUCKET, Key="issues/scylladb_scylladb.csv", Body=b"1,open,bug,title\n"
+        )
+        # No sct/issues/... secret exists, so an unpinned KeyStore would miss here.
+        assert KeyStore(backend="s3").get_file_contents("issues/scylladb_scylladb.csv") == b"1,open,bug,title\n"
+
     def test_sm_region_defaults_without_aws_region_env(self, mocked_s3, monkeypatch):
         """Secrets Manager is regional; the client must not depend on AWS_DEFAULT_REGION.
 

--- a/unit_tests/unit/test_keystore.py
+++ b/unit_tests/unit/test_keystore.py
@@ -40,6 +40,7 @@ from sdcm.keystore import (
     KEYSTORE_SM_REGION,
     KeyStore,
     SSHKey,
+    is_not_found_error,
     materialize_ssh_key,
     pub_key_from_private_key_file,
 )
@@ -526,6 +527,41 @@ class TestArgusCredentials:
                     with pytest.raises(ClientError) as exc_info:
                         ks.get_argus_rest_credentials_per_provider()
                     assert exc_info.value.response["Error"]["Code"] == "AccessDenied"
+
+    def test_jenkins_fallback_on_secrets_manager_resource_not_found(self, ks):
+        """A provider with no dedicated secret must fall back, not blow up.
+
+        Secrets Manager reports a missing secret as ResourceNotFoundException
+        rather than S3's NoSuchKey. Only recognising NoSuchKey made every
+        non-AWS provider fail to initialise its Argus client.
+        """
+        with patch.dict(os.environ, {"JOB_NAME": "test-job"}):
+            with patch("sdcm.keystore.provider", return_value="gce"):
+                real_get_json = ks.get_json
+                error_resp = {"Error": {"Code": "ResourceNotFoundException", "Message": "can't find secret"}}
+
+                def fake_get_json(name):
+                    if name == "argus_rest_credentials_sct_gce.json":
+                        raise ClientError(error_resp, "GetSecretValue")
+                    return real_get_json(name)
+
+                with patch.object(ks, "get_json", side_effect=fake_get_json):
+                    assert ks.get_argus_rest_credentials_per_provider() == FAKE_ARGUS_CREDS
+
+
+class TestIsNotFoundError:
+    @pytest.mark.parametrize("code", ["NoSuchKey", "404", "ResourceNotFoundException"])
+    def test_recognises_missing_entry_codes_from_both_backends(self, code):
+        err = ClientError({"Error": {"Code": code, "Message": "missing"}}, "Get")
+        assert is_not_found_error(err) is True
+
+    @pytest.mark.parametrize("code", ["AccessDenied", "ThrottlingException", "InternalError"])
+    def test_other_codes_are_not_not_found(self, code):
+        err = ClientError({"Error": {"Code": code, "Message": "nope"}}, "Get")
+        assert is_not_found_error(err) is False
+
+    def test_non_client_error_is_not_not_found(self):
+        assert is_not_found_error(ValueError("boom")) is False
 
 
 # ---------------------------------------------------------------------------

--- a/unit_tests/unit/test_keystore.py
+++ b/unit_tests/unit/test_keystore.py
@@ -37,6 +37,7 @@ from moto import mock_aws
 from sdcm import keystore as keystore_module
 from sdcm.keystore import (
     KEYSTORE_S3_BUCKET,
+    KEYSTORE_SM_REGION,
     KeyStore,
     SSHKey,
     materialize_ssh_key,
@@ -98,6 +99,20 @@ def mock_cloud_services():
     for name, value in saved.items():
         if value is not None:
             setattr(KeyStore, name, value)
+
+
+@pytest.fixture(autouse=True)
+def default_to_s3_backend():
+    """Pin the S3 backend for the legacy-path tests in this module.
+
+    `secretsmanager` is the real default, but most tests here exercise the S3
+    code path against the moto bucket -- including ones that never touch a
+    KeyStore directly (e.g. `materialize_ssh_key`), so they can't opt in
+    themselves. Tests that care about the true default or about Secrets Manager
+    override this env var explicitly.
+    """
+    with patch.dict(os.environ, {"SCT_KEYSTORE_BACKEND": "s3"}):
+        yield
 
 
 # --- Test data constants ---------------------------------------------------
@@ -190,7 +205,7 @@ def mocked_s3():
 
 @pytest.fixture
 def ks(mocked_s3):
-    """Return a fresh KeyStore inside the moto context."""
+    """Return a fresh KeyStore inside the moto context (S3 backend, see autouse fixture)."""
     return KeyStore()
 
 
@@ -859,10 +874,34 @@ class TestSecretsManagerBackend:
             ks = KeyStore()
             assert ks.get_json("email_config.json") == FAKE_EMAIL_CONFIG
 
-    def test_s3_backend_is_default(self, mocked_s3, monkeypatch):
+    def test_sm_backend_is_default(self, mocked_s3, monkeypatch):
         monkeypatch.delenv("SCT_KEYSTORE_BACKEND", raising=False)
         ks = KeyStore()
+        assert ks._backend == "secretsmanager"
+
+    def test_s3_backend_via_explicit_override(self, mocked_s3, monkeypatch):
+        monkeypatch.setenv("SCT_KEYSTORE_BACKEND", "s3")
+        ks = KeyStore()
         assert ks._backend == "s3"
+
+    def test_sm_region_defaults_without_aws_region_env(self, mocked_s3, monkeypatch):
+        """Secrets Manager is regional; the client must not depend on AWS_DEFAULT_REGION.
+
+        `boto3.client("s3")` silently falls back to us-east-1, but Secrets Manager
+        raises NoRegionError, so the region has to be pinned by KeyStore itself.
+        """
+        monkeypatch.delenv("SCT_KEYSTORE_BACKEND", raising=False)
+        monkeypatch.delenv("SCT_KEYSTORE_SM_REGION", raising=False)
+        monkeypatch.delenv("AWS_DEFAULT_REGION", raising=False)
+        monkeypatch.delenv("AWS_REGION", raising=False)
+        ks = KeyStore()
+        assert ks._sm_region == KEYSTORE_SM_REGION
+        assert ks.sm_client.meta.region_name == KEYSTORE_SM_REGION
+
+    def test_sm_region_env_override(self, mocked_s3, monkeypatch):
+        monkeypatch.setenv("SCT_KEYSTORE_SM_REGION", "eu-west-1")
+        ks = KeyStore()
+        assert ks.sm_client.meta.region_name == "eu-west-1"
 
     def test_download_file_from_sm(self, sm_ks, tmp_path):
         dest = str(tmp_path / "key")


### PR DESCRIPTION
Credentials are already mirrored into AWS Secrets Manager under the `sct/` prefix,
and the S3 path (`scylla-qa-keystore` bucket) is the legacy one. This flips the
default so runs read from Secrets Manager unless they explicitly opt back into `s3`
(via `keystore_backend: 's3'` or `SCT_KEYSTORE_BACKEND=s3`).

Changes:
- `defaults/test_default.yaml` — `keystore_backend: 's3'` → `'secretsmanager'`
- `sdcm/keystore.py` — the `KeyStore.__init__` env-var fallback is flipped alongside
  the config default, so utility code that builds a `KeyStore` without an
  `SCTConfiguration` (and therefore without `SCT_KEYSTORE_BACKEND` set) resolves to
  the same backend instead of silently disagreeing with the test config.
- `sdcm/keystore.py` — `KeyStore(backend=...)` pins an instance to one backend,
  overriding `SCT_KEYSTORE_BACKEND`.
- `sdcm/utils/issues.py` — `CachedJiraIssues` / `CachedGitHubIssues` pin
  `backend="s3"`. The `issues/*.csv` caches are bulk data, not credentials: the
  largest is 1.6 MB against a 64 KB per-secret limit, and only
  `.github/workflows/cache-issues.yaml` / `cache-jira-issues.yaml` write them —
  to S3. Both retrievers swallow a cache miss and fall back to the live API, so
  reading them through Secrets Manager would have silently pushed every run onto
  the GitHub rate limit the cache exists to avoid. These objects cannot be
  mirrored, so this pin is permanent.
- `sdcm/sct_config.py` — the `SCT_KEYSTORE_*` export moved out of the tail of
  `__init__` into `_propagate_keystore_env()`, called as soon as the config sources
  are merged. `_resolve_xcloud_version_tag` reaches `cloud_env_credentials` → bare
  `KeyStore()` from *inside* `__init__`, so exporting at the end meant a config-file
  `keystore_backend` never reached that fetch — the documented opt-out was a no-op
  for the path that most needs it. The self-export marker is also dropped once the
  environment diverges from it, so an override that later matches the value SCT once
  exported is not mistaken for our own leak.
- docs: regenerated `configuration_options.md`, updated `keystore-secrets-manager.md`
  and the `test_default.yaml` comment block. The credential table now covers the
  runtime-resolved keys (`scylla_cloud_sct_api_creds_{env}.json`, per-provider
  argus tokens, baremetal configs, encryption-at-rest pems) with what a miss does
  for each; the validation snippet is split into required vs optional; and every
  snippet derives `--region` from `SCT_KEYSTORE_SM_REGION` instead of hardcoding
  or omitting it.

No behaviour change beyond backend selection — both fetch paths, the caching layer
and the staleness/rotation detection already exist and are unchanged.

### Mirror state

Probed Secrets Manager per key (no `ListSecrets` permission, so `describe-secret`
by name). **All 29 required entries plus every runtime-resolved key a job in this
repo can reach are mirrored**, verified byte-for-byte against the S3 originals:

- 25 fixed credentials + 4 encryption-at-rest pems
- `scylla_cloud_sct_api_creds_{lab,staging,prod}.json`
- `baremetal_config_example.json`, `baremetal_credentials.json`, `oci_baremetal_config.json`

Intentionally not mirrored:

- `argus_rest_credentials_sct_{gce,azure}.json` — only `aws` has a dedicated entry;
  the others fall back to the shared token by design, now logged at debug.
- `issues/*.csv` — too large for Secrets Manager, handled by the code pin above.

### Testing

- `pytest unit_tests/unit/test_config.py unit_tests/unit/test_keystore.py unit_tests/unit/test_issues_cache_backend.py` — 212 passed
- `pytest unit_tests/integration/test_config.py` — 27 passed
- Provision tests on all four cloud backends requested via labels, since KeyStore is
  on the critical path for SSH keys and per-cloud credentials during provisioning.

**PR pre-checks (self review)**
- [x] I added the relevant backport labels
- [x] I didn't leave commented-out/debugging code

🤖 Generated with [Claude Code](https://claude.com/claude-code)
- [x] 🟢 [longevity-10gb-3h-test #8](https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/longevity-10gb-3h-test/8/)
- [x] 🟢 [longevity-10gb-3h-azure-test #52](https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/longevity-10gb-3h-azure-test/52/)
- [x] 🟢  [longevity-10gb-3h-gce-test #72](https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/longevity-10gb-3h-gce-test/72/)
- [x] 🟢 [artifacts-ami-test #72](https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-ami-test/72/)
- [x] 🟢 [artifacts-docker-test #55](https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-docker-test/55/)
