### PR TITLE
fix(docker_remote): remove the staging temp file after a file transfer

### DIFF
--- a/sdcm/utils/docker_remote.py
+++ b/sdcm/utils/docker_remote.py
@@ -139,25 +139,52 @@ class RemoteDocker(BaseNode):
 
     def send_files(self, src, dst, **kwargs):
         remote_tempfile = self.node.remoter.run("mktemp", verbose=kwargs.get("verbose")).stdout.strip()
-        result = self.node.remoter.send_files(src, remote_tempfile, **kwargs)
-        result &= self.run(f"mkdir -p {Path(dst).parent}", ignore_status=True, verbose=kwargs.get("verbose")).ok
-        result &= self.node.remoter.run(
-            f"{self.sudo_needed} docker cp {remote_tempfile} {self.docker_id}:{dst}",
-            verbose=kwargs.get("verbose"),
-            ignore_status=True,
-        ).ok
+        try:
+            result = self.node.remoter.send_files(src, remote_tempfile, **kwargs)
+            result &= self.run(f"mkdir -p {Path(dst).parent}", ignore_status=True, verbose=kwargs.get("verbose")).ok
+            result &= self.node.remoter.run(
+                f"{self.sudo_needed} docker cp {remote_tempfile} {self.docker_id}:{dst}",
+                verbose=kwargs.get("verbose"),
+                ignore_status=True,
+            ).ok
+        finally:
+            self._remove_staging_file(remote_tempfile, verbose=kwargs.get("verbose"))
         return result
 
     def receive_files(self, src, dst, **kwargs):
         remote_tempfile = self.node.remoter.run("mktemp").stdout.strip()
-
-        result = self.node.remoter.run(
-            f"{self.sudo_needed} docker cp {self.docker_id}:{src} {remote_tempfile}",
-            verbose=kwargs.get("verbose"),
-            ignore_status=True,
-        ).ok
-        result &= self.node.remoter.receive_files(remote_tempfile, dst, **kwargs)
+        try:
+            result = self.node.remoter.run(
+                f"{self.sudo_needed} docker cp {self.docker_id}:{src} {remote_tempfile}",
+                verbose=kwargs.get("verbose"),
+                ignore_status=True,
+            ).ok
+            result &= self.node.remoter.receive_files(remote_tempfile, dst, **kwargs)
+        finally:
+            self._remove_staging_file(remote_tempfile, verbose=kwargs.get("verbose"))
         return result
+
+    def _remove_staging_file(self, remote_tempfile: str, verbose: bool | None = None) -> None:
+        """Remove the host-side 'mktemp' file a transfer was staged through.
+
+        Needs 'sudo' on the 'receive_files()' path: 'docker cp' writes its destination as root, and
+        '/tmp' is sticky, so an unprivileged 'rm' of that file fails. 'send_files()' only reads its
+        staging file, but goes through the same 'sudo' as a superset that works either way.
+
+        Swallows every failure because it runs from a 'finally' and must not become the error the
+        caller sees -- usually the connection that just broke the transfer. Deliberately not
+        'ignore_status': that would silence a non-zero 'rm' in the remoter too (see
+        'CommandRunner._print_command_results'), leaving no record that the file leaked, and it
+        would need a second branch here to log what the exception already carries.
+
+        Quotes the path because 'mktemp' builds it from TMPDIR: unquoted, a directory with a space
+        in it splits into arguments 'rm -f' then reports nothing about, exiting 0 on a path that does
+        not exist and putting the leak back exactly where this is meant to prevent it.
+        """
+        try:
+            self.node.remoter.run(f"{self.sudo_needed} rm -f -- {shlex.quote(remote_tempfile)}", verbose=verbose)
+        except Exception as exc:  # noqa: BLE001
+            self.log.warning("Failed to remove the staging file '%s': %s", remote_tempfile, exc)
 
     def _get_ipv6_ip_address(self):
         pass

