### PR TITLE
feat(monkey): Move SI and MV nemesis into their own module

### DIFF
--- a/data_dir/nemesis.yml
+++ b/data_dir/nemesis.yml
@@ -604,7 +604,7 @@ KillMVBuildingCoordinator:
   manager_operation: false
   modify_table: false
   networking: false
-  schema_changes: false
+  schema_changes: true
   sla: false
   supports_high_disk_utilization: false
   topology_changes: true

--- a/sdcm/nemesis/__init__.py
+++ b/sdcm/nemesis/__init__.py
@@ -105,11 +105,10 @@ from sdcm.utils.common import (
     clean_enospc_on_node,
     parse_nodetool_listsnapshots,
     update_authenticator,
-    sleep_for_percent_of_duration,
     get_views_of_base_table,
 )
 from sdcm.utils.parallel_object import ParallelObject, ParallelObjectResult
-from sdcm.utils.features import is_tablets_feature_enabled, is_views_with_tablets_enabled
+from sdcm.utils.features import is_tablets_feature_enabled
 from sdcm.utils.quota import (
     configure_quota_on_node_for_scylla_user_context,
     is_quota_enabled_on_node,
@@ -137,20 +136,9 @@ from sdcm.utils.ldap import SASLAUTHD_AUTHENTICATOR, LdapServerType
 
 from sdcm.nemesis.utils import NEMESIS_TARGET_POOLS, DefaultValue, node_operations, unique_disruption_name
 from sdcm.nemesis.utils.indexes import (
-    ViewFinishedBuildingException,
     is_cf_a_view,
-    get_random_column_name,
-    create_index,
-    wait_for_index_to_be_built,
-    verify_query_by_index_works,
-    drop_index,
-    wait_for_view_to_be_built,
-    drop_materialized_view,
-    is_cf_a_view,
-    create_materialized_view_for_random_column,
-    wait_materialized_view_building_tasks_started,
 )
-from sdcm.nemesis.utils.node_allocator import NemesisNodeAllocator, NemesisNodeAllocationError
+from sdcm.nemesis.utils.node_allocator import NemesisNodeAllocator
 from sdcm.utils.node import build_node_api_command
 from sdcm.utils.sstable.load_utils import SstableLoadUtils
 from sdcm.utils.sstable.sstable_utils import SstableUtils
@@ -187,9 +175,6 @@ from test_lib.compaction import (
 )
 from test_lib.cql_types import CQLTypeBuilder
 from sdcm.utils.topology_ops import FailedDecommissionOperationMonitoring
-from sdcm.utils.diagnostic_collector.handlers import EventExceptionHandler
-from sdcm.utils.diagnostic_collector.manager import collect_diagnostics
-from sdcm.utils.diagnostic_collector.views import MVDiagnosticCollector
 
 if TYPE_CHECKING:
     from sdcm.audit import AuditStore
@@ -4356,132 +4341,6 @@ class NemesisRunner:
                 f"CDC extension settings are differs. Current: {actual_cdc_settings} expected: {cdc_settings}"
             )
 
-    def disrupt_create_index(self):
-        """
-        Create index on a random column (regular or static) of a table with the most number of partitions and wait until it gets build.
-        Then verify it can be used in a query. Finally, drop the index.
-        """
-        if self.cluster.nemesis_count > 1 and SkipPerIssues(
-            issues="https://github.com/scylladb/scylladb/issues/21695", params=self.tester.params
-        ):
-            raise UnsupportedNemesis("Skip create index nemesis with parallel nemesis run")
-
-        # Disable MV tests with tablets.
-        if is_tablets_feature_enabled(self.target_node):
-            if ComparableScyllaVersion(self.target_node.scylla_version) <= ComparableScyllaVersion("2025.3.99"):
-                raise UnsupportedNemesis("MV/SI for tablets are not supported for Scylla 2025.3 and older versions")
-
-        with (
-            self.cluster.cql_connection_patient(self.target_node, connect_timeout=300) as session,
-            collect_diagnostics(MVDiagnosticCollector(session, exception_handler=EventExceptionHandler())),
-        ):
-            ks_cf_list = self.cluster.get_non_system_ks_cf_list(self.target_node, filter_out_mv=True)
-            if not ks_cf_list:
-                raise UnsupportedNemesis("No table found to create index on")
-            ks, cf = self.random.choice(ks_cf_list).split(".")
-            column = get_random_column_name(
-                session, ks, cf, filter_out_static_columns=True, filter_out_column_types=["counter"]
-            )
-            if not column:
-                raise UnsupportedNemesis("No column found to create index on")
-            try:
-                with (
-                    DbNodeLogger(
-                        self.cluster.nodes,
-                        "create index",
-                        target_node=self.target_node,
-                        additional_info=f"on {ks}.{cf}.{column}",
-                    ),
-                    self.action_log_scope(f"Create {ks}.{cf} {column} index"),
-                ):
-                    index_name = create_index(session, ks, cf, column)
-            except InvalidRequest as exc:
-                LOGGER.warning(exc)
-                raise UnsupportedNemesis("Tried to create already existing index. See log for details")
-            try:
-                with adaptive_timeout(
-                    operation=Operations.CREATE_INDEX, node=self.target_node, timeout=14400
-                ) as timeout:
-                    with self.action_log_scope("Wait for index to be built"):
-                        wait_for_index_to_be_built(self.target_node, ks, index_name, timeout=timeout * 2)
-                verify_query_by_index_works(session, ks, cf, column)
-                sleep_for_percent_of_duration(
-                    self.tester.test_duration * 60, percent=1, min_duration=300, max_duration=2400
-                )
-            finally:
-                with DbNodeLogger(
-                    self.cluster.nodes,
-                    "drop_index",
-                    target_node=self.target_node,
-                    additional_info=f"index: {index_name}",
-                ):
-                    self.actions_log.info(f"Drop {index_name} index")
-                    drop_index(session, ks, index_name)
-
-    def disrupt_add_remove_mv(self):
-        """
-        Create a Materialized view on an existing table while a node is down.
-        Take node up and run a repair.
-        Verify the MV can be used in a query.
-        Finally, drop the MV.
-        """
-
-        # Disable MV tests with tablets.
-        if is_tablets_feature_enabled(self.target_node):
-            if ComparableScyllaVersion(self.target_node.scylla_version) <= ComparableScyllaVersion("2025.3.99"):
-                raise UnsupportedNemesis("MV for tablets are not supported for Scylla 2025.3 and older versions")
-
-        free_nodes = [node for node in self.cluster.data_nodes if not node.running_nemesis]
-        if not free_nodes:
-            raise UnsupportedNemesis("Not enough free nodes for nemesis. Skipping.")
-        cql_query_executor_node = self.random.choice(free_nodes)
-        with self.node_allocator.nodes_running_nemesis(cql_query_executor_node, self.current_disruption):
-            ks_cfs = self.cluster.get_non_system_ks_cf_list(
-                db_node=cql_query_executor_node,
-                filter_empty_tables=True,
-                filter_out_mv=True,
-                filter_out_table_with_counter=True,
-            )
-            if not ks_cfs:
-                raise UnsupportedNemesis("Non-system keyspace and table are not found. nemesis can't be run")
-            ks_name, base_table_name = random.choice(ks_cfs).split(".")
-            view_name = f"{base_table_name}_view"
-            with suppress_expected_unavailability_errors():
-                self.target_node.stop_scylla()
-            with (
-                self.cluster.cql_connection_patient(node=cql_query_executor_node, connect_timeout=600) as session,
-                collect_diagnostics(MVDiagnosticCollector(session, exception_handler=EventExceptionHandler())),
-            ):
-                try:
-                    create_materialized_view_for_random_column(session, ks_name, base_table_name, view_name)
-                except Exception as error:
-                    self.log.warning("Failed creating a materialized view: %s", error)
-                    self.target_node.start_scylla()
-                    raise
-                try:
-                    self.log.info("Starting Scylla on node %s", self.target_node.name)
-                    self.actions_log.info(f"Start Scylla on {self.target_node.name} node")
-                    self.target_node.start_scylla()
-                    with self.action_log_scope(f"Run repair on {self.target_node.name} node"):
-                        self.target_node.run_nodetool(sub_cmd="repair -pr")
-                    with (
-                        adaptive_timeout(
-                            operation=Operations.CREATE_MV, node=self.target_node, timeout=14400
-                        ) as timeout,
-                        self.action_log_scope(
-                            f"Wait for {ks_name}.{view_name} materialized view to be built on "
-                            f"{self.target_node.name} node"
-                        ),
-                    ):
-                        wait_for_view_to_be_built(self.target_node, ks_name, view_name, timeout=timeout * 2)
-                    session.execute(SimpleStatement(f"SELECT * FROM {ks_name}.{view_name} limit 1", fetch_size=10))
-                    sleep_for_percent_of_duration(
-                        self.tester.test_duration * 60, percent=1, min_duration=300, max_duration=2400
-                    )
-                finally:
-                    with self.action_log_scope("Drop materialized view"):
-                        drop_materialized_view(session, ks_name, view_name)
-
     def disrupt_toggle_audit_syslog(self):
         self._disrupt_toggle_audit(store="syslog")
 
