### PR TITLE
feature(triggers): alternate tier1 & rolling-upgrade jobs biweekly

### DIFF
--- a/configurations/triggers/rolling-upgrade.yaml
+++ b/configurations/triggers/rolling-upgrade.yaml
@@ -1,3 +1,6 @@
+jenkinsfiles:
+  - path: "jenkins-pipelines/oss/sct_triggers/rolling-upgrade-trigger.jenkinsfile"
+
 # Rolling upgrade trigger matrix — single source of truth for all rolling-upgrade jobs.
 #
 # Replaces:
@@ -8,15 +11,41 @@
 # and/or image params.
 #
 # Usage patterns:
-#   Weekly (cron):    scylla_version={branch}:latest, labels_selector=weekly
+#   Weekly (cron):    scylla_version={branch}:latest, labels_selector=weekly,week-{a,b}
 #   Release (manual): new_scylla_repo=<url>, scylla_version=<tag>
 #   Image-based:      scylla_ami_id=<id>, backend=aws (or gce_image_db, azure_image_db)
+#
+# Biweekly alternation (SCT-716)
+# ------------------------------
+# Every "weekly" job also carries exactly one of "week-a" / "week-b", and the two cron
+# lines below select one half each — so a job runs roughly every 2 weeks. The halves are
+# balanced on estimated cost (`sct.py sizing preview`), ~$114 vs ~$120 per run.
+#
+# "weekly" on its own still selects the FULL set (labels are AND-matched), so the
+# scylla-pkg release path is unaffected. The "release"-labelled jobs below are not
+# cron-driven and deliberately carry no week label.
+#
+# The phase is deliberately OPPOSITE to tier1.yaml: tier1's heavy half (week-a) shares a
+# weekend with rolling-upgrade's lighter half, spreading concurrent cloud usage.
 
 cron_triggers:
-  - schedule: "00 06 * * 6"  # Saturday 6am UTC — same as old trigger
+  # 1st, 3rd and 5th Saturday of the month, 06:00 UTC.
+  #
+  # Cron has no "every 2 weeks" — there is no week-number field. The alternation is
+  # a day-of-month window AND-ed with day-of-week, which works because Jenkins ANDs
+  # those two fields (standard Vixie cron ORs them). Same idiom as
+  # perf-regression.yaml's "13 6 8-14 * 2" == 2nd Tuesday of the month.
+  # Days 29-31 are attached here so no Saturday is ever left idle.
+  - schedule: "00 06 1-7,15-21,29-31 * 6"
     params:
       scylla_version: "{branch}:latest"
-      labels_selector: "weekly"
+      labels_selector: "weekly,week-b"
+      requested_by_user: "fruch"
+  # 2nd and 4th Saturday of the month, 06:00 UTC.
+  - schedule: "00 06 8-14,22-28 * 6"
+    params:
+      scylla_version: "{branch}:latest"
+      labels_selector: "weekly,week-a"
       requested_by_user: "fruch"
 
 defaults:
@@ -37,6 +66,7 @@ jobs:
     backend: "gce"
     labels:
       - "weekly"
+      - "week-a"
       - "rpm"
     exclude_versions: []
     params:
@@ -51,6 +81,7 @@ jobs:
     backend: "gce"
     labels:
       - "weekly"
+      - "week-b"
       - "deb"
     exclude_versions: []
     params:
@@ -61,6 +92,7 @@ jobs:
     backend: "gce"
     labels:
       - "weekly"
+      - "week-b"
       - "deb"
     exclude_versions: []
     params:
@@ -71,6 +103,7 @@ jobs:
     backend: "gce"
     labels:
       - "weekly"
+      - "week-a"
       - "deb"
     exclude_versions: []
     params:
@@ -85,6 +118,7 @@ jobs:
     backend: "aws"
     labels:
       - "weekly"
+      - "week-b"
       - "image"
       - "ami"
     exclude_versions: []
@@ -97,6 +131,7 @@ jobs:
     arch: "aarch64"
     labels:
       - "weekly"
