### PR TITLE
Improve decommision timeout calculation for longevity test

### DIFF
--- a/test-cases/longevity/longevity-alternator-3h.yaml
+++ b/test-cases/longevity/longevity-alternator-3h.yaml
@@ -48,3 +48,5 @@ alternator_port: 8080
 dynamodb_primarykey_type: HASH_AND_RANGE
 
 docker_network: 'ycsb_net'
+adaptive_timeout_multipliers:
+  decommission: 8


### PR DESCRIPTION
SCT-770 has shown, that current timeout calculation for longevity-alternator-3h test is off - it assumes
`node_info_service.expected_throughput` is achievable by tablet migration. Real data shown the tablet migration throughput is around 13-14 times lower than `expected_throughput`.
This patch fixes the issue by using `adaptive_timeout_multipliers` dictionary and sets `adaptive_timeout_multipliers.decommission` to 8 (the estimated time is already multipied by 2, multiplying it by 8 will bring it to 16, which is above 13-14 we're currently getting).