@@ -4781,91 +4640,6 @@ class NemesisRunner:
             assert self.target_node != new_coordinator_node, (
                 f"New coordinator node was not elected while old one {coordinator_node.name} was stopped"
             )
-
-    @decorate_with_context(suppress_expected_unavailability_errors)
-    def disrupt_kill_mv_building_coordinator(self):
-        """
-        MV building coordinator is responsible for building MV from base table in
-        keyspaces with tablets enabled and located on the same node as raft topology coordinator.
-        If mv building coordinator is died during the mv building process, new mv building coordinator
-        as (group0 leader and raft topology coordinator) should be elected and mv building process continue.
-
-        Nemesis kill mv building coordinator several times while materialized view is being built,
-        and validate that after the node is restarted, the view is successfully built.
-        """
-        if not self.target_node.raft.is_consistent_topology_changes_enabled:
-            raise UnsupportedNemesis("Consistent topology changes feature is disabled")
-
-        if not is_tablets_feature_enabled(self.target_node):
-            raise UnsupportedNemesis("MV building coordinator works only with tablets")
-
-        with self.cluster.cql_connection_patient(node=self.target_node, connect_timeout=600) as session:
-            if not is_views_with_tablets_enabled(session):
-                raise UnsupportedNemesis("MV building coordinator works only with tablets")
-            ks_cfs = self.cluster.get_non_system_ks_cf_with_tablets_list(
-                db_node=self.target_node,
-                filter_empty_tables=True,
-                filter_out_mv=True,
-                filter_out_table_with_counter=True,
-            )
-            if not ks_cfs:
-                raise UnsupportedNemesis(
-                    "Non-system keyspaces with enabled tablets are not found. nemesis can't be run"
-                )
-
-        coordinator_node = get_topology_coordinator_node(self.target_node)
-        try:
-            self.switch_target_node(coordinator_node)
-        except NemesisNodeAllocationError:
-            raise UnsupportedNemesis(f"Coordinator node is busy with {coordinator_node.running_nemesis}")
-
-        with (
-            self.node_allocator.run_nemesis(
-                node_list=self.cluster.nodes, nemesis_label="Verification node for MV"
-            ) as working_node,
-            self.cluster.cql_connection_patient(node=working_node, connect_timeout=600) as session,
-            collect_diagnostics(MVDiagnosticCollector(session, exception_handler=EventExceptionHandler())),
-        ):
-            ks_name, base_table_name = self.random.choice(ks_cfs).split(".")
-            view_name = f"{base_table_name}_view_{str(uuid4())[:8]}"
-            try:
-                create_materialized_view_for_random_column(session, ks_name, base_table_name, view_name)
-                wait_materialized_view_building_tasks_started(session, ks_name, view_name)
-            except ViewFinishedBuildingException:
-                drop_materialized_view(session, ks_name, view_name)
-                raise UnsupportedNemesis(
-                    f"Skip nemesis because view {ks_name}.{view_name} has already finished building"
-                )
-            except Exception as error:  # pylint: disable=broad-except
-                self.log.error("Failed creating a materialized view: %s", error)
-                raise
-            try:
-                num_of_restarts = len(self.cluster.nodes) // 2
-                self.log.debug("Number of serial restart of topology coordinator: %s", num_of_restarts)
-                for i in range(num_of_restarts):
-                    self.log.debug("Kill coordinator node: %s round: %s", self.target_node.name, i + 1)
-                    self._kill_scylla_daemon()
-                    coordinator_node = get_topology_coordinator_node(working_node)
-                    self.log.debug("New coordinator node %s", coordinator_node.name)
-                    try:
-                        self.switch_target_node(coordinator_node)
-                    except NemesisNodeAllocationError:
-                        self.log.debug(
-                            "Coordinator node is busy with %s, number of coordinator successful restarts: %s",
-                            coordinator_node.running_nemesis,
-                            i,
-                        )
-                        break
-
-                with adaptive_timeout(operation=Operations.CREATE_MV, node=working_node, timeout=14400) as timeout:
-                    wait_for_view_to_be_built(working_node, ks_name, view_name, timeout=timeout * 2)
-
-                result = list(
-                    session.execute(SimpleStatement(f"SELECT * FROM {ks_name}.{view_name} limit 1", fetch_size=10))
-                )
-                assert len(result) >= 1, f"MV {ks_name}.{view_name} was not built"
-            finally:
-                drop_materialized_view(session, ks_name, view_name)
 
     def disrupt_trigger_split_merge_tablets_with_alter(self):
         """

--- a/sdcm/nemesis/monkey/__init__.py
+++ b/sdcm/nemesis/monkey/__init__.py
@@ -678,28 +678,6 @@ class StartStopValidationCompaction(NemesisBaseClass):
         self.runner.disrupt_start_stop_validation_compaction()
 
 
-@target_data_nodes
-class CreateIndexNemesis(NemesisBaseClass):
-    disruptive = False
-    schema_changes = True
-    free_tier_set = True
-    supports_high_disk_utilization = False  # Creating an Index consumes disk space
-
-    def disrupt(self):
-        self.runner.disrupt_create_index()
-
-
-@target_data_nodes
-class AddRemoveMvNemesis(NemesisBaseClass):
-    disruptive = True
-    schema_changes = True
-    free_tier_set = True
-    supports_high_disk_utilization = False  # Creating an MV consumes disk space
-
-    def disrupt(self):
-        self.runner.disrupt_add_remove_mv()
-
-
 class ToggleAuditNemesisSyslog(NemesisBaseClass):
     disruptive = True
     schema_changes = True
@@ -764,16 +742,6 @@ class SerialRestartOfElectedTopologyCoordinatorNemesis(NemesisBaseClass):
 
     def disrupt(self):
         self.runner.disrupt_serial_restart_elected_topology_coordinator()
-
-
-@target_all_nodes
-class KillMVBuildingCoordinator(NemesisBaseClass):
-    disruptive = True
-    topology_changes = True
-    supports_high_disk_utilization = False  # Creating an MV consumes disk space
-
-    def disrupt(self):
-        self.runner.disrupt_kill_mv_building_coordinator()
 
 
 @target_all_nodes

--- a/sdcm/nemesis/monkey/views_indexes.py
+++ b/sdcm/nemesis/monkey/views_indexes.py
@@ -1,0 +1,287 @@
+"""
+Module containing materialized view (MV) and secondary index (SI) nemesis classes.
+
+Includes:
+- ``CreateIndexNemesis`` — create a secondary index on a random column, wait for
+  it to be built, verify it can be queried, then drop it.
+- ``AddRemoveMvNemesis`` — create a materialized view while a node is down, bring
+  the node back and repair, verify the MV, then drop it.
+- ``KillMVBuildingCoordinator`` — repeatedly kill the MV building coordinator
+  (raft topology coordinator) while a view is being built and verify the view is
+  still successfully built after re-election.
+"""
+
+import logging
+import random
+from uuid import uuid4
+
+from cassandra import InvalidRequest
+from cassandra.query import SimpleStatement
+
+from sdcm.exceptions import UnsupportedNemesis
+from sdcm.nemesis import NemesisBaseClass, target_data_nodes, target_all_nodes
+from sdcm.nemesis.utils.indexes import (
+    ViewFinishedBuildingException,
+    get_random_column_name,
+    create_index,
+    wait_for_index_to_be_built,
+    verify_query_by_index_works,
+    drop_index,
+    wait_for_view_to_be_built,
+    drop_materialized_view,
+    create_materialized_view_for_random_column,
+    wait_materialized_view_building_tasks_started,
+)
+from sdcm.nemesis.utils.node_allocator import NemesisNodeAllocationError
+from sdcm.sct_events.group_common_events import (
+    decorate_with_context,
+    suppress_expected_unavailability_errors,
+)
+from sdcm.utils.adaptive_timeouts import adaptive_timeout, Operations
+from sdcm.utils.common import sleep_for_percent_of_duration
+from sdcm.utils.context_managers import DbNodeLogger
+from sdcm.utils.diagnostic_collector.handlers import EventExceptionHandler
+from sdcm.utils.diagnostic_collector.manager import collect_diagnostics
+from sdcm.utils.diagnostic_collector.views import MVDiagnosticCollector
+from sdcm.utils.features import is_tablets_feature_enabled, is_views_with_tablets_enabled
+from sdcm.utils.issues import SkipPerIssues
+from sdcm.utils.raft.common import get_topology_coordinator_node
+from sdcm.utils.version_utils import ComparableScyllaVersion
+
+LOGGER = logging.getLogger(__name__)
+
+
+@target_data_nodes
+class CreateIndexNemesis(NemesisBaseClass):
+    disruptive = False
+    schema_changes = True
+    free_tier_set = True
+    supports_high_disk_utilization = False  # Creating an Index consumes disk space
+
+    def disrupt(self):
+        """
+        Create index on a random column (regular or static) of a table with the most number of partitions and wait until it gets build.
+        Then verify it can be used in a query. Finally, drop the index.
+        """
+        if self.runner.cluster.nemesis_count > 1 and SkipPerIssues(
+            issues="https://github.com/scylladb/scylladb/issues/21695", params=self.runner.tester.params
+        ):
+            raise UnsupportedNemesis("Skip create index nemesis with parallel nemesis run")
+
+        # Disable MV tests with tablets.
+        if is_tablets_feature_enabled(self.runner.target_node):
+            if ComparableScyllaVersion(self.runner.target_node.scylla_version) <= ComparableScyllaVersion("2025.3.99"):
+                raise UnsupportedNemesis("MV/SI for tablets are not supported for Scylla 2025.3 and older versions")
+
+        with (
+            self.runner.cluster.cql_connection_patient(self.runner.target_node, connect_timeout=300) as session,
+            collect_diagnostics(MVDiagnosticCollector(session, exception_handler=EventExceptionHandler())),
+        ):
+            ks_cf_list = self.runner.cluster.get_non_system_ks_cf_list(self.runner.target_node, filter_out_mv=True)
+            if not ks_cf_list:
+                raise UnsupportedNemesis("No table found to create index on")
+            ks, cf = self.runner.random.choice(ks_cf_list).split(".")
+            column = get_random_column_name(
+                session, ks, cf, filter_out_static_columns=True, filter_out_column_types=["counter"]
+            )
+            if not column:
+                raise UnsupportedNemesis("No column found to create index on")
+            try:
+                with (
+                    DbNodeLogger(
+                        self.runner.cluster.nodes,
+                        "create index",
+                        target_node=self.runner.target_node,
+                        additional_info=f"on {ks}.{cf}.{column}",
+                    ),
+                    self.runner.action_log_scope(f"Create {ks}.{cf} {column} index"),
+                ):
+                    index_name = create_index(session, ks, cf, column)
+            except InvalidRequest as exc:
+                LOGGER.warning(exc)
+                raise UnsupportedNemesis("Tried to create already existing index. See log for details")
+            try:
+                with adaptive_timeout(
+                    operation=Operations.CREATE_INDEX, node=self.runner.target_node, timeout=14400
+                ) as timeout:
+                    with self.runner.action_log_scope("Wait for index to be built"):
+                        wait_for_index_to_be_built(self.runner.target_node, ks, index_name, timeout=timeout * 2)
+                verify_query_by_index_works(session, ks, cf, column)
+                sleep_for_percent_of_duration(
+                    self.runner.tester.test_duration * 60, percent=1, min_duration=300, max_duration=2400
+                )
+            finally:
+                with DbNodeLogger(
+                    self.runner.cluster.nodes,
+                    "drop_index",
+                    target_node=self.runner.target_node,
+                    additional_info=f"index: {index_name}",
+                ):
+                    self.runner.actions_log.info(f"Drop {index_name} index")
+                    drop_index(session, ks, index_name)
+
+
+@target_data_nodes
+class AddRemoveMvNemesis(NemesisBaseClass):
+    disruptive = True
+    schema_changes = True
+    free_tier_set = True
+    supports_high_disk_utilization = False  # Creating an MV consumes disk space
+
+    def disrupt(self):
+        """
+        Create a Materialized view on an existing table while a node is down.
+        Take node up and run a repair.
+        Verify the MV can be used in a query.
+        Finally, drop the MV.
+        """
+
+        # Disable MV tests with tablets.
+        if is_tablets_feature_enabled(self.runner.target_node):
+            if ComparableScyllaVersion(self.runner.target_node.scylla_version) <= ComparableScyllaVersion("2025.3.99"):
+                raise UnsupportedNemesis("MV for tablets are not supported for Scylla 2025.3 and older versions")
+
+        free_nodes = [node for node in self.runner.cluster.data_nodes if not node.running_nemesis]
+        if not free_nodes:
+            raise UnsupportedNemesis("Not enough free nodes for nemesis. Skipping.")
+        cql_query_executor_node = self.runner.random.choice(free_nodes)
+        with self.runner.node_allocator.nodes_running_nemesis(cql_query_executor_node, self.runner.current_disruption):
+            ks_cfs = self.runner.cluster.get_non_system_ks_cf_list(
+                db_node=cql_query_executor_node,
+                filter_empty_tables=True,
+                filter_out_mv=True,
+                filter_out_table_with_counter=True,
+            )
+            if not ks_cfs:
+                raise UnsupportedNemesis("Non-system keyspace and table are not found. nemesis can't be run")
+            ks_name, base_table_name = random.choice(ks_cfs).split(".")
+            view_name = f"{base_table_name}_view"
+            with suppress_expected_unavailability_errors():
+                self.runner.target_node.stop_scylla()
+            with (
+                self.runner.cluster.cql_connection_patient(
+                    node=cql_query_executor_node, connect_timeout=600
+                ) as session,
+                collect_diagnostics(MVDiagnosticCollector(session, exception_handler=EventExceptionHandler())),
+            ):
+                try:
+                    create_materialized_view_for_random_column(session, ks_name, base_table_name, view_name)
+                except Exception as error:
+                    self.runner.log.warning("Failed creating a materialized view: %s", error)
+                    self.runner.target_node.start_scylla()
+                    raise
+                try:
+                    self.runner.log.info("Starting Scylla on node %s", self.runner.target_node.name)
+                    self.runner.actions_log.info(f"Start Scylla on {self.runner.target_node.name} node")
+                    self.runner.target_node.start_scylla()
+                    with self.runner.action_log_scope(f"Run repair on {self.runner.target_node.name} node"):
+                        self.runner.target_node.run_nodetool(sub_cmd="repair -pr")
+                    with (
+                        adaptive_timeout(
+                            operation=Operations.CREATE_MV, node=self.runner.target_node, timeout=14400
+                        ) as timeout,
+                        self.runner.action_log_scope(
+                            f"Wait for {ks_name}.{view_name} materialized view to be built on "
+                            f"{self.runner.target_node.name} node"
+                        ),
+                    ):
+                        wait_for_view_to_be_built(self.runner.target_node, ks_name, view_name, timeout=timeout * 2)
+                    session.execute(SimpleStatement(f"SELECT * FROM {ks_name}.{view_name} limit 1", fetch_size=10))
+                    sleep_for_percent_of_duration(
+                        self.runner.tester.test_duration * 60, percent=1, min_duration=300, max_duration=2400
+                    )
+                finally:
+                    with self.runner.action_log_scope("Drop materialized view"):
+                        drop_materialized_view(session, ks_name, view_name)
+
+
+@target_all_nodes
+class KillMVBuildingCoordinator(NemesisBaseClass):
+    disruptive = True
+    topology_changes = True
+    supports_high_disk_utilization = False  # Creating an MV consumes disk space
+
+    @decorate_with_context(suppress_expected_unavailability_errors)
+    def disrupt(self):
+        """
+        MV building coordinator is responsible for building MV from base table in
+        keyspaces with tablets enabled and located on the same node as raft topology coordinator.
+        If mv building coordinator is died during the mv building process, new mv building coordinator
+        as (group0 leader and raft topology coordinator) should be elected and mv building process continue.
+
+        Nemesis kill mv building coordinator several times while materialized view is being built,
+        and validate that after the node is restarted, the view is successfully built.
+        """
+        if not self.runner.target_node.raft.is_consistent_topology_changes_enabled:
+            raise UnsupportedNemesis("Consistent topology changes feature is disabled")
+
+        if not is_tablets_feature_enabled(self.runner.target_node):
+            raise UnsupportedNemesis("MV building coordinator works only with tablets")
+
+        with self.runner.cluster.cql_connection_patient(node=self.runner.target_node, connect_timeout=600) as session:
+            if not is_views_with_tablets_enabled(session):
+                raise UnsupportedNemesis("MV building coordinator works only with tablets")
+            ks_cfs = self.runner.cluster.get_non_system_ks_cf_with_tablets_list(
+                db_node=self.runner.target_node,
+                filter_empty_tables=True,
+                filter_out_mv=True,
+                filter_out_table_with_counter=True,
+            )
+            if not ks_cfs:
+                raise UnsupportedNemesis(
+                    "Non-system keyspaces with enabled tablets are not found. nemesis can't be run"
+                )
+
+        coordinator_node = get_topology_coordinator_node(self.runner.target_node)
+        try:
+            self.runner.switch_target_node(coordinator_node)
+        except NemesisNodeAllocationError:
+            raise UnsupportedNemesis(f"Coordinator node is busy with {coordinator_node.running_nemesis}")
+
+        with (
+            self.runner.node_allocator.run_nemesis(
+                node_list=self.runner.cluster.nodes, nemesis_label="Verification node for MV"
+            ) as working_node,
+            self.runner.cluster.cql_connection_patient(node=working_node, connect_timeout=600) as session,
+            collect_diagnostics(MVDiagnosticCollector(session, exception_handler=EventExceptionHandler())),
+        ):
+            ks_name, base_table_name = self.runner.random.choice(ks_cfs).split(".")
+            view_name = f"{base_table_name}_view_{str(uuid4())[:8]}"
+            try:
+                create_materialized_view_for_random_column(session, ks_name, base_table_name, view_name)
+                wait_materialized_view_building_tasks_started(session, ks_name, view_name)
+            except ViewFinishedBuildingException:
+                drop_materialized_view(session, ks_name, view_name)
+                raise UnsupportedNemesis(
+                    f"Skip nemesis because view {ks_name}.{view_name} has already finished building"
+                )
+            except Exception as error:  # pylint: disable=broad-except
+                self.runner.log.error("Failed creating a materialized view: %s", error)
+                raise
+            try:
+                num_of_restarts = len(self.runner.cluster.nodes) // 2
+                self.runner.log.debug("Number of serial restart of topology coordinator: %s", num_of_restarts)
+                for i in range(num_of_restarts):
+                    self.runner.log.debug("Kill coordinator node: %s round: %s", self.runner.target_node.name, i + 1)
+                    self.runner._kill_scylla_daemon()
+                    coordinator_node = get_topology_coordinator_node(working_node)
+                    self.runner.log.debug("New coordinator node %s", coordinator_node.name)
+                    try:
+                        self.runner.switch_target_node(coordinator_node)
+                    except NemesisNodeAllocationError:
+                        self.runner.log.debug(
+                            "Coordinator node is busy with %s, number of coordinator successful restarts: %s",
+                            coordinator_node.running_nemesis,
+                            i,
+                        )
+                        break
+
+                with adaptive_timeout(operation=Operations.CREATE_MV, node=working_node, timeout=14400) as timeout:
+                    wait_for_view_to_be_built(working_node, ks_name, view_name, timeout=timeout * 2)
+
+                result = list(
+                    session.execute(SimpleStatement(f"SELECT * FROM {ks_name}.{view_name} limit 1", fetch_size=10))
+                )
+                assert len(result) >= 1, f"MV {ks_name}.{view_name} was not built"
+            finally:
+                drop_materialized_view(session, ks_name, view_name)

--- a/sdcm/nemesis/monkey/views_indexes.py
+++ b/sdcm/nemesis/monkey/views_indexes.py
@@ -12,7 +12,6 @@ Includes:
 """
 
 import logging
