### PR TITLE
fix(nemesis): skip tombstone sstables in destroy-then-repair

### DIFF
--- a/sdcm/nemesis/__init__.py
+++ b/sdcm/nemesis/__init__.py
@@ -1018,10 +1018,14 @@ class NemesisRunner:
 
         return file_for_destroy if return_one_file else all_files
 
-    def get_all_sstables(self, tables: list[str], node: BaseNode = None):
+    def get_all_sstables(self, tables: list[str], node: BaseNode = None, skip_sstables_with_tombstones: bool = False):
         """
         :param tables: list of tables. Format of name: <keyspace_name.table_name>
         :param node: get SStables from the node
+        :param skip_sstables_with_tombstones: when True, exclude sstables that contain tombstones.
+            Required for destroy/corruption flows that are followed by a repair. The filtering is an
+            offline check - the caller must make sure the sstable set cannot change while it runs.
+            See `SstableUtils.filter_out_sstables_with_tombstones`.
         """
         node = node or self.target_node
 
@@ -1029,6 +1033,8 @@ class NemesisRunner:
         for ks_cf in tables:
             sstable_util = SstableUtils(db_node=node, ks_cf=ks_cf)
             ks_cf_sstables = sstable_util.get_sstables()
+            if skip_sstables_with_tombstones:
+                ks_cf_sstables = sstable_util.filter_out_sstables_with_tombstones(ks_cf_sstables)
             sstables.extend(ks_cf_sstables)
 
         self.log.debug("All Sstables are: %s", sstables)
@@ -1036,7 +1042,12 @@ class NemesisRunner:
         return sstables
 
     @decorate_with_context(suppress_expected_unavailability_errors)
-    def _destroy_data_and_restart_scylla(self, keyspaces_for_destroy: list = None, sstables_to_destroy_perc: int = 50):
+    def _destroy_data_and_restart_scylla(
+        self,
+        keyspaces_for_destroy: list = None,
+        sstables_to_destroy_perc: int = 50,
+        skip_sstables_with_tombstones: bool = False,
+    ):
         tables = self.cluster.get_non_system_ks_cf_list(
             db_node=self.target_node, filter_empty_tables=False, filter_by_keyspace=keyspaces_for_destroy
         )
@@ -1050,15 +1061,30 @@ class NemesisRunner:
             self.target_node.stop_scylla_server(verify_up=False, verify_down=True)
 
         try:
-            # Remove data files
-            if not (all_files_to_destroy := self.get_all_sstables(tables=tables, node=self.target_node)):
-                raise UnsupportedNemesis("SStables for destroy are not found. The nemesis can't be run")
+            # Remove data files - deleting a tombstone-bearing sstable can resurrect the data it
+            # shadows, and a following repair then propagates it to the other replicas. So with
+            # skip_sstables_with_tombstones=True only tombstone-free sstables are destroy candidates,
+            # and the target percentage is applied to that filtered pool.
+            # Scylla is already stopped above, so the sstable set is frozen while it is inspected.
+            # Ref: https://scylladb.atlassian.net/browse/SCT-750
+            if not (
+                all_files_to_destroy := self.get_all_sstables(
+                    tables=tables, node=self.target_node, skip_sstables_with_tombstones=skip_sstables_with_tombstones
+                )
+            ):
+                msg = (
+                    "All sstables contain tombstones - none is safe to destroy. The nemesis can't be run"
+                    if skip_sstables_with_tombstones
+                    else "SStables for destroy are not found. The nemesis can't be run"
+                )
+                raise UnsupportedNemesis(msg)
 
-            # How many SStables are going to be deleted
             sstables_amount_to_destroy = int(len(all_files_to_destroy) * sstables_to_destroy_perc / 100)
+
             self.log.debug(
-                "SStables amount to destroy (%s percent of all SStables): %s",
+                "SStables amount to destroy (%s percent of %s SStables): %s",
                 sstables_to_destroy_perc,
+                "tombstone-free" if skip_sstables_with_tombstones else "all",
                 sstables_amount_to_destroy,
             )
 
@@ -1104,7 +1130,9 @@ class NemesisRunner:
     def disrupt_destroy_data_then_repair(self):
         """repair at the beginning added to avoid c-s failure 'data wasn't validated'"""
         self.run_repair()
