### PR TITLE
fix(cluster): kill only the stress containers when cleaning up loaders

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -6805,8 +6805,15 @@ class BaseLoaderSet:
         test_id = self.tags.get("TestId")
         for loader in self.nodes:
             try:
+                # NOTE: every container of the run carries 'TestId', which on the docker backend includes the db,
+                #       monitoring and vector-store ones sharing the loader host. Narrow it down to the stress
+                #       containers with 'shell_marker', set at every 'RemoteDocker' call site - but not by
+                #       'NoSQLBenchStressThread', whose containers carry no labels at all and never matched.
                 loader.remoter.run(
-                    cmd=f"docker ps -a -q --filter label=TestId={test_id} | xargs docker rm -f",
+                    cmd=(
+                        f"docker ps -a -q --filter label=TestId={test_id} --filter label=shell_marker"
+                        " | xargs -r docker rm -f"
+                    ),
                     verbose=True,
                     ignore_status=True,
                 )

--- a/unit_tests/unit/test_kill_docker_loaders.py
+++ b/unit_tests/unit/test_kill_docker_loaders.py
@@ -1,0 +1,48 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2026 ScyllaDB
+
+"""Tests for the stress containers cleanup done by 'BaseLoaderSet.kill_docker_loaders'."""
+
+from types import MethodType
+from unittest.mock import MagicMock
+
+import pytest
+
+from sdcm.cluster import BaseLoaderSet
+
+TEST_ID = "7001f1a8-74b6-48a7-8a04-395da916410e"
+
+
+@pytest.fixture(name="loader_set")
+def fixture_loader_set():
+    """Bind the real 'kill_docker_loaders' to a mock, so only its remoter calls are faked."""
+    loader_set = MagicMock()
+    loader_set.nodes = [MagicMock(), MagicMock()]
+    loader_set.tags = {"TestId": TEST_ID}
+    loader_set.kill_docker_loaders = MethodType(BaseLoaderSet.kill_docker_loaders, loader_set)
+    return loader_set
+
+
+def test_kill_docker_loaders_removes_stress_containers_only(loader_set):
+    loader_set.kill_docker_loaders()
+
+    # NOTE: 'shell_marker' is set on the stress containers only, so the db, monitoring and
+    #       vector-store containers of the same test survive the cleanup, and 'xargs -r' makes an
+    #       empty match a no-op. Compare the whole command rather than those parts: substring
+    #       checks also pass on a dropped pipe or on a second, unfiltered sweep appended to it.
+    expected_cmd = (
+        f"docker ps -a -q --filter label=TestId={TEST_ID} --filter label=shell_marker | xargs -r docker rm -f"
+    )
+    for node in loader_set.nodes:
+        node.remoter.run.assert_called_once()
+        assert node.remoter.run.call_args.kwargs["cmd"] == expected_cmd


### PR DESCRIPTION
'BaseLoaderSet.kill_docker_loaders()' removed every container carrying the run's 'TestId' label. On the docker backend a loader node runs on the host through LOCALRUNNER, so that filter also matched the db, monitoring and vector-store containers sharing the host, and 'stop_resources()' runs it before 'collect_logs()' and 'collect_grafana_screenshots()' - the loader cleanup took Grafana down before the teardown collected from it.

Every stress container started through 'RemoteDocker' also gets a 'shell_marker' label, so require that as well. Add 'xargs -r' while here, so a run with no stress containers left does not invoke 'docker rm' with no arguments.

All 11 'RemoteDocker' call sites set 'shell_marker', so nothing that used to be cleaned up is missed. 'NoSQLBenchStressThread' is the one 'DockerBasedStressThread' subclass that does not use 'RemoteDocker' at all: it starts its containers with a plain 'docker run' carrying no labels, so the 'TestId' filter never matched them to begin with and this changes nothing for it either way.

Refs: VECTOR-783

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- `pytest unit_tests/unit/test_kill_docker_loaders.py` — 1 passed
- verified the test fails against the unpatched command (it asserts the `shell_marker` filter is present)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