-import random
 from uuid import uuid4
 
 from cassandra import InvalidRequest
@@ -154,45 +153,51 @@ class AddRemoveMvNemesis(NemesisBaseClass):
             )
             if not ks_cfs:
                 raise UnsupportedNemesis("Non-system keyspace and table are not found. nemesis can't be run")
-            ks_name, base_table_name = random.choice(ks_cfs).split(".")
+            ks_name, base_table_name = self.runner.random.choice(ks_cfs).split(".")
             view_name = f"{base_table_name}_view"
             with suppress_expected_unavailability_errors():
                 self.runner.target_node.stop_scylla()
-            with (
-                self.runner.cluster.cql_connection_patient(
-                    node=cql_query_executor_node, connect_timeout=600
-                ) as session,
-                collect_diagnostics(MVDiagnosticCollector(session, exception_handler=EventExceptionHandler())),
-            ):
-                try:
-                    create_materialized_view_for_random_column(session, ks_name, base_table_name, view_name)
-                except Exception as error:
-                    self.runner.log.warning("Failed creating a materialized view: %s", error)
-                    self.runner.target_node.start_scylla()
-                    raise
-                try:
-                    self.runner.log.info("Starting Scylla on node %s", self.runner.target_node.name)
-                    self.runner.actions_log.info(f"Start Scylla on {self.runner.target_node.name} node")
-                    self.runner.target_node.start_scylla()
-                    with self.runner.action_log_scope(f"Run repair on {self.runner.target_node.name} node"):
-                        self.runner.target_node.run_nodetool(sub_cmd="repair -pr")
-                    with (
-                        adaptive_timeout(
-                            operation=Operations.CREATE_MV, node=self.runner.target_node, timeout=14400
-                        ) as timeout,
-                        self.runner.action_log_scope(
-                            f"Wait for {ks_name}.{view_name} materialized view to be built on "
-                            f"{self.runner.target_node.name} node"
-                        ),
-                    ):
-                        wait_for_view_to_be_built(self.runner.target_node, ks_name, view_name, timeout=timeout * 2)
-                    session.execute(SimpleStatement(f"SELECT * FROM {ks_name}.{view_name} limit 1", fetch_size=10))
-                    sleep_for_percent_of_duration(
-                        self.runner.tester.test_duration * 60, percent=1, min_duration=300, max_duration=2400
-                    )
-                finally:
-                    with self.runner.action_log_scope("Drop materialized view"):
-                        drop_materialized_view(session, ks_name, view_name)
+            try:
+                with (
+                    self.runner.cluster.cql_connection_patient(
+                        node=cql_query_executor_node, connect_timeout=600
+                    ) as session,
+                    collect_diagnostics(MVDiagnosticCollector(session, exception_handler=EventExceptionHandler())),
+                ):
+                    try:
+                        create_materialized_view_for_random_column(session, ks_name, base_table_name, view_name)
+                    except Exception as error:
+                        self.runner.log.warning("Failed creating a materialized view: %s", error)
+                        raise
+                    try:
+                        self.runner.log.info("Starting Scylla on node %s", self.runner.target_node.name)
+                        self.runner.actions_log.info(f"Start Scylla on {self.runner.target_node.name} node")
+                        self.runner.target_node.start_scylla()
+                        with self.runner.action_log_scope(f"Run repair on {self.runner.target_node.name} node"):
+                            self.runner.target_node.run_nodetool(sub_cmd="repair -pr")
+                        with (
+                            adaptive_timeout(
+                                operation=Operations.CREATE_MV, node=self.runner.target_node, timeout=14400
+                            ) as timeout,
+                            self.runner.action_log_scope(
+                                f"Wait for {ks_name}.{view_name} materialized view to be built on "
+                                f"{self.runner.target_node.name} node"
+                            ),
+                        ):
+                            wait_for_view_to_be_built(self.runner.target_node, ks_name, view_name, timeout=timeout * 2)
+                        session.execute(SimpleStatement(f"SELECT * FROM {ks_name}.{view_name} limit 1", fetch_size=10))
+                        sleep_for_percent_of_duration(
+                            self.runner.tester.test_duration * 60, percent=1, min_duration=300, max_duration=2400
+                        )
+                    finally:
+                        with self.runner.action_log_scope("Drop materialized view"):
+                            drop_materialized_view(session, ks_name, view_name)
+            except Exception:
+                # Covers both a failed cql_connection_patient (node never restarted otherwise) and
+                # any failure surfaced from inside the session block (start_scylla is a no-op if
+                # the node is already up).
+                self.runner.target_node.start_scylla()
+                raise
 
 
 @target_all_nodes

