### PR TITLE
fix(unit_tests): return the node from configure_scylla_node

### DIFF
--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -209,6 +209,8 @@ def configure_scylla_node(docker_scylla_args: dict, params):  # noqa: PLR0914
         func=db_alternator_up, step=1, text="Waiting for DB services to be up alternator)", timeout=120, throw_exc=True
     )
 
+    return scylla
+
 
 @pytest.fixture(name="docker_scylla", scope="function")
 def fixture_docker_scylla(request: pytest.FixtureRequest, params):  # noqa: PLR0914


### PR DESCRIPTION
Fixes the mass integration-test ERRORs on `branch-perf-v17` (48 ERROR in the last CI run).

## The bug

`configure_scylla_node()` in `unit_tests/conftest.py` creates the `RemoteDocker` node and then ends on its two readiness waits **without returning it**. Every `return` inside that function belongs to the nested `db_up()` / `db_alternator_up()` helpers, not to `configure_scylla_node` itself, so the function falls off the end and returns `None`.

Both callers assume otherwise:

```python
scylla = configure_scylla_node(docker_scylla_args, params)
yield scylla        # yields None
scylla.kill()       # AttributeError: 'NoneType' object has no attribute 'kill'
```

So every test taking `docker_scylla` fails in the test body on a `None` node, and then ERRORs a second time at teardown on `scylla.kill()`. `docker_scylla_2` calls the same function and additionally dereferences `docker_scylla.ip_address`, so it is affected the same way.

`return scylla` is already present on `master`, `branch-2026.3`, `branch-2026.2` and `branch-2026.1`. It is missing only on `branch-perf-v17` and `branch-2025.1` — exactly the two branches whose Docker integration tests mass-ERROR. `branch-2026.1` still uses the same flat `unit_tests/conftest.py` layout and its tests pass, so this is not a layout artefact.

## The fix

```diff
@@ -209,6 +209,8 @@ def configure_scylla_node(docker_scylla_args: dict, params):  # noqa: PLR0914
         func=db_alternator_up, step=1, text="Waiting for DB services to be up alternator)", timeout=120, throw_exc=True
     )

+    return scylla
+

 @pytest.fixture(name="docker_scylla", scope="function")
```

Deliberately minimal. I did **not** port `branch-2026.1`'s version of the function — it diverges substantially (different pinned Scylla image, different SSL/`create_ca` handling, vector-search env vars), and porting it would be a large, risky, out-of-scope change.

## Verification

CI cannot validate this: the integration stage on this branch runs serially and always aborts at its 45-minute timeout, publishing no JUnit. So this was verified locally inside this branch's pinned hydra image `v1.107-PR13751-82c347a` (`docker/env/version`), running a real Scylla container.

### Before (without the fix) — `unit_tests/test_run_cqlsh.py::test_02_cqlsh_check_multiline`

```
unit_tests/test_run_cqlsh.py::test_02_cqlsh_check_multiline FAILED        [100%]
unit_tests/test_run_cqlsh.py::test_02_cqlsh_check_multiline ERROR         [100%]

==================================== ERRORS ====================================
______________ ERROR at teardown of test_02_cqlsh_check_multiline ______________
        scylla = configure_scylla_node(docker_scylla_args, params)
        yield scylla

>       scylla.kill()
E       AttributeError: 'NoneType' object has no attribute 'kill'

unit_tests/conftest.py:221: AttributeError
=================================== FAILURES ===================================
________________________ test_02_cqlsh_check_multiline _________________________

docker_scylla = None

    def test_02_cqlsh_check_multiline(docker_scylla):
        ...
>       res = docker_scylla.run_cqlsh(cql_cmd)
E       AttributeError: 'NoneType' object has no attribute 'run_cqlsh'

unit_tests/test_run_cqlsh.py:43: AttributeError
=========================== short test summary info ============================
FAILED unit_tests/test_run_cqlsh.py::test_02_cqlsh_check_multiline - AttributeError: 'NoneType' object has no attribute 'run_cqlsh'
ERROR unit_tests/test_run_cqlsh.py::test_02_cqlsh_check_multiline - AttributeError: 'NoneType' object has no attribute 'kill'
========================= 1 failed, 1 error in 15.59s ==========================
```

Note `docker_scylla = None` — both the documented failure modes, in one run.

### After (with the fix)

```
unit_tests/test_run_cqlsh.py::test_02_cqlsh_check_multiline PASSED        [100%]

============================= slowest 20 durations =============================
4.59s setup    test_run_cqlsh.py::test_02_cqlsh_check_multiline
0.98s call     test_run_cqlsh.py::test_02_cqlsh_check_multiline
0.48s teardown test_run_cqlsh.py::test_02_cqlsh_check_multiline
============================== 1 passed in 6.09s ===============================
```

### Second-node fixture also confirmed

`docker_scylla_2` needs nothing beyond this one-liner — `unit_tests/test_cluster.py::test_exclusive_connection` takes both fixtures and now boots two real containers and passes:

```
unit_tests/test_cluster.py::test_exclusive_connection PASSED             [100%]

============================= slowest 20 durations =============================
15.09s setup    test_cluster.py::test_exclusive_connection
7.49s teardown test_cluster.py::test_exclusive_connection
0.47s call     test_cluster.py::test_exclusive_connection
============================== 1 passed in 23.12s ==============================
```

Teardown now actually runs, so containers are reaped instead of leaking (before the fix `scylla.kill()` never executed and the container was left running).

`pre-commit run --files unit_tests/conftest.py` passes (ruff-format, ruff, and all `pre-commit-hooks` checks), and commitlint passed on the commit.

## Why no `test-integration` label

Intentionally **not** adding `test-integration`. With the suite still serial on this branch, the integration stage aborts at its 45-minute timeout and publishes no JUnit, so labelling would only produce another aborted build with no result. Making CI able to validate this is tracked by SCT-714 and SCT-804.

## Out of scope / known pre-existing breakage on this branch

- `unit_tests/test_configs/` does not exist on this branch, so `unit_tests/test_config_get_version_based_on_conf.py` (which sets `SCT_CONFIG_FILES=unit_tests/test_configs/minimal_test_case.yaml`) fails regardless. The verification tests above do not depend on it.
- Collecting from the repo root rather than `unit_tests/` trips a pytest 8 `pytest_plugins` in a non-top-level conftest error plus assorted import errors (e.g. missing `thrift`). Not touched here.
- The integration-suite parallelism work is a separate in-flight PR; this branch is based directly on `upstream/branch-perf-v17` and does not stack on it.

Refs: SCT-714, SCT-804
