### PR TITLE
fix(sstable): skip the S3 upload on backends without SSH access

### DIFF
--- a/sdcm/sct_events/handlers/schema_disagreement.py
+++ b/sdcm/sct_events/handlers/schema_disagreement.py
@@ -45,13 +45,17 @@ class SchemaDisagreementHandler(EventHandler):
                 LOGGER.info("Collecting data related to schema disagreement for node: %s", node.name)
                 gossip_info = gossip_info or node.get_gossip_info()
                 peers_info = peers_info or node.get_peers_info()
-                try:
-                    link = upload_sstables_to_s3(
-                        node, keyspace="system_schema", test_id=tester_obj.test_id, public=False
-                    )
-                    event.add_sstable_link(create_proxy_argus_s3_url(link, True))
-                except Exception as exc:  # noqa: BLE001
-                    LOGGER.error("failed to upload system_schema sstables for node %s: %s", node.name, exc)
+                # the upload opens an SSH session of its own, which the containerized and the xcloud
+                # nodes have not -- the gossip and peers info above works on them regardless
+                if not node.is_docker() and node.ssh_login_info:
+                    try:
+                        link = upload_sstables_to_s3(
+                            node, keyspace="system_schema", test_id=tester_obj.test_id, public=False
+                        )
+                        if link:
+                            event.add_sstable_link(create_proxy_argus_s3_url(link, True))
+                    except Exception as exc:  # noqa: BLE001
+                        LOGGER.error("failed to upload system_schema sstables for node %s: %s", node.name, exc)
             event.add_gossip_info(gossip_info)
             event.add_peers_info(peers_info)
             event.ready_to_publish()

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -4189,12 +4189,15 @@ class ClusterTester(unittest.TestCase):
             self.save_cqlsh_output_in_file(
                 node=node, cmd="select JSON * from system.tablets", log_file="system_tablets.log"
             )
-            # Upload system.compaction_history directly to S3 to avoid loading large data into memory
-            s3_link, s3_filename = upload_system_table_to_s3(
-                node=node, table_name="system.compaction_history", test_id=self.test_config.test_id()
-            )
-            if s3_link:
-                self.argus_collect_logs({s3_filename: s3_link})
+            # Upload system.compaction_history directly to S3 to avoid loading large data into memory.
+            # The upload opens an SSH session of its own: the containerized backends run no sshd, and
+            # the xcloud nodes are reached through a tunnel which exposes no ssh login info.
+            if not node.is_docker() and node.ssh_login_info:
+                s3_link, s3_filename = upload_system_table_to_s3(
+                    node=node, table_name="system.compaction_history", test_id=self.test_config.test_id()
+                )
+                if s3_link:
+                    self.argus_collect_logs({s3_filename: s3_link})
             self.save_cqlsh_output_in_file(
                 node=node, cmd="desc schema with internals", log_file="schema_with_internals.log"
             )