--- a/sdcm/nemesis/monkey/views_indexes.py
+++ b/sdcm/nemesis/monkey/views_indexes.py
@@ -198,6 +198,7 @@ class AddRemoveMvNemesis(NemesisBaseClass):
 @target_all_nodes
 class KillMVBuildingCoordinator(NemesisBaseClass):
     disruptive = True
+    schema_changes = True
     topology_changes = True
     supports_high_disk_utilization = False  # Creating an MV consumes disk space
 

--- a/sdcm/nemesis/monkey/views_indexes.py
+++ b/sdcm/nemesis/monkey/views_indexes.py
@@ -57,21 +57,24 @@ class CreateIndexNemesis(NemesisBaseClass):
     free_tier_set = True
     supports_high_disk_utilization = False  # Creating an Index consumes disk space
 
+    def precheck(self, node) -> str | None:
+        if self.runner.cluster.nemesis_count > 1 and SkipPerIssues(
+            issues="https://github.com/scylladb/scylladb/issues/21695", params=self.runner.tester.params
+        ):
+            return "Skip create index nemesis with parallel nemesis run"
+
+        # Disable MV tests with tablets.
+        if is_tablets_feature_enabled(node):
+            if ComparableScyllaVersion(node.scylla_version) <= ComparableScyllaVersion("2025.3.99"):
+                return "MV/SI for tablets are not supported for Scylla 2025.3 and older versions"
+
+        return None
+
     def disrupt(self):
         """
         Create index on a random column (regular or static) of a table with the most number of partitions and wait until it gets build.
         Then verify it can be used in a query. Finally, drop the index.
         """
