### PR TITLE
feature(perf-logstor): add experimental logstor performance testing pipelines

### DIFF
--- a/configurations/performance/enable_logstor.yaml
+++ b/configurations/performance/enable_logstor.yaml
@@ -5,6 +5,7 @@ append_scylla_yaml:
   logstor_disk_size_in_mb: 80000
   logstor_separator_max_memory_in_mb: 256
   logstor_format_on_startup: true
+  force_capacity_based_balancing: true
 
 # Append --task-quota-ms 0.2 to existing append_scylla_args (++ prefix appends instead of replacing)
 append_scylla_args: '++ --task-quota-ms 0.2'

--- a/configurations/performance/latte-perf-regression-latency-650gb-upgrade.yaml
+++ b/configurations/performance/latte-perf-regression-latency-650gb-upgrade.yaml
@@ -33,7 +33,7 @@ stress_cmd_w: >-
     -P replication_factor=3 --threads=7 --concurrency=21 --consistency=QUORUM
     -P key_size=16 -P column_size=128 -P column_count=8 -P row_count=650000000 -P offset=0
     --sampling=10s --retry-number=10 --retry-interval='500ms,5s' --request-timeout=60
-    -P gauss_mean=325000000 -P gauss_stddev=9750000
+    -P distribution=\"gauss\" -P gauss_mean=325000000 -P gauss_stddev=9750000
     data_dir/latte/latte_cs_alike.rn
 
 stress_cmd_r: >-
@@ -41,7 +41,7 @@ stress_cmd_r: >-
     -P replication_factor=3 --threads=7 --concurrency=21 --consistency=QUORUM
     -P key_size=16 -P column_size=128 -P column_count=8 -P row_count=650000000 -P offset=0
     --sampling=10s --retry-number=10 --retry-interval='500ms,5s' --request-timeout=60
-    -P gauss_mean=325000000 -P gauss_stddev=9750000
+    -P distribution=\"gauss\" -P gauss_mean=325000000 -P gauss_stddev=9750000
     data_dir/latte/latte_cs_alike.rn
 
 stress_cmd_m: >-
@@ -49,5 +49,5 @@ stress_cmd_m: >-
     -P replication_factor=3 --threads=7 --concurrency=21 --consistency=QUORUM
     -P key_size=16 -P column_size=128 -P column_count=8 -P row_count=650000000 -P offset=0
     --sampling=10s --retry-number=10 --retry-interval='500ms,5s' --request-timeout=60
-    -P gauss_mean=325000000 -P gauss_stddev=9750000
+    -P distribution=\"gauss\" -P gauss_mean=325000000 -P gauss_stddev=9750000
     data_dir/latte/latte_cs_alike.rn

--- a/configurations/performance/logstor_hotspot_queries.yaml
+++ b/configurations/performance/logstor_hotspot_queries.yaml
@@ -1,23 +1,27 @@
 # Logstor hotspot distribution workload configuration
-# Uses latte_cs_alike_hotspot.rn with hotspot_write/hotspot_read functions
-# 55% of ops target 5M hot keys (1% of dataset), 45% spread across remaining 495M keys
+# Populate: uniform full coverage (`write` delegate in latte_cs_alike_hotspot.rn, which forwards
+# to the base latte_cs_alike.rn write, sequential single pass) so every one of the 500M keys
+# exists before the measured workload.
+# Measured mixed step: hotspot_write/hotspot_read in latte_cs_alike_hotspot.rn, where
+# 55% of ops target 500k hot keys (0.1% of dataset), 45% spread across remaining ~499.5M keys.
 # Schema: 10 columns x 200 bytes each (matching kv_hotspot.rn reference)
-# Only mixed (hotspot_write:30,hotspot_read:70) workload at 750k ops/s for 60m
+# Measured step uses random uniform selection (distribution="random") over an unbounded cycle
+# range (no --end-cycle) so the key sequence never repeats within the 60m run.
 # This test is a part of the benchmark done by Aerospike
 # https://aerospike.com/files/benchmarks/aerospike-vs-scylladb-performance-and-cost-at-multi-terabyte-scale.pdf
 
 perf_gradual_throttle_steps:
   mixed:
-    - {threads: 16, concurrency: 128, rate: '750000'}
+    - {threads: 32, concurrency: 48, rate: '750000', write_rate: '225000', read_rate: '525000', duration: '60m'}
 
 perf_gradual_step_duration: {"mixed": '60m'}
 
-# Cache warmup: read 5M hot keys with CL=ALL before mixed workload
+# Cache warmup: read 500k hot keys with CL=ALL before mixed workload
 stress_cmd_cache_warmup:
   - >-
     latte run --function read --consistency ALL --duration 5m
-    --threads 12 --concurrency 64
-    --start-cycle 1 --end-cycle 5000000
+    --threads 32 --concurrency 24
+    --start-cycle 1 --end-cycle 500000
     -P row_count=500000000 -P offset=0
     -P column_count=10 -P column_size=200 -P key_size=48
     data_dir/latte/latte_cs_alike_hotspot.rn
