### PR TITLE
fix(unit_tests): return the node from configure_scylla_node

### DIFF
--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -145,6 +145,8 @@ def configure_scylla_node(docker_scylla_args: dict, params):  # noqa: PLR0914
         func=db_alternator_up, step=1, text="Waiting for DB services to be up alternator)", timeout=120, throw_exc=True
     )
 
+    return scylla
+
 
 @pytest.fixture(name="docker_scylla", scope="function")
 def fixture_docker_scylla(request: pytest.FixtureRequest, params):  # noqa: PLR0914


### PR DESCRIPTION
Fixes the mass integration-test ERRORs on `branch-2025.1` (35 ERROR in the last CI run).

`unit_tests/conftest.py::configure_scylla_node()` creates the `RemoteDocker` node and then ends on its two readiness waits **without ever returning it**. Every `return` inside that function body belongs to the nested `db_up` / `db_alternator_up` helpers, not to `configure_scylla_node` itself, so the function falls off the end and returns `None`.

Both callers assume otherwise:

```python
@pytest.fixture(name="docker_scylla", scope="function")
def fixture_docker_scylla(request, params):
    scylla = configure_scylla_node(docker_scylla_args, params)
    yield scylla        # yields None
    scylla.kill()       # AttributeError: 'NoneType' object has no attribute 'kill'
```

`docker_scylla_2` / `fixture_docker_2_scylla` has the identical shape and additionally does `docker_scylla.ip_address`, so it is fixed by the same one-liner (verified below).

`return scylla` is present on `master`, `branch-2026.3`, `branch-2026.2` and `branch-2026.1`, and absent on only `branch-2025.1` and `branch-perf-v17` — exactly the two branches whose Docker integration tests mass-ERROR. `branch-2026.1` still uses the same flat `unit_tests/conftest.py` layout and its tests pass, so this is not a layout artefact.

## The diff

```diff
--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -145,6 +145,8 @@ def configure_scylla_node(docker_scylla_args: dict, params):  # noqa: PLR0914
         func=db_alternator_up, step=1, text="Waiting for DB services to be up alternator)", timeout=120, throw_exc=True
     )

+    return scylla
+

 @pytest.fixture(name="docker_scylla", scope="function")
 def fixture_docker_scylla(request: pytest.FixtureRequest, params):  # noqa: PLR0914
```

Deliberately **not** porting `branch-2026.1`'s version of `configure_scylla_node` — the two diverge substantially (different pinned Scylla image, different SSL/`create_ca` handling, an `ssl_dir` parameter, vector-search env vars). That would be a large, risky, out-of-scope change. Only the missing return is changed.

## Verification

Run locally inside this branch's pinned hydra image `v1.90-2025.1-scylla-driver-v3.29.9` (`docker/env/version`), with a genuine Scylla container boot.

### Before the fix

```
$ ./docker/env/hydra.sh python -m pytest -v -p no:warnings -m integration \
    unit_tests/test_run_cqlsh.py::test_02_cqlsh_check_multiline

unit_tests/test_run_cqlsh.py::test_02_cqlsh_check_multiline FAILED        [100%]
unit_tests/test_run_cqlsh.py::test_02_cqlsh_check_multiline ERROR         [100%]

==================================== ERRORS ====================================
______________ ERROR at teardown of test_02_cqlsh_check_multiline ______________
    @pytest.fixture(name="docker_scylla", scope="function")
    def fixture_docker_scylla(request: pytest.FixtureRequest, params):  # noqa: PLR0914
        docker_scylla_args = {}
        if test_marker := request.node.get_closest_marker("docker_scylla_args"):
            docker_scylla_args = test_marker.kwargs
        scylla = configure_scylla_node(docker_scylla_args, params)
        yield scylla

>       scylla.kill()
E       AttributeError: 'NoneType' object has no attribute 'kill'

unit_tests/conftest.py:157: AttributeError
=================================== FAILURES ===================================
________________________ test_02_cqlsh_check_multiline _________________________

docker_scylla = None

    def test_02_cqlsh_check_multiline(docker_scylla):
        cql_cmd = """
            create keyspace if not exists "10gb_keyspace" with replication =
            {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}
        """
>       res = docker_scylla.run_cqlsh(cql_cmd)
E       AttributeError: 'NoneType' object has no attribute 'run_cqlsh'

unit_tests/test_run_cqlsh.py:43: AttributeError
========================= 1 failed, 1 error in 22.10s ==========================
```

Note `docker_scylla = None` in the failure header — the fixture handed the test nothing.

### After the fix

```
$ ./docker/env/hydra.sh python -m pytest -v -p no:warnings -m integration \
    unit_tests/test_run_cqlsh.py::test_02_cqlsh_check_multiline

unit_tests/test_run_cqlsh.py::test_02_cqlsh_check_multiline PASSED        [100%]

============================= slowest 20 durations =============================
4.56s setup    test_run_cqlsh.py::test_02_cqlsh_check_multiline
1.13s call     test_run_cqlsh.py::test_02_cqlsh_check_multiline
0.30s teardown test_run_cqlsh.py::test_02_cqlsh_check_multiline
============================== 1 passed in 5.99s ===============================
```

### `docker_scylla_2` covered by the same one-liner

The only test taking `docker_scylla_2` is `test_cluster.py::test_exclusive_connection`; it needs no further change:

```
$ ./docker/env/hydra.sh python -m pytest -v -p no:warnings -m integration \
    unit_tests/test_cluster.py::test_exclusive_connection

unit_tests/test_cluster.py::test_exclusive_connection PASSED              [100%]

============================= slowest 20 durations =============================
15.03s setup    test_cluster.py::test_exclusive_connection
7.31s teardown test_cluster.py::test_exclusive_connection
0.73s call     test_cluster.py::test_exclusive_connection
============================== 1 passed in 23.15s ==============================
```

The ~5-23s setup/teardown is the real Scylla container boot and is expected; it is not the bug.

## Why no `test-integration` label

Intentionally **not** adding the `test-integration` label. The integration stage on this branch still runs serially and always aborts at its timeout, publishing no JUnit — so labelling this would only produce another ~40-minute aborted build with no result. #15691 is the change that makes CI able to validate this branch's integration suite; once it lands, this fix becomes CI-verifiable. Hence the local, in-hydra verification above.

This PR is based directly on `upstream/branch-2025.1` and does not stack on #15691 — that PR does not touch `conftest.py`, so there is no conflict.

Refs SCT-714, #15691