--- a/sdcm/utils/sstable/s3_uploader.py
+++ b/sdcm/utils/sstable/s3_uploader.py
@@ -90,10 +90,12 @@ def upload_system_table_to_s3(node: BaseNode, table_name: str, test_id: str, pub
 
 def upload_sstables_to_s3(
     node: CollectingNode | BaseNode, keyspace: str, test_id: str, tables: list | None = None, public: bool = True
-):
+) -> str:
     """Uploads given keyspace/tables sstables snapshot to s3.
 
-    Uploaded snapshots will be visible in show-logs command for given test_id."""
+    Uploaded snapshots will be visible in show-logs command for given test_id.
+
+    Returns the S3 download link, or "" on failure."""
     LOGGER.info("Collecting sstables for node %s...", node.name)
     data_directory = "/var/lib/scylla/data"
     snapshot_date = datetime.now().strftime("%Y%m%d_%H%M%S")

--- a/unit_tests/unit/test_schema_disagreement_handler.py
+++ b/unit_tests/unit/test_schema_disagreement_handler.py
@@ -1,0 +1,65 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2026 ScyllaDB
+
+"""Tests for the sstables collected when the loaders report a schema disagreement."""
+
+from unittest.mock import MagicMock, patch
+
+from sdcm.sct_events.handlers.schema_disagreement import SchemaDisagreementHandler
+from sdcm.sct_events.loaders import CassandraStressLogEvent
+
+S3_LINK = "https://cloudius-jenkins-test.s3.amazonaws.com/fake-upload.tar.gz"
+PROXIED_S3_LINK = "https://argus.scylladb.com/api/v1/s3/cloudius-jenkins-test/fake-upload.tar.gz"
+SSH_LOGIN_INFO = {"hostname": "10.0.0.1", "user": "scylla-test", "key_file": "~/.ssh/scylla_test_id_ed25519"}
+
+
+def make_node(name: str, is_docker: bool = False, ssh_login_info: dict | None = SSH_LOGIN_INFO) -> MagicMock:
+    node = MagicMock()
+    node.name = name
+    node.is_docker.return_value = is_docker
+    node.ssh_login_info = ssh_login_info
+    return node
+
+
+def handle(nodes: list[MagicMock], link: str = S3_LINK) -> tuple[MagicMock, list[str]]:
+    """Runs the handler over the given nodes, returning the upload and the recorded sstable links."""
+    tester = MagicMock()
+    tester.db_cluster.nodes = nodes
+    with (
+        patch("sdcm.sct_events.handlers.schema_disagreement.upload_sstables_to_s3", return_value=link) as upload_mock,
+        # NOTE: a stub event -- a real one would need the whole event device to be published to
+        patch("sdcm.sct_events.handlers.schema_disagreement.SchemaDisagreementErrorEvent") as event_class,
+    ):
+        SchemaDisagreementHandler().handle(CassandraStressLogEvent.SchemaDisagreement(), tester)
+    event = event_class.return_value
+    return upload_mock, [call.args[0] for call in event.add_sstable_link.call_args_list]
+
+
+def test_uploads_only_from_the_nodes_with_ssh_access():
+    """The upload opens an SSH session of its own, which the docker, k8s and xcloud nodes have not."""
+    docker_node = make_node("docker-node-1", is_docker=True)
+    xcloud_node = make_node("xcloud-node-1", ssh_login_info=None)
+    ssh_node = make_node("db-node-1")
+
+    upload_mock, links = handle([docker_node, xcloud_node, ssh_node])
+
+    assert [call.args[0] for call in upload_mock.call_args_list] == [ssh_node]
+    assert links == [PROXIED_S3_LINK]
+    # the gossip info works on those nodes, so the skipped ones must still be asked for it
+    docker_node.get_gossip_info.assert_called_once()
+
+
+def test_records_no_link_when_the_upload_fails():
+    _, links = handle([make_node("db-node-1")], link="")
+
+    assert links == []

--- a/unit_tests/unit/test_sstable_s3_uploader.py
+++ b/unit_tests/unit/test_sstable_s3_uploader.py
@@ -1,0 +1,92 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2026 ScyllaDB
+
+"""Tests for the S3 uploads which stream the files over an SSH session to the node."""
+
+from unittest.mock import MagicMock, Mock, patch
+
+from sdcm.cluster import BaseNode
+from sdcm.cluster_k8s import BasePodContainer
+from sdcm.utils.sstable.s3_uploader import upload_sstables_to_s3, upload_system_table_to_s3
+
+TEST_ID = "4352b7b6-0630-4ceb-ac5b-3ba5bd44ceba"
+S3_LINK = "https://cloudius-jenkins-test.s3.amazonaws.com/fake-upload.tar.gz"
+SNAPSHOT_PATH = "/var/lib/scylla/data/keyspace1/standard1-abcd/snapshots/sct-20260802_221441"
+SSH_LOGIN_INFO = {"hostname": "10.0.0.1", "user": "scylla-test", "key_file": "~/.ssh/scylla_test_id_ed25519"}
+
+
+def make_remoter() -> MagicMock:
+    """A remoter which records every command and answers the two commands whose output is read."""
+
+    def run(cmd, **_):
+        if cmd.startswith("stat -c%s"):
+            # NOTE: bigger than the 100 bytes the uploader considers an empty table
+            return Mock(stdout="2048", ok=True)
+        if cmd.startswith("find "):
+            return Mock(stdout=SNAPSHOT_PATH, ok=True)
+        return Mock(stdout="", ok=True)
+
+    remoter = MagicMock()
+    remoter.run.side_effect = run
+    return remoter
+
+
+def make_db_node() -> Mock:
+    node = Mock(spec=BaseNode)
+    node.name = "db-node-1"
+    node.remoter = make_remoter()
+    node.ssh_login_info = SSH_LOGIN_INFO
+    return node
+
+
+def commands_run(node: Mock) -> list[str]:
+    return [call.args[0] for call in node.remoter.run.call_args_list]
+
+
+def test_k8s_nodes_report_being_docker():
+    """The callers skip these uploads on 'is_docker()' alone, which is what covers k8s as well."""
+    assert BasePodContainer.is_docker() is True
+
+
+def test_upload_system_table_to_s3_uploads_from_ssh_node():
+    node = make_db_node()
+
+    with patch(
+        "sdcm.utils.sstable.s3_uploader.upload_remote_files_directly_to_s3", return_value=S3_LINK
+    ) as upload_mock:
+        s3_link, s3_filename = upload_system_table_to_s3(
+            node=node, table_name="system.compaction_history", test_id=TEST_ID
+        )
+
+    assert s3_link == S3_LINK
+    assert s3_filename.startswith("system_compaction_history-")
+    upload_mock.assert_called_once()
+    node._gen_cqlsh_cmd.assert_called_once_with(
+        command="SELECT JSON * FROM system.compaction_history", keyspace=None, timeout=300, connect_timeout=60
+    )
+
+
+def test_upload_sstables_to_s3_uploads_from_ssh_node():
+    node = make_db_node()
+
+    with patch(
+        "sdcm.utils.sstable.s3_uploader.upload_remote_files_directly_to_s3", return_value=S3_LINK
+    ) as upload_mock:
+        s3_link = upload_sstables_to_s3(node=node, keyspace="keyspace1", test_id=TEST_ID)
+
+    assert s3_link == S3_LINK
+    assert upload_mock.call_args.args[1] == [SNAPSHOT_PATH]
+    commands = commands_run(node)
+    assert any(cmd.startswith("nodetool snapshot -t sct-") for cmd in commands)
+    assert any(cmd.startswith("find /var/lib/scylla/data ") for cmd in commands)
+    assert any(cmd.startswith("nodetool clearsnapshot -t sct-") for cmd in commands)

--- a/unit_tests/unit/test_tester.py
+++ b/unit_tests/unit/test_tester.py
@@ -455,6 +455,7 @@ class TestSaveSchema:
         mock_node = MagicMock()
         mock_node.name = "test_node_1"
         mock_node._is_node_ready_run_scylla_commands.return_value = True
+        mock_node.is_docker.return_value = False
 
         # Mock run_cqlsh to return sample data
         mock_result = MagicMock()
@@ -556,6 +557,42 @@ class TestSaveSchema:
         assert mock_nodes[0].run_cqlsh.called
         assert not mock_nodes[1].run_cqlsh.called
         assert not mock_nodes[2].run_cqlsh.called
+
+
+@pytest.mark.parametrize(
+    "node_attrs",
+    (
+        pytest.param({"is_docker.return_value": True}, id="docker-node"),
+        pytest.param({"ssh_login_info": None}, id="xcloud-node"),
+    ),
+)
+def test_save_schema_skips_the_s3_upload_without_ssh_access(tmp_path, node_attrs):
+    """The upload opens an SSH session of its own, which the docker, k8s and xcloud nodes have not."""
+    tester = ClusterTesterForTests()
+    tester._init_logging(tmp_path / "test_save_schema_no_ssh")
+    tester.logdir = str(tmp_path)
+
+    mock_node = MagicMock()
+    mock_node.name = "no-ssh-node-1"
+    mock_node._is_node_ready_run_scylla_commands.return_value = True
+    mock_node.is_docker.return_value = False
+    mock_node.run_cqlsh.return_value = MagicMock(stdout="Sample output")
+    mock_node.configure_mock(**node_attrs)
+
+    tester.db_cluster = MagicMock()
+    tester.db_cluster.nodes = [mock_node]
+
+    with (
+        patch("sdcm.tester.upload_system_table_to_s3") as mock_upload,
+        patch.object(tester, "argus_collect_logs") as mock_argus_logs,
+    ):
+        tester.save_schema()
+
+    mock_upload.assert_not_called()
+    mock_argus_logs.assert_not_called()
+    # the rest of the schema dump does not need SSH, so it must still run
+    assert "desc schema" in [call[0][0] for call in mock_node.run_cqlsh.call_args_list]
+    assert (tmp_path / "schema.log").exists()
 
 
 class TestEmrCleanResources:


### PR DESCRIPTION
'upload_remote_files_directly_to_s3()' streams the files over an SSH session to the node, bypassing the node's remoter. The containerized backends run no sshd, so on docker and k8s both 'upload_system_table_to_s3()' and 'upload_sstables_to_s3()' could only fail with a 'Connection refused' -- for 'save_schema()' during teardown, where it shows up as a scary traceback for something that was never going to work.

Skip the upload at both call sites, 'save_schema()' and 'SchemaDisagreementHandler'. 'is_docker()' covers the k8s pod containers too, as they report it True. It is not a general "has no SSH" predicate though -- 'DockerLoaderNode' returns False while running its commands through LOCALRUNNER -- so it holds here only because both callers iterate the db cluster.

'SchemaDisagreementHandler' now also checks the link before recording it, so a failed upload no longer contributes an empty entry to the error event.

Refs:  VECTOR-783 

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)

