### PR TITLE
fix(syntax): parenthesize multi-exception except clauses [branch-2026.2]

### DIFF
--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -726,7 +726,7 @@ class LogCollector:
                 node.remoter.run(collect_log_command, ignore_status=True, verbose=True)
                 result = node.remoter.run(f"test -f '{log_filename}'", ignore_status=True)
                 ok = result.ok
-            except Libssh2_Failure, InvokeFailure:
+            except (Libssh2_Failure, InvokeFailure):
                 ssh_connected = False
 
         # Check if node is AWS-based

--- a/sdcm/utils/version_utils.py
+++ b/sdcm/utils/version_utils.py
@@ -486,7 +486,7 @@ def get_gemini_version(output: str) -> str | None:
     """
     try:
         return json.loads(output).get("gemini", {}).get("version")
-    except json.JSONDecodeError, AttributeError:
+    except (json.JSONDecodeError, AttributeError):
         return None
 
 


### PR DESCRIPTION
## Problem

Two backports landed on branch-2026.2 with unparenthesized `except A, B:` clauses — PEP 758 syntax that only parses on **Python 3.14+**:

- `sdcm/utils/version_utils.py:489` — from #14939
- `sdcm/logcollector.py:729` — from #15433

CI currently gets away with it because the pinned hydra image (`v1.136-PR15082-42cb1eb`) ships Python 3.14, but the repo declares `requires-python = ">=3.10, <3.15"` — on any interpreter older than 3.14 these files (and everything importing them, including `sdcm.tester`) fail with `SyntaxError`. This also silently diverges from the original master commits, which all use the parenthesized form.

## Fix

Restore the parenthesized `except (A, B):` form used by the corresponding master commits. No behavior change on 3.14 (the two spellings are equivalent there); restores importability on 3.10–3.13.

Sibling PR for branch-2026.1: #15642

🤖 Generated with [Claude Code](https://claude.com/claude-code)