-        if self.runner.cluster.nemesis_count > 1 and SkipPerIssues(
-            issues="https://github.com/scylladb/scylladb/issues/21695", params=self.runner.tester.params
-        ):
-            raise UnsupportedNemesis("Skip create index nemesis with parallel nemesis run")
-
-        # Disable MV tests with tablets.
-        if is_tablets_feature_enabled(self.runner.target_node):
-            if ComparableScyllaVersion(self.runner.target_node.scylla_version) <= ComparableScyllaVersion("2025.3.99"):
-                raise UnsupportedNemesis("MV/SI for tablets are not supported for Scylla 2025.3 and older versions")
-
         with (
             self.runner.cluster.cql_connection_patient(self.runner.target_node, connect_timeout=300) as session,
             collect_diagnostics(MVDiagnosticCollector(session, exception_handler=EventExceptionHandler())),
@@ -127,6 +130,14 @@ class AddRemoveMvNemesis(NemesisBaseClass):
     free_tier_set = True
     supports_high_disk_utilization = False  # Creating an MV consumes disk space
 
+    def precheck(self, node) -> str | None:
+        # Disable MV tests with tablets.
+        if is_tablets_feature_enabled(node):
+            if ComparableScyllaVersion(node.scylla_version) <= ComparableScyllaVersion("2025.3.99"):
+                return "MV for tablets are not supported for Scylla 2025.3 and older versions"
+
+        return None
+
     def disrupt(self):
         """
         Create a Materialized view on an existing table while a node is down.
@@ -134,12 +145,6 @@ class AddRemoveMvNemesis(NemesisBaseClass):
         Verify the MV can be used in a query.
         Finally, drop the MV.
         """
-
-        # Disable MV tests with tablets.
-        if is_tablets_feature_enabled(self.runner.target_node):
-            if ComparableScyllaVersion(self.runner.target_node.scylla_version) <= ComparableScyllaVersion("2025.3.99"):
-                raise UnsupportedNemesis("MV for tablets are not supported for Scylla 2025.3 and older versions")
-
         free_nodes = [node for node in self.runner.cluster.data_nodes if not node.running_nemesis]
         if not free_nodes:
             raise UnsupportedNemesis("Not enough free nodes for nemesis. Skipping.")
@@ -207,6 +212,19 @@ class KillMVBuildingCoordinator(NemesisBaseClass):
     topology_changes = True
     supports_high_disk_utilization = False  # Creating an MV consumes disk space
 
+    def precheck(self, node) -> str | None:
+        if not node.raft.is_consistent_topology_changes_enabled:
+            return "Consistent topology changes feature is disabled"
+
+        if not is_tablets_feature_enabled(node):
+            return "MV building coordinator works only with tablets"
+
+        with self.runner.cluster.cql_connection_patient(node=node, connect_timeout=600) as session:
+            if not is_views_with_tablets_enabled(session):
+                return "MV building coordinator works only with tablets"
+
+        return None
+
     @decorate_with_context(suppress_expected_unavailability_errors)
     def disrupt(self):
         """
@@ -218,25 +236,14 @@ class KillMVBuildingCoordinator(NemesisBaseClass):
         Nemesis kill mv building coordinator several times while materialized view is being built,
         and validate that after the node is restarted, the view is successfully built.
         """
-        if not self.runner.target_node.raft.is_consistent_topology_changes_enabled:
-            raise UnsupportedNemesis("Consistent topology changes feature is disabled")
-
-        if not is_tablets_feature_enabled(self.runner.target_node):
-            raise UnsupportedNemesis("MV building coordinator works only with tablets")
-
-        with self.runner.cluster.cql_connection_patient(node=self.runner.target_node, connect_timeout=600) as session:
-            if not is_views_with_tablets_enabled(session):
-                raise UnsupportedNemesis("MV building coordinator works only with tablets")
-            ks_cfs = self.runner.cluster.get_non_system_ks_cf_with_tablets_list(
-                db_node=self.runner.target_node,
-                filter_empty_tables=True,
-                filter_out_mv=True,
-                filter_out_table_with_counter=True,
-            )
-            if not ks_cfs:
-                raise UnsupportedNemesis(
-                    "Non-system keyspaces with enabled tablets are not found. nemesis can't be run"
-                )
+        ks_cfs = self.runner.cluster.get_non_system_ks_cf_with_tablets_list(
+            db_node=self.runner.target_node,
+            filter_empty_tables=True,
+            filter_out_mv=True,
+            filter_out_table_with_counter=True,
+        )
+        if not ks_cfs:
+            raise UnsupportedNemesis("Non-system keyspaces with enabled tablets are not found. nemesis can't be run")
 
         coordinator_node = get_topology_coordinator_node(self.runner.target_node)
         try:

--- a/unit_tests/unit/nemesis/monkey/test_views_indexes.py
+++ b/unit_tests/unit/nemesis/monkey/test_views_indexes.py
@@ -1,0 +1,296 @@
+"""Tests for sdcm.nemesis.monkey.views_indexes module.
+
+Covers the three MV/SI nemesis extracted in Phase 9: guard clauses that raise
+UnsupportedNemesis, the happy-path flow (create → build → verify → drop) with
+mocked cluster objects, and registry discovery / target-pool resolution.
+"""
+
+from contextlib import nullcontext
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import sdcm.nemesis
+from sdcm.exceptions import UnsupportedNemesis
+from sdcm.nemesis.monkey.views_indexes import (
+    AddRemoveMvNemesis,
+    CreateIndexNemesis,
+    KillMVBuildingCoordinator,
+)
+from sdcm.nemesis.utils import NEMESIS_TARGET_POOLS
+
+_MODULE = "sdcm.nemesis.monkey.views_indexes"
+
+pytestmark = pytest.mark.usefixtures("events")
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def runner(base_runner):
+    """``base_runner`` with attributes the MV/SI nemesis expect."""
+    base_runner.cluster.nemesis_count = 1
+    base_runner.cluster.get_non_system_ks_cf_list.return_value = ["ks1.tbl1"]
+    base_runner.node_allocator = MagicMock()
+    base_runner.current_disruption = "disruption-1"
+    return base_runner
+
+
+# ---------------------------------------------------------------------------
+# CreateIndexNemesis
+# ---------------------------------------------------------------------------
+
+
+def test_create_index_skips_on_parallel_nemesis(runner):
+    """Parallel nemesis run + open issue -> UnsupportedNemesis."""
+    runner.cluster.nemesis_count = 2
+    with patch(f"{_MODULE}.SkipPerIssues", return_value=True):
+        monkey = CreateIndexNemesis(runner)
+        with pytest.raises(UnsupportedNemesis, match="parallel nemesis run"):
+            monkey.disrupt()
+
+
+def test_create_index_raises_when_no_tables(runner):
+    """No non-system table -> UnsupportedNemesis."""
+    runner.cluster.get_non_system_ks_cf_list.return_value = []
+    with patch(f"{_MODULE}.is_tablets_feature_enabled", return_value=False):
+        monkey = CreateIndexNemesis(runner)
+        with pytest.raises(UnsupportedNemesis, match="No table found to create index"):
+            monkey.disrupt()
+
+
+def test_create_index_raises_when_no_column(runner):
+    """No suitable column -> UnsupportedNemesis."""
+    with (
+        patch(f"{_MODULE}.is_tablets_feature_enabled", return_value=False),
+        patch(f"{_MODULE}.get_random_column_name", return_value=None),
+    ):
+        monkey = CreateIndexNemesis(runner)
+        with pytest.raises(UnsupportedNemesis, match="No column found to create index"):
+            monkey.disrupt()
+
+
+def test_create_index_happy_path_creates_and_drops(runner):
+    """Full flow builds the index, verifies the query, and always drops it."""
+    with (
+        patch(f"{_MODULE}.is_tablets_feature_enabled", return_value=False),
+        patch(f"{_MODULE}.get_random_column_name", return_value="col1"),
+        patch(f"{_MODULE}.DbNodeLogger"),
+        patch(f"{_MODULE}.adaptive_timeout") as mock_timeout,
+        patch(f"{_MODULE}.create_index", return_value="idx1") as mock_create,
+        patch(f"{_MODULE}.wait_for_index_to_be_built") as mock_wait,
+        patch(f"{_MODULE}.verify_query_by_index_works") as mock_verify,
+        patch(f"{_MODULE}.sleep_for_percent_of_duration"),
+        patch(f"{_MODULE}.drop_index") as mock_drop,
+    ):
+        mock_timeout.return_value.__enter__.return_value = 100
+        monkey = CreateIndexNemesis(runner)
+        monkey.disrupt()
+
+    mock_create.assert_called_once()
+    mock_wait.assert_called_once()
+    mock_verify.assert_called_once()
+    mock_drop.assert_called_once()
+    assert mock_drop.call_args[0][2] == "idx1"
+
+
+def test_create_index_drops_index_even_when_verify_fails(runner):
+    """If verification raises, the index is still dropped (finally block)."""
+    with (
+        patch(f"{_MODULE}.is_tablets_feature_enabled", return_value=False),
+        patch(f"{_MODULE}.get_random_column_name", return_value="col1"),
+        patch(f"{_MODULE}.DbNodeLogger"),
+        patch(f"{_MODULE}.adaptive_timeout") as mock_timeout,
+        patch(f"{_MODULE}.create_index", return_value="idx1"),
+        patch(f"{_MODULE}.wait_for_index_to_be_built", side_effect=RuntimeError("boom")),
+        patch(f"{_MODULE}.drop_index") as mock_drop,
+    ):
+        mock_timeout.return_value.__enter__.return_value = 100
+        monkey = CreateIndexNemesis(runner)
+        with pytest.raises(RuntimeError, match="boom"):
+            monkey.disrupt()
+
+    mock_drop.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# AddRemoveMvNemesis
+# ---------------------------------------------------------------------------
+
+
+def test_add_remove_mv_raises_when_no_free_nodes(runner):
+    """All data nodes busy -> UnsupportedNemesis."""
+    # base_runner mock nodes have a truthy ``running_nemesis`` by default.
+    with patch(f"{_MODULE}.is_tablets_feature_enabled", return_value=False):
+        monkey = AddRemoveMvNemesis(runner)
+        with pytest.raises(UnsupportedNemesis, match="Not enough free nodes"):
+            monkey.disrupt()
+
+
+def test_add_remove_mv_raises_when_no_tables(runner):
+    """Free node available but no eligible table -> UnsupportedNemesis."""
+    for node in runner.cluster.data_nodes:
+        node.running_nemesis = None
+    runner.cluster.get_non_system_ks_cf_list.return_value = []
+    with (
+        patch(f"{_MODULE}.is_tablets_feature_enabled", return_value=False),
+        patch(f"{_MODULE}.suppress_expected_unavailability_errors", return_value=nullcontext()),
+    ):
+        monkey = AddRemoveMvNemesis(runner)
+        with pytest.raises(UnsupportedNemesis, match="Non-system keyspace and table"):
+            monkey.disrupt()
+
+
+def test_add_remove_mv_happy_path(runner):
+    """Node is stopped, MV created & built, then dropped and scylla restarted."""
+    for node in runner.cluster.data_nodes:
+        node.running_nemesis = None
+    with (
+        patch(f"{_MODULE}.is_tablets_feature_enabled", return_value=False),
+        patch(f"{_MODULE}.suppress_expected_unavailability_errors", return_value=nullcontext()),
+        patch(f"{_MODULE}.create_materialized_view_for_random_column") as mock_create,
+        patch(f"{_MODULE}.adaptive_timeout") as mock_timeout,
+        patch(f"{_MODULE}.wait_for_view_to_be_built") as mock_wait,
+        patch(f"{_MODULE}.sleep_for_percent_of_duration"),
+        patch(f"{_MODULE}.drop_materialized_view") as mock_drop,
+    ):
+        mock_timeout.return_value.__enter__.return_value = 100
+        monkey = AddRemoveMvNemesis(runner)
+        monkey.disrupt()
+
+    runner.target_node.stop_scylla.assert_called_once()
+    runner.target_node.start_scylla.assert_called_once()
+    mock_create.assert_called_once()
+    mock_wait.assert_called_once()
+    mock_drop.assert_called_once()
+
+
+def test_add_remove_mv_restarts_scylla_when_create_fails(runner):
+    """If MV creation fails, scylla is restarted and the error re-raised."""
+    for node in runner.cluster.data_nodes:
+        node.running_nemesis = None
+    with (
+        patch(f"{_MODULE}.is_tablets_feature_enabled", return_value=False),
+        patch(f"{_MODULE}.suppress_expected_unavailability_errors", return_value=nullcontext()),
+        patch(
+            f"{_MODULE}.create_materialized_view_for_random_column",
+            side_effect=RuntimeError("mv boom"),
+        ),
+    ):
+        monkey = AddRemoveMvNemesis(runner)
+        with pytest.raises(RuntimeError, match="mv boom"):
+            monkey.disrupt()
+
+    runner.target_node.stop_scylla.assert_called_once()
+    runner.target_node.start_scylla.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# KillMVBuildingCoordinator
+# ---------------------------------------------------------------------------
+
+
+def test_kill_mv_coordinator_raises_without_consistent_topology(runner):
+    """Consistent topology changes disabled -> UnsupportedNemesis."""
+    runner.target_node.raft.is_consistent_topology_changes_enabled = False
+    monkey = KillMVBuildingCoordinator(runner)
+    with pytest.raises(UnsupportedNemesis, match="Consistent topology changes"):
+        monkey.disrupt()
+
+
+def test_kill_mv_coordinator_raises_without_tablets(runner):
+    """Tablets feature disabled -> UnsupportedNemesis."""
+    runner.target_node.raft.is_consistent_topology_changes_enabled = True
+    with patch(f"{_MODULE}.is_tablets_feature_enabled", return_value=False):
+        monkey = KillMVBuildingCoordinator(runner)
+        with pytest.raises(UnsupportedNemesis, match="works only with tablets"):
+            monkey.disrupt()
+
+
+@pytest.fixture()
+def kill_runner(runner):
+    """``runner`` wired for the full KillMVBuildingCoordinator orchestration.
+
+    Feature guards pass, a single tablet keyspace/table is available, and the
+    verification session returns a non-empty SELECT so the built-view assertion
+    succeeds. ``cluster.nodes`` has two entries -> one coordinator restart.
+    """
+    runner.target_node.raft.is_consistent_topology_changes_enabled = True
+    runner.cluster.nodes = [MagicMock(name="n1"), MagicMock(name="n2")]
+    runner.cluster.get_non_system_ks_cf_with_tablets_list.return_value = ["ks1.tbl1"]
+    runner._kill_scylla_daemon = MagicMock()
+    runner.switch_target_node = MagicMock()
+    # Verification SELECT must yield at least one row for the built-view assertion.
+    session = MagicMock()
+    session.execute.return_value = [MagicMock()]
+    runner.cluster.cql_connection_patient.return_value.__enter__.return_value = session
+    return runner
+
+
+def test_kill_mv_coordinator_happy_path(kill_runner):
+    """Full orchestration: coordinator switch/restart loop, successful build and
+    query, and MV cleanup in the finally block."""
+    coordinator = MagicMock(name="coordinator")
+    with (
+        patch(f"{_MODULE}.is_tablets_feature_enabled", return_value=True),
+        patch(f"{_MODULE}.is_views_with_tablets_enabled", return_value=True),
+        patch(f"{_MODULE}.get_topology_coordinator_node", return_value=coordinator),
+        patch(f"{_MODULE}.create_materialized_view_for_random_column") as mock_create,
+        patch(f"{_MODULE}.wait_materialized_view_building_tasks_started"),
+        patch(f"{_MODULE}.adaptive_timeout") as mock_timeout,
+        patch(f"{_MODULE}.wait_for_view_to_be_built") as mock_wait,
+        patch(f"{_MODULE}.drop_materialized_view") as mock_drop,
+    ):
+        mock_timeout.return_value.__enter__.return_value = 100
+        monkey = KillMVBuildingCoordinator(kill_runner)
+        monkey.disrupt()
+
+    mock_create.assert_called_once()
+    mock_wait.assert_called_once()
+    mock_drop.assert_called_once()
+    # runner delegation: coordinator is targeted and killed once (len(nodes) // 2 == 1).
+    kill_runner.switch_target_node.assert_called_with(coordinator)
+    kill_runner._kill_scylla_daemon.assert_called_once()
+
+
+def test_kill_mv_coordinator_drops_view_when_build_fails(kill_runner):
+    """If the view never finishes building, the MV is still dropped (finally)."""
+    coordinator = MagicMock(name="coordinator")
+    with (
+        patch(f"{_MODULE}.is_tablets_feature_enabled", return_value=True),
+        patch(f"{_MODULE}.is_views_with_tablets_enabled", return_value=True),
+        patch(f"{_MODULE}.get_topology_coordinator_node", return_value=coordinator),
+        patch(f"{_MODULE}.create_materialized_view_for_random_column"),
+        patch(f"{_MODULE}.wait_materialized_view_building_tasks_started"),
+        patch(f"{_MODULE}.adaptive_timeout") as mock_timeout,
+        patch(f"{_MODULE}.wait_for_view_to_be_built", side_effect=RuntimeError("not built")),
+        patch(f"{_MODULE}.drop_materialized_view") as mock_drop,
+    ):
+        mock_timeout.return_value.__enter__.return_value = 100
+        monkey = KillMVBuildingCoordinator(kill_runner)
+        with pytest.raises(RuntimeError, match="not built"):
+            monkey.disrupt()
+
+    mock_drop.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Registry discovery / target pools
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "monkey_cls, expected_pool",
+    [
+        (CreateIndexNemesis, NEMESIS_TARGET_POOLS.data_nodes),
+        (AddRemoveMvNemesis, NEMESIS_TARGET_POOLS.data_nodes),
+        (KillMVBuildingCoordinator, NEMESIS_TARGET_POOLS.all_nodes),
+    ],
+)
+def test_monkey_discovered_with_expected_target_pool(monkey_cls, expected_pool):
+    """Auto-discovery registers each monkey and preserves its target pool."""
+    assert monkey_cls.__name__ in sdcm.nemesis.__all__
+    assert monkey_cls.target_pool == expected_pool

