### PR TITLE
fix(jenkins): bound journal and coredump collection to the current build

### DIFF
--- a/utils/upload_sct_coredump.sh
+++ b/utils/upload_sct_coredump.sh
@@ -15,12 +15,36 @@ if [[ -n "${RUNNER_IP}" ]] ; then
     EXTRA_HYDRA_ARGS="--execute-on-runner ${RUNNER_IP}"
 fi
 
-# Check if the coredumps exists in directory
-if ./docker/env/hydra.sh $EXTRA_HYDRA_ARGS "bash -c \"[[ -n \\\"\$( ls $COREDUMP_DIR )\\\" ]]\"" ; then
+# Only coredumps from this build. On an ephemeral builder or runner the directory is empty at
+# start, so mtime filtering changes nothing there - but on a long-lived agent it holds every dump
+# the host ever produced (other jobs' included), and unbounded this used to tar and upload all of
+# it. collectTestCoredumps passes the build start as COREDUMPS_SINCE_EPOCH; standalone runs
+# fall back to the last 24h.
+SINCE_EPOCH="${COREDUMPS_SINCE_EPOCH:-$(( $(date +%s) - 86400 ))}"
 
-    # Compress the coredumps into a tar.gz file
-    ./docker/env/hydra.sh $EXTRA_HYDRA_ARGS "bash -c \"sudo tar --zstd -cf $COREDUMP_TARBALL -C $COREDUMP_DIR .\""
+# List this build's coredumps. Keep hydra's exit code out of the pipeline: piping straight into
+# grep would report a failed listing as an empty one, and the "nothing to upload" branch below
+# would then state as fact something we never managed to check.
+set +e
+COREDUMP_LISTING=$(./docker/env/hydra.sh $EXTRA_HYDRA_ARGS "bash -c \"find $COREDUMP_DIR -maxdepth 1 -type f -newermt @$SINCE_EPOCH\"")
+HYDRA_STATUS=$?
+set -e
 
-    # Upload the tar.gz file
+if [[ ${HYDRA_STATUS} -ne 0 ]] ; then
+    echo "WARNING: listing $COREDUMP_DIR failed (hydra exited ${HYDRA_STATUS}) - cannot tell whether this build produced coredumps, skipping upload"
+    exit 0
+fi
+
+# grep drops hydra's own preamble; exit 1 here genuinely means the directory held nothing new
+NEW_COREDUMPS=$(echo "${COREDUMP_LISTING}" | grep "^$COREDUMP_DIR/" || true)
+
+if [[ -n "${NEW_COREDUMPS}" ]] ; then
+
+    # Compress only the new coredumps into a tarball (relative paths, like the old -C invocation)
+    ./docker/env/hydra.sh $EXTRA_HYDRA_ARGS "bash -c \"cd $COREDUMP_DIR && find . -maxdepth 1 -type f -newermt @$SINCE_EPOCH -print0 | sudo tar --zstd -cf $COREDUMP_TARBALL --null -T -\""
+
+    # Upload the tarball
     ./docker/env/hydra.sh $EXTRA_HYDRA_ARGS upload --test-id $SCT_TEST_ID $COREDUMP_TARBALL
+else
+    echo "no coredumps newer than @$SINCE_EPOCH in $COREDUMP_DIR - nothing to upload"
 fi

