### PR TITLE
fix(latency): collect latency results on a run without monitoring

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -2258,11 +2258,14 @@ class ClusterTester(unittest.TestCase):
         self.loaders = cluster_docker.LoaderSetDocker(
             n_nodes=self.params.get("n_loaders"), **container_node_params, **common_params
         )
-        self.monitors = cluster_docker.MonitorSetDocker(
-            n_nodes=self.params.get("n_monitor_nodes"),
-            targets=dict(db_cluster=self.db_cluster, loaders=self.loaders),
-            **common_params,
-        )
+        if sum(self.params.get("n_monitor_nodes")) > 0:
+            self.monitors = cluster_docker.MonitorSetDocker(
+                n_nodes=self.params.get("n_monitor_nodes"),
+                targets=dict(db_cluster=self.db_cluster, loaders=self.loaders),
+                **common_params,
+            )
+        else:
+            self.monitors = NoMonitorSet()
 
     def get_cluster_baremetal(self):
         baremetal_info: cluster_baremetal.BareMetalCredentials = KeyStore().get_baremetal_config(

--- a/sdcm/utils/decorators.py
+++ b/sdcm/utils/decorators.py
@@ -198,7 +198,9 @@ def latency_calculator_decorator(  # noqa: PLR0915
 
     For proper usage, it requires workload name (write, read, mixed) to be included in the test name
     or setting 'workload_name' test parameter.
-    Also requires monitoring set and 'use_hdrhistogram' test parameter to be set to True.
+    Also requires the 'use_hdrhistogram' test parameter to be set to True.
+    Monitoring set is optional: without it the Grafana screenshots and the Prometheus based metrics
+    are absent from the results, the rest is collected as usual.
 
     :param func: Remote method to run.
     :return: Wrapped method.
@@ -249,13 +251,15 @@ def latency_calculator_decorator(  # noqa: PLR0915
             all_nodes_list = list(set(start_node_list + end_node_list))
             end = time.time()
             test_name = tester.__repr__().split("testMethod=")[-1].split(">")[0]
-            if not monitoring_set or not monitoring_set.nodes or not tester.params.get("use_hdrhistogram"):
+            if not tester.params.get("use_hdrhistogram"):
                 if func_exception:
                     raise func_exception  # noqa: TRY201
                 return res
             try:
-                monitor = monitoring_set.nodes[0]
-                screenshots = monitoring_set.get_grafana_screenshots(node=monitor, test_start_time=start)
+                monitor = monitoring_set.nodes[0] if monitoring_set and monitoring_set.nodes else None
+                screenshots = (
+                    monitoring_set.get_grafana_screenshots(node=monitor, test_start_time=start) if monitor else []
+                )
                 if workload_type:
                     workload = workload_type
                 elif "read_disk_only" in test_name:
@@ -287,7 +291,9 @@ def latency_calculator_decorator(  # noqa: PLR0915
                     if "cycles" not in latency_results[func_name]:
                         latency_results[func_name]["cycles"] = []
 
-                result = latency.collect_latency(monitor, start, end, workload, cluster, all_nodes_list)
+                result = (
+                    latency.collect_latency(monitor, start, end, workload, cluster, all_nodes_list) if monitor else {}
+                )
                 result["screenshots"] = screenshots
                 result["duration"] = f"{datetime.timedelta(seconds=int(end - start))}"
                 result["duration_in_sec"] = int(end - start)

--- a/unit_tests/unit/test_tester.py
+++ b/unit_tests/unit/test_tester.py
@@ -19,6 +19,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from sdcm.cluster import NoMonitorSet
 from sdcm.sct_config import SCTConfiguration
 from sdcm.sct_events import Severity
 from sdcm.sct_events.base import SctEvent
@@ -735,3 +736,37 @@ def test_init_argus_run_config_excludes_internal_fields(tester_with_argus):
     assert "multi_region_params" not in parsed
     assert "regions_data" not in parsed
     assert "target_db_image_ids" not in parsed
+
+
+# get_cluster_docker: the monitoring set follows 'n_monitor_nodes', as on every other backend
+
+
+def _docker_tester(tmp_path, n_monitor_nodes):
+    tester = ClusterTesterForTests()
+    tester._init_logging(tmp_path / "docker_monitors")
+    tester.params = FakeSCTConfiguration()
+    tester.params["n_monitor_nodes"] = n_monitor_nodes
+    tester.credentials = []
+    return tester
+
+
+def test_get_cluster_docker_zero_monitor_nodes_uses_no_monitor_set(tmp_path):
+    """'n_monitor_nodes: 0' must not start the monitoring stack on the docker backend."""
+    tester = _docker_tester(tmp_path, 0)
+
+    with patch("sdcm.tester.cluster_docker") as cluster_docker_mock, patch("sdcm.tester.UserRemoteCredentials"):
+        tester.get_cluster_docker()
+
+    assert isinstance(tester.monitors, NoMonitorSet)
+    cluster_docker_mock.MonitorSetDocker.assert_not_called()
+
+
+def test_get_cluster_docker_nonzero_monitor_nodes_builds_monitor_set_docker(tmp_path):
+    """A monitored docker run is unchanged: the parameter still builds a 'MonitorSetDocker'."""
+    tester = _docker_tester(tmp_path, 1)
+
+    with patch("sdcm.tester.cluster_docker") as cluster_docker_mock, patch("sdcm.tester.UserRemoteCredentials"):
+        tester.get_cluster_docker()
+
+    cluster_docker_mock.MonitorSetDocker.assert_called_once()
+    assert tester.monitors is cluster_docker_mock.MonitorSetDocker.return_value

--- a/unit_tests/unit/test_utils_decorators.py
+++ b/unit_tests/unit/test_utils_decorators.py
@@ -1,3 +1,4 @@
+import json
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -6,7 +7,12 @@ from google.api_core.exceptions import ServiceUnavailable
 from sdcm.exceptions import UnsupportedNemesis
 from sdcm.provision.provisioner import ProvisionUnrecoverableError
 from sdcm.sct_events import Severity
-from sdcm.utils.decorators import _find_hdr_tags, critical_on_capacity_issues, skip_on_capacity_issues
+from sdcm.utils.decorators import (
+    _find_hdr_tags,
+    critical_on_capacity_issues,
+    latency_calculator_decorator,
+    skip_on_capacity_issues,
+)
 
 
 HDR_TAGS1 = ["foohdr1", "foohdr2"]
@@ -98,3 +104,133 @@ def test_critical_on_capacity_issues_reraises_on_service_unavailable():
             critical_on_capacity_issues(_raise_service_unavailable)()
     assert event_mock.call_args.kwargs["severity"] == Severity.CRITICAL
     event_mock.return_value.publish.assert_called_once()
+
+
+# latency_calculator_decorator: the monitoring set is optional, see 'sdcm.utils.decorators'
+
+HDR_SUMMARY = {"READ--fn--search": {"percentile_50": 0.24, "percentile_99": 0.47, "throughput": 6414}}
+REACTOR_STALLS = {
+    "DatabaseLogEvent.REACTOR_STALLED": {
+        "event": "DatabaseLogEvent.REACTOR_STALLED",
+        "counter": 3,
+        "ms": {10: 2, 20: 1},
+    }
+}
+
+
+class FakeDbCluster:
+    nodes = []
+
+
+class FakeMonitorSet:
+    """Monitoring set without nodes, the same as 'sdcm.cluster.NoMonitorSet' or a 'n_monitor_nodes: 0' set."""
+
+    nodes = []
+
+    def __init__(self):
+        self.screenshot_requests = []
+
+    def get_grafana_screenshots(self, node, test_start_time):
+        self.screenshot_requests.append((node, test_start_time))
+        return ["https://cloudius-jenkins-test.s3.amazonaws.com/fake-screenshot.png"]
+
+
+class FakeMonitorNode:
+    name = "monitor-node-1"
+    external_address = "127.0.0.1"
+
+
+class FakeMonitorSetWithNode(FakeMonitorSet):
+    nodes = [FakeMonitorNode()]
+
+
+class FakeEventCounter:
+    """Stands in for 'EventCounterContextManager' which needs the default events registry."""
+
+    def __init__(self, *_, **__):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        return False
+
+    @staticmethod
+    def get_stats():
+        return REACTOR_STALLS
+
+
+class FakeLatencyTester:
+    """Provides the 'latency_calculator_decorator' dependencies only, without the ClusterTester machinery."""
+
+    def __init__(self, latency_results_file, monitors):
+        self.db_cluster = FakeDbCluster()
+        self.monitors = monitors
+        self.params = {"use_hdrhistogram": True}
+        self.latency_results_file = str(latency_results_file)
+        self.test_config = MagicMock()
+
+    def get_hdrhistogram_by_interval(self, **_):
+        return [HDR_SUMMARY]
+
+    def get_hdrhistogram(self, **_):
+        return HDR_SUMMARY
+
+
+def _run_decorated_search(tester):
+    @latency_calculator_decorator(workload_type="read", legend="fts search", cycle_name="fts_search", row_name="row-1")
+    def _do_search(_self):
+        return {"hdr_tags": ["fn--search"]}
+
+    # NOTE: the decorator resolves the tester from the first positional argument
+    return _do_search(tester)
+
+
+def test_latency_calculator_decorator_without_monitoring_set(tmp_path):
+    tester = FakeLatencyTester(latency_results_file=tmp_path / "latency_results.json", monitors=FakeMonitorSet())
+
+    with (
+        patch("sdcm.tester.ClusterTester", FakeLatencyTester),
+        patch("sdcm.utils.decorators.EventCounterContextManager", FakeEventCounter),
+        patch("sdcm.utils.latency.collect_latency") as collect_latency_mock,
+        patch("sdcm.utils.decorators.send_result_to_argus") as send_to_argus_mock,
+    ):
+        res = _run_decorated_search(tester)
+
+    assert res == {"hdr_tags": ["fn--search"]}
+    collect_latency_mock.assert_not_called()
+    assert not tester.monitors.screenshot_requests
+    # NOTE: the HDR results, the reactor stalls and the Argus reporting are the point of the decorator,
+    #       they must survive
+    send_to_argus_mock.assert_called_once()
+    cycle = send_to_argus_mock.call_args.kwargs["result"]
+    assert cycle["hdr_summary"] == HDR_SUMMARY
+    assert cycle["cycle_hdr_throughput"] == 6414
+    assert cycle["reactor_stalls_stats"] == REACTOR_STALLS
+    assert cycle["screenshots"] == []
+
+    latency_results = json.loads((tmp_path / "latency_results.json").read_text(encoding="utf-8"))
+    assert latency_results["fts_search"]["legend"] == "fts search"
+    assert len(latency_results["fts_search"]["cycles"]) == 1
+
+
+def test_latency_calculator_decorator_with_monitoring_set(tmp_path):
+    tester = FakeLatencyTester(
+        latency_results_file=tmp_path / "latency_results.json", monitors=FakeMonitorSetWithNode()
+    )
+
+    with (
+        patch("sdcm.tester.ClusterTester", FakeLatencyTester),
+        patch("sdcm.utils.decorators.EventCounterContextManager", FakeEventCounter),
+        patch("sdcm.utils.latency.collect_latency", return_value={"Scylla P99_read - node-1": 1.5}) as collect_mock,
+        patch("sdcm.utils.decorators.send_result_to_argus") as send_to_argus_mock,
+    ):
+        _run_decorated_search(tester)
+
+    collect_mock.assert_called_once()
+    assert collect_mock.call_args.args[0] is FakeMonitorSetWithNode.nodes[0]
+    cycle = send_to_argus_mock.call_args.kwargs["result"]
+    assert cycle["Scylla P99_read - node-1"] == 1.5
+    assert len(cycle["screenshots"]) == 1
+    assert tester.monitors.screenshot_requests


### PR DESCRIPTION
`n_monitor_nodes: 0` is a supported configuration — every backend except docker already falls back
to `NoMonitorSet` for it. But a run using it silently collected no latency results at all: no HDR
summary, no reactor stalls, no Argus rows, and no warning that anything was missing. On docker it
could not even be configured in the first place, because that backend built a `MonitorSetDocker`
regardless of the parameter.

Only the Grafana screenshots and the Prometheus based metrics genuinely need a monitor node.
Everything else the decorator collects has a different source — the HDR data comes from the stress
tool's own files, the reactor stalls from the DB logs — so there was never a reason for the absence
of a monitor to suppress them.

Inert for any run that does have a monitoring set: with `monitoring_set.nodes` non-empty every
branch behaves exactly as before.

Refs: VECTOR-785

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