--- a/unit_tests/unit/nemesis/monkey/test_views_indexes.py
+++ b/unit_tests/unit/nemesis/monkey/test_views_indexes.py
@@ -1,8 +1,9 @@
 """Tests for sdcm.nemesis.monkey.views_indexes module.
 
-Covers the three MV/SI nemesis extracted in Phase 9: guard clauses that raise
-UnsupportedNemesis, the happy-path flow (create → build → verify → drop) with
-mocked cluster objects, and registry discovery / target-pool resolution.
+Covers the three MV/SI nemesis extracted in Phase 9: static precheck() skip
+conditions, dynamic guard clauses that raise UnsupportedNemesis from disrupt(),
+the happy-path flow (create → build → verify → drop) with mocked cluster
+objects, and registry discovery / target-pool resolution.
 """
 
 from contextlib import nullcontext
@@ -44,30 +45,40 @@ def runner(base_runner):
 # ---------------------------------------------------------------------------
 
 
-def test_create_index_skips_on_parallel_nemesis(runner):
-    """Parallel nemesis run + open issue -> UnsupportedNemesis."""
+def test_create_index_precheck_skips_on_parallel_nemesis(runner):
+    """Parallel nemesis run + open issue -> skip reason returned."""
     runner.cluster.nemesis_count = 2
     with patch(f"{_MODULE}.SkipPerIssues", return_value=True):
         monkey = CreateIndexNemesis(runner)
