### PR TITLE
fix(remote): write out only complete lines in LogWriteWatcher

### DIFF
--- a/sdcm/remote/base.py
+++ b/sdcm/remote/base.py
@@ -11,7 +11,7 @@
 #
 # Copyright (c) 2020 ScyllaDB
 
-from typing import Optional, List, Callable
+from typing import Callable, List, Optional, TextIO
 from abc import abstractmethod, ABCMeta
 from datetime import datetime
 import shlex
@@ -283,6 +283,27 @@ class OutputWatcher(StreamWatcher):
         self.log.debug("<%s>: %s", self.hostname, line.rstrip("\n"))
 
 
+class PendingLine:
+    """The tail of a stream which has no line end yet, written out once the stream is over.
+
+    'invoke' offers a watcher no end of stream hook, but it reads each stream in a thread of its own
+    and 'StreamWatcher' is a 'threading.local', so an instance of this -- created per reader thread --
+    is finalized when that thread ends, which is exactly when the stream is over.
+    """
+
+    def __init__(self, file_object: TextIO, format_line: Callable[[str], str]):
+        self.file_object = file_object
+        self.format_line = format_line
+        self.text = ""
+
+    def __del__(self):
+        if self.text and not self.file_object.closed:
+            self.file_object.write(self.format_line(self.text))
+            # NOTE: the file is line buffered, so a tail with no line end of its own would sit in the
+            #       buffer until the file gets closed -- which is not guaranteed to ever happen.
+            self.file_object.flush()
+
+
 class LogWriteWatcher(StreamWatcher):
     def __init__(self, log_file: str):
         super().__init__()
@@ -291,17 +312,26 @@ class LogWriteWatcher(StreamWatcher):
         # open fail with line buffering, so prom stats would be as accuracte as possible
 
         self.file_object = open(self.log_file, "a+", encoding="utf-8", buffering=1)
+        # NOTE: 'invoke' watches stdout and stderr in a thread each, so this -- like every attribute
+        #       here -- is per stream, which is exactly what the line buffering needs.
+        self.pending_line = PendingLine(self.file_object, self._format_line)
 
     def _format_line(self, line: str) -> str:
         return line
 
     def submit(self, stream: str) -> list:
+        # NOTE: the stream is read in fixed size chunks (see 'invoke.runners.Runner.read_chunk_size'), so its
+        #       new part usually ends in the middle of a line. Keep that tail for the next 'submit' call --
+        #       same approach as 'OutputWatcher.submit' above -- so that '_format_line' only ever decides on a
+        #       whole line. Deciding on a fragment turns one stress tool line into 2 log lines.
+        #       A last line with no line end of its own is written out by 'PendingLine' instead, once
+        #       the stream is over.
         stream_buffer = stream[self.len :]
-        lines = stream_buffer.splitlines(True)
-        formatted_lines = [self._format_line(line) for line in lines]
-        self.file_object.write("".join(formatted_lines))
-
-        self.len = len(stream)
+        split_at = max(stream_buffer.rfind("\n"), stream_buffer.rfind("\r")) + 1
+        self.pending_line.text = stream_buffer[split_at:]
+        self.len += split_at
+        if complete_part := stream_buffer[:split_at]:
+            self.file_object.write("".join(self._format_line(line) for line in complete_part.splitlines(True)))
         return []
 
     def submit_line(self, line: str):