--- a/unit_tests/integration/test_utils_docker_remote.py
+++ b/unit_tests/integration/test_utils_docker_remote.py
@@ -1,0 +1,81 @@
+"""Integration tests for sdcm.utils.docker_remote.RemoteDocker file transfers.
+
+External services: Docker (Scylla container, via the 'docker_scylla' fixture).
+
+'send_files()' and 'receive_files()' stage the payload through a 'mktemp' file on the container's
+host. The unit tests can only assert that an 'rm' was issued; these run the real transfers against a
+real container and check the host afterwards. Before the cleanup existed, every transfer left one
+staging copy of the payload behind.
+
+'receive_files()' is only checked for that cleanup, not for delivering the file: its 'docker cp' runs
+under 'sudo', which leaves the staging file owned by root, and the unprivileged local copy that
+follows cannot read it. That is a pre-existing failure unrelated to the staging file -- see
+'test_receive_files_removes_the_staging_file_even_when_the_copy_out_fails'.
+"""
+
+import contextlib
+
+import pytest
+
+PAYLOAD = "staging-cleanup-probe\n" * 1000
+CONTAINER_PATH = "/staging-probe/payload.txt"
+
+
+@pytest.fixture(name="staging_dir")
+def fixture_staging_dir(monkeypatch, tmp_path):
+    """Point the host's 'mktemp' at a private directory.
+
+    'mktemp' honours TMPDIR and the remoter runs it in a subprocess that inherits this environment,
+    so the staging file lands somewhere no concurrent test can add to -- globbing /tmp would be racy
+    under xdist.
+    """
+    staging_dir = tmp_path / "staging"
+    staging_dir.mkdir()
+    monkeypatch.setenv("TMPDIR", str(staging_dir))
+    return staging_dir
+
+
+@pytest.fixture(name="payload_in_container")
+def fixture_payload_in_container(docker_scylla, staging_dir, tmp_path):
+    """A payload delivered into the container, with the host staging directory left clean."""
+    src = tmp_path / "payload.txt"
+    src.write_text(PAYLOAD)
+    assert docker_scylla.send_files(str(src), CONTAINER_PATH) is True
+    return src
+
+
+@pytest.mark.integration
+def test_send_files_delivers_the_payload_and_removes_the_staging_file(docker_scylla, staging_dir, payload_in_container):
+    """A real send_files() puts the file in the container and leaves nothing on its host."""
+    assert docker_scylla.run(f"wc -c < {CONTAINER_PATH}").stdout.strip() == str(len(PAYLOAD))
+    assert list(staging_dir.iterdir()) == []
+
+
+@pytest.mark.integration
+def test_receive_files_removes_the_staging_file_even_when_the_copy_out_fails(
+    docker_scylla, staging_dir, payload_in_container, tmp_path
+):
+    """The staging file is gone whether or not the transfer itself succeeded.
+
+    Deliberately asserts nothing about the outcome: 'docker cp' runs under 'sudo' and hands back a
+    root owned staging file that the unprivileged copy which follows cannot read, so today this
+    raises. Suppressing that keeps the test honest now and still correct if it is ever fixed -- and
+    it exercises the real 'finally' path against a real failure, which the unit tests can only mock.
+    """
+    with contextlib.suppress(Exception):
+        docker_scylla.receive_files(CONTAINER_PATH, str(tmp_path / "roundtrip.txt"))
+
+    assert list(staging_dir.iterdir()) == []
+
+
+@pytest.mark.integration
+def test_unremovable_staging_file_is_logged_and_swallowed(docker_scylla, caplog):
+    """A staging file that cannot be removed is reported, not raised.
+
+    '/proc/self/cmdline' exists but cannot be unlinked, which is the only reliable way to make 'rm'
+    fail -- 'rm -f' exits 0 on a path that is merely missing.
+    """
+    with caplog.at_level("WARNING"):
+        docker_scylla._remove_staging_file("/proc/self/cmdline")
+
+    assert "Failed to remove the staging file '/proc/self/cmdline'" in caplog.text