-        with pytest.raises(UnsupportedNemesis, match="parallel nemesis run"):
-            monkey.disrupt()
+        assert "parallel nemesis run" in monkey.precheck(runner.target_node)
+
+
+def test_create_index_precheck_skips_on_old_version_with_tablets(runner):
+    """Tablets enabled + Scylla version <= 2025.3.99 -> skip reason returned."""
+    runner.target_node.scylla_version = "2025.3.0"
+    with patch(f"{_MODULE}.is_tablets_feature_enabled", return_value=True):
+        monkey = CreateIndexNemesis(runner)
+        assert "MV/SI for tablets" in monkey.precheck(runner.target_node)
+
+
+def test_create_index_precheck_runnable(runner):
+    """No static blockers -> precheck returns None."""
+    with patch(f"{_MODULE}.is_tablets_feature_enabled", return_value=False):
+        monkey = CreateIndexNemesis(runner)
+        assert monkey.precheck(runner.target_node) is None
 
 
 def test_create_index_raises_when_no_tables(runner):
     """No non-system table -> UnsupportedNemesis."""
     runner.cluster.get_non_system_ks_cf_list.return_value = []
-    with patch(f"{_MODULE}.is_tablets_feature_enabled", return_value=False):
-        monkey = CreateIndexNemesis(runner)
-        with pytest.raises(UnsupportedNemesis, match="No table found to create index"):
-            monkey.disrupt()
+    monkey = CreateIndexNemesis(runner)
+    with pytest.raises(UnsupportedNemesis, match="No table found to create index"):
+        monkey.disrupt()
 
 
 def test_create_index_raises_when_no_column(runner):
     """No suitable column -> UnsupportedNemesis."""
-    with (
-        patch(f"{_MODULE}.is_tablets_feature_enabled", return_value=False),
-        patch(f"{_MODULE}.get_random_column_name", return_value=None),
-    ):
+    with patch(f"{_MODULE}.get_random_column_name", return_value=None):
         monkey = CreateIndexNemesis(runner)
         with pytest.raises(UnsupportedNemesis, match="No column found to create index"):
             monkey.disrupt()
