### PR TITLE
fix(test-cases/gemini): make preimage-write test drain delete bucket

### DIFF
--- a/test-cases/gemini/gemini-3h-cdc-preimage-write.yaml
+++ b/test-cases/gemini/gemini-3h-cdc-preimage-write.yaml
@@ -10,6 +10,7 @@ gemini_cmd: |
   --mode mixed
   --mutation-concurrency 24
   --read-concurrency 6
+  --partition-count 2000000
   --max-deleted-heap-size 2000000
 
 gemini_table_options:

--- a/test-cases/gemini/gemini-3h-cdc-preimage-write.yaml
+++ b/test-cases/gemini/gemini-3h-cdc-preimage-write.yaml
@@ -7,8 +7,10 @@ user_prefix: 'gemini-cdc-preimage-write'
 
 gemini_cmd: |
   --duration 3h
-  --concurrency 30
-  --mode write
+  --mode mixed
+  --mutation-concurrency 24
+  --read-concurrency 6
+  --max-deleted-heap-size 2000000
 
 gemini_table_options:
   - "cdc={'enabled': true, 'preimage': true}"


### PR DESCRIPTION
## Problem

`gemini-3h-cdc-preimage-write` runs gemini in `--mode write`, so only mutation
workers run. Gemini retires entries from its in-memory deleted-partitions
bucket only from the validation (read) path. Every DELETE in write-only mode
leaks one bucket entry, and the bucket never drains.

Over a 3h run this exhausted loader memory, and gemini was OOM-killed after
about 1h25m. See the failed run at
https://argus.scylladb.com/tests/scylla-cluster-tests/d2321bd5-d8ab-4b1e-b95d-fae152d468de/.

## Change

File: `test-cases/gemini/gemini-3h-cdc-preimage-write.yaml`

Before:
```
--duration 3h
--concurrency 30
--mode write
```

After:
```
--duration 3h
--mode mixed
--mutation-concurrency 24
--read-concurrency 6
--max-deleted-heap-size 2000000
```

1. `--mode mixed` runs both mutation and validation workers, so deletes get
   retired from the bucket. `--mutation-concurrency 24` and
   `--read-concurrency 6` keep the total worker count at 30, same as the old
   `--concurrency 30`, and keep the workload write-centric at a 4:1
   mutation-to-read ratio.
2. `--max-deleted-heap-size 2000000` bounds the deleted-partitions bucket as a
   hard safety check, so it cannot grow unbounded again regardless of the
   read and write balance. This value is gemini's own default, since this
   test does not set `--partition-count`.

## Not in scope

`gemini-3h-cdc-write.yaml` and `gemini-3h-cdc-postimage-write.yaml` carry the
same write-only pattern and are candidates for the same fix, in a separate
change.