### PR TITLE
fix(integration-tests): align AWS keystore tests with the Secrets Manager backend

### DIFF
--- a/sdcm/keystore.py
+++ b/sdcm/keystore.py
@@ -43,6 +43,10 @@ KEYSTORE_S3_BUCKET = "scylla-qa-keystore"
 # client must always be pinned explicitly.
 KEYSTORE_SM_REGION = "us-east-1"
 
+# Namespace the mirrored keystore entries live under in Secrets Manager, so a
+# keystore file `foo.json` maps to the secret `sct/foo.json`.
+KEYSTORE_SM_PREFIX = "sct/"
+
 SSHKey = namedtuple("SSHKey", ["name", "public_key", "private_key"])
 
 BOTO3_CLIENT_CREATION_LOCK = threading.Lock()
@@ -99,7 +103,7 @@ class KeyStore:
         self._cache: dict[str, bytes] = {}
         self._cache_lock = threading.Lock()
         self._backend = backend or os.environ.get("SCT_KEYSTORE_BACKEND") or "secretsmanager"
-        self._sm_prefix = os.environ.get("SCT_KEYSTORE_SM_PREFIX") or "sct/"
+        self._sm_prefix = os.environ.get("SCT_KEYSTORE_SM_PREFIX") or KEYSTORE_SM_PREFIX
         self._sm_region = os.environ.get("SCT_KEYSTORE_SM_REGION") or KEYSTORE_SM_REGION
 
     @property
@@ -431,8 +435,17 @@ class KeyStore:
             self.download_file(filename=key, dest_filename=path)
             os.chmod(path=path, mode=permissions)
             if self._backend == "secretsmanager":
-                with open(f"{path}.version", "w", encoding="utf-8") as vf:
+                with open(version_path, "w", encoding="utf-8") as vf:
                     vf.write(remote_version)
+
+        if self._backend == "secretsmanager":
+            # Match the key's permissions: the sidecar lands in the same
+            # directory (often ~/.ssh, where ssh rejects group/world readable
+            # content) and would otherwise inherit the umask. Enforced on every
+            # sync rather than only after a download, because a sidecar whose
+            # version is still current is never rewritten -- one left at 0o664
+            # by an earlier sync would keep those permissions forever.
+            os.chmod(path=version_path, mode=permissions)
 
     def sync(self, keys, local_path, permissions=0o777):
         """Syncs the local and remote copies from the configured backend."""

--- a/unit_tests/integration/test_aws_services.py
+++ b/unit_tests/integration/test_aws_services.py
@@ -12,7 +12,7 @@ import boto3
 os.environ["MOTO_AMIS_PATH"] = str(Path(__file__).parents[1] / "test_data" / "mocked_ami_data.json")
 from moto.server import ThreadedMotoServer
 
-from sdcm.keystore import KeyStore
+from sdcm.keystore import KEYSTORE_S3_BUCKET, KEYSTORE_SM_PREFIX, KEYSTORE_SM_REGION, KeyStore
 from sdcm.utils.aws_region import AwsRegion
 from sdcm.sct_provision.common.layout import SCTProvisionLayout, create_sct_configuration
 from sdcm.utils.common import get_scylla_ami_versions
@@ -29,7 +29,7 @@ AWS_REGION = "us-east-1"
 @pytest.fixture(scope="session", autouse=True)
 def fixture_get_real_keys():
     KeyStore().sync(
-        keys=["scylla-qa-ec2", "scylla-test", "scylla_test_id_ed25519", "scylla_test_id_ed25519.pub"],
+        keys=["scylla_test_id_ed25519", "scylla_test_id_ed25519.pub"],
         local_path=Path("~/.ssh/").expanduser(),
         permissions=0o0600,
     )
@@ -55,17 +55,27 @@ def moto_server():
 
 @pytest.fixture(scope="module", autouse=True)
 def keystore_configure(moto_server):
-    s3 = boto3.resource(service_name="s3", region_name=AWS_REGION, endpoint_url=moto_server)
+    entries = {
+        "gcp-sct-project-1.json": b"{}",
+        "aws_images_role.json": (
+            b'{"role_arn": "arn:aws:iam::123456789012:role/role-name", "role_session_name": "role-session-name"}'
+        ),
+    }
+    for file in ("scylla_test_id_ed25519", "scylla_test_id_ed25519.pub"):
+        entries[file] = (Path("~/.ssh").expanduser() / file).read_bytes()
 