@@ -27,26 +31,34 @@ prepare_stress_cmd: >-
   -P speculative_retry="\"NONE\"" -P replication_factor=2
   data_dir/latte/latte_cs_alike_hotspot.rn
 
-# Populate 500M rows with hotspot distribution (hot keys written densely, cold keys sparsely)
+# Populate all 500M rows uniformly (sequential single pass, full coverage) so no key is empty.
+# Hotspot skew is applied only to the measured mixed workload below, not to the populate.
 prepare_write_cmd:
   - >-
-    latte run --function hotspot_write --consistency ALL --duration 500000000
-    --threads 32 --concurrency 32 --rate 93750
+    latte run --function write --consistency ALL --duration 500000000
+    --threads 64 --concurrency 16 --rate 250000
     --start-cycle 1 --end-cycle 500000000
     -P row_count=500000000 -P offset=0
     -P column_count=10 -P column_size=200 -P key_size=48
-    -P hotset_items=5000000 -P hotset_chance=55
     data_dir/latte/latte_cs_alike_hotspot.rn
 
 # Mixed workload: hotspot write:30,read:70 for $duration
 stress_cmd_m:
   - >-
-    latte run --function hotspot_write:30,hotspot_read:70 --consistency QUORUM --duration $duration
-    --threads $threads --concurrency $concurrency $throttle
-    --start-cycle 1 --end-cycle 500000000
-    -P row_count=500000000 -P offset=0
+    latte run --function hotspot_write --consistency QUORUM --duration $duration
+    --threads $threads --concurrency $concurrency --rate $write_rate
+    --start-cycle 1
+    -P row_count=500000000 -P offset=0 -P distribution=\"random\"
     -P column_count=10 -P column_size=200 -P key_size=48
-    -P hotset_items=5000000 -P hotset_chance=55
+    -P hotset_items=500000 -P hotset_chance=55
+    data_dir/latte/latte_cs_alike_hotspot.rn
+  - >-
+    latte run --function hotspot_read --consistency ONE --duration $duration
+    --threads $threads --concurrency $concurrency --rate $read_rate
+    --start-cycle 1
+    -P row_count=500000000 -P offset=0 -P distribution=\"random\"
+    -P column_count=10 -P column_size=200 -P key_size=48
+    -P hotset_items=500000 -P hotset_chance=55
     data_dir/latte/latte_cs_alike_hotspot.rn
 
 latte_schema_parameters:
@@ -58,7 +70,10 @@ latte_schema_parameters:
   key_size: 48
   speculative_retry: 'NONE'
   storage_engine: 'logstor'
-  min_per_shard_tablet_count: 32
+  min_per_shard_tablet_count: 64
 
 perf_stress_keyspace: keyspace1
 perf_stress_table: standard1
+
+# Disable rack-aware loader so latte commands are not pinned to a rack (no --rack flag)
+rack_aware_loader: false

--- a/configurations/performance/logstor_uniform_queries.yaml
+++ b/configurations/performance/logstor_uniform_queries.yaml
@@ -1,13 +1,16 @@
 # Logstor uniform distribution workload configuration
-# Uses latte_cs_alike.rn with write/read functions (uniform: i % ROW_COUNT + OFFSET)
+# Uses latte_cs_alike.rn with write/read functions.
+# Populate: sequential (i % ROW_COUNT + OFFSET) for full 500M-row coverage.
+# Measured step: random uniform selection (distribution="random" -> hash_range(i, ROW_COUNT))
+# over an unbounded cycle range (no --end-cycle) so the key sequence never repeats within the run.
 # Schema: 10 columns x 200 bytes each (matching kv_uniform.rn reference)
-# Only mixed (write:30,read:70) workload at 600k ops/s for 60m
+# Mixed (write:30,read:70) workload ramps to 600k ops/s before the 60m measured step
 # This test is a part of the benchmark done by Aerospike
 # https://aerospike.com/files/benchmarks/aerospike-vs-scylladb-performance-and-cost-at-multi-terabyte-scale.pdf
 
 perf_gradual_throttle_steps:
   mixed:
-    - {threads: 12, concurrency: 128, rate: '600000'}
+    - {threads: 64, concurrency: 48, rate: '600000', write_rate: '180000', read_rate: '420000', duration: '60m'}
 
 perf_gradual_step_duration: {"mixed": '60m'}
 
@@ -23,19 +26,26 @@ prepare_stress_cmd: >-
 prepare_write_cmd:
   - >-
     latte run --function write --consistency ALL --duration 500000000
-    --threads 32 --concurrency 32 --rate 93750
+    --threads 32 --concurrency 32 --rate 250000
     --start-cycle 1 --end-cycle 500000000
     -P row_count=500000000 -P offset=0
     -P column_count=10 -P column_size=200 -P key_size=48
     data_dir/latte/latte_cs_alike.rn
 