+      - "week-a"
       - "image"
       - "ami"
     exclude_versions: []
@@ -108,6 +143,7 @@ jobs:
     backend: "gce"
     labels:
       - "weekly"
+      - "week-a"
       - "image"
       - "gce"
     exclude_versions: []
@@ -119,6 +155,7 @@ jobs:
     backend: "azure"
     labels:
       - "weekly"
+      - "week-b"
       - "image"
       - "azure"
     exclude_versions: []
@@ -134,6 +171,7 @@ jobs:
     backend: "gce"
     labels:
       - "weekly"
+      - "week-b"
       - "deb"
     exclude_versions: []
     params:

--- a/configurations/triggers/tier1.yaml
+++ b/configurations/triggers/tier1.yaml
@@ -13,13 +13,42 @@ jenkinsfiles:
 # Related PRs that move tier1 jobs between backends (must align after merge):
 #   - #14629: move longevity-150gb-asymmetric to GCE (12x n2-highmem-4)
 #   - #14594: replace Azure 1TB 5-day test with AWS i8g alternative
+#
+# Biweekly alternation (SCT-716)
+# ------------------------------
+# Every job keeps its "weekly" label and additionally carries exactly one of
+# "week-a" / "week-b". The two cron lines below select one half each, so a job
+# runs roughly every 2 weeks instead of every week. The halves are balanced on
+# estimated cost (`sct.py sizing preview`), ~$970 vs ~$966 per run.
+#
+# "weekly" on its own still selects the FULL set — labels are AND-matched, so
+# release / scylla-pkg triggers passing labels_selector=weekly are unaffected.
+#
+# NOTE: entries that resolve to the same Jenkins job (the x86 + aarch64 twins of
+# longevity-twcs-48h-test and elasticity-90-percent-with-nemesis-test) MUST share
+# the same week label. Only the first match is triggered (dedup by resolved path),
+# so twins on different weeks would make the job fire every week again.
 
 cron_triggers:
-  - schedule: "00 06 * * 6"  # Saturday 6am UTC
+  # 1st, 3rd and 5th Saturday of the month, 06:00 UTC.
+  #
+  # Cron has no "every 2 weeks" — there is no week-number field. The alternation is
+  # a day-of-month window AND-ed with day-of-week, which works because Jenkins ANDs
+  # those two fields (standard Vixie cron ORs them). Same idiom as
+  # perf-regression.yaml's "13 6 8-14 * 2" == 2nd Tuesday of the month.
+  # Days 29-31 are attached here so no Saturday is ever left idle.
+  - schedule: "00 06 1-7,15-21,29-31 * 6"
     params:
       scylla_version: "{branch}:latest"
       job_folder: "scylla-master"
-      labels_selector: "weekly"
+      labels_selector: "weekly,week-a"
+      requested_by_user: "pehala"
+  # 2nd and 4th Saturday of the month, 06:00 UTC.
+  - schedule: "00 06 8-14,22-28 * 6"
+    params:
+      scylla_version: "{branch}:latest"
+      job_folder: "scylla-master"
+      labels_selector: "weekly,week-b"
       requested_by_user: "pehala"
 
 defaults:
@@ -39,6 +68,7 @@ jobs:
       region: "eu-west-1"
     labels:
       - "weekly"
+      - "week-b"
     exclude_versions: ["2024.1", "2025.1", "2025.4", "2026.1"]
 
   - job_name: "tier1/longevity-mv-si-4days-streaming-test"
@@ -47,6 +77,7 @@ jobs:
       region: "eu-west-1"
     labels:
       - "weekly"
+      - "week-a"
 
   - job_name: "tier1/longevity-schema-topology-changes-12h-test"
     backend: "aws"
@@ -54,6 +85,7 @@ jobs:
       region: "eu-west-1"
     labels:
       - "weekly"
+      - "week-a"
 
   - job_name: "tier1/scale-schema-5000-tables-latte-test"
     backend: "aws"