--- a/vars/collectBuilderLogs.groovy
+++ b/vars/collectBuilderLogs.groovy
@@ -2,6 +2,10 @@
 
 def call(Map params){
     def test_config = groovy.json.JsonOutput.toJson(params.test_config)
+    // Bound the journal to this build. On an ephemeral builder the journal is minutes old so the
+    // bound changes nothing, but on a long-lived agent it is weeks of other jobs' history, and
+    // unbounded this used to tar and upload the entire host journal every build.
+    def sinceEpoch = (long) (currentBuild.startTimeInMillis / 1000)
     sh """#!/bin/bash
 
 	set -xe
@@ -9,9 +13,24 @@ def call(Map params){
 	echo "${params.test_config}"
 	export SCT_CONFIG_FILES=${test_config}
 	SHORT_SCT_TEST_ID=\$(echo \$SCT_TEST_ID | cut -c1-8)
-    sudo journalctl --no-tail --no-pager -o short-precise > builder-\$SHORT_SCT_TEST_ID.log
-    tar -zcvf builder-\$SHORT_SCT_TEST_ID.log.tar.gz builder-\$SHORT_SCT_TEST_ID.log
+    # sudo -n so an agent without passwordless sudo fails fast instead of hanging on a password
+    # prompt. Then fall back to an unprivileged read before giving up: on a static agent that is
+    # still the journal this build can see (its own units, and everything else when the agent user
+    # is in systemd-journal), which beats no builder log at all. The if/else keeps a journal we
+    # cannot read from aborting the stage under set -e before anything got uploaded.
+    if sudo -n journalctl --since "@${sinceEpoch}" --no-tail --no-pager -o short-precise > builder-\$SHORT_SCT_TEST_ID.log ; then
+        journal_source="sudo journalctl"
+    elif journalctl --since "@${sinceEpoch}" --no-tail --no-pager -o short-precise > builder-\$SHORT_SCT_TEST_ID.log ; then
+        journal_source="unprivileged journalctl"
+    else
+        journal_source=""
+        echo "WARNING: neither sudo -n journalctl nor an unprivileged journalctl could read the journal on \$(hostname) - skipping builder journal upload"
+    fi
 
-    ./docker/env/hydra.sh upload --test-id \$SCT_TEST_ID builder-\$SHORT_SCT_TEST_ID.log.tar.gz
+    if [[ -n "\${journal_source}" ]] ; then
+        echo "collected builder journal via \${journal_source}"
+        tar -zcvf builder-\$SHORT_SCT_TEST_ID.log.tar.gz builder-\$SHORT_SCT_TEST_ID.log
+        ./docker/env/hydra.sh upload --test-id \$SCT_TEST_ID builder-\$SHORT_SCT_TEST_ID.log.tar.gz
+    fi
     """
 }

--- a/vars/collectTestCoredumps.groovy
+++ b/vars/collectTestCoredumps.groovy
@@ -1,8 +1,14 @@
 #!groovy
 
 def call(){
+    // Bound the coredump sweep to this build: on a long-lived agent the coredump directory holds
+    // every dump the host ever produced (other jobs' included), and unbounded the script tars and
+    // uploads all of it. Epoch seconds, consumed by upload_sct_coredump.sh via -newermt.
+    // Deliberately not SCT_-prefixed: hydra.sh exports every SCT_* variable into the container and
+    // sct_config rejects any that is not a documented config option.
+    def sinceEpoch = (long) (currentBuild.startTimeInMillis / 1000)
     sh """#!/bin/bash
 
-     ./utils/upload_sct_coredump.sh
+     COREDUMPS_SINCE_EPOCH=${sinceEpoch} ./utils/upload_sct_coredump.sh
     """
 }


### PR DESCRIPTION
## What

Split out of #15618 per review: both builder-side collectors assume a builder that dies after its
build, which stops being true the moment a job runs on a **static agent**. Groundwork for that,
independent of any backend.

- `collectBuilderLogs` ran an unbounded `sudo journalctl`, so every build uploaded the host's
  entire journal — weeks of it on a long-lived machine — and a sudo that is not passwordless
  aborted the stage outright. Now bounded by the build's start time: it tries `sudo -n journalctl`
  first, falls back to an unprivileged `journalctl` over the same window, and skips the upload with
  a warning only when neither can read the journal.
- `upload_sct_coredump.sh` tarred every coredump the host had ever produced, including other
  jobs' and other tenants'. Now bounded by build start time as well.

## Why it was in a minicloud PR

Both bit a minicloud run on a lab machine, which is how they were found — but neither has anything
to do with minicloud, so per review they land on their own.

## Review follow-ups

- The build start reaches `upload_sct_coredump.sh` as `COREDUMPS_SINCE_EPOCH`, **not** an
  `SCT_`-prefixed name: `hydra.sh` exports every `SCT_*` variable into the container, and
  `SCTConfiguration` — which `hydra upload` builds whenever Argus is enabled — rejects any `SCT_*`
  that is not a documented config option, so the earlier name would have broken the upload it was
  meant to bound.
- Listing the coredumps keeps hydra's exit code out of the pipeline, so a failed listing is
  reported as a failure instead of being indistinguishable from an empty directory.

## Tests

`sh -n` clean; each bounded command run standalone against a live journal, including the
no-passwordless-sudo path. All three coredump paths exercised with a stub `hydra.sh`: coredumps
found → tar + upload, none found → "nothing to upload", hydra failure → warning and no upload.
No behaviour change on ephemeral cloud builders, where the build start time is a few minutes after
boot and everything is in range anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