-        self._destroy_data_and_restart_scylla()
+        # Skip sstables with tombstones: deleting them could resurrect shadowed data, and the
+        # following repair would then propagate the resurrected data to the other replicas.
+        self._destroy_data_and_restart_scylla(skip_sstables_with_tombstones=True)
         # try to save the node
         self.run_repair()
 
@@ -3189,7 +3217,9 @@ class NemesisRunner:
     def disrupt_mgmt_corrupt_then_repair(self):
         if not self.cluster.params.get("use_mgmt") and not self.cluster.params.get("use_cloud_manager"):
             raise UnsupportedNemesis("Scylla-manager configuration is not defined!")
-        self._destroy_data_and_restart_scylla()
+        # Skip sstables with tombstones: deleting them could resurrect shadowed data, and the
+        # following manager repair would then propagate the resurrected data to the other replicas.
+        self._destroy_data_and_restart_scylla(skip_sstables_with_tombstones=True)
         self.run_repair_manager()
 
     def disrupt_abort_repair(self):
@@ -3800,7 +3830,9 @@ class NemesisRunner:
         3. Stop it with a hard reboot once the repair starts.
         4. Trigger a rebuild on the target node after the reboot.
         """
-        self._destroy_data_and_restart_scylla()
+        # Skip sstables with tombstones: deleting them could resurrect shadowed data, and the
+        # following repair would then propagate the resurrected data to the other replicas.
+        self._destroy_data_and_restart_scylla(skip_sstables_with_tombstones=True)
         trigger = partial(
             self.target_node.run_nodetool,
             sub_cmd="repair",

--- a/sdcm/utils/sstable/sstable_utils.py
+++ b/sdcm/utils/sstable/sstable_utils.py
@@ -22,6 +22,11 @@ class SstableUtils:
 
     REMOTE_SSTABLEDUMP_PATH = "/var/tmp/sstabledump.json"
 
+    # How many sstables to pass to a single "scylla sstable dump-statistics --sstables ..." call.
+    # Bounds the command-line length and the size of the returned JSON while still amortizing the
+    # process/SSH startup cost across many sstables.
+    SSTABLE_DUMP_BATCH_SIZE = 100
+
     def __init__(
         self,
         propagation_delay_in_seconds: int = 0,
@@ -247,6 +252,10 @@ class SstableUtils:
         return True  # Successfully dumped SSTable
 
     def _are_tombstones_in_sstabledump(self, sstable: str, remote_json_path: str = REMOTE_SSTABLEDUMP_PATH) -> bool:
+        # Operates on an already-dumped "Data.db" JSON (see `_run_sstabledump`); it exists for the
+        # data-dump callers that also need the tombstone contents. For a cheap yes/no check over many
+        # sstables (no full data dump), prefer `filter_out_sstables_with_tombstones`, which reads only
+        # "Statistics.db".
         # Check if tombstones exist in the dumped sstable JSON
         check_tombstones_cmd = f"sudo jq -e '.. | .tombstone? | select(. != null)' {remote_json_path} > /dev/null"
         result = self.db_node.remoter.run(check_tombstones_cmd, verbose=False, ignore_status=True)
@@ -366,6 +375,74 @@ class SstableUtils:
                 self.log.debug("Invalid deletion_time format: %s", tombstone_info["deletion_time"])
                 raise
         return None  # No deletion_time found
+
+    def filter_out_sstables_with_tombstones(self, sstables: list) -> list:
+        """
+        Return the subset of ``sstables`` that contains no tombstones.
+
+        Read from the small "Statistics.db" component via ``scylla sstable dump-statistics``: its
+        "estimated_tombstone_drop_time" histogram is populated for tombstones/deletions and for
+        expiring (TTL) cells, so an empty histogram means the sstable is clean.
+
+        Offline check by contract - the caller must guarantee the sstable set cannot change while it
+        runs (stop Scylla on the node, or at least disable autocompaction for the table). Unexpected
+        output therefore raises instead of degrading silently.
+
+        Used to keep destroy/corruption-then-repair nemeses from resurrecting shadowed data:
+        https://scylladb.atlassian.net/browse/SCT-750
+
+        :param sstables: List of sstable "-Data.db" file paths.
+        :return: The subset of ``sstables`` with no tombstones.
+        """
+        if not sstables:
+            return []
+        status_by_sstable = self._get_sstables_tombstone_status(sstables)
+        filtered = [sstable for sstable in sstables if not status_by_sstable[sstable]]
+        self.log.debug(
+            "Filtered sstables without tombstones for %s: %s of %s", self.ks_cf, len(filtered), len(sstables)
+        )
+        return filtered
+
+    def _get_sstables_tombstone_status(self, sstables: list) -> dict:
+        """
+        Resolve, for each sstable, whether it contains tombstones.
+
+        Processed in chunks of ``SSTABLE_DUMP_BATCH_SIZE`` to bound the command-line length and the
+        size of the dumped JSON.
+
+        :param sstables: List of sstable "-Data.db" file paths.
+        :return: Mapping of sstable path -> bool (True if it contains tombstones).
+        """
+        status = {}
+        for start in range(0, len(sstables), self.SSTABLE_DUMP_BATCH_SIZE):
+            chunk = sstables[start : start + self.SSTABLE_DUMP_BATCH_SIZE]
+            status.update(self._dump_statistics_chunk(chunk))
+        return status
+
+    def _dump_statistics_chunk(self, sstables: list) -> dict:
+        """
+        Run one batched ``dump-statistics`` and classify every sstable in ``sstables``.
+
+        Parses exactly the format the ``scylla sstable`` tool of the version under test emits: entries
+        under a top-level "sstables" wrapper, keyed by the path as passed on the command line, with the
+        "estimated_tombstone_drop_time" histogram under "stats" - empty means clean. A failing dump,
+        non-JSON output or a missing key raises. A full sample of the expected format is pinned by
+        ``batch_statistics_json`` in unit_tests/unit/test_sstable_tombstone_filter.py - update it when
+        a Scylla version changes the output.
+
+        :param sstables: List of sstable "-Data.db" file paths (a single batch).
+        :return: Mapping of sstable path -> bool (True if it contains tombstones).
+        """
+        dump_cmd = _generate_sstable_dump_command(self.db_node, "dump-statistics", self.keyspace, self.table)
+        result = self.db_node.remoter.run(f'sudo bash -c "{dump_cmd} {" ".join(sstables)}"', verbose=False)
+        dumped = json.loads(result.stdout, strict=False)["sstables"]
+        return {sstable: self._entry_has_tombstones(sstable, dumped[sstable]) for sstable in sstables}
+
+    def _entry_has_tombstones(self, sstable: str, entry: dict) -> bool:
+        """Classify a single dumped statistics ``entry`` by its "estimated_tombstone_drop_time"."""
+        has_tombstones = bool(entry["stats"]["estimated_tombstone_drop_time"])
+        self.log.debug("SSTable %s contains tombstones: %s", sstable, has_tombstones)
+        return has_tombstones
 
     def corrupt_sstables(self, sstables_to_corrupt_count: int = 1):
         """