-# Mixed workload: uniform write:30,read:70 for $duration
+# Mixed workload: uniform write:30,read:70 for $duration, split to use different consistency levels
 stress_cmd_m:
   - >-
-    latte run --function write:30,read:70 --consistency QUORUM --duration $duration
-    --threads $threads --concurrency $concurrency $throttle
-    --start-cycle 1 --end-cycle 500000000
-    -P row_count=500000000 -P offset=0
+    latte run --function write --consistency QUORUM --duration $duration
+    --threads $threads --concurrency $concurrency --rate $write_rate
+    --start-cycle 1
+    -P row_count=500000000 -P offset=0 -P distribution=\"random\"
+    -P column_count=10 -P column_size=200 -P key_size=48
+    data_dir/latte/latte_cs_alike.rn
+  - >-
+    latte run --function read --consistency ONE --duration $duration
+    --threads $threads --concurrency $concurrency --rate $read_rate
+    --start-cycle 1
+    -P row_count=500000000 -P offset=0 -P distribution=\"random\"
     -P column_count=10 -P column_size=200 -P key_size=48
     data_dir/latte/latte_cs_alike.rn
 
@@ -48,7 +58,10 @@ latte_schema_parameters:
   key_size: 48
   speculative_retry: 'NONE'
   storage_engine: 'logstor'
-  min_per_shard_tablet_count: 32
+  min_per_shard_tablet_count: 64
 
 perf_stress_keyspace: keyspace1
 perf_stress_table: standard1
+
+# Disable rack-aware loader so latte commands are not pinned to a rack (no --rack flag)
+rack_aware_loader: false

--- a/data_dir/latte/latte_cs_alike.rn
+++ b/data_dir/latte/latte_cs_alike.rn
@@ -45,8 +45,16 @@ pub const COLUMN_SIZE = latte::param!("column_size", 128);
 pub const COLUMN_COUNT = latte::param!("column_count", 8);
 pub const ROW_COUNT = latte::param!("row_count", 1_000_000);
 pub const OFFSET = latte::param!("offset", 0);
+// Used only when 'distribution' is set to "gauss"/"normal"
 const GAUSS_MEAN = latte::param!("gauss_mean", 0);
 const GAUSS_STDDEV = latte::param!("gauss_stddev", 0);
+// Key access distribution:
+// - "sequential" (default) walks keys in cycle order (i % ROW_COUNT).
+// - "random" scatters keys uniformly via hash_range(i, ROW_COUNT). Use it together with an
+//   unbounded cycle range (no --end-cycle) so the key sequence never repeats within a timed run.
+// - "gauss" (alias "normal") samples keys from a normal distribution defined by the
+//   'gauss_mean' and 'gauss_stddev' params.
+pub const DISTRIBUTION = latte::param!("distribution", "sequential");
 
 pub const P_STMT_WRITE = "latte_prep_stmt__write";
 pub const P_STMT_READ = "latte_prep_stmt__read";
@@ -162,36 +170,47 @@ pub async fn prepare(db) {
         db.prepare(P_STMT_COUNTER_READ, `SELECT * FROM ${KEYSPACE}.${COUNTER_TABLE} WHERE key = :key`).await?;
     }
 
-    prepare_gauss_distribution(db).await
+    validate_distribution(db).await
 }
 
 ///////////////////////
 // UTILITY FUNCTIONS //
 ///////////////////////
 
