### PR TITLE
test(oci): add configuration for object storage with oci backend

### DIFF
--- a/configurations/object_storage_oci.yaml
+++ b/configurations/object_storage_oci.yaml
@@ -1,0 +1,5 @@
+append_scylla_yaml:
+  auto_snapshot: false
+  object_storage_endpoints:
+    - name: https://idedxcgnkfkt.compat.objectstorage.us-ashburn-1.oci.customer-oci.com
+      aws_region: us-ashburn-1

--- a/defaults/oci_config.yaml
+++ b/defaults/oci_config.yaml
@@ -4,6 +4,7 @@
 user_credentials_path: "~/.ssh/scylla_test_id_ed25519"
 use_preinstalled_scylla: true
 backup_bucket_backend: 's3'
+backup_bucket_location: 'manager-backup-tests-us-ashburn-1'
 
 instance_provision: "on_demand" # NOTE: DenseIO shapes cannot be 'spot'
 oci_region_name:

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -1539,6 +1539,7 @@ the bucket name to be used for backup (e.g., 'manager-backup-tests')
 - `manager-backup-tests-{region}`: aws, aws-siren, k8s-eks
 - `manager-backup-tests-sct-project-1-us-east1`: gce, gce-siren
 - `manager-backup-tests-us-east-1`: azure
