### PR TITLE
fix(syntax): parenthesize multi-exception except clauses [branch-2026.1]

### DIFF
--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -726,7 +726,7 @@ class LogCollector:
                 node.remoter.run(collect_log_command, ignore_status=True, verbose=True)
                 result = node.remoter.run(f"test -f '{log_filename}'", ignore_status=True)
                 ok = result.ok
-            except Libssh2_Failure, InvokeFailure:
+            except (Libssh2_Failure, InvokeFailure):
                 ssh_connected = False
 
         # Check if node is AWS-based

--- a/sdcm/nemesis/__init__.py
+++ b/sdcm/nemesis/__init__.py
@@ -1269,7 +1269,7 @@ class NemesisRunner:
             self.cluster.clean_replacement_node_options(new_node)
             self.cluster.set_seeds()
             self.cluster.update_seed_provider()
-        except NodeSetupFailed, NodeSetupTimeout:
+        except (NodeSetupFailed, NodeSetupTimeout):
             self.log.warning("TestConfig of the '%s' failed, collecting logs and terminating node" % new_node)
             self.cluster.terminate_node(new_node)
             raise
@@ -1320,7 +1320,7 @@ class NemesisRunner:
             self.actions_log.info(f"New nodes initialized: {nodes_names}")
             self.cluster.set_seeds()
             self.cluster.update_seed_provider()
-        except NodeSetupFailed, NodeSetupTimeout:
+        except (NodeSetupFailed, NodeSetupTimeout):
             self.log.warning("TestConfig of the '%s' failed, collecting logs and terminating nodes" % new_nodes)
             for node in new_nodes:
                 self.cluster.terminate_node(node)
@@ -3136,7 +3136,7 @@ class NemesisRunner:
                     long_running=True,
                     retry=0,
                 )
-            except UnexpectedExit, Libssh2UnexpectedExit:
+            except (UnexpectedExit, Libssh2UnexpectedExit):
                 self.actions_log.info("Repair failed as expected")
             except Exception:
                 self.log.error("Repair failed due to the unknown error")

--- a/sdcm/utils/version_utils.py
+++ b/sdcm/utils/version_utils.py
@@ -486,7 +486,7 @@ def get_gemini_version(output: str) -> str | None:
     """
     try:
         return json.loads(output).get("gemini", {}).get("version")
-    except json.JSONDecodeError, AttributeError:
+    except (json.JSONDecodeError, AttributeError):
         return None
 
 


### PR DESCRIPTION
## Problem

Several backports landed on branch-2026.1 with unparenthesized `except A, B:` clauses — PEP 758 syntax that only parses on **Python 3.14+**:

- `sdcm/utils/version_utils.py:489` — from #14938
- `sdcm/logcollector.py:729` — from #15434
- `sdcm/nemesis/__init__.py:1272,1323,3139` — from #14603

CI currently gets away with it because the pinned hydra image (`v1.133-PR15081-42cb1eb`) ships Python 3.14.0, but the repo declares `requires-python = ">=3.10, <3.15"` — on any interpreter older than 3.14 these files (and everything importing them, including `sdcm.tester`) fail with `SyntaxError`. This also silently diverges from the original master commits, which all use the parenthesized form.

## Fix

Restore the parenthesized `except (A, B):` form used by the corresponding master commits. No behavior change on 3.14 (the two spellings are equivalent there); restores importability on 3.10–3.13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)