### PR TITLE
fix(skills): repair perf-weekly-status-report from real report run

### DIFF
--- a/skills/perf-weekly-status-report/SKILL.md
+++ b/skills/perf-weekly-status-report/SKILL.md
@@ -25,7 +25,23 @@ Release builds (`2026.1.5`) run on stable branches and represent prior releases.
 
 **The `argus` binary (Go CLI) is the data source -- not the Python argus client library.**
 
-The Go-based `argus` CLI (`/home/juliayakovlev/.local/bin/argus`) provides `run list` and `run results` subcommands that return JSON. This is faster and more reliable than the Python library for batch data collection. Always use `--url https://argus.scylladb.com` to target the production Argus instance.
+The Go-based `argus` CLI provides `run list` and `run results` subcommands that return JSON. This is faster and more reliable than the Python library for batch data collection. Always use `--url https://argus.scylladb.com` to target the production Argus instance.
+
+Resolve the binary from `PATH` (`which argus`) -- do **not** hardcode a path under any particular user's home directory. A typical install lives in `~/.local/bin/argus`.
+
+> **Name collision:** `argus --version` is not a valid flag. Verify with `argus --help` and confirm `run` and `issue` subcommands are listed.
+
+### Authenticate Argus Before Collecting
+
+**The first `argus` call opens a browser and blocks on `Waiting for login...`.**
+
+This violates the repo-wide rule that commands must be non-interactive, and in a headless or automated run it hangs until timeout. Do a cheap pre-flight call before the batch collection so the login happens once, visibly, at a predictable moment:
+
+```bash
+argus run list --test-id <ANY_TEST_ID> --limit 1 --url https://argus.scylladb.com
+```
+
+If the output contains `Waiting for login...`, tell the user a browser login is required and wait for it to complete before proceeding. Never launch the 16-test collection loop as the first Argus call -- a login prompt mid-fan-out produces confusing partial failures.
 
 ### Gmail-Compatible HTML
 
@@ -50,6 +66,30 @@ Gmail only supports inline CSS styles on elements. Never use `<style>` tags, `<l
 
 **Status column format:** Show just the status badge (PASSED/FAILED/ERROR) of the latest run for that workload. No counts.
 
+### Runs With No Results: Recover the Workload From Jenkins
+
+**A `test_error` run often has ZERO result tables, so its workload cannot be read from table names. Do not drop these runs.**
+
+This is common and can dominate a week: a run that dies during provisioning has `end_time` of `1970-01-01`, an empty `results` array, and no field anywhere in the run object naming its workload. Since the skill's normal path derives workload from table names (`"<workload> - <step> - latencies"`), these runs would silently vanish from the overview -- making a week of failures look like a week with few runs.
+
+Recover the workload from the Jenkins build that produced the run:
+
+1. Each run object has `build_id` and `build_number`. Fetch that build's parameters (Jenkins MCP `get_build_parameters`, or the Jenkins REST API).
+2. The `sub_tests` parameter is an ordered JSON list of the workloads that build ran, e.g.
+   `["test_read_gradual_increase_load", "test_write_gradual_increase_load"]`.
+3. Sub-tests execute **sequentially**, each creating one Argus run. Sort that build's runs by `start_time` and zip them positionally against `sub_tests`.
+4. **Validate the mapping** against the runs in the same build that *do* have tables -- their table-name workload must match the position they were assigned. If it doesn't, stop and report the ambiguity rather than guessing.
+
+Map sub-test names to workload labels: `test_read_gradual_increase_load` -> `read`, `test_write_gradual_increase_load` -> `write`, `test_mixed_gradual_increase_load` -> `mixed`, `test_read_disk_only_gradual_increase_load` -> `read_disk_only`, `test_latency_mixed_with_nemesis` -> `mixed`.
+
+Also determine *why* the run produced nothing, and say so in the Conclusion -- a provisioning abort is not a performance result. Grep the Jenkins console for the cause; the common one is AWS capacity:
+
+```
+sdcm.exceptions.CapacityReservationError: Failed to create capacity reservation in any availability zone.
+```
+
+State the real reason (e.g. `InsufficientInstanceCapacity` for a given instance type and region) rather than reporting a bare `ERROR`. Do **not** list these runs as rows in the Failed Results table -- they have no metrics to show; the Conclusion carries them.
+
 ### Version Display
 
 **Show full version with build date AND revision hash: `2026.3.0.dev-20260612.91ada5517d59`.**
@@ -57,6 +97,8 @@ Gmail only supports inline CSS styles on elements. Never use `<style>` tags, `<l
 The full version is constructed from the `packages[]` array: take `scylla-server-target` package's `version` field (normalize `~` to `.`), append `.` + the `date` field, append `.` + the `revision_id` field. Example: version=`2026.3.0~dev`, date=`20260612`, revision_id=`91ada5517d59` becomes `2026.3.0.dev.20260612.91ada5517d59`.
 
 The "short version" (e.g., `2026.3.0.dev`) is derived by normalizing `~` to `.` in the `scylla_version` field.