@@ -61,6 +93,7 @@ jobs:
       region: "eu-west-1"
     labels:
       - "weekly"
+      - "week-b"
     exclude_versions: ["2024.1", "2025.1", "2025.4", "2026.1"]
 
   - job_name: "tier1/longevity-twcs-48h-test"
@@ -69,6 +102,7 @@ jobs:
       region: "us-east-1"
     labels:
       - "weekly"
+      - "week-b"
 
   - job_name: "tier1/longevity-50gb-3days-test"
     backend: "aws"
@@ -76,6 +110,7 @@ jobs:
       region: "eu-west-1"
     labels:
       - "weekly"
+      - "week-a"
     include_versions: ["2024.1", "2025.1", "2025.4", "2026.1"]
 
   - job_name: "tier1/longevity-150gb-asymmetric-cluster-12h-test"
@@ -84,6 +119,7 @@ jobs:
       region: "us-east-1"
     labels:
       - "weekly"
+      - "week-b"
 
   - job_name: "tier1/elasticity-90-percent-with-nemesis-test"
     backend: "aws"
@@ -91,6 +127,7 @@ jobs:
       region: "us-east-1"
     labels:
       - "weekly"
+      - "week-a"
     exclude_versions: ["2024.1", "2025.1", "2025.4", "2026.1"]
 
   - job_name: "tier1/longevity-multidc-schema-topology-changes-12h-test"
@@ -100,6 +137,7 @@ jobs:
       availability_zone: "a,b,c"
     labels:
       - "weekly"
+      - "week-b"
 
   # ==================== AWS aarch64 ====================
 
@@ -109,6 +147,7 @@ jobs:
       region: "us-east-1"
     labels:
       - "weekly"
+      - "week-b"  # must match the x86 twin above
       - "aarch64"
     exclude_versions: ["2024.1", "2025.1"]
 
@@ -118,6 +157,7 @@ jobs:
       region: "eu-west-1"
     labels:
       - "weekly"
+      - "week-b"
       - "aarch64"
     exclude_versions: ["2024.1", "2025.1", "2025.4", "2026.1", "2026.2"]
 
@@ -127,6 +167,7 @@ jobs:
       region: "us-east-1"
     labels:
       - "weekly"
+      - "week-a"  # must match the x86 twin above
       - "aarch64"
     exclude_versions: ["2024.1", "2025.1", "2025.4", "2026.1"]
 
@@ -139,6 +180,7 @@ jobs:
       availability_zone: ""
     labels:
       - "weekly"
+      - "week-a"
 
   # ==================== Azure ====================
 
@@ -149,4 +191,5 @@ jobs:
       availability_zone: ""
     labels:
       - "weekly"
+      - "week-b"
     include_versions: ["2024.1", "2025.1", "2025.4", "2026.1", "2026.2"]

--- a/docs/testing/trigger-matrix.md
+++ b/docs/testing/trigger-matrix.md
@@ -120,6 +120,53 @@ uv run sct.py trigger-matrix \
 
 Labels use AND logic: `--labels-selector "weekly,additional"` requires jobs to have **both** labels.
 