--- a/unit_tests/unit/test_sstable_tombstone_filter.py
+++ b/unit_tests/unit/test_sstable_tombstone_filter.py
@@ -1,0 +1,189 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2026 ScyllaDB
+
+"""Unit tests for the tombstone-aware sstable filtering used by destroy-then-repair nemeses."""
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from sdcm.utils.sstable.sstable_utils import SstableUtils
+
+SSTABLE = "/var/lib/scylla/data/keyspace1/standard1-abcd/me-1-big-Data.db"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def node():
+    """A mock DB node good enough for SstableUtils statistics dumping."""
+    db_node = MagicMock()
+    db_node.is_enterprise = True
+    db_node.scylla_version = "2026.0.0"
+    db_node.add_install_prefix.side_effect = lambda path: path
+    return db_node
+
+
+@pytest.fixture()
+def sstable_utils(node):
+    """SstableUtils bound to the mock ``node`` for keyspace1.standard1."""
+    return SstableUtils(db_node=node, ks_cf="keyspace1.standard1")
+
+
+@pytest.fixture()
+def sstable_utils_with_mock_status(sstable_utils, monkeypatch):
+    """SstableUtils with _get_sstables_tombstone_status mocked to mark /data/dirty-Data.db as dirty."""
+    dirty = "/data/dirty-Data.db"
+    monkeypatch.setattr(
+        sstable_utils,
+        "_get_sstables_tombstone_status",
+        lambda sstables: {s: (s == dirty) for s in sstables},
+    )
+    return sstable_utils
+
+
+# ---------------------------------------------------------------------------
+# Data builders (construct return values inline - not stateful fixtures)
+# ---------------------------------------------------------------------------
+
+
+def result(ok=True, stdout="", stderr="", exit_status=0):
+    res = MagicMock()
+    res.ok = ok
+    res.stdout = stdout
+    res.stderr = stderr
+    res.exit_status = exit_status
+    return res
+
+
+def batch_statistics_json(status_by_sstable):
+    """Build a batched dump-statistics JSON in the exact format the Scylla tool emits.
+
+    A dirty sstable carries a populated {local_deletion_time: cell_count} map (fractional keys are
+    real - see the gemini ks1.table1 output); a clean one, written without any deletion, carries an
+    empty map, as a plain cassandra-stress write load produces.
+
+    Captured from ``scylla sstable dump-statistics`` on Scylla 2026.3 (gemini ks1.table1). This is
+    the single place the tool's output format is pinned - when a Scylla version changes the format,
+    update this builder, and the parsing in ``SstableUtils._dump_statistics_chunk`` with it.
+    """
+    return json.dumps(
+        {
+            "sstables": {
+                sstable: {
+                    "offsets": {"validation": 36, "compaction": 89, "stats": 117},
+                    "validation": {"partitioner": "org.apache.cassandra.dht.Murmur3Partitioner"},
+                    "compaction": {"cardinality": [255, 255, 255, 254]},
+                    "stats": {
+                        "min_local_deletion_time": 1787205554 if dirty else 2147483647,
+                        "max_local_deletion_time": 2147483647,
+                        "min_ttl": 0,
+                        "max_ttl": 0,
+                        "estimated_tombstone_drop_time": (
+                            {"1787205554.4691358": 81, "1787205580": 48} if dirty else {}
+                        ),
+                    },
+                    "serialization_header": {"static_columns": [], "regular_columns": []},
+                }
+                for sstable, dirty in status_by_sstable.items()
+            }
+        }
+    )
+
+
+@pytest.mark.parametrize(
+    "input_sstables, expected_output",
+    [
+        pytest.param(["/data/clean-Data.db", "/data/dirty-Data.db"], ["/data/clean-Data.db"], id="mixed"),
+        pytest.param(["/data/dirty-Data.db"], [], id="all-dirty"),
+        pytest.param(["/data/clean-Data.db"], ["/data/clean-Data.db"], id="all-clean"),
+        pytest.param([], [], id="empty"),
+    ],
+)
+def test_filter_out_sstables_with_tombstones(sstable_utils_with_mock_status, input_sstables, expected_output):
+    """Verify filter_out_sstables_with_tombstones removes dirty sstables and preserves clean ones."""
+    assert sstable_utils_with_mock_status.filter_out_sstables_with_tombstones(input_sstables) == expected_output
+
+
+# ---------------------------------------------------------------------------
+# _get_sstables_tombstone_status (batched path)
+# ---------------------------------------------------------------------------
+
+
+def test_batch_status_single_process_for_many_sstables(node, sstable_utils):
+    """Verify batched tombstone detection invokes a single dump-statistics process for multiple sstables."""
+    clean = ["/data/c1-Data.db", "/data/c2-Data.db"]
+    dirty = ["/data/d1-Data.db"]
+    node.remoter.run.return_value = result(
+        ok=True,
+        stdout=batch_statistics_json({clean[0]: False, clean[1]: False, dirty[0]: True}),
+    )
+
+    status = sstable_utils._get_sstables_tombstone_status(clean + dirty)
+
+    assert status == {clean[0]: False, clean[1]: False, dirty[0]: True}
+    node.remoter.run.assert_called_once_with(
+        'sudo bash -c "SCYLLA_CONF=/etc/scylla /usr/bin/scylla sstable dump-statistics '
+        "--keyspace keyspace1 --table standard1 --sstables "
+        '/data/c1-Data.db /data/c2-Data.db /data/d1-Data.db"',
+        verbose=False,
+    )
+
+
+def test_batch_status_chunks_respect_batch_size(monkeypatch, node, sstable_utils):
+    """Verify batched tombstone detection splits large sstable lists into chunks of SSTABLE_DUMP_BATCH_SIZE."""
+    monkeypatch.setattr(type(sstable_utils), "SSTABLE_DUMP_BATCH_SIZE", 2)
+    sstables = [f"/data/{i}-Data.db" for i in range(5)]
+    node.remoter.run.side_effect = lambda cmd, **kw: result(
+        ok=True, stdout=batch_statistics_json({s: False for s in sstables if s in cmd})
+    )
+
+    status = sstable_utils._get_sstables_tombstone_status(sstables)
+
+    assert status == {s: False for s in sstables}
+    assert node.remoter.run.call_count == 3
+
+
+def test_batch_status_missing_entry_raises(node, sstable_utils):
+    """Verify an sstable absent from the dump output raises instead of being silently classified.
+
+    The check runs offline (Scylla stopped on the node), so a missing entry can only be a tooling or
+    code problem - never a benign compaction race - and must not be swallowed.
+    """
+    present = "/data/present-Data.db"
+    missing = "/data/missing-Data.db"
+    node.remoter.run.return_value = result(ok=True, stdout=batch_statistics_json({present: False}))
+
+    with pytest.raises(KeyError):
+        sstable_utils._get_sstables_tombstone_status([present, missing])
+
+
+@pytest.mark.parametrize(
+    "stdout, expected_exception",
+    [
+        pytest.param("not-json", json.JSONDecodeError, id="bad-json"),
+        pytest.param(json.dumps({"unexpected": {}}), KeyError, id="no-sstables-wrapper"),
+        pytest.param(json.dumps({"sstables": {SSTABLE: {}}}), KeyError, id="stats-section-absent"),
+        pytest.param(json.dumps({"sstables": {SSTABLE: {"stats": {}}}}), KeyError, id="histogram-field-absent"),
+    ],
+)
+def test_batch_status_raises_on_unusable_dump(node, sstable_utils, stdout, expected_exception):
+    """Verify unusable dump-statistics output fails loudly instead of degrading to 'has tombstones'."""
+    node.remoter.run.return_value = result(ok=True, stdout=stdout)
+
+    with pytest.raises(expected_exception):
+        sstable_utils._get_sstables_tombstone_status([SSTABLE])


