### PR TITLE
fix(scylla_doctor): harden tarball download validation

### DIFF
--- a/unit_tests/test_scylla_doctor.py
+++ b/unit_tests/test_scylla_doctor.py
@@ -383,29 +383,79 @@ def test_download_and_extract_tarball_rejects_non_gzip(mock_node, mock_test_conf
     """When downloaded file is not a gzip tarball, ScyllaDoctorException should be raised."""
     test_config, _params = mock_test_config
 
-    # Make the file check return non-gzip
+    # Magic-byte check returns non-gzip (e.g. "3c45" for an XML error page)
     check_result = MagicMock()
     check_result.ok = True
-    check_result.stdout = "ASCII text"
+    check_result.stdout = "3c45"
 
-    head_result = MagicMock()
-    head_result.stdout = "<Error><Code>AccessDenied</Code></Error>"
+    hexdump_result = MagicMock()
+    hexdump_result.stdout = "000000 3c 45 72 72 6f 72 3e 3c  ><Error><"
+
+    dns_result = MagicMock()
+    dns_result.stdout = "93.184.216.34  example.com"
 
     rm_result = MagicMock()
     rm_result.ok = True
 
-    # First call: curl download (succeeds), second: file check, third: head, fourth: rm
+    # Flow: curl download, magic-byte check (fails), od hexdump, getent hosts, rm -f
     mock_node.remoter.run.side_effect = [
         MagicMock(ok=True),  # curl download
-        check_result,  # file check
-        head_result,  # head -c 500
+        check_result,  # head -c 2 | od (non-gzip magic bytes)
+        hexdump_result,  # od | head -20
+        dns_result,  # getent hosts
         rm_result,  # rm -f
     ]
 
     doc = ScyllaDoctor(node=mock_node, test_config=test_config, offline_install=True)
 
-    with pytest.raises(ScyllaDoctorException, match="not a valid gzip tarball"):
+    with pytest.raises(ScyllaDoctorException, match="not a valid gzip tarball") as exc_info:
         doc._download_and_extract_tarball("https://example.com/bad.tar.gz")
+
+    # The exception must carry both diagnostics: the DNS probe and the hexdump
+    assert "DNS: 93.184.216.34  example.com" in str(exc_info.value)
+    assert "Hexdump:" in str(exc_info.value)
+    assert "><Error><" in str(exc_info.value)
+
+    # The download command must keep the retry/robustness flags
+    curl_cmd = mock_node.remoter.run.call_args_list[0].args[0]
+    assert "--retry" in curl_cmd
+    assert "--compressed" in curl_cmd
+    assert "-f" in curl_cmd.split() and "-L" in curl_cmd.split()
+    assert "'https://example.com/bad.tar.gz'" in curl_cmd  # quoted: pre-signed URLs contain '&'
+    # DNS probe targeted the download host
+    getent_cmd = mock_node.remoter.run.call_args_list[3].args[0]
+    assert "getent hosts example.com" in getent_cmd
+
+
+def test_download_and_extract_tarball_accepts_gzip(mock_node, mock_test_config):
+    """A valid gzip download (1f8b magic) must proceed to extraction and cleanup."""
+    test_config, _params = mock_test_config
+
+    check_result = MagicMock()
+    check_result.ok = True
+    check_result.stdout = "1f8b"
+
+    extract_result = MagicMock()
+    extract_result.ok = True
+
+    rm_result = MagicMock()
+    rm_result.ok = True
+
+    # Flow: curl download, magic-byte check (passes), mkdir (current_dir), tar extract, rm -f
+    mock_node.remoter.run.side_effect = [
+        MagicMock(ok=True),  # curl download
+        check_result,  # head -c 2 | od (gzip magic bytes)
+        MagicMock(ok=True),  # mkdir -p (current_dir cached property)
+        extract_result,  # tar -xzf
+        rm_result,  # rm -f
+    ]
+
+    doc = ScyllaDoctor(node=mock_node, test_config=test_config, offline_install=True)
+    doc._download_and_extract_tarball("https://example.com/good.tar.gz")
+
+    commands = [call.args[0] for call in mock_node.remoter.run.call_args_list]
+    assert "tar -xzf" in commands[3]
+    assert commands[4].startswith("rm -f")
 
 
 # --- _full_edition_downloaded tests ---

--- a/utils/scylla_doctor.py
+++ b/utils/scylla_doctor.py
@@ -16,6 +16,7 @@ from sdcm.cluster import BaseNode
 from sdcm.keystore import KeyStore
 from sdcm.remote.remote_file import remote_file
 from sdcm.test_config import TestConfig
+from sdcm.utils.curl import curl_with_retry
 
 LOGGER = logging.getLogger(__name__)
 
@@ -342,27 +343,44 @@ class ScyllaDoctor:
                 extraction failure.
         """
         tmp_tarball = "/tmp/scylla_doctor_download.tar.gz"
-        # -f/--fail  → exit code 22 on HTTP 4xx/5xx instead of saving the error page
+        # --compressed → handle Content-Encoding (zstd/br/gzip) transparently; prevents
+        #                saving a zstd-compressed blob when CloudFront negotiates
+        #                compression with curl's advertised zstd support
         # -S/--show-error → print error message even when -f is used
-        # -L/--location  → follow redirects
+        # url is quoted: pre-signed S3 URLs contain '&' which the shell would split on
         self.node.remoter.run(
-            f"curl -fSL -o {tmp_tarball} '{url}'",
+            curl_with_retry(
+                f"'{url}'",
+                follow_redirects=True,
+                fail_early=True,
+                output=tmp_tarball,
+                extra_flags="-S --compressed",
+            ),
         )
-        # Sanity-check: a valid tarball is at least a few KB
+        # Sanity-check: verify the downloaded file is a valid gzip archive.
+        # Magic-byte check (1f8b) instead of the `file` command, which is not
+        # installed on minimal ScyllaDB AMIs.
         check = self.node.remoter.run(
-            f"test -s {tmp_tarball} && file {tmp_tarball}",
+            f"test -s {tmp_tarball} && head -c 2 {tmp_tarball} | od -An -tx1 | tr -d ' \\n'",
             verbose=False,
             ignore_status=True,
         )
-        if not check.ok or "gzip" not in check.stdout.lower():
-            body_head = self.node.remoter.run(
-                f"head -c 500 {tmp_tarball}",
+        if not check.ok or "1f8b" not in check.stdout.strip():
+            hexdump = self.node.remoter.run(
+                f"od -Ax -tx1z {tmp_tarball} | head -20",
                 verbose=False,
                 ignore_status=True,
             ).stdout.strip()
+            dns_result = self.node.remoter.run(
+                f"getent hosts {urlparse(url).hostname} || echo 'DNS_LOOKUP_FAILED'",
+                verbose=False,
+                ignore_status=True,
+            )
             self.node.remoter.run(f"rm -f {tmp_tarball}", verbose=False, ignore_status=True)
             raise ScyllaDoctorException(
-                f"Downloaded {description} file is not a valid gzip tarball. First 500 bytes of response:\n{body_head}"
+                f"Downloaded {description} file is not a valid gzip tarball.\n"
+                f"DNS: {dns_result.stdout.strip()}\n"
+                f"Hexdump:\n{hexdump}"
             )
         LOGGER.info("Extracting %s tarball...", description)
         # --no-same-owner: avoid chown failures in Docker containers running as non-root


### PR DESCRIPTION
## What

Three robustness fixes for scylla-doctor tarball downloads, split out of #15617 per review (the changes are not minicloud-specific — they fix real download failures on any backend):

- **Retry-enabled curl**: the download now goes through `curl_with_retry()` per the repository HTTP conventions, so transient connection resets (curl exit 35/56) no longer fail installation. `--compressed` handles `Content-Encoding` transparently — previously a zstd-compressed blob was saved verbatim when CloudFront negotiated compression against curl's advertised zstd support, and the gzip validation then rejected a perfectly good tarball.
- **Magic-byte validation**: the gzip check uses the `1f8b` magic bytes instead of the `file` command, which is not installed on minimal ScyllaDB AMIs. The failure-path hexdump uses `od` (coreutils) instead of `xxd` for the same reason.
- **DNS diagnostic**: on validation failure the exception now includes a `getent hosts` result for the download host, distinguishing DNS resolution failures from HTTP error pages.

Note: the minicloud-related scylla-doctor changes from #15617 (IPv4 forcing, MaintenanceEventsCollector skip) are NOT here — they stay in the minicloud PR, gated on minicloud activation.

## Testing

`unit_tests/test_scylla_doctor.py` updated in lockstep (mocked remoter call sequence follows the new flow); all 29 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)