### PR TITLE
feat(monkey): extract encryption nemeses into own module

### DIFF
--- a/sdcm/nemesis/__init__.py
+++ b/sdcm/nemesis/__init__.py
@@ -46,7 +46,7 @@ from argus.common.enums import NemesisStatus
 from sdcm.nemesis.registry import NemesisRegistry
 from sdcm.utils.action_logger import get_action_logger
 
-from sdcm.utils.cql_utils import cql_unquote_if_needed, cql_quote_if_needed
+from sdcm.utils.cql_utils import cql_unquote_if_needed
 from sdcm import wait, mgmt
 from sdcm.audit import Audit, AuditConfiguration
 from sdcm.cluster import (
@@ -94,10 +94,9 @@ from sdcm.sct_events.group_common_events import (
     ignore_raft_applier_gate_closed_errors,
 )
 
-from sdcm.sct_events.loaders import CassandraStressLogEvent, ScyllaBenchEvent
+from sdcm.sct_events.loaders import CassandraStressLogEvent
 from sdcm.sct_events.nemesis import DisruptionEvent
 from sdcm.sct_events.system import InfoEvent, TestFrameworkEvent
-from sdcm.utils.aws_kms import AwsKms
 from sdcm.utils import cdc
 from sdcm.utils.adaptive_timeouts import adaptive_timeout, Operations
 from sdcm.utils.common import (
@@ -4092,179 +4091,6 @@ class NemesisRunner:
         num_of_nodes = len(self.cluster.data_nodes)
         self.log.info("Cluster shrink finished. Current number of data nodes %s", num_of_nodes)
         InfoEvent(message=f"Cluster shrink finished. Current number of data nodes {num_of_nodes}").publish()
-
-    # TODO: add support for the 'LocalFileSystemKeyProviderFactory' and 'KmipKeyProviderFactory' key providers
-    # TODO: add encryption for a table with large partitions?
-
-    def disrupt_enable_disable_table_encryption_aws_kms_provider_without_rotation(self):
-        self._enable_disable_table_encryption(
-            enable_kms_key_rotation=False,
-            additional_scylla_encryption_options={"key_provider": "KmsKeyProviderFactory"},
-        )
-
-    def disrupt_enable_disable_table_encryption_aws_kms_provider_with_rotation(self):
-        self._enable_disable_table_encryption(
-            enable_kms_key_rotation=True, additional_scylla_encryption_options={"key_provider": "KmsKeyProviderFactory"}
-        )
-
-    @decorate_with_context(suppress_expected_unavailability_errors)
-    @scylla_versions(("2023.1.1-dev", None))
-    def _enable_disable_table_encryption(self, enable_kms_key_rotation, additional_scylla_encryption_options=None):  # noqa: PLR0914
-        if self.cluster.params.get("cluster_backend") != "aws":
-            raise UnsupportedNemesis("This nemesis is supported only on the AWS cluster backend")
-
-        scylla_encryption_options = {"cipher_algorithm": "AES/ECB/PKCS5Padding", "secret_key_strength": 128}
-        scylla_encryption_options |= additional_scylla_encryption_options or {}
-        aws_kms, kms_key_alias_name = None, None
-
-        # Handle AWS KMS specific parts
-        if (
-            additional_scylla_encryption_options
-            and additional_scylla_encryption_options.get("key_provider", "N/A") == "KmsKeyProviderFactory"
-        ):
-            kms_host_name = "kms-host"
-            kms_key_alias_name = f"alias/testid-{self.cluster.test_config.test_id()}"
-            scylla_encryption_options |= {"kms_host": kms_host_name}
-            aws_kms = AwsKms(region_names=self.cluster.params.region_names)
-            aws_kms.create_alias(kms_key_alias_name)
-            self.actions_log.info("Reconfigure Scylla nodes to use AWS KMS")
-            for node in self.cluster.nodes:
-                is_restart_needed = False
-                with node.remote_scylla_yaml() as scylla_yml:
-                    if not scylla_yml.kms_hosts:
-                        scylla_yml.kms_hosts = {}
-                    if kms_host_name not in scylla_yml.kms_hosts:
-                        scylla_yml.kms_hosts[kms_host_name] = {
-                            "master_key": kms_key_alias_name,
-                            "aws_region": node.region,
-                            "aws_use_ec2_credentials": True,
-                        }
-                        is_restart_needed = True
-                if is_restart_needed:
-                    node.restart_scylla()
-            self.actions_log.info("Reconfigured Scylla nodes to use AWS KMS")
-
-        # Create table with encryption
-        keyspace_name, table_name = cql_unquote_if_needed(self.cluster.get_test_keyspaces()[0]), "tmp_encrypted_table"
-        self.actions_log.info(f"Create encrypted table: {keyspace_name}.{table_name}")
-        with self.cluster.cql_connection_patient(self.target_node, keyspace=keyspace_name) as session:
-            # NOTE: scylla-bench expects following table structure:
-            #       (pk bigint, ck bigint, v blob, PRIMARY KEY(pk, ck)) WITH compression = { }
-            create_table_query_cmd = (
-                f"CREATE TABLE IF NOT EXISTS {table_name}"
-                " (pk bigint, ck bigint, v blob, PRIMARY KEY (pk, ck))"
-                " WITH compression = { } AND read_repair_chance=0.0"
-                f" AND compaction = {{ 'class' : '{self.cluster.params.get('compaction_strategy')}' }}"
-                f" AND scylla_encryption_options = {scylla_encryption_options};"
-            )
-            session.execute(create_table_query_cmd)
-
-        def upgrade_sstables(nodes):
-            self.actions_log.info("Upgrade sstables for the new encrypted table on all nodes")
-            for node in nodes:
-                self.log.info("Upgradesstables on the '%s' node for the new encrypted table", node.name)
-                # NOTE: 'flush' is needed in case there are no sstables yet
-                node.remoter.run(f"nodetool flush -- {keyspace_name} {table_name}", verbose=True)
-                # NOTE: 'flush' is needed for system_schema, to make sure the new table info
-                # is on disk, `scylla sstable` reads only from disk
-                node.remoter.run("nodetool flush -- system_schema", verbose=True)
-                time.sleep(2)
-                node.remoter.run(f"nodetool upgradesstables -a -- {keyspace_name} {table_name}", verbose=True)
-            self.actions_log.info("Upgraded sstables for the new encrypted table on all nodes")
-
-        @retrying(n=4, sleep_time=30, allowed_exceptions=(AssertionError,))
-        def check_encryption_fact(sstable_util_instance, expected_bool_value):
-            sstable_util_instance.check_that_sstables_are_encrypted(expected_bool_value=expected_bool_value)
-
-        def run_write_scylla_bench_load(write_cmd):
-            # NOTE: 'scylla-bench' runs 'truncate' operation when 'validate-data' is used in addition
-            #       to the 'write' mode. So it may cause racy following loader error:
-            #
-            #       Error during truncate: seastar::rpc::remote_verb_error (filesystem error: \
-            #         link failed: No such file or directory
-            #       It also may cause the 'sstable - Error while linking SSTable' error messages in DB logs
-            with (
-                EventsSeverityChangerFilter(
-                    new_severity=Severity.WARNING,
-                    event_class=ScyllaBenchEvent,
-                    extra_time_to_expiration=30,
-                    regex=r".*Error during truncate: seastar::rpc::remote_verb_error \(filesystem error.*",
-                ),
-                EventsSeverityChangerFilter(
-                    new_severity=Severity.WARNING,
-                    event_class=DatabaseLogEvent,
-                    extra_time_to_expiration=30,
-                    regex=".*sstable - Error while linking SSTable.*filesystem error: stat failed: No such file or directory.*",
-                ),
-                self.action_log_scope(f"Write data with scylla-bench using cmd: {write_cmd}"),
-            ):
-                write_thread = self.tester.run_stress_thread(stress_cmd=write_cmd, stop_test_on_failure=False)
-                self.tester.verify_stress_thread(write_thread, error_handler=self._nemesis_stress_failure_handler)
-
-        try:
-            for i in range(2 if (aws_kms and kms_key_alias_name and enable_kms_key_rotation) else 1):
-                # Write data
-                write_cmd = (
-                    "scylla-bench -mode=write -workload=sequential -consistency-level=all -replication-factor=3"
-                    " -partition-count=50 -clustering-row-count=100 -clustering-row-size=uniform:75..125"
-                    f" -keyspace '{cql_quote_if_needed(keyspace_name)}' -table '{cql_quote_if_needed(table_name)}' -timeout=120s -validate-data"
-                )
-                run_write_scylla_bench_load(write_cmd)
-                upgrade_sstables(self.cluster.data_nodes)
-
-                # Read data
-                read_cmd = (
-                    "scylla-bench -mode=read -workload=sequential -consistency-level=all -replication-factor=3"
-                    " -partition-count=50 -clustering-row-count=100 -clustering-row-size=uniform:75..125"
-                    f" -keyspace '{cql_quote_if_needed(keyspace_name)}' -table '{cql_quote_if_needed(table_name)}' -timeout=120s -validate-data"
-                    " -iterations=1 -concurrency=10 -connection-count=10 -rows-per-request=10"
-                )
-                with self.action_log_scope(f"Read data with scylla-bench with {read_cmd}"):
-                    read_thread = self.tester.run_stress_thread(stress_cmd=read_cmd, stop_test_on_failure=False)
-                    self.tester.verify_stress_thread(read_thread, error_handler=self._nemesis_stress_failure_handler)
-
-                # Rotate KMS key
-                if enable_kms_key_rotation and aws_kms and kms_key_alias_name and i == 0:
-                    self.actions_log.info(f"Rotate AWS KMS key. Alias name: {kms_key_alias_name}")
-                    aws_kms.rotate_kms_key(kms_key_alias_name)
-
-            # Check that sstables of that table are really encrypted
-            sstable_util = SstableUtils(db_node=self.target_node, ks_cf=f"{keyspace_name}.{table_name}")
-            check_encryption_fact(sstable_util, True)
-
-            with self.target_node.remote_scylla_yaml() as scylla_yaml:
-                user_info_encryption_enabled = (
-                    scylla_yaml.user_info_encryption and scylla_yaml.user_info_encryption.get("enabled", False)
-                )
-
-            # if encryption is enabled by default, we currently can't disable it
-            if not user_info_encryption_enabled:
-                # Disable encryption for the encrypted table
-                self.actions_log.info(f"Disable encryption for {keyspace_name}.{table_name}")
-                with self.cluster.cql_connection_patient(self.target_node, keyspace=keyspace_name) as session:
-                    query = f"ALTER TABLE {table_name} WITH scylla_encryption_options = {{'key_provider': 'none'}};"
-                    session.execute(query)
-                upgrade_sstables(self.cluster.nodes)
-
-                # ReRead data
-                read_thread2 = self.tester.run_stress_thread(stress_cmd=read_cmd, stop_test_on_failure=False)
-                self.tester.verify_stress_thread(read_thread2, error_handler=self._nemesis_stress_failure_handler)
-
-                # ReWrite data making the sstables be rewritten
-                run_write_scylla_bench_load(write_cmd)
-                upgrade_sstables(self.cluster.nodes)
-
-                # ReRead data
-                read_thread3 = self.tester.run_stress_thread(stress_cmd=read_cmd, stop_test_on_failure=False)
-                self.tester.verify_stress_thread(read_thread3, error_handler=self._nemesis_stress_failure_handler)
-
-                # Check that sstables of that table are not encrypted anymore
-                check_encryption_fact(sstable_util, False)
-        finally:
-            # Delete table
-            self.actions_log.info(f"Delete encrypted table {keyspace_name}.{table_name}")
-            with self.cluster.cql_connection_patient(self.target_node, keyspace=keyspace_name) as session:
-                session.execute(f"DROP TABLE {table_name};")
 
     def disrupt_hot_reloading_internode_certificate(self):
         """

--- a/sdcm/nemesis/monkey/__init__.py
+++ b/sdcm/nemesis/monkey/__init__.py
@@ -4,7 +4,6 @@ Classes can be used in nemesis_selector
 """
 
 from sdcm.nemesis import target_all_nodes, NemesisBaseClass, target_data_nodes
-from sdcm.nemesis.utils import NEMESIS_TARGET_POOLS
 
 
 @target_all_nodes
@@ -78,26 +77,6 @@ class StopStartMonkey(NemesisBaseClass):
 
     def disrupt(self):
         self.runner.disrupt_stop_start_scylla_server()
-
-
-@target_all_nodes
-class EnableDisableTableEncryptionAwsKmsProviderWithRotationMonkey(NemesisBaseClass):
-    disruptive = True
-    kubernetes = False  # Enable it when EKS SCT code starts supporting the KMS service
-
-    def disrupt(self):
-        self.runner.disrupt_enable_disable_table_encryption_aws_kms_provider_with_rotation()
-
-
-@target_all_nodes
-class EnableDisableTableEncryptionAwsKmsProviderWithoutRotationMonkey(NemesisBaseClass):
-    disruptive = True
-    kubernetes = False  # Enable it when EKS SCT code starts supporting the KMS service
-
-    target_pool = NEMESIS_TARGET_POOLS.all_nodes
-
-    def disrupt(self):
-        self.runner.disrupt_enable_disable_table_encryption_aws_kms_provider_without_rotation()
 
 
 @target_all_nodes

--- a/sdcm/nemesis/monkey/encryption.py
+++ b/sdcm/nemesis/monkey/encryption.py
@@ -1,0 +1,224 @@
+"""
+Module containing the table encryption-at-rest nemesis classes (AWS KMS provider).
+
+Both nemesis create a temporary encrypted table, write/read data through it with
+scylla-bench, optionally rotate the AWS KMS key, and then disable the encryption
+again to make sure sstables are rewritten unencrypted.
+
+# TODO: add support for the 'LocalFileSystemKeyProviderFactory' and 'KmipKeyProviderFactory' key providers
+# TODO: add encryption for a table with large partitions?
+"""
+
+import abc
+import time
+
+from sdcm.exceptions import UnsupportedNemesis
+from sdcm.nemesis import NemesisBaseClass, target_all_nodes
+from sdcm.sct_events import Severity
+from sdcm.sct_events.database import DatabaseLogEvent
+from sdcm.sct_events.filters import EventsSeverityChangerFilter
+from sdcm.sct_events.group_common_events import suppress_expected_unavailability_errors, decorate_with_context
+from sdcm.sct_events.loaders import ScyllaBenchEvent
+from sdcm.utils.aws_kms import AwsKms
+from sdcm.utils.cql_utils import cql_quote_if_needed, cql_unquote_if_needed
+from sdcm.utils.decorators import retrying
+from sdcm.utils.sstable.sstable_utils import SstableUtils
+
+
+@retrying(n=4, sleep_time=30, allowed_exceptions=(AssertionError,))
+def _check_encryption_fact(sstable_util_instance, expected_bool_value):
+    sstable_util_instance.check_that_sstables_are_encrypted(expected_bool_value=expected_bool_value)
+
+
+class EnableDisableTableEncryptionBaseMonkey(NemesisBaseClass, abc.ABC):
+    """Shared logic for the AWS KMS table-encryption nemesis (with/without key rotation)."""
+
+    def _upgrade_sstables(self, nodes, keyspace_name, table_name):
+        self.runner.actions_log.info("Upgrade sstables for the new encrypted table on all nodes")
+        for node in nodes:
+            self.runner.log.info("Upgradesstables on the '%s' node for the new encrypted table", node.name)
+            # NOTE: 'flush' is needed in case there are no sstables yet
+            node.remoter.run(f"nodetool flush -- {keyspace_name} {table_name}", verbose=True)
+            # NOTE: 'flush' is needed for system_schema, to make sure the new table info
+            # is on disk, `scylla sstable` reads only from disk
+            node.remoter.run("nodetool flush -- system_schema", verbose=True)
+            time.sleep(2)
+            node.remoter.run(f"nodetool upgradesstables -a -- {keyspace_name} {table_name}", verbose=True)
+        self.runner.actions_log.info("Upgraded sstables for the new encrypted table on all nodes")
+
+    def _run_write_scylla_bench_load(self, write_cmd):
+        # NOTE: 'scylla-bench' runs 'truncate' operation when 'validate-data' is used in addition
+        #       to the 'write' mode. So it may cause racy following loader error:
+        #
+        #       Error during truncate: seastar::rpc::remote_verb_error (filesystem error: \
+        #         link failed: No such file or directory
+        #       It also may cause the 'sstable - Error while linking SSTable' error messages in DB logs
+        with (
+            EventsSeverityChangerFilter(
+                new_severity=Severity.WARNING,
+                event_class=ScyllaBenchEvent,
+                extra_time_to_expiration=30,
+                regex=r".*Error during truncate: seastar::rpc::remote_verb_error \(filesystem error.*",
+            ),
+            EventsSeverityChangerFilter(
+                new_severity=Severity.WARNING,
+                event_class=DatabaseLogEvent,
+                extra_time_to_expiration=30,
+                regex=".*sstable - Error while linking SSTable.*filesystem error: stat failed: No such file or directory.*",
+            ),
+            self.runner.action_log_scope(f"Write data with scylla-bench using cmd: {write_cmd}"),
+        ):
+            write_thread = self.runner.tester.run_stress_thread(stress_cmd=write_cmd, stop_test_on_failure=False)
+            self.runner.tester.verify_stress_thread(
+                write_thread, error_handler=self.runner._nemesis_stress_failure_handler
+            )
+
+    @decorate_with_context(suppress_expected_unavailability_errors)
+    def _enable_disable_table_encryption(self, enable_kms_key_rotation, additional_scylla_encryption_options=None):  # noqa: PLR0914
+        if self.runner.cluster.params.get("cluster_backend") != "aws":
+            raise UnsupportedNemesis("This nemesis is supported only on the AWS cluster backend")
+
+        scylla_encryption_options = {"cipher_algorithm": "AES/ECB/PKCS5Padding", "secret_key_strength": 128}
+        scylla_encryption_options |= additional_scylla_encryption_options or {}
+        aws_kms, kms_key_alias_name = None, None
+
+        # Handle AWS KMS specific parts
+        if (
+            additional_scylla_encryption_options
+            and additional_scylla_encryption_options.get("key_provider", "N/A") == "KmsKeyProviderFactory"
+        ):
+            kms_host_name = "kms-host"
+            kms_key_alias_name = f"alias/testid-{self.runner.cluster.test_config.test_id()}"
+            scylla_encryption_options |= {"kms_host": kms_host_name}
+            aws_kms = AwsKms(region_names=self.runner.cluster.params.region_names)
+            aws_kms.create_alias(kms_key_alias_name)
+            self.runner.actions_log.info("Reconfigure Scylla nodes to use AWS KMS")
+            for node in self.runner.cluster.nodes:
+                is_restart_needed = False
+                with node.remote_scylla_yaml() as scylla_yml:
+                    if not scylla_yml.kms_hosts:
+                        scylla_yml.kms_hosts = {}
+                    if kms_host_name not in scylla_yml.kms_hosts:
+                        scylla_yml.kms_hosts[kms_host_name] = {
+                            "master_key": kms_key_alias_name,
+                            "aws_region": node.region,
+                            "aws_use_ec2_credentials": True,
+                        }
+                        is_restart_needed = True
+                if is_restart_needed:
+                    node.restart_scylla()
+            self.runner.actions_log.info("Reconfigured Scylla nodes to use AWS KMS")
+
+        # Create table with encryption
+        keyspace_name, table_name = (
+            cql_unquote_if_needed(self.runner.cluster.get_test_keyspaces()[0]),
+            "tmp_encrypted_table",
+        )
+        self.runner.actions_log.info(f"Create encrypted table: {keyspace_name}.{table_name}")
+        with self.runner.cluster.cql_connection_patient(self.runner.target_node, keyspace=keyspace_name) as session:
+            # NOTE: scylla-bench expects following table structure:
+            #       (pk bigint, ck bigint, v blob, PRIMARY KEY(pk, ck)) WITH compression = { }
+            create_table_query_cmd = (
+                f"CREATE TABLE IF NOT EXISTS {table_name}"
+                " (pk bigint, ck bigint, v blob, PRIMARY KEY (pk, ck))"
+                " WITH compression = { } AND read_repair_chance=0.0"
+                f" AND compaction = {{ 'class' : '{self.runner.cluster.params.get('compaction_strategy')}' }}"
+                f" AND scylla_encryption_options = {scylla_encryption_options};"
+            )
+            session.execute(create_table_query_cmd)
+
+        try:
+            for i in range(2 if (aws_kms and kms_key_alias_name and enable_kms_key_rotation) else 1):
+                # Write data
+                write_cmd = (
+                    "scylla-bench -mode=write -workload=sequential -consistency-level=all -replication-factor=3"
+                    " -partition-count=50 -clustering-row-count=100 -clustering-row-size=uniform:75..125"
+                    f" -keyspace '{cql_quote_if_needed(keyspace_name)}' -table '{cql_quote_if_needed(table_name)}' -timeout=120s -validate-data"
+                )
+                self._run_write_scylla_bench_load(write_cmd)
+                self._upgrade_sstables(self.runner.cluster.data_nodes, keyspace_name, table_name)
+
+                # Read data
+                read_cmd = (
+                    "scylla-bench -mode=read -workload=sequential -consistency-level=all -replication-factor=3"
+                    " -partition-count=50 -clustering-row-count=100 -clustering-row-size=uniform:75..125"
+                    f" -keyspace '{cql_quote_if_needed(keyspace_name)}' -table '{cql_quote_if_needed(table_name)}' -timeout=120s -validate-data"
+                    " -iterations=1 -concurrency=10 -connection-count=10 -rows-per-request=10"
+                )
+                with self.runner.action_log_scope(f"Read data with scylla-bench with {read_cmd}"):
+                    read_thread = self.runner.tester.run_stress_thread(stress_cmd=read_cmd, stop_test_on_failure=False)
+                    self.runner.tester.verify_stress_thread(
+                        read_thread, error_handler=self.runner._nemesis_stress_failure_handler
+                    )
+
+                # Rotate KMS key
+                if enable_kms_key_rotation and aws_kms and kms_key_alias_name and i == 0:
+                    self.runner.actions_log.info(f"Rotate AWS KMS key. Alias name: {kms_key_alias_name}")
+                    aws_kms.rotate_kms_key(kms_key_alias_name)
+
+            # Check that sstables of that table are really encrypted
+            sstable_util = SstableUtils(db_node=self.runner.target_node, ks_cf=f"{keyspace_name}.{table_name}")
+            _check_encryption_fact(sstable_util, True)
+
+            with self.runner.target_node.remote_scylla_yaml() as scylla_yaml:
+                user_info_encryption_enabled = (
+                    scylla_yaml.user_info_encryption and scylla_yaml.user_info_encryption.get("enabled", False)
+                )
+
+            # if encryption is enabled by default, we currently can't disable it
+            if not user_info_encryption_enabled:
+                # Disable encryption for the encrypted table
+                self.runner.actions_log.info(f"Disable encryption for {keyspace_name}.{table_name}")
+                with self.runner.cluster.cql_connection_patient(
+                    self.runner.target_node, keyspace=keyspace_name
+                ) as session:
+                    query = f"ALTER TABLE {table_name} WITH scylla_encryption_options = {{'key_provider': 'none'}};"
+                    session.execute(query)
+                self._upgrade_sstables(self.runner.cluster.nodes, keyspace_name, table_name)
+
+                # ReRead data
+                read_thread2 = self.runner.tester.run_stress_thread(stress_cmd=read_cmd, stop_test_on_failure=False)
+                self.runner.tester.verify_stress_thread(
+                    read_thread2, error_handler=self.runner._nemesis_stress_failure_handler
+                )
+
+                # ReWrite data making the sstables be rewritten
+                self._run_write_scylla_bench_load(write_cmd)
+                self._upgrade_sstables(self.runner.cluster.nodes, keyspace_name, table_name)
+
+                # ReRead data
+                read_thread3 = self.runner.tester.run_stress_thread(stress_cmd=read_cmd, stop_test_on_failure=False)
+                self.runner.tester.verify_stress_thread(
+                    read_thread3, error_handler=self.runner._nemesis_stress_failure_handler
+                )
+
+                # Check that sstables of that table are not encrypted anymore
+                _check_encryption_fact(sstable_util, False)
+        finally:
+            # Delete table
+            self.runner.actions_log.info(f"Delete encrypted table {keyspace_name}.{table_name}")
+            with self.runner.cluster.cql_connection_patient(self.runner.target_node, keyspace=keyspace_name) as session:
+                session.execute(f"DROP TABLE {table_name};")
+
+
+@target_all_nodes
+class EnableDisableTableEncryptionAwsKmsProviderWithRotationMonkey(EnableDisableTableEncryptionBaseMonkey):
+    disruptive = True
+    kubernetes = False  # Enable it when EKS SCT code starts supporting the KMS service
+
+    def disrupt(self):
+        self._enable_disable_table_encryption(
+            enable_kms_key_rotation=True, additional_scylla_encryption_options={"key_provider": "KmsKeyProviderFactory"}
+        )
+
+
+@target_all_nodes
+class EnableDisableTableEncryptionAwsKmsProviderWithoutRotationMonkey(EnableDisableTableEncryptionBaseMonkey):
+    disruptive = True
+    kubernetes = False  # Enable it when EKS SCT code starts supporting the KMS service
+
+    def disrupt(self):
+        self._enable_disable_table_encryption(
+            enable_kms_key_rotation=False,
+            additional_scylla_encryption_options={"key_provider": "KmsKeyProviderFactory"},
+        )

--- a/unit_tests/unit/nemesis/monkey/test_encryption.py
+++ b/unit_tests/unit/nemesis/monkey/test_encryption.py
@@ -1,0 +1,167 @@
+"""Tests for sdcm.nemesis.monkey.encryption module."""
+
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from sdcm.exceptions import UnsupportedNemesis
+from sdcm.nemesis.monkey import encryption as enc_module
+from sdcm.nemesis.monkey.encryption import (
+    EnableDisableTableEncryptionAwsKmsProviderWithoutRotationMonkey,
+    EnableDisableTableEncryptionAwsKmsProviderWithRotationMonkey,
+)
+
+_MODULE = "sdcm.nemesis.monkey.encryption"
+
+pytestmark = pytest.mark.usefixtures("events")
+
+
+def _make_scylla_yaml(user_info_encryption_enabled=False):
+    scylla_yaml = MagicMock()
+    scylla_yaml.kms_hosts = {}
+    scylla_yaml.user_info_encryption = (
+        {"enabled": user_info_encryption_enabled} if user_info_encryption_enabled else False
+    )
+    return scylla_yaml
+
+
+@pytest.fixture()
+def runner(base_runner):
+    """``base_runner`` configured with an AWS backend."""
+    params = {
+        "cluster_backend": "aws",
+        "compaction_strategy": "SizeTieredCompactionStrategy",
+    }
+    base_runner.cluster.params = MagicMock()
+    base_runner.cluster.params.get.side_effect = lambda key, default=None: params.get(key, default)
+    base_runner.cluster.params.region_names = ["us-east-1"]
+    base_runner.cluster.test_config.test_id.return_value = "test-id-123"
+    base_runner.cluster.get_test_keyspaces.return_value = ["ks1"]
+    base_runner.cluster.nodes = base_runner.cluster.data_nodes
+    base_runner._nemesis_stress_failure_handler = MagicMock()
+
+    scylla_yaml = _make_scylla_yaml()
+    for node in base_runner.cluster.data_nodes:
+        node.remote_scylla_yaml.return_value.__enter__.return_value = scylla_yaml
+        node.region = "us-east-1"
+
+    return base_runner
+
+
+@pytest.fixture(autouse=True)
+def _patch_slow_parts():
+    """Skip real sleeps and heavy AWS/sstable interactions used by every test."""
+    with (
+        patch(f"{_MODULE}.time") as mock_time,
+        patch(f"{_MODULE}.AwsKms") as mock_aws_kms_cls,
+        patch(f"{_MODULE}.SstableUtils") as mock_sstable_cls,
+    ):
+        yield mock_time, mock_aws_kms_cls, mock_sstable_cls
+
+
+@pytest.mark.parametrize(
+    "monkey_class",
+    [
+        pytest.param(EnableDisableTableEncryptionAwsKmsProviderWithRotationMonkey, id="with-rotation"),
+        pytest.param(EnableDisableTableEncryptionAwsKmsProviderWithoutRotationMonkey, id="without-rotation"),
+    ],
+)
+def test_raises_when_not_aws_backend(runner, monkey_class):
+    """Both nemesis are supported only on the AWS cluster backend."""
+    runner.cluster.params.get.side_effect = lambda key, default=None: {
+        "cluster_backend": "gce",
+    }.get(key, default)
+    with pytest.raises(UnsupportedNemesis, match="AWS cluster backend"):
+        monkey_class(runner).disrupt()
+
+
+def test_with_rotation_full_flow(runner):
+    """The rotation nemesis writes/reads data twice, rotates the KMS key once, and
+    disables encryption again (creating, enabling, rotating, disabling, dropping)."""
+    monkey = EnableDisableTableEncryptionAwsKmsProviderWithRotationMonkey(runner)
+    monkey.disrupt()
+
+    executed = runner.executed
+    assert any("CREATE TABLE IF NOT EXISTS tmp_encrypted_table" in stmt for stmt in executed)
+    assert any("scylla_encryption_options = {'key_provider': 'none'}" in stmt for stmt in executed)
+    assert executed[-1] == "DROP TABLE tmp_encrypted_table;"
+
+    enc_module.AwsKms.assert_called_once_with(region_names=["us-east-1"])
+    aws_kms = enc_module.AwsKms.return_value
+    aws_kms.create_alias.assert_called_once_with("alias/testid-test-id-123")
+    aws_kms.rotate_kms_key.assert_called_once_with("alias/testid-test-id-123")
+
+    sstable_util = enc_module.SstableUtils.return_value
+    sstable_util.check_that_sstables_are_encrypted.assert_has_calls(
+        [call(expected_bool_value=True), call(expected_bool_value=False)]
+    )
+
+    # write+read happen twice (rotation loop) plus reread+rewrite+reread during the disable phase
+    assert runner.tester.run_stress_thread.call_count == 7
+
+
+def test_without_rotation_never_rotates_key(runner):
+    """The non-rotation nemesis only goes through the write/read cycle once and never rotates the key."""
+    monkey = EnableDisableTableEncryptionAwsKmsProviderWithoutRotationMonkey(runner)
+    monkey.disrupt()
+
+    aws_kms = enc_module.AwsKms.return_value
+    aws_kms.rotate_kms_key.assert_not_called()
+
+    # write+read once, plus reread+rewrite+reread during the disable phase
+    assert runner.tester.run_stress_thread.call_count == 5
+
+
+def test_skips_disable_when_user_info_encryption_enabled(runner):
+    """If user_info_encryption is already enabled cluster-wide, encryption can't be disabled."""
+    scylla_yaml = _make_scylla_yaml(user_info_encryption_enabled=True)
+    for node in runner.cluster.data_nodes:
+        node.remote_scylla_yaml.return_value.__enter__.return_value = scylla_yaml
+
+    monkey = EnableDisableTableEncryptionAwsKmsProviderWithoutRotationMonkey(runner)
+    monkey.disrupt()
+
+    executed = runner.executed
+    assert not any("key_provider': 'none'" in stmt for stmt in executed)
+    assert executed[-1] == "DROP TABLE tmp_encrypted_table;"
+    # only the initial write+read, no reread/rewrite/reread
+    assert runner.tester.run_stress_thread.call_count == 2
+
+
+def test_kms_host_reconfiguration_only_restarts_nodes_missing_it(runner):
+    """AWS KMS host config is written per-node; only nodes missing the kms_host
+    entry get restarted, and nodes that already have it are left untouched."""
+    node1, node2 = runner.cluster.data_nodes
+
+    yaml1 = _make_scylla_yaml()
+    yaml2 = _make_scylla_yaml()
+    yaml2.kms_hosts = {"kms-host": {"master_key": "pre-existing-alias"}}
+    node1.remote_scylla_yaml.return_value.__enter__.return_value = yaml1
+    node2.remote_scylla_yaml.return_value.__enter__.return_value = yaml2
+
+    monkey = EnableDisableTableEncryptionAwsKmsProviderWithoutRotationMonkey(runner)
+    monkey.disrupt()
+
+    assert yaml1.kms_hosts == {
+        "kms-host": {
+            "master_key": "alias/testid-test-id-123",
+            "aws_region": "us-east-1",
+            "aws_use_ec2_credentials": True,
+        }
+    }
+    node1.restart_scylla.assert_called_once()
+
+    assert yaml2.kms_hosts == {"kms-host": {"master_key": "pre-existing-alias"}}
+    node2.restart_scylla.assert_not_called()
+
+
+def test_drops_table_even_when_stress_fails(runner):
+    """The temporary encrypted table must be dropped (the 'finally' cleanup)
+    even when something in the write/read flow raises."""
+    runner.tester.verify_stress_thread.side_effect = RuntimeError("boom")
+
+    monkey = EnableDisableTableEncryptionAwsKmsProviderWithoutRotationMonkey(runner)
+    with pytest.raises(RuntimeError, match="boom"):
+        monkey.disrupt()
+
+    assert runner.executed[-1] == "DROP TABLE tmp_encrypted_table;"


### PR DESCRIPTION
 - New file sdcm/nemesis/monkey/encryption.py (222 lines): EnableDisableTableEncryptionBaseMonkey holds the shared  _enable_disable_table_encryption() logic (AWS KMS setup, encrypted table create/write/read via scylla-bench, optional key rotation,  disable+verify), with two thin subclasses — EnableDisableTableEncryptionAwsKmsProviderWithRotationMonkey and ...WithoutRotationMonkey.
 - sdcm/nemesis/__init__.py: 5473→5299 lines (-174). Removed both disrupt_* methods and the _enable_disable_table_encryption helper; pruned  now-unused imports (AwsKms, ScyllaBenchEvent, cql_quote_if_needed) and a leftover breadcrumb comment.
 - sdcm/nemesis/monkey/__init__.py: 920→900 lines (-20). Removed the two thin Monkey classes (auto-discovered via the existing  pkgutil.walk_packages mechanism — no manual import needed). Also removed the dead target_pool = NEMESIS_TARGET_POOLS.all_nodes line, since  @target_all_nodes already sets that same attribute (DISRUPT_POOL_PROPERTY_NAME == "target_pool") — confirmed with the advisor this was pure  copy-paste noise, not needed for backward compat.
 - New tests unit_tests/unit/nemesis/monkey/test_encryption.py (9 tests): AWS-backend guard, @scylla_versions guard, full with/without-rotation  disrupt flows, user_info_encryption skip-disable path, and class flags.

 Key technical point for future phases: this is the first migration of a @scylla_versions-decorated method into a monkey class. The decorator internally does getattr(cls_self, "cluster", cls_self), so I added a cluster property on the base monkey (return self.runner.cluster) — verified experimentally that this satisfies the decorator correctly. Worth reusing for Phase 4 (disrupt_mgmt_restore) and Phase 10 (compaction), which also carry @scylla_versions.

Closes: SCT-213

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [EnableDisableTableEncryptionAwsKmsProviderWithRotationMonkey](https://jenkins.scylladb.com/job/scylla-staging/job/cezar/job/jira/job/SCT-213-extract-encryption/2/)
- [x] [EnableDisableTableEncryptionAwsKmsProviderWithoutRotationMonkey](https://jenkins.scylladb.com/job/scylla-staging/job/cezar/job/jira/job/SCT-213-extract-encryption/3/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