### PR DESCRIPTION
fix(nemesis): skip tombstone sstables in destroy-then-repair

Deleting an sstable that holds a tombstone can resurrect the data it
shadows. For destroy/corruption nemeses that are followed by a repair,
the bidirectional repair then propagates the resurrected data to the
other replicas, causing c-s 'data wasn't validated' failures.

Add tombstone detection via 'scylla sstable dump-statistics' (reads only
the tiny Statistics.db component - the estimated_tombstone_drop_time
histogram: empty means no tombstones/expiring cells) and exclude such
sstables from the destroy candidate pool for the repair-based nemeses
(destroy_data_then_repair, mgmt_corrupt_then_repair,
start_and_interrupt_repair_streaming).

When filtering is enabled, the destroy target percentage is applied to
the tombstone-free sstables only, making deletion proportional across
tables based on their clean sstable counts. Rebuild-based nemeses are
unaffected (unidirectional streaming cannot spread resurrected data).

The check is offline by contract: _destroy_data_and_restart_scylla stops
Scylla on the target node before the sstables are listed and dumped, so
no compaction can remove one mid-check and there is no race to guard
against. It therefore fails loudly - a failing dump, non-JSON output, an
sstable missing from the result or a missing histogram all raise - rather
than falling back to per-sstable checks and classifying an unresolvable
sstable as tombstoned. That fallback made a genuine Scylla/tooling
problem indistinguishable from an expected condition, and let a broken
dump-statistics look like 'all sstables have tombstones' and silently
turn the nemesis into UnsupportedNemesis. A future caller that needs this
on a live node must freeze the sstable set itself (stop the node, or at
least 'nodetool disableautocompaction' for the tables).

For the same reason the parsing targets exactly one output format - that
of the scylla sstable tool shipped with the version under test - instead
of tolerating shapes no current Scylla emits. Entries are indexed by the
exact path passed on the command line and the histogram is read straight
from entry["stats"], so the recursive key search and the multi-shape
histogram handling are gone.

Verified against a live cluster: gemini ks1.table1 reports 0 of 369
sstables tombstone-free (deletes throughout) while the cassandra-stress
tables report 246 of 246 clean, so the destroy candidates are exactly the
sstables that cannot resurrect data.

Fixes https://scylladb.atlassian.net/browse/SCT-750

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- https://jenkins.scylladb.com/job/scylla-master/job/reproducers/job/gemini-1tb-10h-test/2/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