-/// Utility function that enables and validates the gauss/normal distribution
-async fn prepare_gauss_distribution(db) {
-    if GAUSS_MEAN > 0 && GAUSS_STDDEV > 0 {
+/// Utility function that validates the 'distribution' param and its dependent params
+pub async fn validate_distribution(db) {
+    if DISTRIBUTION == "gauss" || DISTRIBUTION == "normal" {
+        if GAUSS_MEAN <= 0 || GAUSS_STDDEV <= 0 {
+            return Err(format!(
+                "'distribution'='{distribution}' requires 'gauss_mean' and 'gauss_stddev' " +
+                "to be set in range of '{min}..{max}' (offset..(offset+row_count))",
+                distribution=DISTRIBUTION, min=OFFSET, max=OFFSET+ROW_COUNT))
+        }
+        // Convert once here instead of in each 'get_partition_idx' call
         db.data.gauss_mean = GAUSS_MEAN as f64;
         db.data.gauss_stddev = GAUSS_STDDEV as f64;
-        db.data.gauss_enabled = true;
         println!(
             "debug: Gauss/normal distribution is enabled: mean='{mean}', stddev='{stddev}'",
-            mean=db.data.gauss_mean, stddev=db.data.gauss_stddev);
-    } else if GAUSS_MEAN == 0 && GAUSS_STDDEV == 0 {
-        db.data.gauss_enabled = false;
-        println!("debug: Gauss/normal distribution is disabled");
+            mean=GAUSS_MEAN, stddev=GAUSS_STDDEV);
+    } else if DISTRIBUTION == "sequential" || DISTRIBUTION == "random" {
+        if GAUSS_MEAN != 0 || GAUSS_STDDEV != 0 {
+            return Err(format!(
+                "'gauss_mean' and 'gauss_stddev' are set, but 'distribution' is " +
+                "'{distribution}'. Set 'distribution' to 'gauss'/'normal' to use them.",
+                distribution=DISTRIBUTION))
+        }
+        println!("debug: '{distribution}' distribution is enabled", distribution=DISTRIBUTION);
     } else {
         Err(format!(
-            "'gauss_mean' and 'gauss_stddev' both must be either '0' (disabled) " +
-            "or in range of '{min}..{max}' (offset..(offset+row_count))",
-            min=OFFSET, max=OFFSET+ROW_COUNT))
+            "Unsupported 'distribution' value: '{distribution}'. " +
+            "Supported values are 'sequential', 'random' and 'gauss'/'normal'.",
+            distribution=DISTRIBUTION))
     }
 }
 
 /// Utility function which generates partition index based on the cycle id and distribution type
 async fn get_partition_idx(db, i) {
-    if db.data.gauss_enabled {
+    if DISTRIBUTION == "gauss" || DISTRIBUTION == "normal" {
         let current_idx = normal(i, db.data.gauss_mean, db.data.gauss_stddev) as i64;
         if current_idx >= OFFSET + ROW_COUNT {
             current_idx = OFFSET + ROW_COUNT - 1;
@@ -199,6 +218,9 @@ async fn get_partition_idx(db, i) {
             current_idx = OFFSET;
         }
         return current_idx;
+    } else if DISTRIBUTION == "random" {
+        // Uniform random: hash the (monotonically increasing) cycle id into [0, ROW_COUNT).
+        return OFFSET + hash_range(i, ROW_COUNT);
     } else {
         return i % ROW_COUNT + OFFSET;
     }

--- a/data_dir/latte/latte_cs_alike_hotspot.rn
+++ b/data_dir/latte/latte_cs_alike_hotspot.rn
@@ -3,15 +3,14 @@
 // Hotspot means HOTSET_CHANCE% of operations target HOTSET_ITEMS keys (the "hot set"),
 // while the remaining operations are spread uniformly across the rest of the keyspace.
 //
-// Run populate (write all rows using hotspot distribution):
+// Run populate (uniform sequential single pass over all rows, no hotspot skew):
 // $ latte run /path/to/latte_cs_alike_hotspot.rn %IP% -q \
-//     -f hotspot_write \
+//     -f write \
 //     --consistency ALL \
 //     --threads 64 --concurrency 128 --rate 200000 \
 //     --start-cycle 1 --end-cycle 500000000 \
 //     -P row_count=500_000_000 -P offset=0 \
-//     -P column_count=10 -P column_size=200 -P key_size=48 \
-//     -P hotset_items=5000000 -P hotset_chance=55
+//     -P column_count=10 -P column_size=200 -P key_size=48
 //
 // Run mixed hotspot workload:
 // $ latte run /path/to/latte_cs_alike_hotspot.rn %IP% -q \
@@ -25,7 +24,7 @@
 mod latte_cs_alike;
 
 use latte_cs_alike::{
-    KEYSPACE, TABLE, KEY_SIZE, COLUMN_SIZE, COLUMN_COUNT, ROW_COUNT, OFFSET,
+    KEY_SIZE, ROW_COUNT, OFFSET, DISTRIBUTION,
     P_STMT_WRITE, P_STMT_READ,
     get_blob_columns_data,
 };
@@ -33,6 +32,10 @@ use latte::*;
 
 const HOTSET_ITEMS = latte::param!("hotset_items", 5000000);
 const HOTSET_CHANCE = latte::param!("hotset_chance", 55);
+// The 'distribution' param is imported from the base script. Hotspot supports only:
+// "sequential" (default) selects hot/cold and in-region keys in cycle order; "random" uses
+// decoupled hashes so the hot/cold coin flip and the in-region key index are uncorrelated.
+// Use "random" with an unbounded cycle range (no --end-cycle) for timed runs.
 
 pub async fn schema(db) {
     latte_cs_alike::schema(db).await;
@@ -52,6 +55,12 @@ pub async fn prepare(db) {
             "'hotset_chance' ({chance}) must be between 1 and 99",
             chance=HOTSET_CHANCE));
     }
+    if DISTRIBUTION != "sequential" && DISTRIBUTION != "random" {
+        return Err(format!(
+            "'distribution' ({distribution}) is not supported by the hotspot script. " +
+            "Supported values are 'sequential' and 'random'.",
+            distribution=DISTRIBUTION));
+    }
     println!(
         "debug: Hotspot distribution enabled: hotset_items={items}, hotset_chance={chance}%",
         items=HOTSET_ITEMS, chance=HOTSET_CHANCE);
@@ -64,10 +73,20 @@ pub async fn prepare(db) {
 
 /// Hotspot index: HOTSET_CHANCE% of ops target HOTSET_ITEMS keys, rest spread across remaining
 fn get_hotspot_idx(i) {
-    if i % 100 < HOTSET_CHANCE {
-        OFFSET + (i % HOTSET_ITEMS)
+    if DISTRIBUTION == "random" {
+        // Decoupled seeds: hash_range(i, 100) picks the hot/cold region; hash(i)/hash2(i, 1)
+        // seed independent uniform draws for the in-region key so the flip and index don't correlate.
+        if hash_range(i, 100) < HOTSET_CHANCE {
+            OFFSET + hash_range(hash(i), HOTSET_ITEMS)
+        } else {
+            OFFSET + HOTSET_ITEMS + hash_range(hash2(i, 1), ROW_COUNT - HOTSET_ITEMS)
+        }
     } else {
-        OFFSET + HOTSET_ITEMS + (i % (ROW_COUNT - HOTSET_ITEMS))
+        if i % 100 < HOTSET_CHANCE {
+            OFFSET + (i % HOTSET_ITEMS)
+        } else {
+            OFFSET + HOTSET_ITEMS + (i % (ROW_COUNT - HOTSET_ITEMS))
+        }
     }
 }
 
@@ -85,6 +104,11 @@ pub async fn hotspot_read(db, i) {
     let partition_idx = get_hotspot_idx(i);
     let key = blob(partition_idx, KEY_SIZE);
     db.execute_prepared(P_STMT_READ, [key]).await?
+}
+
+/// Delegate plain write to base module (uniform populate: sequential full-coverage pass)
+pub async fn write(db, i) {
+    latte_cs_alike::write(db, i).await
 }
 
 /// Delegate plain read to base module (useful for cache warmup)

--- a/performance_regression_gradual_grow_throughput.py
+++ b/performance_regression_gradual_grow_throughput.py
@@ -8,9 +8,10 @@ from dataclasses import dataclass, replace
 from typing import List, Union
 
 from performance_regression_test import PerformanceRegressionTest
-from sdcm.utils.common import skip_optional_stage
+from sdcm.stress.latte_thread import find_latte_fn_names
 from sdcm.sct_events import Severity
 from sdcm.sct_events.system import TestFrameworkEvent
+from sdcm.utils.common import skip_optional_stage
 from sdcm.utils.decorators import latency_calculator_decorator
 from sdcm.utils.latency import calculate_latency, analyze_hdr_percentiles
 
@@ -370,6 +371,21 @@ class PerformanceRegressionPredefinedStepsTest(PerformanceRegressionTest):
             self.log.info("Schema has been prepared")
             self.run_post_prepare_cql(workload=workload)
 
+    @staticmethod
+    def _aggregate_ops_rate(results: list, num_loaders: int, num_commands: int) -> float:
+        # round-robin: 1 cmd/loader, so sum == avg×loaders; additive: distinct cmds, so multiply by loaders.
+        if not results:
+            return 0.0
+
+        def _op_rate(result):
+            try:
+                return float(result.get("op rate", 0) or 0)
+            except TypeError, ValueError:
+                return 0.0
+
+        total = sum(_op_rate(r) for r in results)
+        return total if num_commands == num_loaders else total * num_loaders
+
     def check_latency_during_steps(self, step):
         with open(self.latency_results_file, encoding="utf-8") as file:
             latency_results = json.load(file)
@@ -388,14 +404,18 @@ class PerformanceRegressionPredefinedStepsTest(PerformanceRegressionTest):
             return latency_results
         return {step: {"step": step, "legend": "", "cycles": []}}
 
-    def run_step(self, stress_cmds, step_params, step_duration):
+    def run_step(self, stress_cmds, step_params, step_duration, hdr_tags=None):
         """
         Run a single stress step with parameters from step_params dict.
 
         Args:
-            stress_cmds: List of stress command templates
-            step_params: Dict with step parameters (threads, concurrency, rate, throttle)
+            stress_cmds:   List of stress command templates
+            step_params:   Dict with step parameters (threads, concurrency, rate, throttle)
             step_duration: Duration for this step
+            hdr_tags:      Optional explicit list of HDR tag strings.  When provided,
+                           latency_calculator_decorator uses it directly so that all
+                           function tags (write + read) are reported rather than only
+                           the first queue's tags.  Pass None to use auto-detection.
         """
         results = []
         stress_queue = []
@@ -404,12 +424,8 @@ class PerformanceRegressionPredefinedStepsTest(PerformanceRegressionTest):
             stress_cmd_to_run = stress_cmd
 
             # Replace placeholders from step_params dict
-            if "threads" in step_params:
-                stress_cmd_to_run = stress_cmd_to_run.replace("$threads", str(step_params["threads"]))
-            if "concurrency" in step_params:
-                stress_cmd_to_run = stress_cmd_to_run.replace("$concurrency", str(step_params["concurrency"]))
-            if "throttle" in step_params:
-                stress_cmd_to_run = stress_cmd_to_run.replace("$throttle", step_params["throttle"])
+            for param_name, param_value in sorted(step_params.items(), key=lambda item: len(item[0]), reverse=True):
+                stress_cmd_to_run = stress_cmd_to_run.replace(f"${param_name}", str(param_value))
             if step_duration is not None:
                 # For latte, --duration accepts an integer iteration count (number of cycles to run)
                 # rather than a time string like cassandra-stress
@@ -559,13 +575,20 @@ class PerformanceRegressionPredefinedStepsTest(PerformanceRegressionTest):
             step_params["throttle"] = self.current_throttle(
                 throttle_step_dict, num_loaders, stress_num, workload.cs_cmd_tmpl[0]
             )
+            step_duration = throttle_step_dict.get("duration", workload.step_duration)
 
             self.log.info(
-                "Run cs command with rate: %s Kops; threads: %s; step name: %s",
+                "Run cs command with rate: %s Kops; threads: %s; step name: %s; duration: %s",
                 throttle_step_dict.get("rate", "unthrottled"),
                 step_params["threads"],
                 current_throttle_step,
+                step_duration,
             )
+            # Pre-compute flattened HDR tags from command templates so both write
+            # and read tags are passed explicitly to the decorator.  This prevents
+            # _find_hdr_tags from stopping at the first queue and omitting the read tag.
+            step_hdr_tags = [f"fn--{fn}" for cmd in workload.cs_cmd_tmpl for fn in find_latte_fn_names(cmd)]
+
             run_step = (
                 latency_calculator_decorator(
                     legend=f"Gradual test step {current_throttle_step} op/s", cycle_name=current_throttle_step
@@ -574,20 +597,22 @@ class PerformanceRegressionPredefinedStepsTest(PerformanceRegressionTest):
             results, _ = run_step(
                 stress_cmds=workload.cs_cmd_tmpl,
                 step_params=step_params,
-                step_duration=workload.step_duration,
+                step_duration=step_duration,
+                hdr_tags=step_hdr_tags or None,
             )
             self.log.debug("All c-s commands results collected and saved in Argus")
 
-            calculate_result = self._calculate_average_max_latency(results)
             summary_result = self.check_latency_during_steps(step=current_throttle_step)
-            summary_result[current_throttle_step].update({"ops_rate": calculate_result["op rate"] * num_loaders})
+            summary_result[current_throttle_step].update(
+                {"ops_rate": self._aggregate_ops_rate(results, num_loaders, len(workload.cs_cmd_tmpl))}
+            )
             total_summary.update(summary_result)
             if workload.drop_keyspace:
                 self.drop_keyspace(keyspace_name=workload.test_keyspace)
             # We want 3 minutes (180 sec) wait between steps.
             # In case of "mixed" workflow - wait for compactions finished.
             # In case of "read" workflow -  it just will wait for 3 minutes
-            if workload.wait_no_compactions:
+            if throttle_step_dict.get("wait_no_compactions", workload.wait_no_compactions):
                 if (wait_time := self.wait_no_compactions_running()[0]) < 180:
                     time.sleep(180 - wait_time)
                 self.log.info("All compactions are finished")

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -4252,6 +4252,30 @@ class SCTConfiguration(BaseModel):
             )
             return default
 
+    # perf_gradual_throttle_steps dict-entry fields: (key, is_valid, description-for-error-message)
+    _THROTTLE_STEP_FIELD_CHECKS: ClassVar[tuple] = (
+        ("threads", lambda v: isinstance(v, int) and v > 0, "a positive integer"),
+        ("concurrency", lambda v: isinstance(v, int) and v > 0, "a positive integer"),
+        ("rate", lambda v: isinstance(v, str), "a string"),
+        ("duration", lambda v: isinstance(v, str) and v, "a non-empty string"),
+        ("wait_no_compactions", lambda v: isinstance(v, bool), "a boolean"),
+    )
+
+    @staticmethod
+    def _validate_throttle_step_dict(workload: str, step_idx: int, step: dict) -> None:
+        """Validate a single dict-format perf_gradual_throttle_steps entry."""
+        if not step:
+            raise ValueError(
+                f"perf_gradual_throttle_steps for {workload} step {step_idx}: "
+                f"dict must have at least one key (threads, concurrency, or rate)"
+            )
+        for key, is_valid, description in SCTConfiguration._THROTTLE_STEP_FIELD_CHECKS:
+            if key in step and not is_valid(step[key]):
+                raise ValueError(
+                    f"perf_gradual_throttle_steps for {workload} step {step_idx}: "
+                    f"'{key}' must be {description}, got {step[key]!r}"
+                )
+
     def _validate_perf_gradual_throttle_steps(self):
         """Validate perf_gradual_throttle_steps configuration parameter."""
         if not (performance_throughput_params := self.get("perf_gradual_throttle_steps")):
@@ -4271,36 +4295,7 @@ class SCTConfiguration(BaseModel):
                     # String format for backward compatibility (cassandra-stress)
                     continue
                 elif isinstance(step, dict):
-                    # Dict format for latte and other multi-parameter tools
-                    if not step:
-                        raise ValueError(
-                            f"perf_gradual_throttle_steps for {workload} step {step_idx}: "
-                            f"dict must have at least one key (threads, concurrency, or rate)"
-                        )
-
-                    # Validate threads if present
-                    if "threads" in step:
-                        if not isinstance(step["threads"], int) or step["threads"] <= 0:
-                            raise ValueError(
-                                f"perf_gradual_throttle_steps for {workload} step {step_idx}: "
-                                f"'threads' must be a positive integer, got {step['threads']}"
-                            )
-
-                    # Validate concurrency if present
-                    if "concurrency" in step:
-                        if not isinstance(step["concurrency"], int) or step["concurrency"] <= 0:
-                            raise ValueError(
-                                f"perf_gradual_throttle_steps for {workload} step {step_idx}: "
-                                f"'concurrency' must be a positive integer, got {step['concurrency']}"
-                            )
-
-                    # Validate rate if present
-                    if "rate" in step:
-                        if not isinstance(step["rate"], str):
-                            raise ValueError(
-                                f"perf_gradual_throttle_steps for {workload} step {step_idx}: "
-                                f"'rate' must be a string, got {type(step['rate']).__name__}"
-                            )
+                    self._validate_throttle_step_dict(workload, step_idx, step)
                 else:
                     raise ValueError(
                         f"perf_gradual_throttle_steps for {workload} step {step_idx}: "

--- a/test-cases/cassandra/cassandra-preload-1tb-latte.yaml
+++ b/test-cases/cassandra/cassandra-preload-1tb-latte.yaml
@@ -70,6 +70,6 @@ stress_cmd:
     latte run --function=read --tag=latte-read --duration=30m
     -P replication_factor=1 --threads=7 --concurrency=21 --consistency=ONE
     -P column_size=128 -P column_count=8 -P row_count=1000000000 -P offset=0
-    -P gauss_mean=500000000 -P gauss_stddev=15000000
+    -P distribution=\"gauss\" -P gauss_mean=500000000 -P gauss_stddev=15000000
     --sampling=10s --retry-number=10 --retry-interval='500ms,5s' --request-timeout=60
     data_dir/latte/latte_cs_alike.rn

--- a/test-cases/cassandra/cassandra-preload-2tb-latte.yaml
+++ b/test-cases/cassandra/cassandra-preload-2tb-latte.yaml
@@ -70,6 +70,6 @@ stress_cmd:
     latte run --function=read --tag=latte-read --duration=30m
     -P replication_factor=1 --threads=7 --concurrency=21 --consistency=ONE
     -P column_size=128 -P column_count=8 -P row_count=2000000000 -P offset=0
-    -P gauss_mean=1000000000 -P gauss_stddev=30000000
+    -P distribution=\"gauss\" -P gauss_mean=1000000000 -P gauss_stddev=30000000
     --sampling=10s --retry-number=10 --retry-interval='500ms,5s' --request-timeout=60
     data_dir/latte/latte_cs_alike.rn

--- a/test-cases/cassandra/cassandra-preload-500gb-latte.yaml
+++ b/test-cases/cassandra/cassandra-preload-500gb-latte.yaml
@@ -70,6 +70,6 @@ stress_cmd:
     latte run --function=read --tag=latte-read --duration=30m
     -P replication_factor=1 --threads=7 --concurrency=21 --consistency=ONE
     -P column_size=128 -P column_count=8 -P row_count=500000000 -P offset=0
-    -P gauss_mean=250000000 -P gauss_stddev=7500000
+    -P distribution=\"gauss\" -P gauss_mean=250000000 -P gauss_stddev=7500000
     --sampling=10s --retry-number=10 --retry-interval='500ms,5s' --request-timeout=60
     data_dir/latte/latte_cs_alike.rn

--- a/test-cases/cassandra/cassandra-preload-5tb-latte.yaml
+++ b/test-cases/cassandra/cassandra-preload-5tb-latte.yaml
@@ -70,6 +70,6 @@ stress_cmd:
     latte run --function=read --tag=latte-read --duration=30m
     -P replication_factor=1 --threads=7 --concurrency=21 --consistency=ONE
     -P column_size=128 -P column_count=8 -P row_count=5500000000 -P offset=0
-    -P gauss_mean=2750000000 -P gauss_stddev=82500000
+    -P distribution=\"gauss\" -P gauss_mean=2750000000 -P gauss_stddev=82500000
     --sampling=10s --retry-number=10 --retry-interval='500ms,5s' --request-timeout=60
     data_dir/latte/latte_cs_alike.rn

--- a/unit_tests/unit/test_gradual_grow_throughput.py
+++ b/unit_tests/unit/test_gradual_grow_throughput.py
@@ -183,3 +183,36 @@ def test_get_test_table_name_non_latte_ignores_schema_params():
             {"latte_schema_parameters": {"keyspace": "my_latte_ks", "table": "my_latte_tbl"}},
             ["cassandra-stress write cl=QUORUM n=1000"],
         )
+
+
+# ---------------------------------------------------------------------------
+# _aggregate_ops_rate: round-robin vs. additive command patterns
+# ---------------------------------------------------------------------------
+
+
+def _aggregate_ops_rate(results, num_loaders, num_commands):
+    return gradual_grow_module.PerformanceRegressionPredefinedStepsTest._aggregate_ops_rate(
+        results, num_loaders, num_commands
+    )
+
+
+def test_aggregate_ops_rate_round_robin_uses_average_times_loaders():
+    """num_commands == num_loaders: one partition-slice command per loader, avg × loaders."""
+    results = [{"op rate": "100"}, {"op rate": "200"}]
+    assert _aggregate_ops_rate(results, num_loaders=2, num_commands=2) == 150 * 2
+
+
+def test_aggregate_ops_rate_additive_commands_are_summed():
+    """num_commands != num_loaders: distinct concurrent commands (write + read) are additive."""
+    results = [{"op rate": "100"}, {"op rate": "50"}]
+    assert _aggregate_ops_rate(results, num_loaders=1, num_commands=2) == 150 * 1
+
+
+def test_aggregate_ops_rate_ignores_bad_values():
+    """Non-numeric 'op rate' entries are treated as 0 rather than raising."""
+    results = [{"op rate": "100"}, {"op rate": "not-a-number"}, {}]
+    assert _aggregate_ops_rate(results, num_loaders=1, num_commands=3) == 100
+
+
+def test_aggregate_ops_rate_empty_results():
+    assert _aggregate_ops_rate([], num_loaders=2, num_commands=2) == 0.0


### PR DESCRIPTION
## Summary

Adds experimental logstor Latte performance testing infrastructure: uniform and hotspot workload configurations, Jenkins pipelines, rune scripts, and supporting orchestration code.

### Changes

**Configurations:**
- `configurations/performance/enable_logstor.yaml` — adds `force_capacity_based_balancing: true`
- `configurations/performance/logstor_uniform_queries.yaml` — 600k op/s uniform write:30/read:70 Latte workload
- `configurations/performance/logstor_hotspot_queries.yaml` — 750k op/s hotspot write:30/read:70 Latte workload (55% ops target 1% hot keys)

**Rune scripts:**
- `data_dir/latte/latte_cs_alike.rn` — adds a `random` key-access distribution (uniform hash into `[0, ROW_COUNT)`, for use with an unbounded cycle range) alongside the existing `sequential` default; fixes the Gaussian clamp off-by-one (`>` → `>=`)
- `data_dir/latte/latte_cs_alike_hotspot.rn` — new hotspot write/read functions

**Jenkins pipelines:**
- `logstor_uniform.jenkinsfile` — runs `test_mixed_gradual_increase_load` for the uniform workload
- `logstor_hotspot.jenkinsfile` — runs `test_mixed_gradual_increase_load` for the hotspot workload

**Orchestration (`performance_regression_gradual_grow_throughput.py`):**
- `_aggregate_ops_rate` — cluster-total op-rate calculation that distinguishes round-robin partition-slice commands (avg × num_loaders, preserving the historical calculation) from additive distinct commands like write+read (sum × num_loaders)
- `run_step(..., hdr_tags=None)` — generalized `$param` substitution loop; accepts explicit HDR tags so both write and read tags are reported instead of only the first queue's
- `current_step_duration` / `should_wait_no_compactions` — per-step overrides read from `perf_gradual_throttle_steps` dict entries
- `run_gradual_increase_load` pre-computes HDR tags from command templates and uses `_aggregate_ops_rate` for throughput

**Config validation (`sdcm/sct_config.py`):**
- `_validate_throttle_step_dict` helper extracted to keep branch count in range
- `duration` and `wait_no_compactions` per-step dict field validation

**Pipeline (`vars/perfRegressionParallelPipeline.groovy`):**
- `byo_build_both_arch` now accepts a value from `pipelineParams` instead of always defaulting to `false` — needed by the uniform, hotspot, and dual-engine jenkinsfiles (all pass `byo_build_both_arch: true`)

**Tests (`unit_tests/unit/test_gradual_grow_throughput.py`):**
- Keyspace/table resolution tests for cassandra-stress/cql-stress/scylla-bench/latte
- `_aggregate_ops_rate` tests: round-robin averaging, additive summing, bad-value handling, empty results
