### PR TITLE
fix(integration-tests): stop pinning artifact URLs that get garbage collected

### DIFF
--- a/sdcm/utils/version_utils.py
+++ b/sdcm/utils/version_utils.py
@@ -677,7 +677,11 @@ def get_specific_tag_of_docker_image(docker_repo: str, architecture: Literal["x8
         branch = "master"
     elif docker_repo == "scylladb/scylla-enterprise-nightly":
         product = "scylla-enterprise"
-        branch = "enterprise"
+        # The `enterprise` rolling branch stopped producing builds when
+        # enterprise development folded into the unified releases, and its
+        # relocatables are gone from downloads.scylladb.com. `enterprise-2024.1`
+        # is the only branch still publishing scylla-enterprise-nightly images.
+        branch = "enterprise-2024.1"
     else:
         raise ValueError(f"SCT doesn't support getting latest from {docker_repo}")
 

--- a/unit_tests/integration/test_config_get_version_based_on_conf.py
+++ b/unit_tests/integration/test_config_get_version_based_on_conf.py
@@ -18,6 +18,7 @@ import pytest
 
 from sdcm import sct_config
 from sdcm.utils.common import get_latest_scylla_release
+from sdcm.utils.version_utils import latest_unified_package
 
 pytestmark = [
     pytest.mark.integration,
@@ -159,14 +160,14 @@ def test_baremetal(monkeypatch):
 
 
 def test_unified_package(monkeypatch):
+    # Unlike the sibling tests below, this one actually downloads and unpacks the
+    # package to read SCYLLA-VERSION-FILE, so the URL has to point at a package
+    # that still exists. Resolve the current master build instead of pinning one:
+    # unstable relocatables are garbage collected within a few months.
+    unified_package = latest_unified_package()
+
     monkeypatch.setenv("SCT_CLUSTER_BACKEND", "gce")
-    monkeypatch.setenv(
-        "SCT_UNIFIED_PACKAGE",
-        (
-            "https://downloads.scylladb.com/unstable/scylla/master/relocatable/2023-11-13T03:04:27Z/"
-            "scylla-unified-5.5.0~dev-0.20231113.7b08886e8dd8.x86_64.tar.gz"
-        ),
-    )
+    monkeypatch.setenv("SCT_UNIFIED_PACKAGE", unified_package)
     monkeypatch.setenv(
         "SCT_GCE_IMAGE_DB",
         "https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-stream-9",
@@ -180,7 +181,9 @@ def test_unified_package(monkeypatch):
 
     _version, _is_enterprise = conf.get_version_based_on_conf()
 
-    assert "5.5.0" in _version
+    # e.g. scylla-unified-2026.4.0~dev-0.20260804.0cba3cd2a4b0.x86_64.tar.gz -> 2026.4.0
+    expected_version = unified_package.rsplit("/", 1)[-1].removeprefix("scylla-unified-").split("~")[0]
+    assert expected_version in _version
     assert not _is_enterprise
 
 

--- a/unit_tests/integration/test_external_backtrace_service.py
+++ b/unit_tests/integration/test_external_backtrace_service.py
@@ -16,8 +16,12 @@
 External services: HTTPS to backtrace.scylladb.com
 """
 
-import pytest
+from http import HTTPStatus
 
+import pytest
+import yaml
+
+from sdcm.utils.session import create_retry_session
 from unit_tests.lib.dummy_remote import DummyRemote
 from unit_tests.lib.fake_cluster import DummyNode
 
@@ -25,8 +29,10 @@ pytestmark = [
     pytest.mark.integration,
 ]
 
-# Known-good build from Scylla 2026.1.0~dev (SCYLLADB-403)
-KNOWN_BUILD_ID = "527bc25417c81c8106b33400a4372616c7c90894"
+LATEST_MASTER_BUILD_URL = (
+    "https://s3.amazonaws.com/downloads.scylladb.com/unstable/scylla/master/relocatable/latest/00-Build.txt"
+)
+# Addresses inside Scylla's text segment, so any build symbolizes them to something.
 SAMPLE_BACKTRACE_ADDRESSES = "0x4a3c9b7\n0x11ddd33\n0x11ddcec"
 
 
@@ -37,9 +43,33 @@ def node_fixture(tmp_path):
     return node
 
 
-def test_decode_via_external_service_returns_symbols(node):
+@pytest.fixture(name="known_build_id", scope="module")
+def known_build_id_fixture():
+    """Resolve a build the service can still symbolize.
+
+    A pinned build id rots: the service needs the build's unstripped package,
+    and unstable relocatables are garbage collected within a few months. Take
+    the current promoted master build instead - newer builds exist, but they
+    are not indexed by the service until they are promoted.
+    """
+    session = create_retry_session()
+
+    res = session.get(LATEST_MASTER_BUILD_URL, timeout=30)
+    res.raise_for_status()
+    build_id = yaml.safe_load(res.content)["scylla-x86_64-BuildID[sha1]"]
+
+    known = session.get("https://backtrace.scylladb.com/api/search/build_id", params={"build_id": build_id}, timeout=30)
+    # Only an unindexed build is a reason to skip. Anything else -- an outage, an
+    # auth error -- must fail loudly rather than quietly pass the suite.
+    if known.status_code == HTTPStatus.NOT_FOUND:
+        pytest.skip(f"backtrace.scylladb.com has not indexed the latest master build ({build_id}) yet")
+    known.raise_for_status()
+    return build_id
+
+
+def test_decode_via_external_service_returns_symbols(node, known_build_id):
     """Verify _decode_via_external_service returns decoded symbols for a known build."""
-    result = node._decode_via_external_service(KNOWN_BUILD_ID, SAMPLE_BACKTRACE_ADDRESSES)
+    result = node._decode_via_external_service(known_build_id, SAMPLE_BACKTRACE_ADDRESSES)
 
     assert result, "Decoded output should not be empty"
     assert "Backtrace" in result


### PR DESCRIPTION
Fixes the three remaining integration test failures from [PR-15647 build 1](https://jenkins.scylladb.com/job/sct-github-PRs-scan/job/scylla-cluster-tests/job/PR-15647/1/testReport/) (unrelated to that PR — a renovate gemini bump). All three are pinned artifact URLs that have since been garbage collected or retired upstream. Companion to #15670, which covers the Secrets Manager failures.

### What was failing

| Test | Error |
|---|---|
| `test_config_get_version_based_on_conf::test_unified_package` | `FileNotFoundError: Unified package not found or failed to download: .../2023-11-13T03:04:27Z/scylla-unified-5.5.0~dev-...tar.gz` |
| `test_external_backtrace_service::test_decode_via_external_service_returns_symbols` | `404 ... for url: https://backtrace.scylladb.com/api/backtrace` |
| `test_version_utils::test_get_specific_tag_of_docker_image[scylladb/scylla-enterprise-nightly]` | `404 ... /unstable/scylla-enterprise/enterprise/relocatable/latest/00-Build.txt` |

### Fixes

**Unified package.** The test pinned a master relocatable from November 2023. Unlike its sibling tests, which only run config validation, this one calls `get_version_based_on_conf()`, which downloads and unpacks the package to read `SCYLLA-VERSION-FILE` — so the URL has to actually exist, and unstable relocatables are collected within months. Now resolved through the existing `latest_unified_package()` helper, with the expected version derived from the returned filename.

**Backtrace service.** The pinned build id (`527bc254…`, 2026.1.0~dev) is still indexed, but the unstripped package it needs is gone, so the API answers:

```
{"detail":"Unstripped package does not exist (https://downloads.scylladb.com/unstable/scylla/master/
relocatable/2026-01-22T20:32:01Z/scylla-unstripped-2026.1.0~dev-...tar.gz) for 527bc254..."}
```

Now resolved from `unstable/scylla/master/relocatable/latest/00-Build.txt`. Newer builds exist in S3 but the service does not index them until they are promoted (checked: today's 14:11 and 16:36 builds return `Could not find any build with BuildID`, while `latest/` resolves and symbolizes), so `latest/` is the freshest reliably-known id. If it happens not to be indexed yet the test skips rather than reporting a failure that says nothing about SCT.

**Enterprise nightly.** `get_specific_tag_of_docker_image` resolved `scylladb/scylla-enterprise-nightly` under the `enterprise` rolling branch. That branch is gone from downloads.scylladb.com — `unstable/scylla-enterprise/` now holds only `enterprise-2024.1/`, which is still building (last build June 2026) and still publishes exactly those images:

```
docker-image-name-x86_64: scylla-enterprise-nightly:2024.1.22-0.20260125.edbbdaf63453-x86_64
```

So the lookup points there. This is a production fix, not just a test fix — `sct_config` calls this function to resolve `scylla_docker_image` for enterprise versions and it was raising for every caller.

### Testing

```
unit_tests/integration/test_external_backtrace_service.py
unit_tests/integration/test_version_utils.py                            14 passed
unit_tests/integration/test_config_get_version_based_on_conf.py -k unified
                                                                 8 passed, 25 deselected
unit_tests/unit/test_version_utils.py unit_tests/unit/test_config.py   417 passed
```
