### PR TITLE
fix(argus): don't raise KeyError when no argus run is registered

### DIFF
--- a/sdcm/argus_results.py
+++ b/sdcm/argus_results.py
@@ -489,7 +489,7 @@ def send_iotune_results_to_argus(argus_client: ArgusClient, results: dict, node,
         return
 
     run = argus_client.get_run()
-    if not run["test_id"]:
+    if not run.get("test_id"):
         LOGGER.warning("No test exists for this run, skipping submitting results")
         return
 

--- a/unit_tests/unit/test_argus_results.py
+++ b/unit_tests/unit/test_argus_results.py
@@ -14,9 +14,15 @@
 import json
 from unittest.mock import MagicMock, call
 
+import pytest
 from argus.client.generic_result import Cell, Status
 
-from sdcm.argus_results import ReactorStallStatsResult, send_result_to_argus, LatencyCalculatorMixedResult
+from sdcm.argus_results import (
+    ReactorStallStatsResult,
+    send_iotune_results_to_argus,
+    send_result_to_argus,
+    LatencyCalculatorMixedResult,
+)
 
 
 def test_send_latency_decorator_result_to_argus(test_data_dir):
@@ -78,3 +84,14 @@ def test_send_latency_decorator_result_to_argus(test_data_dir):
         ),
     ]
     argus_mock.submit_results.assert_has_calls(expected_calls, any_order=True)
+
+
+@pytest.mark.parametrize("run", [{}, {"test_id": None}], ids=["no-run-registered", "empty-test-id"])
+def test_send_iotune_results_to_argus_skips_when_no_run(run):
+    """In replay-log-only mode get_run() returns an empty payload, it should be skipped, not raise."""
+    argus_mock = MagicMock()
+    argus_mock.get_run = MagicMock(return_value=run)
+
+    send_iotune_results_to_argus(argus_client=argus_mock, results={}, node=MagicMock(), params={})
+
+    argus_mock.submit_results.assert_not_called()


### PR DESCRIPTION
`send_iotune_results_to_argus()` guards against "no Argus run for this test" by indexing a key that may not be present:

```python
run = argus_client.get_run()
if not run["test_id"]:   # KeyError when the key is absent, not merely falsy
    LOGGER.warning("No test exists for this run, skipping submitting results")
    return
```

When the Argus client runs in replay-log-only mode (Argus disabled / no registered run), `get_run()` returns an empty payload, so the guard itself raises `KeyError: 'test_id'` instead of taking its early-return branch. The intent and its log message are already correct — only the condition is wrong.

Net effect: `ArtifactsTest.test_scylla_service` fails with

```
(TestFrameworkEvent Severity.ERROR) source={'ArtifactsTest'}
  message=Error during IOTune params validation.
...
  File "sdcm/argus_results.py", line 492, in send_iotune_results_to_argus
KeyError: 'test_id'
```

Observed on GCE artifacts run `20260728-204855-048490` and AWS run `20260727-111016-398044` — in both, this was the *only* ERROR event in an otherwise clean run.

Not backend-specific: any run whose Argus client has no registered run hits this; it shows up reliably on local runs because those are always in that state.

This is the only `get_run()` call site that indexes `test_id` — the other call sites in `sct.py` already use `.get()` or dict-spread.

Added a parametrized unit test covering both the empty payload and an explicit `test_id: None`; it fails with `KeyError` before the fix.

Fixes: https://scylladb.atlassian.net/browse/SCT-709

## Testing
- `pytest unit_tests/unit/test_argus_results.py` — 3 passed
- verified the new test fails (KeyError) against the unpatched condition

**PR pre-checks:**
- [x] I added the relevant backport labels
- [x] I didn't leave commented-out/debugging code

🤖 Generated with [Claude Code](https://claude.com/claude-code)