### PR TITLE
fix(cdc longevity): add missing availability zone

### DIFF
--- a/test-cases/longevity/longevity-cdc-100gb-8h-multi-dc-large-cluster.yaml
+++ b/test-cases/longevity/longevity-cdc-100gb-8h-multi-dc-large-cluster.yaml
@@ -12,6 +12,7 @@ n_loaders: '2 2 2'
 
 rack_aware_loader: true
 region_aware_loader: true
+availability_zone: 'a,b,c'
 simulated_racks: 0
 
 nemesis_class_name: 'SisyphusMonkey'


### PR DESCRIPTION
Since the test has `simulated_racks: 0`, it needs multiple AZs to get more than 1 rack when triggered by argus cli.
https://argus.scylladb.com/tests/scylla-cluster-tests/5d42b816-a5d1-471b-9809-67f19a5e6ac6

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