-    bucket = s3.Bucket("scylla-qa-keystore")
+    s3 = boto3.resource(service_name="s3", region_name=AWS_REGION, endpoint_url=moto_server)
+    bucket = s3.Bucket(KEYSTORE_S3_BUCKET)
     bucket.create()
-    bucket.put_object(Key="gcp-sct-project-1.json", Body=b"{}")
-    bucket.put_object(
-        Key="aws_images_role.json",
-        Body=b'{"role_arn": "arn:aws:iam::123456789012:role/role-name", "role_session_name": "role-session-name"}',
-    )
-    for file in ("scylla-qa-ec2", "scylla-test", "scylla_test_id_ed25519", "scylla_test_id_ed25519.pub"):
-        bucket.upload_file(Filename=str(Path("~/.ssh").expanduser() / file), Key=file)
+    for key, body in entries.items():
+        bucket.put_object(Key=key, Body=body)
+
+    # KeyStore reads from Secrets Manager by default, so mirror the same entries
+    # there under the `sct/` prefix - seeding only the bucket would leave every
+    # lookup failing with ResourceNotFoundException.
+    sm = boto3.client("secretsmanager", region_name=KEYSTORE_SM_REGION, endpoint_url=moto_server)
+    for key, body in entries.items():
+        sm.create_secret(Name=f"{KEYSTORE_SM_PREFIX}{key}", SecretBinary=body)
 
 
 @pytest.fixture(scope="module")