+- `manager-backup-tests-us-ashburn-1`: oci
 - `minio-bucket`: k8s-local-kind, k8s-local-kind-aws, k8s-local-kind-gce, k8s-gke
 
 

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2573,9 +2573,24 @@ class BaseNode(AutoSshContainerMixin):
         if general_config is provided.
         """
         backup_backend = self.parent_cluster.params.get("backup_bucket_backend")
+        cluster_backend = self.parent_cluster.params.get("cluster_backend")
         backup_backend_config = {}
         if backup_backend == "s3":
-            if region and region != self.region:
+            if cluster_backend == "oci":
+                # OCI is compatible with S3, so we use the S3 backend for OCI
+                # but requires different endpoint and region configuration, as well as access keys.
+                endpoint_data = self.parent_cluster.params.get("append_scylla_yaml")
+                # object_storage_endpoints is a list of endpoints, we take the first one
+                backup_backend_config["endpoint"] = endpoint_data["object_storage_endpoints"][0]["name"]
+                backup_backend_config["region"] = endpoint_data["object_storage_endpoints"][0]["aws_region"]
+                backup_backend_config["access_key_id"] = self.test_config.backup_oci_credentials["access_key_id"]
+                backup_backend_config["secret_access_key"] = self.test_config.backup_oci_credentials[
+                    "secret_access_key"
+                ]
+                # forces path-style addressing, e.g.
+                # endpoint/bucket instead of bucket.endpoint
+                backup_backend_config["provider"] = "Minio"
+            elif region and region != self.region:
                 backup_backend_config["region"] = region
         elif backup_backend == "gcs":
             backup_backend_config["endpoint"] = "https://storage.googleapis.com"

--- a/sdcm/cluster_oci.py
+++ b/sdcm/cluster_oci.py
@@ -13,6 +13,9 @@
 
 import json
 import logging
+import os
+import stat
+import tempfile
 import time
 from datetime import datetime
 from functools import cached_property
@@ -27,6 +30,8 @@ from sdcm.provision.helpers.certificate import CA_CERT_FILE, CA_KEY_FILE, create
 from sdcm.sct_events.system import SpotTerminationEvent
 from sdcm.sct_provision import region_definition_builder
 from sdcm.sct_provision.instances_provider import provision_instances_with_fallback
+from sdcm.keystore import KeyStore
+from sdcm.remote.base import shell_script_cmd
 from sdcm.utils.decorators import retrying
 from sdcm.utils.net import resolve_ip_to_dns
 from sdcm.utils.oci_utils import get_oci_compartment_id
@@ -187,6 +192,43 @@ class OciNode(cluster.BaseNode):
             self.log.warning("Error during getting OCI spot termination notification: %s", details)
 
         return SPOT_TERMINATION_CHECK_DELAY
+
+    def fix_scylla_server_systemd_config(self):
+        super().fix_scylla_server_systemd_config()
+        if self.is_docker():
+            return
+        # OCI S3-compatible object storage authenticates via AWS-style credentials.
+        # Override whatever AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY are in the
+        # environment (SCT runner credentials) with the OCI backup credentials so
+        # Scylla talks to the right endpoint.
+        oci_creds = KeyStore().get_backup_oci_credentials()
+        access_key = oci_creds["access_key_id"]
+        secret_key = oci_creds["secret_access_key"]
+        self.log.debug("Setting OCI S3 credentials in scylla-server systemd unit")
+        dropin = (
+            f"[Service]\nEnvironment=AWS_ACCESS_KEY_ID={access_key}\nEnvironment=AWS_SECRET_ACCESS_KEY={secret_key}\n"
+        )
+        # Write to a local temp file (mode 0600) then transfer; credentials
+        # must never appear on a command line where they would be logged.
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".conf", delete=False) as tmp:
+            os.chmod(tmp.name, stat.S_IRUSR | stat.S_IWUSR)
+            tmp.write(dropin)
+            tmp.flush()
+            tmp_remote = f"/tmp/{os.path.basename(tmp.name)}"
+            try:
+                self.remoter.send_files(src=tmp.name, dst=tmp_remote)
+            finally:
+                os.unlink(tmp.name)
+        drop_in_dir = "/etc/systemd/system/scylla-server.service.d"
+        drop_in_path = f"{drop_in_dir}/oci-s3-creds.conf"
+        self.remoter.sudo(
+            shell_script_cmd(f"""\
+            mkdir -p {drop_in_dir}
+            install -m 0600 -o root -g root {tmp_remote} {drop_in_path}
+            rm -f {tmp_remote}
+            systemctl daemon-reload
+        """)
+        )
 
     def restart(self):
         self._instance.reboot(wait=True, hard=False)

--- a/sdcm/keystore.py
+++ b/sdcm/keystore.py
@@ -235,6 +235,9 @@ class KeyStore:
     def get_backup_azure_blob_credentials(self):
         return self.get_json("backup_azure_blob.json")
 
+    def get_backup_oci_credentials(self):
+        return self.get_json("backup_oci.json")
+
     def get_docker_hub_credentials(self):
         return self.get_json("docker.json")
 

--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -948,6 +948,10 @@ class ScyllaLogCollector(LogCollector):
         ),
         CommandLog(name="cassandra-rackdc.properties", command=f"cat {SCYLLA_PROPERTIES_PATH}"),
         CommandLog(name="scylla-manager-agent.yaml", command=f"cat {SCYLLA_MANAGER_AGENT_YAML_PATH}"),
+        CommandLog(
+            name="scylla-manager-agent.log",
+            command="sudo journalctl --no-tail --no-pager -u scylla-manager-agent.service -o short-precise",
+        ),
         CommandLog(name="setup_scripts_errors.log", command="for i in /var/tmp/scylla/*.log;do echo [$i]; cat $i;done"),
         CommandLog(name="scylla_doctor.vitals.json", command="cat *.vitals.json"),
         CommandLog(name="cloud-init-output.log", command="cat /var/log/cloud-init-output.log"),

--- a/sdcm/test_config.py
+++ b/sdcm/test_config.py
@@ -73,6 +73,7 @@ class TestConfig(metaclass=Singleton):
     _agent_api_key = None
 
     backup_azure_blob_credentials = {}
+    backup_oci_credentials = {}
 
     @classmethod
     def test_id(cls):
@@ -268,6 +269,10 @@ class TestConfig(metaclass=Singleton):
     @classmethod
     def set_backup_azure_blob_credentials(cls) -> None:
         cls.backup_azure_blob_credentials = KeyStore().get_backup_azure_blob_credentials()
+
+    @classmethod
+    def set_backup_oci_credentials(cls) -> None:
+        cls.backup_oci_credentials = KeyStore().get_backup_oci_credentials()
 
     @classmethod
     def reuse_cluster(cls, val=False):

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1293,6 +1293,9 @@ class ClusterTester(unittest.TestCase):
         if self.params.get("backup_bucket_backend") == "azure":
             self.test_config.set_backup_azure_blob_credentials()
 
+        if self.params.get("backup_bucket_backend") == "s3" and self.params.get("cluster_backend") == "oci":
+            self.test_config.set_backup_oci_credentials()
+
         self.test_config.BACKTRACE_DECODING = self.params.get("backtrace_decoding")
         if self.test_config.BACKTRACE_DECODING:
             self.test_config.set_decoding_queue()

--- a/unit_tests/unit/test_cluster_oci.py
+++ b/unit_tests/unit/test_cluster_oci.py
@@ -1,5 +1,6 @@
 """Unit tests for OCI cluster node behavior."""
 
+import stat
 from unittest.mock import Mock, patch
 
 import pytest
@@ -213,3 +214,106 @@ def test_add_nodes_rack_none_consistent_across_node_index_offsets(
 
     actual_racks = [call.kwargs["rack"] for call in oci_cluster_for_rack_tests._create_node.call_args_list]
     assert actual_racks == expected_racks
+
+
+# --- fix_scylla_server_systemd_config tests ---
+
+# Sentinel values — distinctive enough that accidental interpolation into any
+# command string would be caught immediately by the leak-assertion test.
+_SENTINEL_ACCESS_KEY = "SENTINEL_OCI_ACCESS_KEY_ID"
+_SENTINEL_SECRET_KEY = "SENTINEL_OCI_SECRET_ACCESS_KEY"
+_DROP_IN_PATH = "/etc/systemd/system/scylla-server.service.d/oci-s3-creds.conf"
+
+
+@pytest.fixture()
+def _oci_node_for_systemd(monkeypatch):
+    """OciNode with a mocked remoter, ready to exercise fix_scylla_server_systemd_config.
+
+    BaseNode.__init__ is patched away for construction; BaseNode's own
+    fix_scylla_server_systemd_config is monkeypatched so its remoter calls
+    don't interfere with assertions on the OCI-specific behaviour.
+    """
+    with patch("sdcm.cluster.BaseNode.__init__", new=_base_node_init):
+        node = OciNode(_mock_cloud_instance(), MOCK_CREDENTIALS, MOCK_PARENT_CLUSTER)
+    node.remoter = Mock()
+    node.is_docker = Mock(return_value=False)
+    mock_base_fix = Mock()
+    monkeypatch.setattr("sdcm.cluster.BaseNode.fix_scylla_server_systemd_config", mock_base_fix)
+    return node, mock_base_fix
+
+
+def _fake_oci_keystore():
+    """Return a patch context manager for sdcm.cluster_oci.KeyStore with sentinel credentials."""
+    mock_ks = Mock()
+    mock_ks.return_value.get_backup_oci_credentials.return_value = {
+        "access_key_id": _SENTINEL_ACCESS_KEY,
+        "secret_access_key": _SENTINEL_SECRET_KEY,
+    }
+    return patch("sdcm.cluster_oci.KeyStore", mock_ks)
+
+
+def test_fix_scylla_server_systemd_config_calls_super(_oci_node_for_systemd):
+    """super().fix_scylla_server_systemd_config() must be called unconditionally."""
+    node, mock_base_fix = _oci_node_for_systemd
+    with _fake_oci_keystore():
+        node.fix_scylla_server_systemd_config()
+    mock_base_fix.assert_called_once()
+
+
+def test_fix_scylla_server_systemd_config_skips_on_docker(_oci_node_for_systemd):
+    """Docker nodes must be skipped — no KeyStore lookup and no file transfer or sudo call."""
+    node, _ = _oci_node_for_systemd
+    node.is_docker.return_value = True
+    with patch("sdcm.cluster_oci.KeyStore") as mock_ks:
+        node.fix_scylla_server_systemd_config()
+    mock_ks.assert_not_called()
+    node.remoter.send_files.assert_not_called()
+    node.remoter.sudo.assert_not_called()
+
+
+def test_fix_scylla_server_systemd_config_credentials_not_on_command_line(_oci_node_for_systemd):
+    """Credentials must travel only inside the transferred file, never on any sudo command line.
+
+    This is a regression guard: if a future change embeds credentials in a
+    shell command (which remoter logs verbatim), this test will catch it.
+    """
+    node, _ = _oci_node_for_systemd
+    with _fake_oci_keystore():
+        node.fix_scylla_server_systemd_config()
+
+    node.remoter.send_files.assert_called_once()
+    dst = node.remoter.send_files.call_args.kwargs["dst"]
+    assert dst.startswith("/tmp/"), f"credentials should be staged under /tmp/, got {dst!r}"
+
+    for sudo_call in node.remoter.sudo.call_args_list:
+        cmd = sudo_call.args[0]
+        assert _SENTINEL_ACCESS_KEY not in cmd, "access_key_id must not appear in sudo command"
+        assert _SENTINEL_SECRET_KEY not in cmd, "secret_access_key must not appear in sudo command"
+
+
+def test_fix_scylla_server_systemd_config_installs_dropin_with_mode_0600(_oci_node_for_systemd):
+    """Drop-in must be installed with mode 0600 on the remote host, and the local temp file
+    must also be protected before transfer."""
+    node, _ = _oci_node_for_systemd
+    with _fake_oci_keystore(), patch("sdcm.cluster_oci.os.chmod") as mock_chmod:
+        node.fix_scylla_server_systemd_config()
+
+    # Remote: install command must carry -m 0600
+    sudo_cmd = node.remoter.sudo.call_args.args[0]
+    assert "install" in sudo_cmd
+    assert "0600" in sudo_cmd
+    assert _DROP_IN_PATH in sudo_cmd
+
+    # Local: temp file must be restricted before transfer
+    mock_chmod.assert_called_once()
+    _, mode = mock_chmod.call_args.args
+    assert mode == stat.S_IRUSR | stat.S_IWUSR
+
+
+def test_fix_scylla_server_systemd_config_reloads_systemd_daemon(_oci_node_for_systemd):
+    """systemctl daemon-reload must be issued so the new drop-in takes effect immediately."""
+    node, _ = _oci_node_for_systemd
+    with _fake_oci_keystore():
+        node.fix_scylla_server_systemd_config()
+    sudo_cmd = node.remoter.sudo.call_args.args[0]
+    assert "daemon-reload" in sudo_cmd


### PR DESCRIPTION
- add object storage config for oci
- get oci credentials from keystore bucket
- also collect scylla-manager-agent logs

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] Backup https://argus.scylladb.com/tests/scylla-cluster-tests/24d56454-9d98-4c4c-aff2-d4dd64cb551b
- [x] Restore https://argus.scylladb.com/tests/scylla-cluster-tests/e9138881-a116-415b-bad7-c24766ef847d

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