--- a/unit_tests/unit/test_utils_docker_remote.py
+++ b/unit_tests/unit/test_utils_docker_remote.py
@@ -1,0 +1,201 @@
+"""Unit tests for sdcm.utils.docker_remote.RemoteDocker.
+
+Covers the host-side staging file that 'send_files()' and 'receive_files()' create with 'mktemp' to
+move data in and out of the container.  Both must remove it on every path, or each transfer leaks a
+full copy of the payload into the /tmp of the node hosting the container -- a loader instance on the
+cloud backends, the machine running the test on the docker one.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from invoke.exceptions import UnexpectedExit
+
+from sdcm.remote.base import RetryableNetworkException
+from sdcm.utils.docker_remote import RemoteDocker
+
+
+@pytest.fixture(name="remote_docker")
+def fixture_remote_docker():
+    """A RemoteDocker whose container host is a mock remoter, built without starting a container."""
+    remote_docker = RemoteDocker.__new__(RemoteDocker)  # __init__ would 'docker run' over ssh
+    remote_docker.log = MagicMock()
+    remote_docker.docker_id = "dummy-container-id"
+    remote_docker.sudo_needed = ""
+
+    remote_docker.node = MagicMock()
+    remote_docker.node.remoter.run.return_value = MagicMock(stdout="/tmp/tmpXXXXXX\n", ok=True)
+    remote_docker.node.remoter.send_files.return_value = True
+    remote_docker.node.remoter.receive_files.return_value = True
+
+    # 'send_files()' runs 'mkdir -p' inside the container through RemoteDocker.run()
+    with patch.object(RemoteDocker, "run", return_value=MagicMock(ok=True)):
+        yield remote_docker
+
+
+def _failing_docker_cp(tempfile_path):
+    """Return a remoter.run() side effect where 'mktemp' succeeds and 'docker cp' exits non-zero."""
+
+    def run(cmd, *_args, **_kwargs):
+        result = MagicMock(ok=True)
+        if cmd.startswith("mktemp"):
+            result.stdout = f"{tempfile_path}\n"
+        elif "docker cp" in cmd:
+            result.ok = False
+        return result
+
+    return run
+
+
+def _cleanup_commands(remote_docker):
+    """The 'rm -f' commands the container host was asked to run, with the 'sudo_needed' padding
+    normalized away."""
+    return [
+        " ".join(call.args[0].split())
+        for call in remote_docker.node.remoter.run.call_args_list
+        if "rm -f" in call.args[0]
+    ]
+
+
+def _cleanup_ran_last(remote_docker):
+    """Whether the cleanup was the transfer's final command."""
+    return "rm -f" in remote_docker.node.remoter.run.call_args_list[-1].args[0]
+
+
+# --------------------------------------------------------------------------------------------------
+# send_files
+# --------------------------------------------------------------------------------------------------
+
+
+def test_send_files_success_removes_staging_file(remote_docker):
+    """A completed transfer removes the staging file and still reports success."""
+    remote_docker.node.remoter.run.return_value = MagicMock(stdout="/tmp/tmpABC\n", ok=True)
+
+    result = remote_docker.send_files("/local/file.tsv", "/container/dst/file.tsv")
+
+    assert result is True
+    assert _cleanup_commands(remote_docker) == ["rm -f -- /tmp/tmpABC"]
+    assert _cleanup_ran_last(remote_docker)
+
+
+def test_send_files_docker_cp_failure_removes_staging_file(remote_docker):
+    """A failed 'docker cp' still removes the staging file, and is still reported as a failure."""
+    remote_docker.node.remoter.run.side_effect = _failing_docker_cp("/tmp/tmpFAIL")
+
+    result = remote_docker.send_files("/local/file.tsv", "/container/dst/file.tsv")
+
+    assert result is False
+    assert _cleanup_commands(remote_docker) == ["rm -f -- /tmp/tmpFAIL"]
+
+
+def test_send_files_transfer_exception_removes_staging_file(remote_docker):
+    """A raising transfer removes the staging file and propagates the original exception."""
+    remote_docker.node.remoter.run.return_value = MagicMock(stdout="/tmp/tmpRSYNC\n", ok=True)
+    remote_docker.node.remoter.send_files.side_effect = UnexpectedExit(MagicMock())
+
+    with pytest.raises(UnexpectedExit):
+        remote_docker.send_files("/local/file.tsv", "/container/dst/file.tsv")
+
+    assert _cleanup_commands(remote_docker) == ["rm -f -- /tmp/tmpRSYNC"]
+
+
+# --------------------------------------------------------------------------------------------------
+# receive_files
+# --------------------------------------------------------------------------------------------------
+
+
+def test_receive_files_success_removes_staging_file(remote_docker):
+    """A completed transfer removes the staging file and still reports success."""
+    remote_docker.node.remoter.run.return_value = MagicMock(stdout="/tmp/tmpRCV\n", ok=True)
+
+    result = remote_docker.receive_files("/container/src/file.tsv", "/local/dst/file.tsv")
+
+    assert result is True
+    assert _cleanup_commands(remote_docker) == ["rm -f -- /tmp/tmpRCV"]
+    assert _cleanup_ran_last(remote_docker)
+
+
+def test_receive_files_docker_cp_failure_removes_staging_file(remote_docker):
+    """A failed 'docker cp' still removes the staging file, and is still reported as a failure."""
+    remote_docker.node.remoter.run.side_effect = _failing_docker_cp("/tmp/tmpRCVFAIL")
+
+    result = remote_docker.receive_files("/container/src/file.tsv", "/local/dst/file.tsv")
+
+    assert result is False
+    assert _cleanup_commands(remote_docker) == ["rm -f -- /tmp/tmpRCVFAIL"]
+
+
+def test_receive_files_transfer_exception_removes_staging_file(remote_docker):
+    """A raising transfer removes the staging file and propagates the original exception."""
+    remote_docker.node.remoter.run.return_value = MagicMock(stdout="/tmp/tmpRCVEXC\n", ok=True)
+    remote_docker.node.remoter.receive_files.side_effect = OSError("disk full")
+
+    with pytest.raises(OSError):
+        remote_docker.receive_files("/container/src/file.tsv", "/local/dst/file.tsv")
+
+    assert _cleanup_commands(remote_docker) == ["rm -f -- /tmp/tmpRCVEXC"]
+
+
+# --------------------------------------------------------------------------------------------------
+# Both transfers
+# --------------------------------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("transfer", ["send_files", "receive_files"])
+def test_cleanup_uses_the_same_sudo_as_docker_cp(transfer, remote_docker):
+    """The removal runs with the privileges 'docker cp' had -- see '_remove_staging_file()'."""
+    remote_docker.sudo_needed = "sudo "
+    remote_docker.node.remoter.run.return_value = MagicMock(stdout="/tmp/tmpSUDO\n", ok=True)
+
+    getattr(remote_docker, transfer)("/some/src", "/some/dst")
+
+    assert _cleanup_commands(remote_docker) == ["sudo rm -f -- /tmp/tmpSUDO"]
+
+
+@pytest.mark.parametrize("transfer", ["send_files", "receive_files"])
+def test_cleanup_failure_does_not_mask_the_transfer_error(transfer, remote_docker):
+    """A staging file that cannot be removed must not replace the error that broke the transfer."""
+    transfer_error = UnexpectedExit(MagicMock())
+
+    def run(cmd, *_args, **_kwargs):
+        if "rm -f" in cmd:
+            raise RetryableNetworkException("connection lost", original=OSError("connection lost"))
+        return MagicMock(stdout="/tmp/tmpMASK\n", ok=True)
+
+    remote_docker.node.remoter.run.side_effect = run
+    remote_docker.node.remoter.send_files.side_effect = transfer_error
+    remote_docker.node.remoter.receive_files.side_effect = transfer_error
+
+    with pytest.raises(UnexpectedExit):
+        getattr(remote_docker, transfer)("/some/src", "/some/dst")
+
+    remote_docker.log.warning.assert_called_once()
+
+
+def test_cleanup_quotes_a_staging_path_that_needs_it(remote_docker):
+    """'mktemp' builds the path from TMPDIR, so it is only as tame as the caller's environment.
+
+    Unquoted, a directory with a space splits into arguments and 'rm -f' exits 0 on a path that does
+    not exist -- a silent leak, in the one case this cleanup exists to prevent.
+    """
+    remote_docker.node.remoter.run.return_value = MagicMock(stdout="/tmp/a b/tmp.X$(id)\n", ok=True)
+
+    remote_docker.send_files("/local/file.tsv", "/container/dst/file.tsv")
+
+    cleanup = remote_docker.node.remoter.run.call_args_list[-1].args[0]
+    assert cleanup.strip() == "rm -f -- '/tmp/a b/tmp.X$(id)'"
+
+
+def test_cleanup_failure_is_logged_and_keeps_a_good_transfer_successful(remote_docker):
+    """A staging file that cannot be removed is logged, but does not fail a transfer that worked."""
+
+    def run(cmd, *_args, **_kwargs):
+        if "rm -f" in cmd:
+            raise UnexpectedExit(MagicMock(exited=1, stderr="rm: cannot remove: Operation not permitted"))
+        return MagicMock(stdout="/tmp/tmpNOPERM\n", ok=True)
+
+    remote_docker.node.remoter.run.side_effect = run
+
+    assert remote_docker.send_files("/local/file.tsv", "/container/dst/file.tsv") is True
+    remote_docker.log.warning.assert_called_once()
+    assert "/tmp/tmpNOPERM" in str(remote_docker.log.warning.call_args)


