### PR TITLE
fix(out-of-space-prevention): ignore expected errors

### DIFF
--- a/longevity_oos_test.py
+++ b/longevity_oos_test.py
@@ -79,6 +79,20 @@ def ignore_repair_errors():
         yield
 
 
+@contextmanager
+def ignore_runtime_errors():
+    with ExitStack() as stack:
+        stack.enter_context(
+            EventsSeverityChangerFilter(
+                new_severity=Severity.NORMAL,
+                event_class=DatabaseLogEvent,
+                regex=r".*Failed to load SSTable.*due to std::runtime_error \(critical disk utilization\).*",
+                extra_time_to_expiration=60,
+            )
+        )
+        yield
+
+
 class LongevityOutOfSpaceTest(LongevityTest):
     def tearDown(self):
         # an extra failure check for disk usage
@@ -204,7 +218,7 @@ class LongevityOutOfSpaceTest(LongevityTest):
         """
         self.prepare()
 
-        with ignore_stress_errors():
+        with ignore_stress_errors(), ignore_runtime_errors():
             result = self.run_write_stress()
             if result:
                 TestFrameworkEvent(
@@ -226,7 +240,7 @@ class LongevityOutOfSpaceTest(LongevityTest):
         """
         self.prepare()
 
-        with ignore_stress_errors():
+        with ignore_stress_errors(), ignore_runtime_errors():
             stress_thread = Thread(target=self.run_write_stress)
             stress_thread.start()
 
@@ -278,7 +292,7 @@ class LongevityOutOfSpaceTest(LongevityTest):
         prepare_thread.join()
         self.log.info("Prepare write command finished.")
 
-        with ignore_stress_errors():
+        with ignore_stress_errors(), ignore_runtime_errors():
             stress_thread = Thread(target=self.run_write_stress)
             stress_thread.start()
             self.log.info("Started stress write thread.")
@@ -334,7 +348,7 @@ class LongevityOutOfSpaceTest(LongevityTest):
         self.prepare()
 
         # fill to 98%
-        with ignore_stress_errors():
+        with ignore_stress_errors(), ignore_runtime_errors():
             self.run_write_stress()
 
         # Check that the node that got to 98% does not have running compactions


### PR DESCRIPTION
Example occurrence:
https://argus.scylladb.com/tests/scylla-cluster-tests/dfe87ddc-7aff-4c4a-8d88-ed328504b462

> (DatabaseLogEvent Severity.ERROR) period_type=one-time event_id=389bfc93-cf5b-492f-af59-95cc517ecf82: type=RUNTIME_ERROR regex=std::runtime_error line_number=15853 node=oos-test-2026-3-db-node-dfe87ddc-1
2026-08-03T16:05:52.944 oos-test-2026-3-db-node-dfe87ddc-1  !ERR | scylla[7222]  [shard 1:strm] table - Failed to load SSTable /var/lib/scylla/data/keyspace1/standard1-8cfee2008f3c11f18ab2e4efdb66ca47/mt-3h2n_18hq_1ufz42893v6bzptvgx-big-Data.db of origin compaction due to std::runtime_error (critical disk utilization), it will be unlinked... 


### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