+### Biweekly alternation: `week-a` / `week-b`
+
+`tier1.yaml` and `rolling-upgrade.yaml` halve their weekly load (SCT-716). Every `weekly` job also
+carries exactly one of `week-a` / `week-b`, and each matrix has **two cron lines** — same time of day,
+one per half — so a job runs roughly every 2 weeks instead of weekly. The halves are balanced on
+estimated cost via `sct.py sizing preview`.
+
+```bash
+# just the half that runs on the 1st/3rd/5th Saturday of the month
+uv run sct.py trigger-matrix \
+    --matrix configurations/triggers/tier1.yaml \
+    --scylla-version "master:latest" \
+    --labels-selector "weekly,week-a" \
+    --dry-run
+```
+
+`--labels-selector weekly` (no week label) still selects the **full** set — that is what the scylla-pkg
+release path uses, so releases keep testing everything.
+
+Two invariants are enforced by `unit_tests/trigger_matrix/test_biweekly_split.py`:
+
+- **Every `weekly` job has exactly one week label.** None means it never runs; both means it runs weekly.
+- **Entries that resolve to the same Jenkins job share a week label.** The x86 and `aarch64` twins of
+  `longevity-twcs-48h-test` / `elasticity-90-percent-with-nemesis-test` are deduplicated by resolved path,
+  so twins on different weeks would make the job fire on *both* weeks — silently undoing the alternation.
+
+**Why the cron expressions look odd.** Cron has no "every 2 weeks" — there is no week-number field, and
+`*/14` in day-of-month restarts each month (days 1, 15, 29), so AND-ed with Saturday it fires only when
+the 1st/15th/29th happens to be a Saturday. The alternation is therefore a day-of-month window AND-ed
+with day-of-week:
+
+| schedule | fires on |
+|---|---|
+| `00 06 1-7,15-21,29-31 * 6` | 1st, 3rd, 5th Saturday, 06:00 UTC |
+| `00 06 8-14,22-28 * 6` | 2nd, 4th Saturday, 06:00 UTC |
+
+This works because **Jenkins ANDs the day-of-month and day-of-week fields** — standard Vixie cron ORs
+them, where `1-7 * 6` would mean "days 1-7 *or* any Saturday". `perf-regression.yaml` already relies on
+this with `13 6 8-14 * 2` (2nd Tuesday). Days 29-31 are attached to the first window so no Saturday is
+idle; the cost is that `week-a` occasionally runs on two consecutive Saturdays across a month boundary.
+Over a year the split is ~28 / ~24 Saturdays. Jenkins shows an advisory *"Short cycles in the
+day-of-month field will behave oddly near the end of a month"* for any day-of-month range — it is benign
+and already present on the perf-regression trigger.
+
+The two matrices are deliberately in **opposite phase**: tier1's heavier half shares a weekend with
+rolling-upgrade's lighter half.
+
 ### Backend Filtering
 
 ```bash

--- a/jenkins-pipelines/master-triggers/sct_triggers/tier1-custom-time-trigger.jenkinsfile
+++ b/jenkins-pipelines/master-triggers/sct_triggers/tier1-custom-time-trigger.jenkinsfile
@@ -4,5 +4,6 @@
 def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 triggerMatrixPipeline(
     matrix_file: 'configurations/triggers/tier1.yaml',
-    cron: '00 06 * * 6 % scylla_version={branch}:latest;job_folder=scylla-master;labels_selector=weekly;requested_by_user=pehala'
+    cron: '''00 06 1-7,15-21,29-31 * 6 % scylla_version={branch}:latest;job_folder=scylla-master;labels_selector=weekly,week-a;requested_by_user=pehala
+00 06 8-14,22-28 * 6 % scylla_version={branch}:latest;job_folder=scylla-master;labels_selector=weekly,week-b;requested_by_user=pehala'''
 )

--- a/jenkins-pipelines/oss/sct_triggers/rolling-upgrade-trigger.jenkinsfile
+++ b/jenkins-pipelines/oss/sct_triggers/rolling-upgrade-trigger.jenkinsfile
@@ -1,5 +1,9 @@
+// AUTO-GENERATED from configurations/triggers/rolling-upgrade.yaml — do not edit manually.
+// Run: python utils/build_system/generate_trigger_jenkinsfiles.py
+
 def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 triggerMatrixPipeline(
     matrix_file: 'configurations/triggers/rolling-upgrade.yaml',
-    cron: '00 06 * * 6 % scylla_version={branch}:latest;labels_selector=weekly;requested_by_user=fruch'
+    cron: '''00 06 1-7,15-21,29-31 * 6 % scylla_version={branch}:latest;labels_selector=weekly,week-b;requested_by_user=fruch
+00 06 8-14,22-28 * 6 % scylla_version={branch}:latest;labels_selector=weekly,week-a;requested_by_user=fruch'''
 )

--- a/unit_tests/trigger_matrix/test_biweekly_split.py
+++ b/unit_tests/trigger_matrix/test_biweekly_split.py
@@ -1,0 +1,130 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2026 ScyllaDB
+
+"""Invariants for the SCT-716 biweekly alternation of tier1 / rolling-upgrade triggers.
+
+Each matrix splits its `weekly` jobs into two halves labelled `week-a` / `week-b`, and has
+two cron lines selecting one half each. These tests guard the properties that make the
+split lossless and keep it from silently degrading back to "everything, every week".
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+from sdcm.utils.trigger_matrix import filter_jobs, load_matrix_config
+
+TRIGGERS_DIR = Path(__file__).parent.parent.parent / "configurations" / "triggers"
+BIWEEKLY_MATRICES = ["tier1.yaml", "rolling-upgrade.yaml"]
+WEEK_LABELS = {"week-a", "week-b"}
+
+
+@pytest.fixture(name="config", params=BIWEEKLY_MATRICES)
+def fixture_config(request):
+    return load_matrix_config(TRIGGERS_DIR / request.param)
+
+
+def test_every_weekly_job_has_exactly_one_week_label(config):
+    """A weekly job with no week label would never run; with both it would run every week."""
+    for job in config.jobs:
+        if "weekly" not in job.labels:
+            continue
+        week_labels = WEEK_LABELS.intersection(job.labels)
+        assert len(week_labels) == 1, (
+            f"Job '{job.job_name}' has week labels {week_labels or 'none'}, expected exactly one"
+        )
+
+
+def test_week_labels_only_on_weekly_jobs(config):
+    """The cron selectors are the only consumers of week labels — a non-weekly job carrying
+    one (e.g. a `release`-only rolling-upgrade job) would start firing on the cron."""
+    for job in config.jobs:
+        if stray := WEEK_LABELS.intersection(job.labels):
+            assert "weekly" in job.labels, f"Job '{job.job_name}' has {stray} but is not labelled 'weekly'"
+
+
+def test_cron_selectors_partition_the_weekly_set(config):
+    """week-a and week-b must be disjoint and together cover exactly the full weekly set."""
+    selectors = [cron.params["labels_selector"] for cron in config.cron_triggers]
+    assert len(selectors) == 2, f"Expected 2 biweekly cron lines, got {selectors}"
+
+    halves = [
+        {job.job_name for job in filter_jobs(config.jobs, scylla_version="master:latest", labels_selector=selector)}
+        for selector in selectors
+    ]
+    full = {job.job_name for job in filter_jobs(config.jobs, scylla_version="master:latest", labels_selector="weekly")}
+
+    assert not halves[0] & halves[1], f"Halves overlap: {halves[0] & halves[1]}"
+    assert halves[0] | halves[1] == full, f"Halves do not cover the weekly set: {full - (halves[0] | halves[1])}"
+    assert halves[0] and halves[1], "Both halves must be non-empty"
+
+
+def test_duplicate_job_entries_share_a_week_label(config):
+    """Entries resolving to the same Jenkins job (x86 + aarch64 twins) are deduplicated by
+    resolved path, so only the first is triggered. Twins on different weeks would make the
+    job fire on both weeks — silently defeating the alternation."""
+    labels_by_job: dict[str, set[frozenset[str]]] = {}
+    for job in config.jobs:
+        if "weekly" not in job.labels:
+            continue
+        week_label = frozenset(WEEK_LABELS.intersection(job.labels))
+        labels_by_job.setdefault(job.job_name, set()).add(week_label)
+
+    for job_name, week_labels in labels_by_job.items():
+        assert len(week_labels) == 1, (
+            f"Duplicate entries for '{job_name}' use different week labels {week_labels} — "
+            f"the job would be triggered on both weeks"
+        )
+
+
+def test_cron_lines_same_time_of_day_and_disjoint_day_windows(config):
+    """Both halves fire at the same time of day, and their day-of-month windows tile 1-31
+    without overlap — so exactly one half runs on any given Saturday."""
+    schedules = [cron.schedule.split() for cron in config.cron_triggers]
+    assert len(schedules) == 2
+
+    minutes_hours = {(fields[0], fields[1]) for fields in schedules}
+    assert len(minutes_hours) == 1, f"Halves fire at different times of day: {minutes_hours}"
+
+    days_of_week = {fields[4] for fields in schedules}
+    assert len(days_of_week) == 1, f"Halves fire on different days of the week: {days_of_week}"
+
+    def days(field: str) -> set[int]:
+        result: set[int] = set()
+        for part in field.split(","):
+            if match := re.fullmatch(r"(\d+)-(\d+)", part):
+                result |= set(range(int(match.group(1)), int(match.group(2)) + 1))
+            else:
+                result.add(int(part))
+        return result
+
+    window_a, window_b = (days(fields[2]) for fields in schedules)
+    assert not window_a & window_b, f"Day-of-month windows overlap on {sorted(window_a & window_b)}"
+    assert window_a | window_b == set(range(1, 32)), (
+        f"Day-of-month windows leave gaps: {sorted(set(range(1, 32)) - (window_a | window_b))}"
+    )
+
+
+def test_tier1_and_rolling_upgrade_are_in_opposite_phase():
+    """tier1's heavy half must not share a weekend with rolling-upgrade's heavy half."""
+    phases = {}
+    for filename in BIWEEKLY_MATRICES:
+        config = load_matrix_config(TRIGGERS_DIR / filename)
+        phases[filename] = {cron.schedule: cron.params["labels_selector"] for cron in config.cron_triggers}
+
+    for schedule, tier1_selector in phases["tier1.yaml"].items():
+        rolling_selector = phases["rolling-upgrade.yaml"][schedule]
+        assert tier1_selector != rolling_selector, (
+            f"Both matrices select '{tier1_selector}' on '{schedule}' — phases should be opposite"
+        )

--- a/unit_tests/trigger_matrix/test_rolling_upgrade.py
+++ b/unit_tests/trigger_matrix/test_rolling_upgrade.py
@@ -126,7 +126,11 @@ def test_empty_version_no_resolution():
 def test_rolling_upgrade_yaml_loads():
     config = load_matrix_config(ROLLING_UPGRADE_YAML)
     assert len(config.jobs) > 0
-    assert config.cron_triggers[0].schedule == "00 06 * * 6"
+    # Two biweekly cron lines, both at Saturday 06:00 UTC (SCT-716).
+    assert [cron.schedule for cron in config.cron_triggers] == [
+        "00 06 1-7,15-21,29-31 * 6",
+        "00 06 8-14,22-28 * 6",
+    ]
 
 
 def test_all_jobs_have_new_scylla_repo():


### PR DESCRIPTION
Fixes [SCT-716](https://scylladb.atlassian.net/browse/SCT-716).

Tier1 and rolling-upgrade currently fire **every** `weekly`-labelled job on `00 06 * * 6` (Saturday 06:00 UTC). This splits each matrix's weekly set into two cost-balanced halves labelled `week-a` / `week-b`, each driven by its own cron line at the **same time of day**, so a job runs roughly every 2 weeks instead of every week.

`weekly` stays on every job, so `labels_selector=weekly` still selects the **full** set — the scylla-pkg release path is unaffected. Only the cron lines narrow it to a half.

## Why the cron looks like that

Cron has no notion of "every 2 weeks" — there is no week-number field in any cron dialect, and the near-miss syntaxes don't do what they look like:

- `*/2` in the day-of-week field is just Sun/Tue/Thu/Sat — unrelated to weeks.
- `*/14` in day-of-month restarts every month → days 1, 15, 29. AND-ed with `6` (Saturday) it only fires when the 1st/15th/29th *happens* to be a Saturday — roughly one run every 2-3 months.
- Jenkins' `H` spreads load inside a window; it is not a period.

So the alternation is expressed as two **day-of-month windows** AND-ed with day-of-week:

| schedule | fires on |
|---|---|
| `00 06 1-7,15-21,29-31 * 6` | 1st, 3rd and 5th Saturday of the month, 06:00 UTC |
| `00 06 8-14,22-28 * 6` | 2nd and 4th Saturday of the month, 06:00 UTC |

This relies on **Jenkins ANDing the day-of-month and day-of-week fields**. Standard Vixie cron *ORs* them — there, `1-7 * 6` would mean "days 1-7 *or* any Saturday" — so this expression would be wrong in `crontab(5)` and is correct here. The repo already depends on this behaviour: `configurations/triggers/perf-regression.yaml` uses `13 6 8-14 * 2` for "2nd Tuesday of the month".

Days 29-31 are attached to the first window so that no Saturday is ever idle. The cost is that `week-a` can run on two consecutive Saturdays across a month boundary (the 29th, then the 1st-7th) — accepted as the cheaper trade against skipping a run every couple of months.

The two matrices are deliberately in **opposite phase**: tier1's heavy half shares a weekend with rolling-upgrade's lighter half.

### Verified against the live plugin, not just by reading

Parsed the exact generated spec with `ParameterizedCronTabList` on our Jenkins controller:

```
2026-08-01 (dom  1) -> weekly,week-a      2026-10-03 (dom  3) -> weekly,week-a
2026-08-08 (dom  8) -> weekly,week-b      2026-10-10 (dom 10) -> weekly,week-b
2026-08-15 (dom 15) -> weekly,week-a      2026-10-17 (dom 17) -> weekly,week-a
2026-08-22 (dom 22) -> weekly,week-b      2026-10-24 (dom 24) -> weekly,week-b
2026-08-29 (dom 29) -> weekly,week-a      2026-10-31 (dom 31) -> weekly,week-a
2026-09-05 (dom  5) -> weekly,week-a      2026-11-07 (dom  7) -> weekly,week-a
2026-09-12 (dom 12) -> weekly,week-b      2026-11-14 (dom 14) -> weekly,week-b
...
Mon 3 Aug (dom in 1-7):  no match  <- AND semantics confirmed, not OR
Mon 10 Aug (dom in 8-14): no match
2027 full year: {week-a: 28, week-b: 24}
```

Exactly one half matches every Saturday — never both, never none. The back-to-back `week-a` case is visible at 2026-08-29 → 2026-09-05 and 2026-10-31 → 2026-11-07, as designed.

Also confirmed the **comma inside a parameter value survives** the `%`/`;` cron-spec syntax — `getParameterValues()` returns `labels_selector: weekly,week-a` as a single value. There was no precedent for that in the repo, so it was worth checking rather than assuming.

Two notes for reviewers:

- Jenkins shows an advisory *"Short cycles in the day-of-month field will behave oddly near the end of a month"* for **any** day-of-month range — including the existing `13 6 8-14 * 2` trigger. Benign and pre-existing.
- Cron is force-disabled unless `JOB_NAME` starts with `scylla-master/` (`vars/triggerMatrixPipeline.groovy`), so staging copies show no schedule.

## How the halves were chosen

Balanced on estimated cost from `sct.py sizing preview`, reading each job's own backend column. For tier1, `--duration 1800` because the matrix sets `stress_duration: "1440"` and SCT's real duration is `prepare_stress_duration (300) + stress_duration (1440) + TEST_WARMUP_TEARDOWN (60)` (`sdcm/tester.py`) — `sizing preview` otherwise reads only `test_duration`.

```bash
uv run sct.py sizing preview jenkins-pipelines/oss/tier1/<job>.jenkinsfile --duration 1800
```

### tier1 — $1,936.57/run today

| week | job | backend | est. $/run |
|---|---|---|---|
| **a** | `longevity-mv-si-4days-streaming-test` | aws | 509.91 |
| **a** | `longevity-large-partition-200k-pks-4days-gce-test` | gce | 268.72 |
| **a** | `longevity-schema-topology-changes-12h-test` | aws | 136.76 |
| **a** | `elasticity-90-percent-with-nemesis-test` | aws | 54.80 |
| | **week-a** | | **970.19** |
| **b** | `scale-schema-5000-tables-latte-test` | aws | 271.02 |
| **b** | `gemini-1tb-10h-test` | aws | 163.98 |
| **b** | `longevity-multidc-schema-topology-changes-12h-test` | aws | 159.82 |
| **b** | `longevity-2tb-5days-test` | aws (aarch64) | 147.47 |
| **b** | `longevity-150gb-asymmetric-cluster-12h-test` | aws | 143.75 |
| **b** | `longevity-twcs-48h-test` | aws | 80.34 |
| | **week-b** | | **966.38** |

0.4% apart, and the single GCE job sits on the lighter side.

### rolling-upgrade — $233.66/run today

| week | job | backend | est. $/run |
|---|---|---|---|
| **a** | `rolling-upgrade-gce-image-test` | gce | 42.68 |
| **a** | `rolling-upgrade-ami-arm-test` | aws | 27.35 |
| **a** | `rolling-upgrade-rocky10-test` | gce | 21.94 |
| **a** | `rolling-upgrade-ubuntu2604-test` | gce | 21.94 |
| | **week-a** | | **113.91** |
| **b** | `rolling-upgrade-ami-test` | aws | 27.34 |
| **b** | `rolling-upgrade-azure-image-test` | azure | 26.59 |
| **b** | `rolling-upgrade-debian13-test` | gce | 21.94 |
| **b** | `rolling-upgrade-ubuntu2404-test` | gce | 21.94 |
| **b** | `rolling-upgrade-alternator-test` | gce | 21.94 |
| | **week-b** | | **119.75** |

Each half keeps an image-based job and a deb distro. `rocky10` is the only RPM job and `alternator` the only Alternator job, so those two alternate — inherent to halving the set. `rollingUpgradePipeline` fans out one sub-build per base version, so these are per-base-version figures; the multiplier applies equally to every job.

Expected saving at on-demand list price: **≈ $56K/year** (tier1 ~$100.7K → ~$50.3K, rolling-upgrade ~$12.2K → ~$6.1K), coverage preserved on a 2-week cycle.

## The aarch64-twin trap

`longevity-twcs-48h-test` and `elasticity-90-percent-with-nemesis-test` each have two matrix entries (x86 + `aarch64`) that resolve to the same Jenkins job; only the first is triggered (dedup by resolved path). **Twins on different week labels would make the job fire on both weeks**, silently defeating the change — so twins share a label, and a unit test enforces it. This is the one way this PR could have quietly no-opped.

## Drive-by fix

`rolling-upgrade.yaml` had no `jenkinsfiles:` key, so `generate_trigger_jenkinsfiles.py` skipped it and its hand-written Jenkinsfile kept a stale literal cron — YAML schedule changes never reached Jenkins. Added the key; that Jenkinsfile is now generated like the others.

## Testing

New `unit_tests/trigger_matrix/test_biweekly_split.py` (parametrised over both matrices) asserts: every `weekly` job has exactly one week label; week labels appear only on `weekly` jobs; the two selectors **partition** the weekly set (disjoint, union == full); duplicate entries share a week label; both cron lines share minute/hour/day-of-week and their day-of-month windows tile 1-31 without overlap; and the two matrices are in opposite phase.

```
150 passed  (unit_tests/trigger_matrix/)
```

Dry-runs confirm the split is lossless:

```
tier1  week-a: 4 jobs   week-b: 6 jobs   weekly: 10 jobs   (4 + 6 = 10)
r-upg  week-a: 4 jobs   week-b: 5 jobs   weekly:  9 jobs   (4 + 5 = 9)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[SCT-716]: https://scylladb.atlassian.net/browse/SCT-716?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