@@ -93,7 +103,7 @@ def test_02_keystore_sync(tmp_path) -> None:
     Validate the sync is working and setting right permissions.
     """
     k = KeyStore()
-    k.sync(keys=["scylla-qa-ec2", "scylla-test", "scylla_test_id_ed25519"], local_path=tmp_path, permissions=0o0600)
+    k.sync(keys=["scylla_test_id_ed25519", "scylla_test_id_ed25519.pub"], local_path=tmp_path, permissions=0o0600)
 
     for file in tmp_path.iterdir():
         assert stat.S_IMODE(file.stat().st_mode) == 0o600

--- a/unit_tests/integration/test_aws_services.py
+++ b/unit_tests/integration/test_aws_services.py
@@ -9,7 +9,7 @@ import boto3
 # we need to set the environment variable before importing moto
 # otherwise it won't pick it up
 
-os.environ["MOTO_AMIS_PATH"] = str(Path(__file__).parent / "test_data" / "mocked_ami_data.json")
+os.environ["MOTO_AMIS_PATH"] = str(Path(__file__).parents[1] / "test_data" / "mocked_ami_data.json")
 from moto.server import ThreadedMotoServer
 
 from sdcm.keystore import KeyStore

--- a/unit_tests/integration/test_sync.py
+++ b/unit_tests/integration/test_sync.py
@@ -23,7 +23,7 @@ def test_multiple_sync_on_lots_of_files():
     if not is_using_aws_mock():
         key_store = KeyStore()
         key_store.sync(
-            keys=["scylla-qa-ec2", "scylla-test", "scylla_test_id_ed25519"] * 20,
+            keys=["scylla_test_id_ed25519", "scylla_test_id_ed25519.pub"] * 30,
             local_path=Path("~/.ssh/").expanduser(),
             permissions=0o0600,
         )

--- a/unit_tests/unit/test_keystore.py
+++ b/unit_tests/unit/test_keystore.py
@@ -22,6 +22,7 @@ import io
 import json
 import logging
 import os
+import stat
 import time
 from concurrent.futures.thread import ThreadPoolExecutor
 from unittest.mock import MagicMock, PropertyMock, patch
@@ -975,6 +976,24 @@ class TestSecretsManagerBackend:
             assert fh.read() == FAKE_SSH_PRIVATE_KEY
         # Version sidecar written alongside the key
         assert (tmp_path / "scylla_test_id_ed25519.version").exists()
+
+    def test_sync_from_sm_applies_permissions_to_sidecar(self, sm_ks, tmp_path):
+        """The sidecar must not inherit the umask - ssh rejects a group/world readable ~/.ssh."""
+        sm_ks.sync(["scylla_test_id_ed25519"], str(tmp_path), 0o600)
+        for name in ("scylla_test_id_ed25519", "scylla_test_id_ed25519.version"):
+            assert stat.S_IMODE((tmp_path / name).stat().st_mode) == 0o600, f"{name} has wrong permissions"
+
+    def test_sync_from_sm_repairs_sidecar_permissions_on_cache_hit(self, sm_ks, tmp_path):
+        """A sidecar left too permissive by an earlier sync is repaired without a re-download."""
+        sm_ks.get_obj_if_needed("scylla_test_id_ed25519", str(tmp_path), 0o600)
+        sidecar = tmp_path / "scylla_test_id_ed25519.version"
+        sidecar.chmod(0o664)
+
+        # Version is unchanged, so this must fix the permissions without downloading again
+        with patch.object(sm_ks, "download_file") as mock_dl:
+            sm_ks.get_obj_if_needed("scylla_test_id_ed25519", str(tmp_path), 0o600)
+            mock_dl.assert_not_called()
+        assert stat.S_IMODE(sidecar.stat().st_mode) == 0o600
 
     def test_get_sm_version_id_returns_awscurrent(self, sm_ks):
         version_id = sm_ks.get_sm_version_id("scylla_test_id_ed25519")


### PR DESCRIPTION
Fixes the 9 Secrets Manager related integration test failures seen in [PR-15647 build 1](https://jenkins.scylladb.com/job/sct-github-PRs-scan/job/scylla-cluster-tests/job/PR-15647/1/testReport/). They are unrelated to that PR (a renovate gemini bump) — the tests were still written for the S3 keystore backend, which `KeyStore` no longer defaults to.

### What was failing

```
integration.test_aws_services::test_01_keystore
integration.test_aws_services::test_02_keystore_sync
integration.test_aws_services::test_03_provision[on_demand|spot|spot_fleet]
integration.test_aws_services::test_04_get_scylla_ami_versions
integration.test_aws_services::test_04b_get_scylla_ami_versions_full_tag
integration.test_aws_services::test_05_ec2_client_spot
integration.test_sync::test_multiple_sync_on_lots_of_files
```

all with `ResourceNotFoundException ... calling the DescribeSecret operation`.

### Root causes

Three distinct bugs, stacked — CI only ever showed the first because it aborted at session-fixture time.

1. **Retired keys.** `fixture_get_real_keys` synced `scylla-qa-ec2` and `scylla-test`. Those are the legacy RSA keys; they exist in the `scylla-qa-keystore` bucket but were never mirrored into Secrets Manager and never will be. Everything in SCT (including `sct.py`) already uses `scylla_test_id_ed25519`. Verified against the real account:

   ```
   sct/scylla-qa-ec2              -> ResourceNotFoundException
   sct/scylla-test                -> ResourceNotFoundException
   sct/scylla_test_id_ed25519     -> sct/scylla_test_id_ed25519
   sct/scylla_test_id_ed25519.pub -> sct/scylla_test_id_ed25519.pub
   ```

2. **Fixture seeded the wrong backend.** `keystore_configure` populated the moto S3 bucket only, so with the keys fixed the tests still failed on `GetSecretValue`. Now the same entries are seeded into moto's Secrets Manager under the `sct/` prefix, and the fixture uses the `KEYSTORE_*` constants instead of repeating the bucket name and prefix.

3. **Broken `MOTO_AMIS_PATH`.** The AMI fixtures live in `unit_tests/test_data/`, but the path was computed relative to the test file, which since the move to `unit_tests/integration/` resolves to a directory that does not exist. Moto loaded no AMI data and returned a 500 for every `DescribeImages`, so the four EC2 tests could not pass even with a working keystore.

### Also fixed

`get_obj_if_needed` chmods the downloaded key but wrote the `<file>.version` sidecar at the umask (0o664). The sidecar lands next to the key it describes, usually in `~/.ssh`, where ssh refuses a directory holding group/world readable material. `test_02_keystore_sync` asserts every synced file is 0600 and caught it. Covered by a new unit test.

### Testing

```
unit_tests/integration/test_aws_services.py unit_tests/integration/test_sync.py   9 passed
unit_tests/unit/test_keystore.py                                                120 passed
```
