### PR TITLE
feat(sct_event): ignore "ignoring error response" globally

### DIFF
--- a/sdcm/sct_events/group_common_events.py
+++ b/sdcm/sct_events/group_common_events.py
@@ -297,20 +297,6 @@ def ignore_compaction_stopped_exceptions():
 
 
 @contextmanager
-def ignore_ignore_runtime_errors():
-    # These are actually INFO logs, but they get caught by RUNTIME_ERROR filter
-    with ExitStack() as stack:
-        stack.enter_context(
-            EventsSeverityChangerFilter(
-                new_severity=Severity.NORMAL,
-                event_class=DatabaseLogEvent,
-                regex=r".*ignoring error response: std::runtime_error.*",
-            )
-        )
-        yield
-
-
-@contextmanager
 def ignore_large_collection_warning():
     with ExitStack() as stack:
         stack.enter_context(DbEventsFilter(db_event=DatabaseLogEvent.WARNING, line="Writing large collection"))
@@ -639,7 +625,6 @@ NODE_UNAVAILABLE_CONTEXTS: list[Callable[[], ContextManager]] = [
     ignore_ycsb_connection_refused,
     ignore_stream_mutation_fragments_errors,
     ignore_compaction_stopped_exceptions,
-    ignore_ignore_runtime_errors,
     ignore_hints_sending_errors,
 ]
 

--- a/sdcm/sct_events/setup.py
+++ b/sdcm/sct_events/setup.py
@@ -186,6 +186,15 @@ def enable_default_filters(sct_config: SCTConfiguration):
         regex=r".*audit - Unexpected exception when writing.*unavailable_exception.*",
     ).publish()
 
+    # These are actually INFO logs from Scylla, but the RUNTIME_ERROR subevent regex
+    # ("std::runtime_error", sdcm/sct_events/database.py:147) matches the message body.
+    # Severity.NORMAL (not WARNING) because there is no underlying error at all.
+    EventsSeverityChangerFilter(
+        new_severity=Severity.NORMAL,
+        event_class=DatabaseLogEvent,
+        regex=r".*ignoring error response: std::runtime_error.*",
+    ).publish()
+
     DbEventsFilter(db_event=DatabaseLogEvent.BACKTRACE, line="Rate-limit: supressed").publish()
     DbEventsFilter(db_event=DatabaseLogEvent.BACKTRACE, line="Rate-limit: suppressed").publish()
     DbEventsFilter(db_event=DatabaseLogEvent.WARNING, line="abort_requested_exception").publish()

--- a/unit_tests/integration/test_events.py
+++ b/unit_tests/integration/test_events.py
@@ -31,7 +31,7 @@ class TestSctEventsIntegration(RealEventsTest):
         with environment(SCT_CLUSTER_BACKEND="docker"):
             enable_default_filters(SCTConfiguration())
 
-        with self.wait_for_n_events(self.get_events_logger(), count=6):
+        with self.wait_for_n_events(self.get_events_logger(), count=7):
             DatabaseLogEvent.BACKTRACE().add_info(
                 node="A",
                 line_number=22,
@@ -72,18 +72,30 @@ class TestSctEventsIntegration(RealEventsTest):
                 "std::runtime_error (exception exceptions::unavailable_exception (Cannot achieve consistency level for cl ONE. Requires 1, alive 0))",
             ).publish()
 
+            DatabaseLogEvent.RUNTIME_ERROR().add_info(
+                node="A",
+                line_number=22,
+                line="INFO 2023-12-18 12:45:25,673 [shard 0: gms] storage_proxy - Failed to apply mutation from 10.0.0.1#0: "
+                "ignoring error response: std::runtime_error (Rate limit exceeded)",
+            ).publish()
+
         log_content = self.get_event_log_file("events.log")
 
         assert "other back trace" in log_content
         assert "supressed" not in log_content
 
+        normal_log_content = self.get_event_log_file("normal.log")
+        assert "ignoring error response" in normal_log_content
+
         warnings_log_content = self.get_event_log_file("warning.log")
         assert "data_dictionary::no_such_column_family" in warnings_log_content
         assert "Authentication error" in warnings_log_content
         assert "Unexpected exception when writing login log" in warnings_log_content
+        assert "ignoring error response" not in warnings_log_content
 
         error_log_content = self.get_event_log_file("error.log")
         assert "data_dictionary::no_such_column_family" not in error_log_content
         assert "Authentication error" not in error_log_content
         assert "Unexpected exception when writing login log" not in error_log_content
         assert "topology change coordinator fiber got error" not in error_log_content
+        assert "ignoring error response" not in error_log_content


### PR DESCRIPTION
Instead of trying to ignore the log when it's assumed it will happen, ignore it globally instead, since it's just an INFO log that is wrongly upgraded to error due to its contents.

Closes: SCT-772

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