@@ -76,7 +87,6 @@ def test_create_index_raises_when_no_column(runner):
 def test_create_index_happy_path_creates_and_drops(runner):
     """Full flow builds the index, verifies the query, and always drops it."""
     with (
-        patch(f"{_MODULE}.is_tablets_feature_enabled", return_value=False),
         patch(f"{_MODULE}.get_random_column_name", return_value="col1"),
         patch(f"{_MODULE}.DbNodeLogger"),
         patch(f"{_MODULE}.adaptive_timeout") as mock_timeout,
@@ -100,7 +110,6 @@ def test_create_index_happy_path_creates_and_drops(runner):
 def test_create_index_drops_index_even_when_verify_fails(runner):
     """If verification raises, the index is still dropped (finally block)."""
     with (
-        patch(f"{_MODULE}.is_tablets_feature_enabled", return_value=False),
         patch(f"{_MODULE}.get_random_column_name", return_value="col1"),
         patch(f"{_MODULE}.DbNodeLogger"),
         patch(f"{_MODULE}.adaptive_timeout") as mock_timeout,
@@ -121,13 +130,27 @@ def test_create_index_drops_index_even_when_verify_fails(runner):
 # ---------------------------------------------------------------------------
 
 
+def test_add_remove_mv_precheck_skips_on_old_version_with_tablets(runner):
+    """Tablets enabled + Scylla version <= 2025.3.99 -> skip reason returned."""
+    runner.target_node.scylla_version = "2025.3.0"
+    with patch(f"{_MODULE}.is_tablets_feature_enabled", return_value=True):
+        monkey = AddRemoveMvNemesis(runner)
+        assert "MV for tablets" in monkey.precheck(runner.target_node)
+
+
+def test_add_remove_mv_precheck_runnable(runner):
+    """No static blockers -> precheck returns None."""
+    with patch(f"{_MODULE}.is_tablets_feature_enabled", return_value=False):
+        monkey = AddRemoveMvNemesis(runner)
+        assert monkey.precheck(runner.target_node) is None
+
+
 def test_add_remove_mv_raises_when_no_free_nodes(runner):
     """All data nodes busy -> UnsupportedNemesis."""
     # base_runner mock nodes have a truthy ``running_nemesis`` by default.
-    with patch(f"{_MODULE}.is_tablets_feature_enabled", return_value=False):
-        monkey = AddRemoveMvNemesis(runner)
-        with pytest.raises(UnsupportedNemesis, match="Not enough free nodes"):
-            monkey.disrupt()
+    monkey = AddRemoveMvNemesis(runner)
+    with pytest.raises(UnsupportedNemesis, match="Not enough free nodes"):
+        monkey.disrupt()
 
 
 def test_add_remove_mv_raises_when_no_tables(runner):
@@ -135,10 +158,7 @@ def test_add_remove_mv_raises_when_no_tables(runner):
     for node in runner.cluster.data_nodes:
         node.running_nemesis = None
     runner.cluster.get_non_system_ks_cf_list.return_value = []
-    with (
-        patch(f"{_MODULE}.is_tablets_feature_enabled", return_value=False),
-        patch(f"{_MODULE}.suppress_expected_unavailability_errors", return_value=nullcontext()),
-    ):
+    with patch(f"{_MODULE}.suppress_expected_unavailability_errors", return_value=nullcontext()):
         monkey = AddRemoveMvNemesis(runner)
         with pytest.raises(UnsupportedNemesis, match="Non-system keyspace and table"):
             monkey.disrupt()
@@ -149,7 +169,6 @@ def test_add_remove_mv_happy_path(runner):
     for node in runner.cluster.data_nodes:
         node.running_nemesis = None
     with (
-        patch(f"{_MODULE}.is_tablets_feature_enabled", return_value=False),
         patch(f"{_MODULE}.suppress_expected_unavailability_errors", return_value=nullcontext()),
         patch(f"{_MODULE}.create_materialized_view_for_random_column") as mock_create,
         patch(f"{_MODULE}.adaptive_timeout") as mock_timeout,
@@ -173,7 +192,6 @@ def test_add_remove_mv_restarts_scylla_when_create_fails(runner):
     for node in runner.cluster.data_nodes:
         node.running_nemesis = None
     with (
-        patch(f"{_MODULE}.is_tablets_feature_enabled", return_value=False),
         patch(f"{_MODULE}.suppress_expected_unavailability_errors", return_value=nullcontext()),
         patch(
             f"{_MODULE}.create_materialized_view_for_random_column",
@@ -194,10 +212,7 @@ def test_add_remove_mv_restarts_scylla_when_connection_fails(runner):
     for node in runner.cluster.data_nodes:
         node.running_nemesis = None
     runner.cluster.cql_connection_patient.side_effect = RuntimeError("connection boom")
-    with (
-        patch(f"{_MODULE}.is_tablets_feature_enabled", return_value=False),
-        patch(f"{_MODULE}.suppress_expected_unavailability_errors", return_value=nullcontext()),
-    ):
+    with patch(f"{_MODULE}.suppress_expected_unavailability_errors", return_value=nullcontext()):
         monkey = AddRemoveMvNemesis(runner)
         with pytest.raises(RuntimeError, match="connection boom"):
             monkey.disrupt()
@@ -211,21 +226,41 @@ def test_add_remove_mv_restarts_scylla_when_connection_fails(runner):
 # ---------------------------------------------------------------------------
 
 
-def test_kill_mv_coordinator_raises_without_consistent_topology(runner):
-    """Consistent topology changes disabled -> UnsupportedNemesis."""
+def test_kill_mv_coordinator_precheck_skips_without_consistent_topology(runner):
+    """Consistent topology changes disabled -> skip reason returned."""
     runner.target_node.raft.is_consistent_topology_changes_enabled = False
     monkey = KillMVBuildingCoordinator(runner)
-    with pytest.raises(UnsupportedNemesis, match="Consistent topology changes"):
-        monkey.disrupt()
+    assert "Consistent topology changes" in monkey.precheck(runner.target_node)
 
 
-def test_kill_mv_coordinator_raises_without_tablets(runner):
-    """Tablets feature disabled -> UnsupportedNemesis."""
+def test_kill_mv_coordinator_precheck_skips_without_tablets(runner):
+    """Tablets feature disabled -> skip reason returned."""
     runner.target_node.raft.is_consistent_topology_changes_enabled = True
     with patch(f"{_MODULE}.is_tablets_feature_enabled", return_value=False):
         monkey = KillMVBuildingCoordinator(runner)
-        with pytest.raises(UnsupportedNemesis, match="works only with tablets"):
-            monkey.disrupt()
+        assert "works only with tablets" in monkey.precheck(runner.target_node)
+
+
+def test_kill_mv_coordinator_precheck_skips_without_views_with_tablets(runner):
+    """Tablets enabled but the views-with-tablets feature isn't -> skip reason returned."""
+    runner.target_node.raft.is_consistent_topology_changes_enabled = True
+    with (
+        patch(f"{_MODULE}.is_tablets_feature_enabled", return_value=True),
+        patch(f"{_MODULE}.is_views_with_tablets_enabled", return_value=False),
+    ):
+        monkey = KillMVBuildingCoordinator(runner)
+        assert "works only with tablets" in monkey.precheck(runner.target_node)
+
+
+def test_kill_mv_coordinator_precheck_runnable(runner):
+    """No static blockers -> precheck returns None."""
+    runner.target_node.raft.is_consistent_topology_changes_enabled = True
+    with (
+        patch(f"{_MODULE}.is_tablets_feature_enabled", return_value=True),
+        patch(f"{_MODULE}.is_views_with_tablets_enabled", return_value=True),
+    ):
+        monkey = KillMVBuildingCoordinator(runner)
+        assert monkey.precheck(runner.target_node) is None
 
 
 @pytest.fixture()
@@ -253,8 +288,6 @@ def test_kill_mv_coordinator_happy_path(kill_runner):
     query, and MV cleanup in the finally block."""
     coordinator = MagicMock(name="coordinator")
     with (
-        patch(f"{_MODULE}.is_tablets_feature_enabled", return_value=True),
-        patch(f"{_MODULE}.is_views_with_tablets_enabled", return_value=True),
         patch(f"{_MODULE}.get_topology_coordinator_node", return_value=coordinator),
         patch(f"{_MODULE}.create_materialized_view_for_random_column") as mock_create,
         patch(f"{_MODULE}.wait_materialized_view_building_tasks_started"),
@@ -278,8 +311,6 @@ def test_kill_mv_coordinator_drops_view_when_build_fails(kill_runner):
     """If the view never finishes building, the MV is still dropped (finally)."""
     coordinator = MagicMock(name="coordinator")
     with (
-        patch(f"{_MODULE}.is_tablets_feature_enabled", return_value=True),
-        patch(f"{_MODULE}.is_views_with_tablets_enabled", return_value=True),
         patch(f"{_MODULE}.get_topology_coordinator_node", return_value=coordinator),
         patch(f"{_MODULE}.create_materialized_view_for_random_column"),
         patch(f"{_MODULE}.wait_materialized_view_building_tasks_started"),

--- a/unit_tests/unit/nemesis/monkey/test_views_indexes.py
+++ b/unit_tests/unit/nemesis/monkey/test_views_indexes.py
@@ -188,6 +188,24 @@ def test_add_remove_mv_restarts_scylla_when_create_fails(runner):
     runner.target_node.start_scylla.assert_called_once()
 
 
+def test_add_remove_mv_restarts_scylla_when_connection_fails(runner):
+    """If opening the CQL session itself fails, scylla is still restarted (not just
+    when MV creation fails after a session was successfully opened)."""
+    for node in runner.cluster.data_nodes:
+        node.running_nemesis = None
+    runner.cluster.cql_connection_patient.side_effect = RuntimeError("connection boom")
+    with (
+        patch(f"{_MODULE}.is_tablets_feature_enabled", return_value=False),
+        patch(f"{_MODULE}.suppress_expected_unavailability_errors", return_value=nullcontext()),
+    ):
+        monkey = AddRemoveMvNemesis(runner)
+        with pytest.raises(RuntimeError, match="connection boom"):
+            monkey.disrupt()
+
+    runner.target_node.stop_scylla.assert_called_once()
+    runner.target_node.start_scylla.assert_called_once()
+
+
 # ---------------------------------------------------------------------------
 # KillMVBuildingCoordinator
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
 Extracted the MV/index nemesis into sdcm/nemesis/monkey/views_indexes.py (275 lines) following the established extraction pattern (disrupt logic inlined into monkey classes, self.* → self.runner.*).

 New module contains 3 monkey classes with inlined disrupt() logic:
 - CreateIndexNemesis (@target_data_nodes) — create secondary index, wait/verify/drop
 - AddRemoveMvNemesis (@target_data_nodes) — create MV while node down, repair, verify, drop
 - KillMVBuildingCoordinator (@target_all_nodes) — repeatedly kill topology coordinator while view builds

 Removed:
 - disrupt_create_index, disrupt_add_remove_mv, disrupt_kill_mv_building_coordinator from nemesis/__init__.py (−216 lines: 5470 → 5254)
 - The 3 thin monkey classes from monkey/__init__.py (−32 lines: 920 → 888)
 - Now-unused imports (is_views_with_tablets_enabled, sleep_for_percent_of_duration, NemesisNodeAllocationError, and 11 helpers from
   utils.indexes)

 Details caught during extraction (not in the plan's stale line numbers):
 - disrupt_kill_mv_building_coordinator carried a @decorate_with_context(suppress_expected_unavailability_errors) decorator — preserved on the  new disrupt() method.
 - CreateIndexNemesis had a @target_data_nodes decorator — preserved.

 Tests: Added unit_tests/unit/nemesis/monkey/test_views_indexes.py (14 tests: guard clauses, happy-path create/build/verify/drop, failure/cleanup paths, registry discovery + target-pool assertions).

Closes: SCT-218

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [AddRemoveMvNemesis](https://jenkins.scylladb.com/job/scylla-staging/job/cezar/job/jira/job/SCT-218-extract-mv-si/2/)
- [x] [CreateIndexNemesis](https://jenkins.scylladb.com/job/scylla-staging/job/cezar/job/jira/job/SCT-218-extract-mv-si/3/)
- [x] [KillMVBuildingCoordinator](https://jenkins.scylladb.com/job/scylla-staging/job/cezar/job/jira/job/SCT-218-extract-mv-si/4/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
