### PR TITLE
fix(cluster.py): skip nodes under nemesis in wait_for_schema_agreement

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -5703,7 +5703,9 @@ class BaseScyllaCluster:
 
     @retrying(n=10, sleep_time=5, allowed_exceptions=(AssertionError,))
     def wait_for_schema_agreement(self):
-        for node in self.nodes:
+        nodes_to_check = [node for node in self.nodes if not node.running_nemesis]
+        assert nodes_to_check, "All nodes are under active nemesis, schema agreement could not be verified"
+        for node in nodes_to_check:
             err = check_schema_agreement_in_gossip_and_peers(node)
             assert not err, err
         self.log.debug("Schema agreement is reached")


### PR DESCRIPTION
Nodes under active nemesis (e.g. DecommissionStreamingErrMonkey, DecommissionSeedNode) may have Scylla intentionally unresponsive, causing nodetool gossipinfo to return empty and triggering a false AssertionError after 10 retries.

Skip nodes with running_nemesis set, consistent with the pattern used in check_cluster_health and other health-check callers.

Fix for https://argus.scylladb.com/tests/scylla-cluster-tests/f8fbe59a-e639-4d32-8868-c9f52ec0152d

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] No testing needed

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