--- a/unit_tests/unit/test_remote_base.py
+++ b/unit_tests/unit/test_remote_base.py
@@ -1,0 +1,152 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2026 ScyllaDB
+
+"""Tests for the stress log writing watchers used by the command runners."""
+
+import gc
+import re
+import threading
+
+import pytest
+
+from sdcm.remote.base import LogWriteWatcher, TimestampedLogWriteWatcher
+
+# NOTE: latte 'LOG' section lines, the ones parsed by the 'sdcm.loader.LatteExporter'
+STRESS_OUTPUT = (
+    "   1.001       299         0       299       0.202     1.626     1.934"
+    "     2.269     2.427     2.632     3.369     3.369\n"
+    "   2.001       412         0       412       0.204     1.502     1.812"
+    "     2.101     2.302     2.501     3.001     3.001\n"
+    "            99.99               0.2001 ± 0.0000\n"
+)
+TIMESTAMP_PREFIX_PATTERN = re.compile(r"^\[\d{4}-\d\d-\d\d \d\d:\d\d:\d\d\.\d{3}\] ")
+
+
+def submit_in_chunks(watcher: LogWriteWatcher, stream: str, chunk_size: int) -> None:
+    """Feed the watcher the way 'invoke.runners.Runner' does it - with a cumulative stream read in chunks."""
+    for end in range(chunk_size, len(stream) + chunk_size, chunk_size):
+        watcher.submit(stream[:end])
+
+
+@pytest.mark.parametrize("chunk_size", (1, 7, 40, 1000), ids=lambda size: f"chunk-{size}")
+def test_log_write_watcher_writes_the_stream_verbatim(tmp_path, chunk_size):
+    """The base class writes lines as they are, so its output has to stay byte for byte the stream.
+
+    NOTE: this passes before the fix too - 'LogWriteWatcher._format_line' is the identity, so holding
+          the tail back changes nothing here. It is a guard on the new buffering, not on the bug.
+    """
+    log_file = tmp_path / "stress.log"
+    watcher = LogWriteWatcher(str(log_file))
+
+    submit_in_chunks(watcher, STRESS_OUTPUT, chunk_size)
+
+    assert log_file.read_text(encoding="utf-8") == STRESS_OUTPUT
+
+
+@pytest.mark.parametrize("chunk_size", (1, 7, 40, 1000), ids=lambda size: f"chunk-{size}")
+def test_timestamped_log_write_watcher_does_not_split_lines(tmp_path, chunk_size):
+    log_file = tmp_path / "stress.log"
+    watcher = TimestampedLogWriteWatcher(str(log_file))
+
+    submit_in_chunks(watcher, STRESS_OUTPUT, chunk_size)
+
+    written_lines = log_file.read_text(encoding="utf-8").splitlines()
+    assert len(written_lines) == len(STRESS_OUTPUT.splitlines())
+    for written_line, expected_line in zip(written_lines, STRESS_OUTPUT.splitlines()):
+        assert TIMESTAMP_PREFIX_PATTERN.match(written_line), f"'{written_line}' is missing the timestamp prefix"
+        assert TIMESTAMP_PREFIX_PATTERN.sub("", written_line) == expected_line
+
+
+def test_a_last_line_without_a_line_end_is_written_once_the_stream_is_over(tmp_path):
+    """'invoke' gives a watcher no end of stream hook, so 'PendingLine' hangs the write off the death
+    of the thread reading that stream -- the point at which nothing more can arrive to complete it."""
+    log_file = tmp_path / "stress.log"
+    watcher = TimestampedLogWriteWatcher(str(log_file))
+    held_back = {}
+
+    def watch_stdout():  # invoke reads each stream in a thread of its own
+        submit_in_chunks(watcher, STRESS_OUTPUT + "   Errors: 0", chunk_size=40)
+        held_back["while_the_stream_is_open"] = "Errors: 0" not in log_file.read_text(encoding="utf-8")
+
+    thread = threading.Thread(target=watch_stdout, name="handle_stdout")
+    thread.start()
+    thread.join(timeout=5)
+    gc.collect()
+
+    assert held_back["while_the_stream_is_open"], "the tail must not be written while it may still grow"
+    written = log_file.read_text(encoding="utf-8").splitlines()
+    assert len(written) == len(STRESS_OUTPUT.splitlines()) + 1
+    assert TIMESTAMP_PREFIX_PATTERN.sub("", written[-1]) == "   Errors: 0"
+
+
+def test_the_line_buffering_is_per_stream(tmp_path):
+    """One watcher watches both stdout and stderr, in a thread each.
+
+    'invoke' hands each of its two reader threads its own cumulative stream and calls 'submit' on the
+    same watcher object for both. That is safe only because 'StreamWatcher' subclasses
+    'threading.local', which gives every thread its own 'len' and 'pending_line'. Were the state
+    shared, the stderr call below would advance 'len' past the stdout tail and truncate it.
+    """
+    log_file = tmp_path / "stress.log"
+    watcher = TimestampedLogWriteWatcher(str(log_file))
+    stdout_line = STRESS_OUTPUT.splitlines(True)[0]
+    stdout_held, stderr_written = threading.Event(), threading.Event()
+
+    def watch_stdout():
+        watcher.submit(stdout_line[:20])  # half a line, so it is held back
+        stdout_held.set()
+        stderr_written.wait(timeout=5)  # ... while the other stream reports a whole one
+        watcher.submit(stdout_line)  # the rest of the line arrives
+
+    def watch_stderr():
+        stdout_held.wait(timeout=5)
+        watcher.submit("warn: something\n")
+        stderr_written.set()
+
+    threads = [
+        threading.Thread(target=watch_stdout, name="handle_stdout"),
+        threading.Thread(target=watch_stderr, name="handle_stderr"),
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=5)
+
+    written = [TIMESTAMP_PREFIX_PATTERN.sub("", line) for line in log_file.read_text(encoding="utf-8").splitlines()]
+    assert stdout_line.rstrip("\n") in written, f"the stdout line did not survive the stderr call: {written}"
+    assert "warn: something" in written, f"the stderr line is missing: {written}"
+
+
+def test_timestamped_log_write_watcher_submit_line_timestamps_each_line(tmp_path):
+    """'submit_line' is the whole-line path, used by the libssh2 and agent runners."""
+    log_file = tmp_path / "stress.log"
+    watcher = TimestampedLogWriteWatcher(str(log_file))
+
+    for line in STRESS_OUTPUT.splitlines(True):
+        watcher.submit_line(line)
+
+    written_lines = log_file.read_text(encoding="utf-8").splitlines()
+    assert len(written_lines) == len(STRESS_OUTPUT.splitlines())
+    for written_line, expected_line in zip(written_lines, STRESS_OUTPUT.splitlines()):
+        assert TIMESTAMP_PREFIX_PATTERN.sub("", written_line) == expected_line
+
+
+def test_log_write_watcher_submit_line_writes_the_line_as_is(tmp_path):
+    """The base class adds nothing, so 'submit_line' output is byte for byte its input."""
+    log_file = tmp_path / "stress.log"
+    watcher = LogWriteWatcher(str(log_file))
+
+    for line in STRESS_OUTPUT.splitlines(True):
+        watcher.submit_line(line)
+
+    assert log_file.read_text(encoding="utf-8") == STRESS_OUTPUT


