### PR TITLE
test(manager): add event-based-hold backup test

### DIFF
--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -238,7 +238,7 @@ class ManagerBackupTests(ManagerRestoreTests):
         self.log.info("starting test_backup_purge_removes_orphan_files")
 
         mgr_cluster = self.db_cluster.get_cluster_manager()
-        snapshot_file_list_pre_test = self.get_all_snapshot_files(cluster_id=mgr_cluster.id)
+        snapshot_file_list_pre_test = self.get_cluster_bucket_files(cluster_id=mgr_cluster.id)
 
         backup_task = mgr_cluster.create_backup_task(
             location_list=self.locations, retention=1, method=self.backup_method
@@ -253,7 +253,7 @@ class ManagerBackupTests(ManagerRestoreTests):
         with ctx:
             backup_task.stop()
 
-        snapshot_file_list_post_task_stopping = self.get_all_snapshot_files(cluster_id=mgr_cluster.id)
+        snapshot_file_list_post_task_stopping = self.get_cluster_bucket_files(cluster_id=mgr_cluster.id)
         orphan_files_pre_rerun = snapshot_file_list_post_task_stopping.difference(snapshot_file_list_pre_test)
         assert orphan_files_pre_rerun, "SCT could not create orphan snapshots by stopping a backup task"
 
@@ -271,7 +271,7 @@ class ManagerBackupTests(ManagerRestoreTests):
             backup_task.start(continue_task=False)
             backup_task.wait_and_get_final_status(step=10)
 
-        snapshot_file_list_post_purge = self.get_all_snapshot_files(cluster_id=mgr_cluster.id)
+        snapshot_file_list_post_purge = self.get_cluster_bucket_files(cluster_id=mgr_cluster.id)
         orphan_files_post_rerun = snapshot_file_list_post_purge.intersection(orphan_files_pre_rerun)
         assert not orphan_files_post_rerun, "orphan files were not deleted!"
 
@@ -374,7 +374,7 @@ class ManagerBackupTests(ManagerRestoreTests):
             task_status = backup_task.wait_and_get_final_status(timeout=1500)
             assert task_status == TaskStatus.DONE, f"Backup task ended in {task_status} instead of {TaskStatus.DONE}"
 
-            snapshot_files = self.get_all_snapshot_files(
+            snapshot_files = self.get_cluster_bucket_files(
                 cluster_id=mgr_cluster.id,
                 bucket_location=worm_bucket_name,
                 only_sstables=False,

--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -353,16 +353,13 @@ class ManagerBackupTests(ManagerRestoreTests):
         self.log.info("Create WORM backup bucket")
         worm_bucket_name = f"manager-worm-backup-test-{self.test_id[:8]}"
         location = f"gcs:{worm_bucket_name}"
-        worm_bucket = self.create_worm_bucket(region=self.params.gce_datacenters[0], bucket_name=worm_bucket_name)
+        worm_bucket = self.create_object_lock_bucket(
+            region=self.params.gce_datacenters[0], bucket_name=worm_bucket_name
+        )
 
         try:
-            self.log.info("Wait 30s for backup location accessibility after bucket creation")
-            # We tried to use `scylla-manager-agent check-location` here instead of dummy sleep, but the approach
-            # turned out to be not stable enough - check-location could proceed while the follow-up sctool backup
-            # could fail immediately due to bucket access issue. The reason - check-location command issued in test
-            # initializes rclone from scratch with fresh tokens, while backup runs through the SM agent server may
-            # hold stale tokens. A fixed sleep is the most robust approach here.
-            time.sleep(30)
+            self.log.info("Wait for backup location accessibility after bucket creation")
+            self.wait_for_location_accessibility_after_bucket_creation()
 
             self.log.info("Create backup task and wait for its completion")
             backup_task = mgr_cluster.create_backup_task(
@@ -392,10 +389,135 @@ class ManagerBackupTests(ManagerRestoreTests):
             self.log.info("All snapshot files are properly protected by object lock")
 
         finally:
-            self.destroy_worm_bucket(bucket=worm_bucket)
+            self.destroy_object_lock_bucket(bucket=worm_bucket)
             mgr_cluster.delete()
 
         self.log.info("finishing test_worm_backup")
+
+    def test_event_based_hold_backup(self):  # noqa: PLR0914
+        """Verify GCS event-based hold retention for Manager backups.
+
+        Steps:
+        1. Write a fresh batch of rows to a second keyspace, to be dropped once backup #1 is done.
+        2. Create a GCS bucket with event-based hold enabled and a default retention period.
+        3. Wait for the backup location to become accessible after bucket creation.
+        4. Run backup #1 and wait for its completion; capture its snapshot tag.
+        5. Verify snapshot #1's files exist, are marked with an event-based hold, and cannot be deleted.
+        6. Drop the second keyspace, so its snapshot #1 files end up in a vanished backup dir.
+        7. Write a fresh batch of rows and compact all nodes so sstables get rewritten,
+           producing files from snapshot #1 that become stale.
+        8. Run backup #2 (restart the same task); capture its snapshot tag and compute the
+           stale files left over from snapshot #1 (including the dropped keyspace's files).
+        9. Verify the stale snapshot #1 files (dropped keyspace and rewritten sstables) have had
+           their event-based hold released.
+        10. Verify snapshot #2's current files are still protected by an event-based hold.
+        11. Attempt to explicitly delete snapshot #1; expect it to fail since its retention window has not elapsed yet.
+        12. Sleep for the retention period so snapshot #1's default retention window elapses.
+        13. Run backup #3 and capture its snapshot tag.
+        14. Verify only snapshots #2 and #3 remain in the backup location (snapshot #1 purged).
+        15. Verify snapshot #1's stale (orphaned) files were purged from the bucket.
+        """
+        self.log.info("starting test_event_based_hold_backup")
+        mgr_cluster = self.db_cluster.get_cluster_manager()
+
+        second_keyspace = "keyspace2"
+        self.log.info("Write initial rows to a second keyspace, to be dropped after backup #1")
+        second_keyspace_stress_cmd = (
+            f"cassandra-stress write cl=QUORUM n=1000000 -schema 'keyspace={second_keyspace} "
+            "replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native "
+            "-rate threads=400 -pop seq=1..1000000"
+        )
+        second_keyspace_write_thread = self.run_stress_thread(stress_cmd=second_keyspace_stress_cmd, round_robin=False)
+        self.verify_stress_thread(second_keyspace_write_thread)
+
+        retention_seconds = 10 * 60
+        self.log.info("Create bucket with event-based hold and a %s seconds default retention", retention_seconds)
+        bucket_name = f"manager-event-based-hold-backup-test-{self.test_id[:8]}"
+        location = f"gcs:{bucket_name}"
+        bucket = self.create_event_hold_bucket(
+            region=self.params.gce_datacenters[0],
+            bucket_name=bucket_name,
+            retention_seconds=retention_seconds,
+        )
+
+        try:
+            self.log.info("Wait for backup location accessibility after bucket creation")
+            self.wait_for_location_accessibility_after_bucket_creation()
+
+            self.log.info("Run backup #1 and wait for its completion")
+            backup_task = self.backup_with_manager_task(
+                mgr_cluster,
+                location_list=[location],
+                retention=1,
+                retention_lock_mode=BackupRetentionLockMode.EVENT_BASED_HOLD,
+            )
+            snapshot_tag_1 = backup_task.get_snapshot_tag()
+
+            snapshot_files_1 = self.get_snapshot_files(bucket_location=bucket_name, snapshot_tag=snapshot_tag_1)
+            assert snapshot_files_1, "No snapshot files found after backup #1"
+
+            self.log.info("Verify snapshot #1 files are protected by an event-based hold")
+            self.assert_blobs_event_based_hold(bucket, snapshot_files_1, expected=True)
+            self.assert_blobs_deletion_forbidden(bucket, snapshot_files_1)
+
+            self.log.info("Drop the second keyspace to verify SM releases holds on vanished backup dirs")
+            with self.db_cluster.cql_connection_patient(self.db_cluster.nodes[0]) as session:
+                session.execute(f"DROP KEYSPACE IF EXISTS {second_keyspace}")
+
+            self.log.info("Write a fresh batch of rows to keyspace1")
+            extra_rows_stress_cmd = (
+                "cassandra-stress write cl=QUORUM n=1000000 -schema 'replication(strategy=NetworkTopologyStrategy,"
+                "replication_factor=3)' -mode cql3 native -rate threads=400 -pop seq=700000000..701000000"
+            )
+            write_thread = self.run_stress_thread(stress_cmd=extra_rows_stress_cmd, round_robin=False)
+            self.verify_stress_thread(write_thread)
+
+            self.log.info("Compact all nodes so sstables get rewritten")
+            for node in self.db_cluster.nodes:
+                node.run_nodetool("compact")
+
+            self.log.info("Run backup #2 and wait for its completion")
+            self.backup_rerun_with_manager_task(backup_task)
+            snapshot_tag_2 = backup_task.get_snapshot_tag()
+
+            snapshot_files_2 = self.get_snapshot_files(bucket_location=bucket_name, snapshot_tag=snapshot_tag_2)
+            stale_files = snapshot_files_1 - snapshot_files_2
+            assert stale_files, "No stale files were found"
+
+            self.log.info("Verify stale snapshot files have their event-based hold removed")
+            self.assert_blobs_event_based_hold(bucket, stale_files, expected=False)
+
+            self.log.info("Verify snapshot #2 files are protected by an event-based hold")
+            self.assert_blobs_event_based_hold(bucket, snapshot_files_2, expected=True)
+
+            self.log.info("Attempt to explicitly delete snapshot #1 before its retention window elapses")
+            try:
+                backup_task.delete_backup_snapshot(snapshot_tag_1)
+                raise AssertionError(f"Deletion of snapshot {snapshot_tag_1} unexpectedly succeeded")
+            except ScyllaManagerError as error:
+                self.log.info("Explicit deletion of snapshot #1 failed as expected: %s", error)
+
+            self.log.info("Sleep %s seconds for snapshot's #1 default retention window to pass", retention_seconds)
+            time.sleep(retention_seconds)
+
+            self.log.info("Run backup #3 and wait for its completion")
+            self.backup_rerun_with_manager_task(backup_task, timeout=200)
+            snapshot_tag_3 = backup_task.get_snapshot_tag()
+
+            self.log.info("Verify only snapshot #2 and #3 remain in the backup location")
+            remaining_snapshot_tags = mgr_cluster.list_backup_snapshot_tags(location=f"gcs:{bucket_name}")
+            assert remaining_snapshot_tags == {snapshot_tag_2, snapshot_tag_3}, (
+                f"Expected to remain snapshots: {snapshot_tag_2}, {snapshot_tag_3}, got {remaining_snapshot_tags}"
+            )
+
+            self.log.info("Verify snapshot's #1 orphaned files were purged from the bucket")
+            self.assert_blobs_purged(bucket, stale_files)
+
+        finally:
+            self.destroy_event_hold_bucket(bucket=bucket)
+            mgr_cluster.delete()
+
+        self.log.info("finishing test_event_based_hold_backup")
 
     def test_backup_feature(self):
         self.generate_load_and_wait_for_results()
@@ -411,6 +533,8 @@ class ManagerBackupTests(ManagerRestoreTests):
             # WORM backup feature is currently available for GCP only
             with self.subTest("Test WORM backup with object lock"):
                 self.test_worm_backup()
+            with self.subTest("Test event-based hold backup"):
+                self.test_event_based_hold_backup()
         with self.subTest("Test Backup end of space"):  # Preferably at the end
             self.test_enospc_during_backup()
         with self.subTest("Test Restore end of space"):

--- a/sdcm/mgmt/cli.py
+++ b/sdcm/mgmt/cli.py
@@ -46,6 +46,9 @@ from sdcm.wait import WaitForTimeoutError
 
 LOGGER = logging.getLogger(__name__)
 
+# node_id -> keyspace -> table -> list of S3 backup file paths
+BackupFilesByNode = dict[str, dict[str, dict[str, list[str]]]]
+
 STATUS_DONE = "done"
 STATUS_ERROR = "error"
 SSL_CONF_DIR = Path("/tmp/ssl_conf")
@@ -894,20 +897,24 @@ class ManagerCluster(ScyllaManagerBase):
         if not res:
             raise ScyllaManagerError(f"Unknown failure for sctool {cmd} command")
 
-    def get_backup_files_dict(self, snapshot_tag, location=None, all_clusters=None):
+    def _get_backup_files(self, snapshot_tag, location=None, all_clusters=None) -> list[str]:
         location_flag = f" --location {location}" if location else ""
         all_clusters_flag = "--all-clusters" if all_clusters else ""
         command = f" -c {self.id} backup files --snapshot-tag {snapshot_tag} {location_flag} {all_clusters_flag}"
-        # The sctool backup files command prints the s3 paths of all of the files that are required to restore the
-        # cluster from the backup
+
         snapshot_files = self.sctool.run(command)
-        snapshot_file_list = [file_path_list[0] for file_path_list in snapshot_files]
         # sctool.run returns a list of lists, each of them is a 1 length list that contains the row.
         # This list comprehension turns the list into a list of strings (rows) instead
-        return self.snapshot_files_to_dict(snapshot_file_list)
+        return [file_path_list[0] for file_path_list in snapshot_files]
+
+    def get_backup_files_dict(self, *args, **kwargs) -> BackupFilesByNode:
+        return self.snapshot_files_to_dict(self._get_backup_files(*args, **kwargs))
+
+    def get_backup_files_set(self, *args, **kwargs) -> set[str]:
+        return {file.split(" ")[0].strip() for file in self._get_backup_files(*args, **kwargs)}
 
     @staticmethod
-    def snapshot_files_to_dict(snapshot_file_lines):
+    def snapshot_files_to_dict(snapshot_file_lines) -> BackupFilesByNode:
         per_node_keyspaces_and_tables_backup_files = {}
         for line in snapshot_file_lines:
             s3_file_path, keyspace_and_table = [string.strip() for string in line.split(" ")]

--- a/sdcm/mgmt/cli.py
+++ b/sdcm/mgmt/cli.py
@@ -472,6 +472,7 @@ class BackupTask(ManagerTask):
         if snapshot_index >= len(snapshot_line):
             snapshot_index = -1
         snapshot_tag = snapshot_line[snapshot_index].split(":")[1].strip()
+        LOGGER.debug("Snapshot tag: %s", snapshot_tag)
         return snapshot_tag
 
     def is_task_in_uploading_stage(self):
@@ -487,16 +488,17 @@ class BackupTask(ManagerTask):
         )
         return is_status_reached
 
-    def delete_backup_snapshot(self):
-        if self.status == TaskStatus.DONE:
+    def delete_backup_snapshot(self, snapshot_tag: str | None = None):
+        if snapshot_tag is None:
+            if self.status != TaskStatus.DONE:
+                LOGGER.warning(
+                    f"Did not delete the snapshot of task {self.id}, since the status of said task is {self.status!s}, "
+                    "and the manager can only delete snapshots of finished tasks"
+                )
+                return
             snapshot_tag = self.get_snapshot_tag()
-            command = f" -c {self.cluster_id} backup delete --snapshot-tag {snapshot_tag}"
-            self.sctool.run(command, parse_table_res=False, is_verify_errorless_result=True)
-        else:
-            LOGGER.warning(
-                f"Did not delete the snapshot of task {self.id}, since the status of said task is {self.status!s}, and the "
-                "manager can only delete snapshots of finished tasks"
-            )
+        command = f" -c {self.cluster_id} backup delete --snapshot-tag {snapshot_tag}"
+        self.sctool.run(command, parse_table_res=False, is_verify_errorless_result=True)
 
 
 class RestoreTask(ManagerTask):
@@ -928,6 +930,17 @@ class ManagerCluster(ScyllaManagerBase):
                 per_node_keyspaces_and_tables_backup_files[node_id][keyspace][table] = []
             per_node_keyspaces_and_tables_backup_files[node_id][keyspace][table].append(s3_file_path)
         return per_node_keyspaces_and_tables_backup_files
+
+    def list_backup_snapshot_tags(self, location: str) -> set[str]:
+        """Return the set of snapshot tags still present in the given backup location.
+
+        Wraps `sctool backup list -c <cluster> -L <location>`.
+        """
+        command = f" -c {self.id} backup list --location {location}"
+        parsed_table = self.sctool.run(command)
+        if not parsed_table:
+            return set()
+        return self.sctool.parse_snapshot_tags_from_backup_list(parsed_table)
 
     def delete(self):
         """
@@ -1548,6 +1561,38 @@ class SCTool:
         column_name_index = column_titles.index(column_name.upper())
         column_values = [row[column_name_index] for row in parsed_table[1:]]
         return column_values
+
+    @staticmethod
+    def parse_snapshot_tags_from_backup_list(parsed_table) -> set[str]:
+        """
+        Parses the output of `sctool backup list`, which is a free-form report rather
+        than a column table, e.g.:
+
+            backup/2f4a07b9-17e7-4735-87c1-d367dae9959b
+            Snapshots:
+              - sm_20260804122044UTC (3.359GiB, 3 nodes)
+              - sm_20260804120320UTC (3.359GiB, 3 nodes)
+            Keyspaces:
+              - keyspace1 (1 table)
+              ...
+
+        A location can list several backup tasks, each with its own `Snapshots:`
+        section, so all of them are collected.
+        """
+        snapshot_tags = set()
+        in_snapshots_section = False
+        for row in parsed_table:
+            line = row[0].strip()
+            if line == "Snapshots:":
+                in_snapshots_section = True
+                continue
+            if not in_snapshots_section:
+                continue
+            if not line.startswith("-"):
+                in_snapshots_section = False
+                continue
+            snapshot_tags.add(line.lstrip("- ").split()[0])
+        return snapshot_tags
 
     @staticmethod
     def _is_found_in_table(parsed_table, identifier, is_search_substring=False):

--- a/sdcm/mgmt/common.py
+++ b/sdcm/mgmt/common.py
@@ -58,6 +58,7 @@ class BackupRetentionLockMode(StrEnum):
     DISABLED = "disabled"
     UNLOCKED = "unlocked"
     LOCKED = "locked"
+    EVENT_BASED_HOLD = "event-based-hold"
 
 
 class HostRestStatus(Enum):

--- a/sdcm/mgmt/operations.py
+++ b/sdcm/mgmt/operations.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 
 import boto3
 import yaml
+from google.api_core.exceptions import Forbidden
 from invoke import exceptions
 
 from sdcm.mgmt import get_scylla_manager_tool, TaskStatus
@@ -27,7 +28,13 @@ from sdcm.utils.azure_utils import AzureService
 from sdcm.utils.cluster_tools import flush_nodes, major_compaction_nodes, clear_snapshot_nodes
 from sdcm.utils.compaction_ops import CompactionOps
 from sdcm.utils.gce_region import GceRegion
-from sdcm.utils.gce_utils import create_gce_storage_bucket, get_gce_storage_client, gce_override_object_retention
+from sdcm.utils.gce_utils import (
+    create_event_based_hold_bucket,
+    create_object_retention_bucket,
+    gce_clear_event_based_hold,
+    gce_override_object_retention,
+    get_gce_storage_client,
+)
 from sdcm.utils.loader_utils import LoaderUtilsMixin
 from sdcm.utils.time_utils import ExecutionTimer
 
@@ -231,10 +238,8 @@ class BucketOperations(ClusterTester):
             raise ValueError(f"Unsupported cluster backend - {cluster_backend}, should be either aws or gce")
 
     @staticmethod
-    def create_worm_bucket(region: str, bucket_name: str) -> "Bucket":
-        bucket = create_gce_storage_bucket(name=bucket_name, region=region, object_lock_enabled=True)
-
-        # Grant the access to this bucket for sct-manager-backup service account
+    def _grant_backup_sa_access_to_bucket(bucket: "Bucket") -> None:
+        """Grant the sct-manager-backup service account objectAdmin access to the given bucket."""
         project_id = KeyStore().get_gcp_credentials()["project_id"]
         sa_email = f"{GceRegion.SCT_BACKUP_SERVICE_ACCOUNT}@{project_id}.iam.gserviceaccount.com"
 
@@ -242,17 +247,81 @@ class BucketOperations(ClusterTester):
         policy.bindings.append({"role": "roles/storage.objectAdmin", "members": {f"serviceAccount:{sa_email}"}})
         bucket.set_iam_policy(policy)
 
-        return bucket
-
     @staticmethod
-    def destroy_worm_bucket(bucket: "Bucket") -> None:
-        gce_override_object_retention(bucket_name=bucket.name, path="")
-
+    def delete_bucket_with_content(bucket: "Bucket") -> None:
+        """Delete all blobs in the bucket, then the bucket itself."""
         blobs = list(bucket.list_blobs())
         for blob in blobs:
             blob.delete()
 
         bucket.delete()
+
+    @staticmethod
+    def create_object_lock_bucket(region: str, bucket_name: str) -> "Bucket":
+        """Create object lock bucket."""
+        bucket = create_object_retention_bucket(name=bucket_name, region=region)
+        BucketOperations._grant_backup_sa_access_to_bucket(bucket)
+        return bucket
+
+    @staticmethod
+    def destroy_object_lock_bucket(bucket: "Bucket") -> None:
+        """Destroy object lock bucket."""
+        gce_override_object_retention(bucket_name=bucket.name, path="")
+        BucketOperations.delete_bucket_with_content(bucket)
+
+    @staticmethod
+    def create_event_hold_bucket(region: str, bucket_name: str, retention_seconds: int) -> "Bucket":
+        """Create event based hold bucket."""
+        bucket = create_event_based_hold_bucket(name=bucket_name, region=region, retention_seconds=retention_seconds)
+        BucketOperations._grant_backup_sa_access_to_bucket(bucket)
+        return bucket
+
+    @staticmethod
+    def destroy_event_hold_bucket(bucket: "Bucket") -> None:
+        """Destroy event based hold bucket."""
+        bucket.retention_period = None
+        bucket.patch()
+
+        gce_clear_event_based_hold(bucket_name=bucket.name, path="")
+
+        BucketOperations.delete_bucket_with_content(bucket)
+
+    @staticmethod
+    def wait_for_location_accessibility_after_bucket_creation() -> None:
+        """Wait for backup location to become available after bucket creation.
+
+        We tried to use `scylla-manager-agent check-location` here instead of dummy sleep, but the approach
+        turned out to be not stable enough - check-location could proceed while the follow-up sctool backup
+        could fail immediately due to bucket access issue. The reason - check-location command issued in test
+        initializes rclone from scratch with fresh tokens, while backup runs through the SM agent server may
+        hold stale tokens. A fixed sleep is the most robust approach here.
+        """
+        time.sleep(30)
+
+    def assert_blobs_event_based_hold(self, bucket: "Bucket", file_paths: set[str], expected: bool) -> None:
+        for file_path in file_paths:
+            self.log.debug("Validating event based hold for file_path: %s", file_path)
+            blob = bucket.blob(file_path)
+            blob.reload()
+            assert blob.event_based_hold == expected, (
+                f"File {file_path} is expected to have event_based_hold={expected}"
+            )
+
+    def assert_blobs_deletion_forbidden(self, bucket: "Bucket", file_paths: set[str]) -> None:
+        for file_path in file_paths:
+            self.log.debug("Validating deletion forbidden for file_path: %s", file_path)
+            blob = bucket.blob(file_path)
+            try:
+                blob.delete()
+                raise AssertionError(f"Deletion of protected file {file_path} unexpectedly succeeded")
+            except Forbidden:
+                pass
+
+    def assert_blobs_purged(self, bucket: "Bucket", file_paths: set[str]) -> None:
+        for file_path in file_paths:
+            self.log.debug("Validating purged status for file_path: %s", file_path)
+            blob = bucket.blob(file_path)
+            assert not blob.exists(), f"File {file_path} exists in the bucket"
 
 
 @dataclass

--- a/sdcm/mgmt/operations.py
+++ b/sdcm/mgmt/operations.py
@@ -321,7 +321,7 @@ class SnapshotOperations(ClusterTester):
         return snapshot_data
 
     @staticmethod
-    def _get_all_snapshot_files_s3(bucket_name: str, region_name: str, prefixes: list[str]) -> set[str]:
+    def _get_cluster_bucket_files_s3(bucket_name: str, region_name: str, prefixes: list[str]) -> set[str]:
         file_set = set()
         s3_client = boto3.client("s3", region_name=region_name)
         paginator = s3_client.get_paginator("list_objects")
@@ -335,7 +335,7 @@ class SnapshotOperations(ClusterTester):
         return file_set
 
     @staticmethod
-    def _get_all_snapshot_files_gce(bucket_name: str, prefixes: list[str]) -> set[str]:
+    def _get_cluster_bucket_files_gce(bucket_name: str, prefixes: list[str]) -> set[str]:
         file_set = set()
         storage_client, _ = get_gce_storage_client()
         for prefix in prefixes:
@@ -346,7 +346,7 @@ class SnapshotOperations(ClusterTester):
         return file_set
 
     @staticmethod
-    def _get_all_snapshot_files_azure(bucket_name: str, prefixes: list[str]) -> set[str]:
+    def _get_cluster_bucket_files_azure(bucket_name: str, prefixes: list[str]) -> set[str]:
         file_set = set()
         azure_service = AzureService()
         container_client = azure_service.blob.get_container_client(container=bucket_name)
@@ -356,7 +356,7 @@ class SnapshotOperations(ClusterTester):
                 file_set.add(listing_object.name)
         return file_set
 
-    def get_all_snapshot_files(
+    def get_cluster_bucket_files(
         self,
         cluster_id: str,
         bucket_location: str | None = None,
@@ -373,20 +373,51 @@ class SnapshotOperations(ClusterTester):
         Returns:
             Set of object path strings found in the bucket.
         """
+        backend = self.params.get("backup_bucket_backend")
         region_name = next(iter(self.params.region_names), "")
         bucket_name = bucket_location or self.params.get("backup_bucket_location")[0].format(region=region_name)
 
         file_type_prefixes = ("backup/sst",) if only_sstables else self.BACKUP_FILE_PREFIXES
         prefixes = [f"{p}/cluster/{cluster_id}" for p in file_type_prefixes]
 
-        if self.params.get("backup_bucket_backend") == "s3":
-            return self._get_all_snapshot_files_s3(bucket_name=bucket_name, region_name=region_name, prefixes=prefixes)
-        elif self.params.get("backup_bucket_backend") == "gcs":
-            return self._get_all_snapshot_files_gce(bucket_name=bucket_name, prefixes=prefixes)
-        elif self.params.get("backup_bucket_backend") == "azure":
-            return self._get_all_snapshot_files_azure(bucket_name=bucket_name, prefixes=prefixes)
+        if backend == "s3":
+            return self._get_cluster_bucket_files_s3(
+                bucket_name=bucket_name, region_name=region_name, prefixes=prefixes
+            )
+        elif backend == "gcs":
+            return self._get_cluster_bucket_files_gce(bucket_name=bucket_name, prefixes=prefixes)
+        elif backend == "azure":
+            return self._get_cluster_bucket_files_azure(bucket_name=bucket_name, prefixes=prefixes)
         else:
-            raise ValueError(f'"{self.params.get("backup_bucket_backend")}" not supported')
+            raise ValueError(f"'{backend}' backend is not supported")
+
+    def get_snapshot_files(
+        self,
+        snapshot_tag: str,
+        bucket_location: str | None = None,
+        remove_prefix: bool = True,
+    ) -> set[str]:
+        """Return backup object paths that belong to a specific snapshot.
+
+        Args:
+            snapshot_tag: Snapshot tag to fetch files for, for example, 'sm_20240816185129UTC'.
+            bucket_location: Bucket name; falls back to `backup_bucket_location` param.
+            remove_prefix: If True, remove the bucket prefix (`<backend>://<bucket_name>/`) from the file paths.
+
+        Returns:
+            Set of object path strings (relative to the bucket) that belong to the given snapshot.
+        """
+        backend = self.params.get("backup_bucket_backend")
+        region_name = next(iter(self.params.region_names), "")
+        bucket_name = bucket_location or self.params.get("backup_bucket_location")[0].format(region=region_name)
+        location = f"{backend}:{bucket_name}"
+
+        mgr_cluster = self.db_cluster.get_cluster_manager()
+        files = mgr_cluster.get_backup_files_set(snapshot_tag=snapshot_tag, location=location)
+
+        if remove_prefix:
+            return {file_path.removeprefix(f"{backend}://{bucket_name}/") for file_path in files}
+        return files
 
 
 class SnapshotPreparerOperations(ClusterTester):

--- a/sdcm/mgmt/operations.py
+++ b/sdcm/mgmt/operations.py
@@ -976,6 +976,13 @@ class ManagerTestFunctionsMixIn(
         assert task_status == TaskStatus.DONE, f"Backup task ended in {task_status} instead of {TaskStatus.DONE}"
         return backup_task
 
+    def backup_rerun_with_manager_task(self, backup_task, timeout=1500):
+        """Start an existing backup task, wait for completion, assert success, and return the task."""
+        backup_task.start()
+        task_status = backup_task.wait_and_get_final_status(timeout=timeout)
+        assert task_status == TaskStatus.DONE, f"Backup task ended in {task_status} instead of {TaskStatus.DONE}"
+        return backup_task
+
     def restore_with_manager_task(
         self,
         mgr_cluster,

--- a/sdcm/utils/gce_utils.py
+++ b/sdcm/utils/gce_utils.py
@@ -19,7 +19,7 @@ import logging
 import time
 import uuid
 from functools import cached_property
-from typing import Any, List, Literal, TYPE_CHECKING
+from typing import Any, Callable, List, Literal, TYPE_CHECKING
 
 import google.api_core.exceptions
 from google.oauth2 import service_account
@@ -98,6 +98,8 @@ SUPPORTED_REGIONS = [
 SUPPORTED_PROJECTS = {"gcp-sct-project-1", "gcp-local-ssd-latency"} | {
     os.environ.get("SCT_GCE_PROJECT", "gcp-sct-project-1")
 }
+
+GCS_BATCH_CHUNK_SIZE = 100  # GCS batch requests are capped at 100 sub-requests each.
 
 
 def _get_zone_letters_for_region(region: str) -> list[str]:
@@ -187,42 +189,46 @@ def get_gce_storage_client() -> tuple[storage.Client, dict]:
     return storage.Client(credentials=credentials), info
 
 
-def create_gce_storage_bucket(name: str, region: str, object_lock_enabled: bool = False) -> storage.Bucket:
-    """Create a GCS bucket.
-
-    Args:
-        name: bucket name
-        region: GCS region (e.g., 'us-east1')
-        object_lock_enabled: if True, enables object retention (object lock) on the bucket.
-                             Requires uniform bucket-level access (set automatically).
-
-    Returns:
-        the created Bucket object
+def create_object_retention_bucket(name: str, region: str) -> storage.Bucket:
+    """Create a GCS bucket with per-object "Object Retention Lock" enabled.
+    Requires uniform bucket-level access, which is set automatically.
     """
     storage_client, _ = get_gce_storage_client()
 
     bucket = storage_client.bucket(name)
-    if object_lock_enabled:
-        bucket.iam_configuration.uniform_bucket_level_access_enabled = True
+    bucket.iam_configuration.uniform_bucket_level_access_enabled = True
 
-    storage_client.create_bucket(
-        bucket,
-        location=region,
-        enable_object_retention=object_lock_enabled,
-    )
-    LOGGER.info("Created GCS bucket gs://%s in %s (object_lock_enabled=%s)", name, region, object_lock_enabled)
+    storage_client.create_bucket(bucket, location=region, enable_object_retention=True)
+    LOGGER.info("Created GCS bucket gs://%s in %s with object retention lock enabled", name, region)
+
     return bucket
 
 
-def gce_override_object_retention(bucket_name: str, path: str) -> None:
-    """Override governance-mode object retention locks on blobs in a GCS bucket.
+def create_event_based_hold_bucket(name: str, region: str, retention_seconds: int) -> storage.Bucket:
+    """Create a GCS bucket with the event-based hold mechanism enabled."""
+    storage_client, _ = get_gce_storage_client()
 
-    Processes all matching blobs individually — if one blob fails, the rest are
-    still attempted. Raises after all blobs have been processed if any failed.
+    bucket = storage_client.bucket(name)
+    storage_client.create_bucket(bucket, location=region)
+    LOGGER.info("Created GCS bucket gs://%s in %s", name, region)
+
+    bucket.default_event_based_hold = True
+    bucket.retention_period = retention_seconds
+    bucket.patch()
+    LOGGER.info("Enabled default_event_based_hold on gs://%s (retention_period=%s seconds)", name, retention_seconds)
+
+    return bucket
+
+
+def _gce_iterate_blobs(bucket_name: str, path: str, action_desc: str, action: Callable[[storage.Blob], None]) -> None:
+    """Run `action` against every blob matching `path` in a GCS bucket, batching requests in
+    chunks of up to `GCS_BATCH_CHUNK_SIZE` to cut down on the number of HTTP round-trips.
 
     Args:
         bucket_name: the name of the GCS bucket
         path: path prefix to match blobs (empty string means all blobs)
+        action_desc: short description of the action, used for logging (e.g. "Overriding retention")
+        action: callable invoked with each matching blob
     """
     storage_client, _ = get_gce_storage_client()
 
@@ -234,18 +240,59 @@ def gce_override_object_retention(bucket_name: str, path: str) -> None:
         LOGGER.warning("No blobs found in gs://%s/%s to unlock", bucket_name, path)
         return
 
-    LOGGER.info("Overriding retention on %d blob(s) in gs://%s/%s", len(blobs), bucket_name, path)
-    failed = []
-    for blob in blobs:
+    LOGGER.info("%s on %d blob(s) in gs://%s/%s", action_desc, len(blobs), bucket_name, path)
+    failed_chunks = 0
+    for i in range(0, len(blobs), GCS_BATCH_CHUNK_SIZE):
+        chunk = blobs[i : i + GCS_BATCH_CHUNK_SIZE]
         try:
-            blob.retention.mode = None
-            blob.retention.retain_until_time = None
-            blob.patch(override_unlocked_retention=True)
+            with storage_client.batch():
+                for blob in chunk:
+                    action(blob)
         except Exception as exc:  # noqa: BLE001
-            LOGGER.error("Failed to override retention on gs://%s/%s: %s", bucket_name, blob.name, exc)
-            failed.append((blob.name, exc))
-    if failed:
-        raise RuntimeError(f"Failed to override retention on {len(failed)}/{len(blobs)} blob(s) in gs://{bucket_name}")
+            LOGGER.error(
+                "Failed action %r on a batch of %d blob(s) in gs://%s/%s: %s",
+                action_desc,
+                len(chunk),
+                bucket_name,
+                path,
+                exc,
+            )
+            failed_chunks += 1
+    if failed_chunks:
+        raise RuntimeError(f"Failed action {action_desc!r} on {failed_chunks} batch(es) in gs://{bucket_name}/{path}")
+
+
+def gce_override_object_retention(bucket_name: str, path: str) -> None:
+    """Override the per-object "Object Retention Lock" governance-mode retention on blobs in a GCS bucket,
+    so they become deletable.
+
+    Args:
+        bucket_name: the name of the GCS bucket
+        path: path prefix to match blobs (empty string means all blobs)
+    """
+
+    def clear_retention(blob: storage.Blob) -> None:
+        blob.retention.mode = None
+        blob.retention.retain_until_time = None
+        blob.patch(override_unlocked_retention=True)
+
+    _gce_iterate_blobs(bucket_name, path, "Overriding retention", clear_retention)
+
+
+def gce_clear_event_based_hold(bucket_name: str, path: str) -> None:
+    """Clear the event_based_hold flag on blobs in a GCS bucket (used with buckets configured via
+    event_based_hold_enabled), so they become deletable.
+
+    Args:
+        bucket_name: the name of the GCS bucket
+        path: path prefix to match blobs (empty string means all blobs)
+    """
+
+    def clear_hold(blob: storage.Blob) -> None:
+        blob.event_based_hold = False
+        blob.patch()
+
+    _gce_iterate_blobs(bucket_name, path, "Clearing event_based_hold", clear_hold)
 
 
 def get_gce_compute_disks_client() -> tuple[compute_v1.DisksClient, dict]:


### PR DESCRIPTION
Closes https://scylladb.atlassian.net/browse/CLOUD-2889

## Summary
- Split WORM bucket creation into object-lock and event-based-hold variants
- Split `get_all_snapshot_files` into bucket-wide and per-snapshot methods
- Add a manager backup test covering the event-based-hold WORM mode

## Testing
- [x] [sct-feature-test-backup-gce](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/mikita/job/manager-master-clone/job/sct-feature-test-backup-gce/63/)