+
+**When the period spans more than one build** (common -- e.g. most tests on `...20260723.4fc12a81b3c5` but a nemesis run on `...20260720.a78d406c2ed8`), the Summary title takes the version covering the **most runs**; break ties with the most recent build date. Every per-run version still appears in the Detailed Results `Version` column, and the detailed test sub-heading uses that test's own version -- so a test built from a different revision is never mislabelled with the Summary's version.
 
 ### Detailed Results: Argus Links and Throughput
 
@@ -109,7 +151,7 @@ This provides better readability for tables with multiple columns.
 
 **The report file (`perf-weekly-status-report.html`) must NOT be saved into the SCT repository.**
 
-Write it to `/tmp/opencode/perf-weekly-status-report.html` or the user's home directory. Never commit it to the repo.
+Write it anywhere outside the working tree -- the agent's own scratchpad/temp directory is the natural choice, or the user's home directory. Never commit it to the repo. (`/tmp/opencode/` also works but is specific to one agent harness; don't treat it as required.)
 
 ## When to Use
 
@@ -148,6 +190,10 @@ These are the enterprise performance tests tracked in the weekly report:
 | simple-query-weekly-microbenchmark_arm64-write | dcc1afa0-2225-468c-9f45-5cfc8486f7f8 | Microbenchmarks |
 | simple-query-weekly-microbenchmark_x86_64 | 03464849-60e8-46c8-91b9-955cdeb07ea6 | Microbenchmarks |
 | simple-query-weekly-microbenchmark_x86_64-write | 6e745123-cb53-482b-836c-0609bd36a4e6 | Microbenchmarks |
+
+**Most of this registry is usually empty for a given week, and that is expected.** These tests are not all scheduled weekly, and several run predominantly on release branches -- their runs get filtered out by the master-only rule. It is normal for whole categories (i8g Vnodes, i4i Tablets, i4i Vnodes) to contribute zero rows because they only ran release builds such as `2026.2.2` / `2026.1.9`.
+
+Do not treat a mostly-empty result as a collection failure, and do not list tests with no runs in the report. Do state in the Conclusion which categories had no master runs, so readers can tell "passed" apart from "never ran".
 
 ## Input Parameters
 
@@ -212,7 +258,18 @@ Returns JSON array of issue objects. Key fields:
 - `state` -- Jira state ("new", "todo", "done", "duplicate")
 - `url` -- Direct Jira link
 
-Note: Does NOT expose Jira creation dates. Agent must ask user to classify new vs reproduced.
+Note: the Argus payload does NOT include Jira creation dates -- but you can look them up directly instead of asking the user (see below).
+
+**`argus issue list` frequently returns `[]` even for failed runs.** Linking a run to a Jira ticket is a manual step in Argus, so an unlinked failure is normal, not a collection bug. When every failed run returns no issues, do not conclude there are no relevant issues -- ask the user whether a known ticket covers the failure, and say plainly in your summary that the attribution came from them rather than from Argus.
+
+### Resolve new vs reproduced from Jira, not from the user
+
+Fetch each issue's `created` field via the Atlassian MCP `getJiraIssue` tool (`fields: ["summary","status","created","resolution"]`) and compare it to the report window:
+
+- `created` **inside** the window -> **New Issues - Regression**
+- `created` **before** the window -> **Reproduced Issues**
+
+Use `status` / `resolution` for the State column, and to support any "no progress since last week" statement -- an issue whose `updated` timestamp predates the previous report genuinely has had no activity. Only fall back to asking the user if Jira is unreachable.
 
 ## Report Structure
 
@@ -221,7 +278,7 @@ The output HTML file must contain:
 1. **Header** -- Report title, date range, "Master (~dev) builds only" indicator
 2. **Summary** -- Title format: "Summary for Scylla version {full_version}" where full_version includes build date and revision hash (e.g., "2026.3.0.dev.20260612.91ada5517d59"). Body: Total tests run, passed count, failed count, error count. **Counts are per run, not per test group.** Each workload is a separate run, so a test with 4 workloads (mixed, read, write, read_disk_only) counts as 4 runs. Microbenchmark tests count as 1 run each. This ensures that Total = Passed + Failed/Error always holds.
 3. **Conclusion** -- Hierarchical bullet-point lines summarizing weekly results. Structure: top-level items are test names in bold (prefixed with `- `), sub-items are specific observations (prefixed with `&#8226;`). The agent MUST print the generated conclusion text to the user and ask for confirmation or edits BEFORE saving it into the final HTML report file. This ensures the user can review and adjust the conclusion wording.
-4. **New Issues - Regression** -- Shown after Conclusion when new issues exist. Lists Jira issues whose tickets were created during the report period (i.e., newly filed regressions). Since Argus CLI doesn't expose Jira creation dates, the agent MUST present the collected issues to the user and ask them to identify which are new vs reproduced BEFORE saving the report. If no new issues, this section is omitted.
+4. **New Issues - Regression** -- Shown after Conclusion when new issues exist. Lists Jira issues whose tickets were created during the report period (i.e., newly filed regressions). Classify by fetching each issue's `created` date from Jira (Atlassian MCP `getJiraIssue`) and comparing it to the report window; only ask the user if Jira is unreachable. If no new issues, this section is omitted.
 5. **Reproduced Issues** -- Always shown after New Issues (or after Conclusion if no new issues). Lists issues linked to runs whose Jira tickets were created before the report period. If no reproduced issues, displays "No reproduced issues in this period."
 6. **Overview Table** -- Grouped by category, then test, then workload. Columns: Category | Test | Workload | Status | Link. Microbenchmarks use "-" as workload.
 7. **Detailed Results** -- **ONLY shown when there are actual failures.** When all tests pass, this section is completely omitted. When failures exist, shows per-category breakdown of failed steps with P99/throughput, and optionally a Max Throughput table for failed predefined-throughput-steps tests where the unthrottled step itself has FAIL/ERROR status.
@@ -259,8 +316,18 @@ A valid weekly status report:
 - [ ] Groups tests by platform category in detailed results
 - [ ] States the reporting period in the header
 - [ ] Table width is 700px
-- [ ] Output file is NOT saved into the SCT repository (use /tmp/opencode/ or home dir)
+- [ ] Output file is NOT saved into the SCT repository (scratchpad/temp dir or home dir)
 - [ ] Conclusion text is printed to the user for review/editing BEFORE being saved into the HTML report
 - [ ] Conclusion uses hierarchical format: bold test names as top-level items, specific observations as sub-bullets
 - [ ] Issues are split into "New Issues - Regression" (created during period) and "Reproduced Issues" (pre-existing)
-- [ ] Agent asks user to classify issues as new vs reproduced BEFORE saving the report
+- [ ] Issue classification comes from Jira `created` dates; the user is asked only for unlinked failures or if Jira is unreachable
+- [ ] `argus` resolved from PATH, not a hardcoded home directory; login handled by a pre-flight call
+- [ ] Every master run in the window is accounted for, including `test_error` runs with zero result tables
+- [ ] Workload for runs with no result tables recovered from the Jenkins `sub_tests` order and validated against runs that do have tables
+- [ ] Runs that produced nothing state the actual cause (e.g. `CapacityReservationError`) rather than a bare ERROR
+- [ ] Categories with no master runs are named in the Conclusion, so "passed" is distinguishable from "never ran"
+- [ ] Summary version chosen by run count when the period spans multiple builds; per-run versions shown in Detailed Results
+- [ ] Data tables use `border="1"` plus per-cell borders (CSS-only cell borders get stripped)
+- [ ] Status badges use `bgcolor` on a `<td>`, not a bare `<span>`
+- [ ] Rendering verified visually in a browser before any email draft is created
+- [ ] Email step (if requested) creates a DRAFT only -- never sends

--- a/skills/perf-weekly-status-report/references/html-template.md
+++ b/skills/perf-weekly-status-report/references/html-template.md
@@ -143,19 +143,25 @@ Key details:
 
 ## Status Badges
 
+A badge carries **white text**, so its colour must never be droppable -- if a client strips the
+`background-color`, the label becomes white-on-white and the status is invisible. `bgcolor` is not a
+valid attribute on `<span>`, so wrap the badge in a one-cell table and put `bgcolor` on the `<td>`
+alongside the style. This is also what the "always pair `bgcolor` with `background-color`" rule
+above requires.
+
 ```html
 <!-- Passed -->
-<span style="background-color:#28a745;color:#ffffff;padding:2px 8px;font-size:11px;font-weight:bold;display:inline-block;">PASSED</span>
+<table cellpadding="0" cellspacing="0" border="0" style="border-collapse:collapse;"><tr>
+  <td bgcolor="#28a745" align="center" style="background-color:#28a745;padding:3px 10px;font-size:11px;font-weight:bold;color:#ffffff;font-family:Arial,Helvetica,sans-serif;">PASSED</td>
+</tr></table>
 
-<!-- Failed -->
-<span style="background-color:#dc3545;color:#ffffff;padding:2px 8px;font-size:11px;font-weight:bold;display:inline-block;">FAILED</span>
-
-<!-- Error -->
-<span style="background-color:#fd7e14;color:#ffffff;padding:2px 8px;font-size:11px;font-weight:bold;display:inline-block;">ERROR</span>
-
-<!-- No Runs -->
-<span style="background-color:#6c757d;color:#ffffff;padding:2px 8px;font-size:11px;font-weight:bold;display:inline-block;">NO_RUNS</span>
+<!-- Failed: bgcolor="#dc3545" / background-color:#dc3545 -->
+<!-- Error:  bgcolor="#fd7e14" / background-color:#fd7e14 -->
+<!-- No Runs: bgcolor="#6c757d" / background-color:#6c757d -->
 ```
+
+Avoid the older single-`<span>` form (`<span style="background-color:#28a745;color:#ffffff;...">`) --
+it renders in most clients but has no fallback when the background is stripped.
 
 ## Data Tables
 

--- a/skills/perf-weekly-status-report/workflows/generate-report.md
+++ b/skills/perf-weekly-status-report/workflows/generate-report.md
@@ -12,6 +12,14 @@ Step-by-step process for generating the Gmail-compatible HTML performance report
 
 **Entry criteria:** Argus CLI is available and authenticated.
 
+0. Resolve and authenticate the CLI first. Use `argus` from `PATH` (`which argus`) -- never a
+   hardcoded path under someone's home directory. Then make one cheap call so the interactive
+   browser login happens once, up front, rather than in the middle of the fan-out:
+   ```bash
+   argus run list --test-id d6ebf1a5-135f-43fc-a7ba-0716b60dfa94 --limit 1 --url https://argus.scylladb.com
+   ```
+   If the output says `Waiting for login...`, tell the user a browser login is needed and wait.
+
 1. Calculate the time window (default 7 days, user can override):
    ```bash
    DAYS=${DAYS:-7}
@@ -126,7 +134,27 @@ master_runs = [
 4. Important: Each run covers a single workload. Build a mapping of test_name -> workload -> [run entries].
    This means the Argus link for each workload points to the run that produced that workload's results.
 
+5. **Runs with an empty results array still need a workload.** A `test_error` run that died during
+   provisioning has no tables, so step 1 cannot classify it -- and skipping it would hide most of a
+   bad week. Recover the workload from Jenkins:
+
+   ```bash
+   # run object carries build_id + build_number
+   # Jenkins MCP: get_build_parameters(fullname=<build_id>, number=<build_number>)
+   # -> sub_tests = ["test_read_gradual_increase_load", "test_write_gradual_increase_load"]
+   ```
+
+   Sub-tests run sequentially, one Argus run each. Sort that build's runs by `start_time` and zip
+   positionally against `sub_tests`. Validate against the runs in the same build that *do* have
+   tables -- their table-name workload must match their assigned position; if not, report the
+   ambiguity instead of guessing.
+
+   Then find the failure cause for the Conclusion (`get_build_console_output` with a pattern such as
+   `InsufficientInstanceCapacity|CapacityReservationError|Unable to provision`) so the report can say
+   *why* nothing was produced rather than just `ERROR`.
+
 **Exit criteria:** Data organized by category > test > workload > step, throughput tracker populated.
+Every master run in the window is accounted for -- including those with zero result tables.
 
 ## Phase 4a: Collect Issues
 
@@ -153,27 +181,27 @@ master_runs = [
 
 3. De-duplicate issues by `key` (same issue may appear on multiple runs).
 
-4. **Classification: New vs Reproduced**
+4. **Classification: New vs Reproduced -- look it up, don't ask**
 
-   Since the Argus CLI does not expose Jira issue creation dates, the agent MUST present the full de-duplicated issue list to the user and ask them to classify each issue:
-   - **New Issues - Regression**: Jira ticket was created during the report period (newly filed regression)
-   - **Reproduced Issues**: Jira ticket existed before the report period but was reproduced this week
+   Fetch each issue from Jira via the Atlassian MCP `getJiraIssue` tool with
+   `fields: ["summary","status","created","updated","resolution"]`, then compare `created` to the
+   report window:
+   - `created` **inside** the window -> **New Issues - Regression**
+   - `created` **before** the window -> **Reproduced Issues**
 
-   Example interaction:
-   ```
-   I found the following issues linked to failed runs this week:
+   `status` / `resolution` fill the State column. `updated` supports any "no progress since last
+   week" claim -- verify it rather than asserting it. Only fall back to asking the user if Jira is
+   unreachable.
 
-   1. PROJECT-123: <issue title>
-   2. PROJECT-456: <issue title>
-   3. PROJECT-789: <issue title>
+5. **If `argus issue list` returns `[]` for every failed run** -- which is common, since linking runs
+   to tickets is manual -- do not report "no issues". Ask the user whether a known ticket covers the
+   failure, then confirm that ticket's `created` date via Jira as above. State in your summary that
+   the attribution came from the user, not from Argus.
 
-   Which of these are NEW issues (Jira ticket created this week)?
-   Please provide the issue keys that are new (e.g., "PROJECT-789"), or "none" if all are reproduced.
-   ```
+6. Store the classification for use in the HTML report generation.
 
-5. Store the classification for use in the HTML report generation.
-
-**Exit criteria:** Issues collected and classified as new vs reproduced based on user input.
+**Exit criteria:** Issues collected and classified as new vs reproduced from Jira creation dates
+(user consulted only for unlinked failures or if Jira is unreachable).
 
 ## Phase 5: Generate HTML Report
 
@@ -243,17 +271,26 @@ master_runs = [
         - NOT shown for nemesis or rolling-upgrade tests (they have no unthrottled steps)
 
 4. Key HTML rules for Gmail compatibility:
+   - **Copy the table markup from [references/html-template.md](../references/html-template.md) -- do not invent your own.**
+     Data tables there use `border="1"` on the table plus an explicit `border:1px solid #dee2e6` on
+     every `<th>`/`<td>`. CSS-only borders (e.g. `border-bottom` on a cell of a `border="0"` table)
+     get stripped, and the table renders as unaligned floating text with no gridlines.
    - All styles inline: `style="..."` on each element
    - Use `<table>` for layout, not CSS grid/flex
-   - Use `<span>` with inline background-color for badges
+   - Badges: one-cell table with `bgcolor` on the `<td>` (see rule 5) -- not a bare `<span>`
+   - Dark header row (`bgcolor="#343a40"`, white bold text), alternating row backgrounds
+     (`#ffffff` / `#f8f9fa`) with `bgcolor` set on each cell
    - No `<style>` tags, no `class` attributes, no `border-radius`
    - Content table width: `width="700"` (not 1400)
    - Font-family: Arial,Helvetica,sans-serif on each cell
    - Always use `bgcolor` attribute alongside `background-color` style
 
-5. Status badge format:
+5. Status badge format -- `bgcolor` on a real `<td>`, so white text can never land on a
+   white background if the CSS background is stripped:
    ```html
-   <span style="background-color:#28a745;color:#ffffff;padding:2px 8px;font-size:11px;font-weight:bold;display:inline-block;">PASSED</span>
+   <table cellpadding="0" cellspacing="0" border="0" style="border-collapse:collapse;"><tr>
+     <td bgcolor="#28a745" align="center" style="background-color:#28a745;padding:3px 10px;font-size:11px;font-weight:bold;color:#ffffff;font-family:Arial,Helvetica,sans-serif;">PASSED</td>
+   </tr></table>
    ```
 
 6. Color scheme:
@@ -262,7 +299,40 @@ master_runs = [
    - Error: `#fd7e14` (orange)
    - No runs: `#6c757d` (gray)
 
-**Exit criteria:** Conclusion text printed to user and confirmed/edited. Issues classified by user. File `perf-weekly-status-report.html` written to /tmp/opencode/ (NOT in the SCT repo) and renderable in a browser.
+**Exit criteria:** Conclusion text printed to user and confirmed/edited. Issues classified (from Jira `created` dates; user asked only if Jira is unreachable). File `perf-weekly-status-report.html` written outside the SCT repo and renderable in a browser.
+
+### Verify the rendering, don't assume it
+
+Open the generated file in a browser and look at it before drafting any email. A `file://` URL may be
+blocked by browser-automation tooling; serve it over loopback instead:
+
+```bash
+cd <output-dir> && python3 -m http.server 8791 --bind 127.0.0.1
+# then screenshot http://127.0.0.1:8791/perf-weekly-status-report.html and stop the server
+```
+
+Check specifically that every data table shows gridlines and that each status badge shows coloured
+fill behind white text -- these are the two things that break when the markup drifts from
+`references/html-template.md`.
+
+## Phase 5b: Email Draft (Optional)
+
+Only when the user asks for an email draft.
+
+1. Find the previous week's message to reuse its audience -- search Gmail for
+   `subject:"Weekly performance status"` and take the most recent thread.
+2. Reuse that message's recipients exactly (check `cc`/`bcc` too, not just `to`).
+3. Subject follows the series format: `Weekly performance status, MM/DD/YYYY` (the report end date).
+4. Match the established header wording so the series stays consistent:
+   `ScyllaDB Enterprise - Performance Weekly Status` / `Period: YYYY-MM-DD to YYYY-MM-DD | Master (~dev) builds only`.
+5. Pass the report HTML as the draft's `htmlBody`, **and** supply a plain-text `body` that carries the
+   same Summary / Conclusion / Overview content -- some clients show only the text alternative.
+6. **Create a draft only. Never send.** Sending on the user's behalf needs explicit per-message
+   consent, and this report goes to a wide internal audience.
+
+> **Cost note:** the draft tool takes inline content only, so the whole HTML is retyped as a tool
+> argument. Keep the generated HTML lean -- set `font-family` once on the outer table rather than
+> repeating it on all ~80 cells -- or the draft call becomes slow and expensive.
 
 ## Phase 5a: Conclusion and Issues Review (Interactive)
 
@@ -338,14 +408,27 @@ This ensures the user has final control over both the conclusion wording and iss
 16. Verify Conclusion text was shown to user before final save
 17. Verify Conclusion uses hierarchical format (bold test names + indented sub-bullets)
 18. Verify issues are split into "New Issues - Regression" and "Reproduced Issues" sections
-19. Verify user was asked to classify issues before final save
+19. Verify issues were classified from Jira `created` dates (user asked only for unlinked failures)
 20. Verify report is NOT placed inside the SCT repository
+21. Verify every data table has `border="1"` plus per-cell `border:1px solid #dee2e6` (no CSS-only borders)
+22. Verify status badges use `bgcolor` on a `<td>`, not a bare `<span>` (`grep -c '<span[^>]*background-color'` must be 0)
+23. Verify the page was actually opened in a browser and the tables/badges checked visually
+24. Verify every master run in the window appears somewhere in the report, including runs with zero result tables
 
 **Exit criteria:** Report is ready for email distribution.
 
 ## Complete Example Command Sequence
 
 ```bash
+# OUT = any directory outside the repo (agent scratchpad, or $HOME)
+OUT=${OUT:-$HOME/perf-weekly}
+mkdir -p "$OUT"
+
+# 0. Resolve + authenticate the CLI (one cheap call, so the browser login happens up front)
+which argus
+argus run list --test-id d6ebf1a5-135f-43fc-a7ba-0716b60dfa94 --limit 1 \
+  --url https://argus.scylladb.com >/dev/null
+
 # 1. Set time window (default 7 days, override with DAYS=14 etc.)
 DAYS=${DAYS:-7}
 AFTER=$(date -d "${DAYS} days ago" +%s)
@@ -356,23 +439,31 @@ argus run list \
   --after $AFTER \
   --limit 200 \
   --full \
-  --url https://argus.scylladb.com > /tmp/opencode/runs.json
+  --url https://argus.scylladb.com > "$OUT/runs.json"
 
 # 3. Filter master (~dev) versions (in Python/jq)
 # Keep only runs where scylla_version matches ^\d{4}\.\d+\.\d+.+dev$
+# Expect most of the 16 tests to yield zero master runs -- that is normal.
 
 # 4. Fetch results per filtered run
 argus run results \
   --run-id <RUN_ID> \
-  --url https://argus.scylladb.com > /tmp/opencode/results.json
+  --url https://argus.scylladb.com > "$OUT/results.json"
 
-# 5. Fetch issues for failed/errored runs
+# 4b. For runs whose results are empty (test_error), recover the workload from Jenkins
+#     sub_tests order (build_id + build_number on the run object) and grep the console
+#     for the abort cause, e.g. CapacityReservationError / InsufficientInstanceCapacity.
+
+# 5. Fetch issues for failed/errored runs (often returns [] -- linking is manual)
 argus issue list \
   --run-id <RUN_ID> \
   --url https://argus.scylladb.com
 
-# 6. Generate HTML report (output to /tmp/opencode/, NOT to repo)
+# 6. Generate HTML report (output to $OUT, NOT to repo)
 # - Ask user to confirm conclusion text
-# - Ask user to classify issues as new vs reproduced
-# - Write /tmp/opencode/perf-weekly-status-report.html
+# - Classify issues from Jira `created` dates (Atlassian MCP getJiraIssue)
+# - Write "$OUT/perf-weekly-status-report.html"
+
+# 7. Verify rendering before drafting any email
+cd "$OUT" && python3 -m http.server 8791 --bind 127.0.0.1   # screenshot, then stop
 ```


### PR DESCRIPTION
## Why

I ran `perf-weekly-status-report` end-to-end to produce the 2026-07-29 report. It worked, but only after
working around several defects in the skill. This PR folds those lessons back in so the next run doesn't
hit them.

## The one that actually matters

**Runs with zero result tables were silently dropped.**

The skill derives a run's workload from its result-table names (`"<workload> - <step> - latencies"`). A
`test_error` run that dies during provisioning has an empty results array, `end_time` of `1970-01-01`, and
**no field anywhere in the run object naming its workload** — so it matched nothing and vanished from the
report.

This week that was **6 of 13 master runs**. A week where AWS capacity aborted most of the fleet would have
rendered as a quiet week with a handful of runs. That's the failure mode worth preventing: the report
under-reports exactly when things are worst.

The fix documents recovering the workload from the Jenkins build's `sub_tests` parameter — sub-tests run
sequentially, one Argus run each, so sorting the build's runs by `start_time` and zipping positionally
against `sub_tests` recovers the mapping. Crucially it also says to **validate** that mapping against the
runs in the same build that *do* have tables (their table-name workload must match their assigned
position), and to stop and report ambiguity rather than guess. In this week's data the validation matched
exactly.

It also says to report *why* nothing was produced — `sdcm.exceptions.CapacityReservationError` /
`InsufficientInstanceCapacity` for a given instance type and region — instead of a bare `ERROR`.

## Also fixed

- **Hardcoded binary path.** The skill pinned `argus` to a path under one developer's home directory, which
  doesn't exist for anyone else. Now resolved from `PATH`.
- **Undocumented interactive login.** The first `argus` call opens a browser and blocks on
  `Waiting for login...` — this violates the repo-wide non-interactive rule and hangs headless runs. Added a
  cheap pre-flight call so the login happens once, up front, instead of mid-fan-out.
- **Jira dates are available after all.** The skill stated that creation dates aren't exposed and therefore
  the agent *must* ask the user to classify new-vs-reproduced. The Atlassian MCP `getJiraIssue` returns
  `created`, so this is now looked up, with the user asked only if Jira is unreachable.
- **`argus issue list` often returns `[]`.** Run-to-ticket linking is manual, so unlinked failures are
  normal — not "no issues". This week every failed run returned empty and the actual attribution came from
  the user; the skill now says to ask, and to be explicit in the summary that the attribution wasn't from
  Argus.
- **Multi-build periods.** Runs spanned two builds; there was no rule for which version titles the Summary.
  Now: the version covering the most runs, ties broken by build date, with per-run versions still shown in
  Detailed Results so a differently-built test is never mislabelled.
- **Mostly-empty registry is normal.** 10 of the 16 registered tests had no master runs and 3 categories had
  only release builds. Documented so it isn't misread as a collection failure — and the Conclusion should
  name those categories so "passed" is distinguishable from "never ran".
- **De-harnessed the output path.** `/tmp/opencode/` was specific to one agent harness; the real requirement
  is just "outside the repo".
- **Documented the email-draft step** (reuse the prior week's recipients, supply a plain-text alternative,
  create a draft and never send) — it wasn't covered at all, and it's how this report is actually delivered.

## Rendering: badges

Status badges were a bare `<span>` whose colour came only from CSS `background-color`. The label text is
white, so any client that strips that property renders **white-on-white** and the status disappears.
`bgcolor` isn't valid on `<span>`, so they're now a one-cell table with `bgcolor` on the `<td>` — which is
also what the skill's own "always pair `bgcolor` with `background-color`" rule already demanded. This is
defensive: the old form did render in Gmail in practice.

## One correction to my own first read

I initially thought the skill was also wrong about data-table borders. It isn't —
`references/html-template.md` already specified `border="1"` plus explicit per-cell borders. My generator
deviated from the reference and used CSS-only `border-bottom` on a `border="0"` table, which Gmail strips,
so the tables lost their gridlines. That was operator error, not a skill defect.

Rather than leave it, I added a rule pointing at the reference template and explaining the failure mode,
since the trap is easy to fall into when generating markup programmatically, plus checklist items that catch
both this and the badge regression mechanically:

```
grep -c '<span[^>]*background-color'   # must be 0
```

## Scope

Docs only — three files under `skills/perf-weekly-status-report/`. No code, no test changes. All pre-commit
hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