### PR DESCRIPTION
fix(remote): write out only complete lines in LogWriteWatcher

'invoke' reads a command's output in fixed size chunks, so the new part of the
stream handed to 'LogWriteWatcher.submit()' usually ends in the middle of a
line. 'submit()' fed each of those chunks to '_format_line()' as if it were a
line of its own, and 'TimestampedLogWriteWatcher._format_line()' then made a
fragment look like a whole line -- it prefixed it with a timestamp and, because
the fragment has no line end, appended one. A chunk boundary landing inside a
stress tool line therefore turned it into two log lines:

  [2026-08-02 22:14:41.001]    1.001       299         0       299
  [2026-08-02 22:14:41.001]       0.202     1.626     1.934

The base class was never affected: its '_format_line()' is the identity, so it
wrote the stream back byte for byte whatever the chunking. Every stress thread
passes 'timestamp_logs=True' though, so in practice every stress log has this.

The synthesized line end is what does the damage, and it defeats a reader that
already guards against short reads: 'FileFollowerIterator' accumulates until it
sees a '\n' (sdcm/utils/common.py), so a genuinely partial write would only have
been held back for an iteration. A fragment carrying its own '\n' is instead
parsed as a complete record -- 'LatteExporter' and friends either fail on it or,
worse, read it as a partial row and export bogus Prometheus metrics.

This is not specific to one backend. Any runner that feeds watchers through
'submit()' hits it: 'LocalCmdRunner', which is what the docker backend's loaders
run on, and 'RemoteCmdRunner', selected on real ssh loaders by
'ssh_transport: fabric', which
test-cases/performance/perf-regression-throughput-baremetal-5gb.yaml sets.
'RemoteLibSSH2CmdRunner' (the default) is unaffected, it feeds watchers whole
lines via 'submit_line()'.

Keep the tail that has no line end yet and write it out on the next submit, the
same way 'OutputWatcher.submit()' already does, so that '_format_line()' only
ever decides on a whole line. Doing it the other way round -- letting the
subclass track whether it is at a line start -- looks smaller but is wrong: the
blank line check needs the whole line, and on a small chunk the first fragment
of an indented stress tool line is all spaces, which silently drops that line's
timestamp.

The tail still has to reach the log once nothing more can arrive to complete it,
and 'invoke' offers a watcher no end of stream hook to do it from. It does read
each stream in a thread of its own though, and 'StreamWatcher' subclasses
'threading.local' -- so 'PendingLine', created per reader thread, is finalized
exactly when that thread ends, i.e. when the stream is over. That is where the
last line without a line end of its own gets written. Hanging it off the runner's
'run()' instead would not work: 'run()' returns in the main thread, whose copy of
a 'threading.local' attribute is a different object that no reader ever touched.

That same 'threading.local' is why one watcher can serve both streams: invoke
calls 'submit()' on the same object for stdout and for stderr, with a separate
cumulative stream for each, and every attribute of it is per-thread, so the two
never share 'len' or a pending line.


Refs: VECTOR-783

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->

No Argus/Jenkins run — a framework fix with no test-case behaviour to observe in one. Checked on the
code path the bug is on instead: a command run through `LocalCmdRunner` with `timestamp_logs=True`,
every log line compared against the command's real output.

| Command output | before | after |
|---|---|---|
| 200 rows, stdout only | 208 log lines, 16 malformed | 200 lines, exact |
| 200 rows + periodic stderr | 8 lines missing, 16 corrupt | exact |
| 200 rows + 200 stderr rows | 20 missing, 40 corrupt | exact |
| last line with no line end | not written | written once the stream ends |

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