### PR DESCRIPTION
'RemoteDocker.send_files()' and 'receive_files()' stage the payload through a
'mktemp' file on the node hosting the container and never removed it, so every
transfer leaked a full copy of whatever it moved into that node's /tmp. This is
not specific to the docker backend: every 'RemoteDocker' in sdcm is built on a
loader, so on the cloud backends it is each loader instance that fills up, and
on the docker one it happens to be the machine running the test.

An ordinary run leaks the SSL certs and the c-s user profile. A latte run leaks
one per file in the script directory, which is how a large dataset turns this
into tens of GB on a loader's root volume.

Delete it in a 'finally', so it goes away on the failure paths too, and with the
same 'sudo' the 'docker cp' above it used. 'receive_files()' needs that: its
'docker cp' writes the host file as root, and '/tmp' is sticky, so an
unprivileged 'rm' of it fails -- which would leave the leak in place on every
backend reached over ssh. 'send_files()' only reads its staging file, so plain
'rm' would do there; it goes through the same 'sudo' anyway, as a superset that
works on either path.

The cleanup must not become the failure the caller sees: it runs from a
'finally', and 'remoter.run()' raises on a broken connection -- typically the
very connection that just broke the transfer. Swallow and log that instead of
masking the real error, deliberately without 'ignore_status', which would
silence a non-zero 'rm' in the remoter too and leave no record of the leak.

Refs: VECTOR-783

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] `uv run sct.py unit-tests -t unit/test_utils_docker_remote.py` — 12 passed
- [x] `uv run python -m pytest unit_tests/integration/test_utils_docker_remote.py -v -m integration -n0` — 3 passed

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)

