### PR TITLE
feature(trigger-matrix): resolve scylla_version per backend (SCT-665)

### DIFF
--- a/configurations/triggers/perf-regression.yaml
+++ b/configurations/triggers/perf-regression.yaml
@@ -44,6 +44,11 @@ cron_triggers:
       labels_selector: "gce-custom-monthly"
       requested_by_user: "valerii.ponomarov"
 
+# Performance numbers are only comparable when every job of a run measures the same build,
+# so all jobs get the newest build published on every backend/region/arch in this matrix,
+# instead of each backend running whatever nightly it happens to have.
+version_resolution: "common"
+
 defaults:
   provision_type: "on_demand"
   post_behavior_db_nodes: "destroy"
@@ -57,6 +62,7 @@ jobs:
 
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-i8g-vnodes"
     backend: "aws"
+    arch: "aarch64"
     include_versions: ["master"]
     labels: ["master-monthly"]
     job_throttle_category: "SCT-perf-eu-west-2-i8g"
@@ -66,6 +72,7 @@ jobs:
 
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-i8g-vnodes"
     backend: "aws"
+    arch: "aarch64"
     exclude_versions: ["2025.2", "2025.1", "2024.2", "2024.1", "master"]
     labels: []
     job_throttle_category: "SCT-perf-eu-west-2-i8g"
@@ -75,6 +82,7 @@ jobs:
 
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-with-nemesis-i8g-vnodes"
     backend: "aws"
+    arch: "aarch64"
     include_versions: ["master"]
     labels: ["master-monthly"]
     job_throttle_category: "SCT-perf-eu-north-1-i8g"
@@ -84,6 +92,7 @@ jobs:
 
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-with-nemesis-i8g-vnodes"
     backend: "aws"
+    arch: "aarch64"
     exclude_versions: ["2025.2", "2025.1", "2024.2", "2024.1", "master"]
     labels: []
     job_throttle_category: "SCT-perf-eu-west-1-i8g"
@@ -143,6 +152,7 @@ jobs:
 
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-simple-query-weekly-microbenchmark_arm64"
     backend: "aws"
+    arch: "aarch64"
     labels: ["master-weekly"]
     params:
       region: "us-east-1"
@@ -150,6 +160,7 @@ jobs:
 
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-simple-query-weekly-microbenchmark_arm64-write"
     backend: "aws"
+    arch: "aarch64"
     labels: ["master-weekly"]
     params:
       region: "us-east-1"
@@ -210,6 +221,7 @@ jobs:
 
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-i8g-tablets"
     backend: "aws"
+    arch: "aarch64"
     include_versions: ["master"]
     labels: ["master-weekly"]
     job_throttle_category: "SCT-perf-us-east-1-i8g"
@@ -219,6 +231,7 @@ jobs:
 
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-i8g-tablets"
     backend: "aws"
+    arch: "aarch64"
     exclude_versions: ["2025.2", "2025.1", "2024.1", "2024.2", "master"]
     labels: []
     job_throttle_category: "SCT-perf-us-west-2-i8g"
@@ -273,6 +286,7 @@ jobs:
 
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-during-rolling-upgrade-i8g-tablets"
     backend: "aws"
+    arch: "aarch64"
     include_versions: ["master"]
     labels: ["master-3weeks"]
     job_throttle_category: "SCT-perf-us-east-2-i8g"
@@ -284,6 +298,7 @@ jobs:
 
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-during-rolling-upgrade-i8g-tablets"
     backend: "aws"
+    arch: "aarch64"
     exclude_versions: ["2025.2", "2025.1", "2024.2", "2024.1", "master"]
     labels: []
     job_throttle_category: "SCT-perf-eu-west-2-i8g"
@@ -297,6 +312,7 @@ jobs:
 
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-with-nemesis-i8g-tablets"
     backend: "aws"
+    arch: "aarch64"
     include_versions: ["master"]
     labels: ["master-3weeks"]
     job_throttle_category: "SCT-perf-eu-north-1-i8g"
@@ -306,6 +322,7 @@ jobs:
 
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-with-nemesis-i8g-tablets"
     backend: "aws"
+    arch: "aarch64"
     exclude_versions: ["2025.2", "2025.1", "2024.2", "2024.1", "master"]
     labels: []
     job_throttle_category: "SCT-perf-eu-west-2-i8g"
@@ -317,6 +334,7 @@ jobs:
 
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-2.5tb-i8g-elasticity"
     backend: "aws"
+    arch: "aarch64"
     exclude_versions: ["2024.1", "2024.2", "2025.1", "2025.4", "master"]
     labels: []
     params:
@@ -325,6 +343,7 @@ jobs:
 
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-2.5tb-i8g-elasticity"
     backend: "aws"
+    arch: "aarch64"
     include_versions: ["master"]
     labels: ["master-monthly"]
     params:

--- a/configurations/triggers/scylla-doctor-gating.yaml
+++ b/configurations/triggers/scylla-doctor-gating.yaml
@@ -33,6 +33,7 @@ jobs:
 
   - job_name: "/scylla-doctor/oss/artifacts/artifacts-ami-arm-test"
     backend: "aws"
+    arch: "aarch64"
     wait: true
     wait_timeout: 7200
     fail_on_error: true

--- a/configurations/triggers/tier1.yaml
+++ b/configurations/triggers/tier1.yaml
@@ -29,6 +29,11 @@ jenkinsfiles:
 # the same week label. Only the first match is triggered (dedup by resolved path),
 # so twins on different weeks would make the job fire every week again.
 
+# Tier1 jobs are independent of each other, so every backend runs its own latest build
+# rather than waiting for one build to be published everywhere. This is the default, spelled
+# out here because handing GCE an AWS-only build is what SCT-665 was.
+version_resolution: "per-backend"
+
 cron_triggers:
   # 1st, 3rd and 5th Saturday of the month, 06:00 UTC.
   #

--- a/docs/testing/trigger-matrix.md
+++ b/docs/testing/trigger-matrix.md
@@ -317,8 +317,40 @@ The trigger matrix always passes a **full version tag** (e.g., `2026.2.0~dev-0.2
 ### Resolution Flow
 
 1. **Full version tag provided** (e.g., `2024.2.5-0.20250221.cb9e2a54ae6d-1`): used as-is
-2. **Partial version** (e.g., `master:latest`, `2025.4`): resolved to full tag via AMI lookup (`get_branched_ami`)
+2. **Partial version** (e.g., `master:latest`, `2025.4`): resolved to a full tag per backend — see [strategies](#version-resolution-strategies)
 3. **Image param only** (e.g., `--scylla-ami-id ami-xxx`): version extracted from image tags, then used for all jobs
+
+### Version Resolution Strategies
+
+Nightly images are built per backend and per architecture, so at any moment AWS may have a build GCE
+doesn't have yet. Handing every job the AWS build then aborts the non-AWS jobs during config validation
+(`GCE image for scylla_version='…' was not found`, SCT-665). Which build each job gets is decided by
+`version_resolution` in the matrix YAML, overridable per run with `--version-resolution`:
+
+| Strategy | What every job gets | Use it when |
+|----------|--------------------|-------------|
+| `per-backend` (default) | Each backend/region/arch resolves its own latest build | Jobs are independent — a GCE job may run yesterday's nightly while AWS runs today's |
+| `common` | The newest build published on **every** backend/region/arch in the matrix (i.e. the lowest of their latest builds) | Results must be comparable across jobs — perf regression |
+| `aws-strict` | The AWS build; jobs whose backend doesn't have that exact build are **not triggered** | You want the AWS build or nothing |
+
+`common` fails the trigger run when no build is shared by all backends; `per-backend` and `aws-strict`
+skip only the jobs they can't serve and report them in the skipped list.
+
+Jobs that don't install from an image (rolling-upgrade jobs using `new_scylla_repo`, PGO jobs using
+`unified_package`) are left out of resolution entirely.
+
+```bash
+# per-backend: GCE jobs get the newest GCE build, AWS jobs the newest AMI
+uv run sct.py trigger-matrix --matrix configurations/triggers/tier1.yaml \
+    --scylla-version "master:latest" --version-resolution per-backend --dry-run
+
+# common: one build for the whole matrix
+uv run sct.py trigger-matrix --matrix configurations/triggers/perf-regression.yaml \
+    --scylla-version "master:latest" --version-resolution common --dry-run
+```
+
+ARM jobs must declare `arch: "aarch64"` in the matrix YAML — images are published per architecture, and
+without it their version is resolved against x86_64 images.
 
 ### Triggering from an Image (scylla-pkg flow)
 
@@ -376,8 +408,8 @@ uv run sct.py trigger-matrix \
 
 ```bash
 # Run all trigger matrix unit tests
-uv run python -m pytest unit_tests/test_trigger_matrix.py -v -n0
+uv run python -m pytest unit_tests/trigger_matrix/ -v -n0
 
 # Run with coverage
-uv run python -m pytest unit_tests/test_trigger_matrix.py --cov=sdcm.utils.trigger_matrix --cov-report=term-missing -n0
+uv run python -m pytest unit_tests/trigger_matrix/ --cov=sdcm.utils.trigger_matrix --cov-report=term-missing -n0
 ```

--- a/sct.py
+++ b/sct.py
@@ -75,6 +75,7 @@ from sdcm.utils.ci_tools import get_job_name, get_job_url
 from sdcm.utils.decorators import retrying
 from sdcm.utils.git import get_git_commit_id, get_git_status_info, clone_repo
 from sdcm.utils.trigger_matrix import (
+    VERSION_RESOLUTION_STRATEGIES,
     resolve_image_architecture,
     resolve_scylla_version_from_image,
     resolve_to_full_version,
@@ -3324,6 +3325,15 @@ def hdr_investigate(
     "Comma-separated base versions to upgrade FROM (e.g., '2025.1,2025.2'). "
     "When empty, the downstream job auto-selects base versions.",
 )
+@click.option(
+    "--version-resolution",
+    default=None,
+    type=click.Choice(VERSION_RESOLUTION_STRATEGIES),
+    help="How the version passed to the jobs is picked (overrides the matrix YAML): "
+    "per-backend — every backend runs its own latest build; "
+    "common — all jobs run the newest build published on every backend in the matrix; "
+    "aws-strict — the AWS build for everyone, backends missing that build are not triggered",
+)
 @click.option("--dry-run", is_flag=True, default=False, help="Preview mode — do not trigger jobs")
 @click.option(
     "--use-job-throttling/--no-use-job-throttling",
@@ -3353,6 +3363,7 @@ def trigger_matrix_cmd(  # noqa: PLR0912, PLR0913
     unified_package,
     new_scylla_repo,
     base_versions,
+    version_resolution,
     dry_run,
     use_job_throttling,
     requested_by_user,
@@ -3395,6 +3406,9 @@ def trigger_matrix_cmd(  # noqa: PLR0912, PLR0913
                 sys.exit(1)
 
     # For user-provided partial versions (master:latest, 2025.4), resolve to full version.
+    # This is the AWS reference version — it decides pre_release job filtering, and is what
+    # aws-strict stamps on every job. Each backend still resolves its own build later on,
+    # according to the matrix' version_resolution strategy.
     # Skip if version was already resolved from image tags — that's already the real version.
     original_version = scylla_version
     if scylla_version and not version_from_image:
@@ -3402,8 +3416,11 @@ def trigger_matrix_cmd(  # noqa: PLR0912, PLR0913
             scylla_version = resolve_to_full_version(scylla_version, region=region)
             click.echo(f"Using full version: {scylla_version}")
         except Exception as exc:  # noqa: BLE001
-            click.echo(f"Error resolving full version: {exc}", err=True)
-            sys.exit(1)
+            if version_resolution == "aws-strict":
+                click.echo(f"Error resolving full version: {exc}", err=True)
+                sys.exit(1)
+            click.echo(f"Warning: {exc}")
+            click.echo(f"Leaving '{original_version}' unresolved — each backend resolves its own build")
 
     # Detect image architecture for arch-aware job filtering
     image_arch = None
@@ -3457,6 +3474,7 @@ def trigger_matrix_cmd(  # noqa: PLR0912, PLR0913
             dry_run=dry_run,
             email_recipients=email_recipients.split(",") if email_recipients else None,
             image_arch=image_arch,
+            version_resolution=version_resolution,
             **overrides,
         )
     except Exception as exc:  # noqa: BLE001

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -1157,6 +1157,40 @@ def get_vector_store_ami_versions(
     )
 
 
+# RC builds are tagged with a dotted form (2026.3.0.rc1.0.20260730.726f67a532e2) that
+# SCYLLA_VERSION_GROUPED_RE doesn't parse, yet it still points at one exact build.
+RC_VERSION_TAG_RE = re.compile(r"^\d+\.\d+\.\d+\.rc\d+\.\d+\.\d{8}\.[0-9a-f]+$")
+
+
+def gce_image_version_label(version: str) -> str:
+    """Convert a full Scylla version tag to the `scylla_version` label used on GCE images.
+
+    GCE labels can't hold dots or tildes, so they are replaced with dashes. The trailing
+    packaging revision AWS carries on release tags (`…-1`) is not part of the GCE label.
+
+    Returns an empty string when the version isn't a full (single build) version tag.
+
+    Examples:
+        >>> gce_image_version_label("2026.4.0~dev-0.20260804.9a3aba9e452a")
+        '2026-4-0-dev-0-20260804-9a3aba9e452a'
+        >>> gce_image_version_label("2025.4.10-0.20260609.99f4121cd8e1-1")
+        '2025-4-10-0-20260609-99f4121cd8e1'
+        >>> gce_image_version_label("2026.3.0.rc1.0.20260730.726f67a532e2")
+        '2026-3-0-rc1-0-20260730-726f67a532e2'
+        >>> gce_image_version_label("2025.4")
+        ''
+    """
+    if not version:
+        return ""
+    if version_tag := parse_scylla_version_tag(version):
+        label = f"{version_tag.base_version}-{version_tag.build}-{version_tag.date}-{version_tag.commit_id}"
+    elif RC_VERSION_TAG_RE.match(version):
+        label = version
+    else:
+        return ""
+    return label.replace(".", "-").replace("~", "-")
+
+
 def build_gce_image_filter(version: str = None, arch: VmArch = None) -> str:
     """Build the server-side filter string for GCE image listing.
 
@@ -1166,14 +1200,20 @@ def build_gce_image_filter(version: str = None, arch: VmArch = None) -> str:
     or you can see brief explanation here:
       https://github.com/apache/libcloud/blob/trunk/libcloud/compute/drivers/gce.py#L274
     """
-    filters = "(family eq 'scylla(-enterprise)?')(labels.environment eq 'production')"
+    # Check if this is a full version tag (e.g., 2024.2.5-0.20250221.cb9e2a54ae6d-1,
+    # 2026.4.0~dev-0.20260804.9a3aba9e452a or 2026.3.0.rc1.0.20260730.726f67a532e2)
+    exact_build_label = gce_image_version_label(version) if version and version != "all" else ""
+
+    filters = "(family eq 'scylla(-enterprise)?')"
+    if not exact_build_label:
+        # Released images only. Nightly/dev builds are labeled `environment=daily` and freshly
+        # built release candidates `environment=candidate`, so this filter must not be applied
+        # when looking up one exact build by its full version tag.
+        filters += "(labels.environment eq 'production')"
+
     if version and version != "all":
-        # Check if this is a full version tag (e.g., 2024.2.5-0.20250221.cb9e2a54ae6d-1)
-        if parse_scylla_version_tag(version):
-            # For full version tags, use the complete tag for exact matching
-            # GCE labels require dots to be replaced with dashes
-            normalized_version = version.replace(".", "-").replace("~", "-")
-            filters += f"(labels.scylla_version eq '{normalized_version}')"
+        if exact_build_label:
+            filters += f"(labels.scylla_version eq '{exact_build_label}')(name ne debug-.*)"
         else:
             # For simple versions, use the existing wildcard logic
             filters += f"(labels.scylla_version eq '{version.replace('.', '-').replace('~', '-')}.*"

--- a/sdcm/utils/trigger_matrix.py
+++ b/sdcm/utils/trigger_matrix.py
@@ -91,11 +91,31 @@ BRANCH_VERSION_RE = re.compile(r"^(?P<branch>[a-zA-Z0-9._-]+):(?P<qualifier>.+)$
 
 VALID_BACKENDS = {"aws", "gce", "azure", "docker", "oci"}
 
+# Backends whose Scylla build is published as an image SCT looks up by version
+VALID_IMAGE_BACKENDS = {"aws", "gce", "azure", "oci"}
+
+DEFAULT_ARCH = "x86_64"
+
 MAX_TRIGGER_RETRIES = 3
 RETRY_BACKOFF_BASE = 2
 
 # Default region used for AMI tag lookups
 DEFAULT_AWS_REGION = "eu-west-1"
+DEFAULT_AZURE_REGION = "eastus"
+
+# Backends whose images are region scoped — both resolution and availability of a
+# given build have to be checked in the region the job actually runs in.
+REGIONAL_BACKENDS = {"aws", "azure", "oci"}
+
+# How the version passed to the downstream jobs is picked:
+#   per-backend — every backend resolves its own latest build (jobs may run different builds)
+#   common      — one build for the whole matrix: the newest one published on *every* backend
+#                 in the matrix (i.e. the lowest of the per-backend latest builds)
+#   aws-strict  — the AWS latest build for everyone; jobs on a backend that doesn't have that
+#                 exact build published are not triggered
+VersionResolution = Literal["per-backend", "common", "aws-strict"]
+VERSION_RESOLUTION_STRATEGIES: tuple[str, ...] = ("per-backend", "common", "aws-strict")
+DEFAULT_VERSION_RESOLUTION: VersionResolution = "per-backend"
 
 WAIT_POLL_INTERVAL = 30
 WAIT_TIMEOUT = 14400
@@ -113,18 +133,34 @@ def is_full_version_tag(version: str) -> bool:
     return bool(FULL_VERSION_TAG_RE.match(version))
 
 
+def is_resolvable_partial_version(scylla_version: str) -> bool:
+    """Check whether a version string points at "whatever is newest" rather than one build.
+
+    Those are the versions that have to be resolved against a backend's published images:
+    branch:qualifier (``master:latest``) and simple versions (``2025.4``).
+    """
+    if not scylla_version or is_full_version_tag(scylla_version) or RELEASE_VERSION_RE.match(scylla_version):
+        return False
+    return bool(BRANCH_VERSION_RE.match(scylla_version) or SIMPLE_VERSION_RE.match(scylla_version))
+
+
 def resolve_to_full_version(
     scylla_version: str,
     region: str | None = None,
+    backend: str = "aws",
+    arch: str = DEFAULT_ARCH,
 ) -> str:
-    """Resolve a partial version to a full version tag.
+    """Resolve a partial version to a full version tag using a backend's published images.
 
     If the version is already a full tag, return it as-is.
-    Otherwise, look up the latest AMI matching the version and extract the full tag.
+    Otherwise, look up the latest image matching the version on ``backend`` and extract
+    the full tag from its tags/labels.
 
     Args:
         scylla_version: Version string in any format (e.g., master:latest, 2025.4, or full tag).
-        region: AWS region for AMI lookup.
+        region: Region for the image lookup (ignored for region-less backends like GCE).
+        backend: Backend to resolve against — aws, gce, azure or oci.
+        arch: CPU architecture of the images to look up (x86_64 or aarch64).
 
     Returns:
         Full version tag string.
@@ -138,27 +174,111 @@ def resolve_to_full_version(
     if RELEASE_VERSION_RE.match(scylla_version):
         return scylla_version
 
-    # For branch:qualifier or simple versions, resolve via AMI lookup
-    lookup_region = region or DEFAULT_AWS_REGION
-    branch_match = BRANCH_VERSION_RE.match(scylla_version)
-
-    if branch_match:
-        # e.g., master:latest, branch-2025.4:latest
-        version = _resolve_version_via_branched_ami(scylla_version, lookup_region)
-        if version:
-            return version
-
-    if SIMPLE_VERSION_RE.match(scylla_version):
-        # e.g., 2025.4 — try as branch:latest
-        version = _resolve_version_via_branched_ami(scylla_version, lookup_region)
-        if version:
+    lookup_region = _backend_region(backend, region)
+    if is_resolvable_partial_version(scylla_version):
+        # e.g., master:latest, branch-2025.4:latest, or 2025.4 (treated as a branch)
+        if version := _resolve_latest_version_for_backend(scylla_version, backend, lookup_region, arch):
             return version
 
     raise TriggerMatrixError(
-        f"Cannot resolve '{scylla_version}' to a full version tag. "
+        f"Cannot resolve '{scylla_version}' to a full version tag on backend '{backend}'. "
         f"Provide a full version tag (e.g., 2024.2.5-0.20250221.cb9e2a54ae6d-1) "
-        f"or ensure AMIs exist for the version in region '{lookup_region}'."
+        f"or ensure images exist for the version"
+        f"{f' in region {lookup_region!r}' if lookup_region else ''}."
     )
+
+
+def split_regions(region: str | None) -> list[str]:
+    """Split a matrix `region` value into single regions.
+
+    Multi-DC jobs carry a JSON list (`'["eu-west-1", "eu-west-2"]'`), single-DC jobs a plain
+    region name.
+
+    Examples:
+        >>> split_regions("eu-west-1")
+        ['eu-west-1']
+        >>> split_regions('["eu-west-1", "eu-west-2"]')
+        ['eu-west-1', 'eu-west-2']
+        >>> split_regions("")
+        []
+    """
+    value = (region or "").strip()
+    if not value:
+        return []
+    if value.startswith("["):
+        try:
+            return [str(item).strip() for item in json.loads(value) if str(item).strip()]
+        except json.JSONDecodeError:
+            logger.warning("Could not parse region list %r — treating it as a plain region", value)
+    return [part for part in re.split(r"[,\s]+", value) if part]
+
+
+def _backend_region(backend: str, region: str | None) -> str:
+    """Regions to use for a backend's image lookups, comma separated.
+
+    Empty for region-less backends (GCE); the backend default when a job declares no region.
+    """
+    if backend not in REGIONAL_BACKENDS:
+        return ""
+    regions = split_regions(region)
+    if not regions:
+        return {"aws": DEFAULT_AWS_REGION, "azure": DEFAULT_AZURE_REGION}.get(backend, "")
+    return ",".join(regions)
+
+
+def _as_branch_qualifier(scylla_version: str) -> str:
+    """Normalize a partial version to the branch:qualifier form all image lookups expect.
+
+    Examples:
+        >>> _as_branch_qualifier("master:latest")
+        'master:latest'
+        >>> _as_branch_qualifier("2025.4")
+        'branch-2025.4:latest'
+        >>> _as_branch_qualifier("2025.4.0")
+        'branch-2025.4:latest'
+    """
+    if BRANCH_VERSION_RE.match(scylla_version):
+        return scylla_version
+    if simple_match := SIMPLE_VERSION_RE.match(scylla_version):
+        return f"branch-{simple_match.group('major')}.{simple_match.group('minor')}:latest"
+    return scylla_version
+
+
+def _vm_arch(arch: str):
+    """Convert an architecture string to the VmArch enum used by the image lookups."""
+    from sdcm.provision.provisioner import VmArch  # noqa: PLC0415 - circular import avoidance
+
+    return VmArch.ARM if arch == "aarch64" else VmArch.X86
+
+
+def _aws_arch(arch: str) -> str:
+    """AWS names the ARM architecture `arm64`, not `aarch64`, on both AMIs and instances."""
+    from sdcm.utils.aws_utils import vmarch_to_aws  # noqa: PLC0415 - circular import avoidance
+
+    return vmarch_to_aws(_vm_arch(arch))
+
+
+def _resolve_latest_version_for_backend(
+    scylla_version: str, backend: str, region: str, arch: str = DEFAULT_ARCH
+) -> str:
+    """Resolve a branch:qualifier version to the full tag of that backend's newest image.
+
+    Multi-DC jobs resolve in their first region; `version_exists_for_backend` is what makes
+    sure the build reached every region the job runs in.
+    """
+    branch_version = _as_branch_qualifier(scylla_version)
+    region = next(iter(split_regions(region)), "")
+    match backend:
+        case "aws":
+            return _resolve_version_via_branched_ami(branch_version, region, arch)
+        case "gce":
+            return _resolve_version_via_branched_gce_image(branch_version, arch)
+        case "azure":
+            return _resolve_version_via_branched_azure_image(branch_version, region, arch)
+        case "oci":
+            return _resolve_version_via_branched_oci_image(branch_version, region, arch)
+    logger.warning("No image lookup implemented for backend '%s' — cannot resolve '%s'", backend, scylla_version)
+    return ""
 
 
 def resolve_scylla_version_from_image(
@@ -219,7 +339,7 @@ def resolve_scylla_version_from_image(
     raise TriggerMatrixError(f"Cannot resolve scylla_version from images: {provided}")
 
 
-def _resolve_version_via_branched_ami(scylla_version: str, region: str) -> str:
+def _resolve_version_via_branched_ami(scylla_version: str, region: str, arch: str = DEFAULT_ARCH) -> str:
     """Resolve a branch:qualifier version to a full tag via AMI lookup.
 
     Uses get_branched_ami which searches across both Scylla images account and default credentials.
@@ -227,7 +347,7 @@ def _resolve_version_via_branched_ami(scylla_version: str, region: str) -> str:
     try:
         from sdcm.utils.common import get_branched_ami  # noqa: PLC0415 - circular import avoidance
 
-        amis = get_branched_ami(scylla_version, region_name=region, arch="x86_64")
+        amis = get_branched_ami(scylla_version, region_name=region, arch=_aws_arch(arch))
         if amis:
             tags = {t["Key"]: t["Value"] for t in (amis[0].tags or [])}
             if version := tags.get("scylla_version"):
@@ -236,6 +356,146 @@ def _resolve_version_via_branched_ami(scylla_version: str, region: str) -> str:
     except Exception as exc:  # noqa: BLE001 - best-effort cloud lookup
         logger.warning("Failed to resolve '%s' via AMI lookup: %s", scylla_version, exc)
     return ""
+
+
+def _gce_label_to_version(label: str) -> str:
+    """Rebuild a full version tag from the dashed `scylla_version` label of a GCE image.
+
+    GCE labels can't hold dots or tildes, so the separators have to be put back:
+
+        >>> _gce_label_to_version("2026-4-0-dev-0-20260804-9a3aba9e452a")
+        '2026.4.0~dev-0.20260804.9a3aba9e452a'
+        >>> _gce_label_to_version("2026-3-0-rc1-0-20260730-726f67a532e2")
+        '2026.3.0.rc1.0.20260730.726f67a532e2'
+        >>> _gce_label_to_version("2025-4-10-0-20260609-99f4121cd8e1")
+        '2025.4.10-0.20260609.99f4121cd8e1'
+
+    Returns an empty string when the result isn't a valid full version tag.
+    """
+    parts = label.split("-")
+    if len(parts) < 4:
+        logger.warning("GCE label '%s' doesn't look like a full version label", label)
+        return ""
+    major, minor, patch, *rest = parts
+    if rest[0] == "dev":
+        version = f"{major}.{minor}.{patch}~dev-" + ".".join(rest[1:])
+    elif rest[0].startswith("rc"):
+        version = f"{major}.{minor}.{patch}." + ".".join(rest)
+    else:
+        version = f"{major}.{minor}.{patch}-" + ".".join(rest)
+
+    if not is_full_version_tag(version):
+        logger.warning("GCE label '%s' doesn't map to a valid full version tag (got '%s')", label, version)
+        return ""
+    return version
+
+
+def _resolve_version_via_branched_gce_image(scylla_version: str, arch: str = DEFAULT_ARCH) -> str:
+    """Resolve a branch:qualifier version to a full tag via GCE image lookup."""
+    try:
+        from sdcm.utils.common import get_branched_gce_images  # noqa: PLC0415 - circular import avoidance
+
+        images = get_branched_gce_images(scylla_version, arch=_vm_arch(arch))
+        if images and (label := images[0].labels.get("scylla_version")):
+            if version := _gce_label_to_version(label):
+                logger.info(
+                    "Resolved '%s' → full version '%s' (via GCE image %s)", scylla_version, version, images[0].name
+                )
+                return version
+    except Exception as exc:  # noqa: BLE001 - best-effort cloud lookup
+        logger.warning("Failed to resolve '%s' via GCE image lookup: %s", scylla_version, exc)
+    return ""
+
+
+def _resolve_version_via_branched_azure_image(scylla_version: str, region: str, arch: str = DEFAULT_ARCH) -> str:
+    """Resolve a branch:qualifier version to a full tag via Azure image lookup."""
+    try:
+        import sdcm.provision.azure.utils as azure_utils  # noqa: PLC0415 - optional cloud dependency
+
+        images = azure_utils.get_scylla_images(scylla_version=scylla_version, region_name=region, arch=_vm_arch(arch))
+        if images and (version := _extract_version_from_tags(images[0].tags or {})):
+            logger.info(
+                "Resolved '%s' → full version '%s' (via Azure image %s)", scylla_version, version, images[0].name
+            )
+            return version
+    except Exception as exc:  # noqa: BLE001 - best-effort cloud lookup
+        logger.warning("Failed to resolve '%s' via Azure image lookup: %s", scylla_version, exc)
+    return ""
+
+
+def _resolve_version_via_branched_oci_image(scylla_version: str, region: str, arch: str = DEFAULT_ARCH) -> str:
+    """Resolve a branch:qualifier version to a full tag via OCI image lookup."""
+    try:
+        from sdcm.utils import oci_utils  # noqa: PLC0415 - optional cloud dependency
+
+        # rows are [backend, name, image_id, created, build_id, arch, scylla_version]
+        rows = oci_utils.get_scylla_images_by_branch(branch=scylla_version, region=region or None, arch=_vm_arch(arch))
+        if rows and (version := rows[0][-1]) and version != "N/A":
+            logger.info("Resolved '%s' → full version '%s' (via OCI image %s)", scylla_version, version, rows[0][1])
+            return version
+    except Exception as exc:  # noqa: BLE001 - best-effort cloud lookup
+        logger.warning("Failed to resolve '%s' via OCI image lookup: %s", scylla_version, exc)
+    return ""
+
+
+def version_exists_for_backend(version: str, backend: str, region: str = "", arch: str = DEFAULT_ARCH) -> bool:
+    """Check whether an exact build is published as an image on a backend.
+
+    Mirrors the lookups `SCTConfiguration` runs when it turns `scylla_version` into a
+    backend image, so a version that passes here won't abort provisioning downstream.
+    A multi-DC job needs the build in *every* region it provisions in, exactly like the
+    downstream config does.
+
+    Backends without an image lookup (docker) are reported as available.
+    """
+    lookup_regions = split_regions(_backend_region(backend, region)) or [""]
+    return all(_version_exists_in_region(version, backend, single, arch) for single in lookup_regions)
+
+
+def _version_exists_in_region(version: str, backend: str, lookup_region: str, arch: str) -> bool:
+    try:
+        match backend:
+            case "aws":
+                from sdcm.utils.common import get_scylla_ami_versions  # noqa: PLC0415 - circular import avoidance
+
+                found = bool(get_scylla_ami_versions(version=version, region_name=lookup_region, arch=_aws_arch(arch)))
+            case "gce":
+                from sdcm.utils.common import (  # noqa: PLC0415 - circular import avoidance
+                    get_scylla_gce_images_versions,
+                )
+
+                found = bool(get_scylla_gce_images_versions(version=version, arch=_vm_arch(arch)))
+            case "azure":
+                import sdcm.provision.azure.utils as azure_utils  # noqa: PLC0415 - optional cloud dependency
+
+                found = bool(
+                    azure_utils.get_scylla_images(
+                        scylla_version=version, region_name=lookup_region, arch=_vm_arch(arch)
+                    )
+                )
+            case "oci":
+                from sdcm.utils import oci_utils  # noqa: PLC0415 - optional cloud dependency
+
+                found = bool(
+                    oci_utils.get_scylla_images_by_version(
+                        version=version, region=lookup_region or None, arch=_vm_arch(arch)
+                    )
+                )
+            case _:
+                return True
+    except Exception as exc:  # noqa: BLE001 - best-effort cloud lookup
+        logger.warning("Failed to check '%s' availability on %s/%s: %s", version, backend, lookup_region, exc)
+        return False
+
+    logger.info(
+        "Version '%s' (%s) is %savailable on %s%s",
+        version,
+        arch,
+        "" if found else "NOT ",
+        backend,
+        f"/{lookup_region}" if lookup_region else "",
+    )
+    return found
 
 
 def _extract_version_from_tags(tags: dict, tag_keys: tuple[str, ...] = ("scylla_version", "ScyllaVersion")) -> str:
@@ -458,6 +718,9 @@ class JobConfig(BaseModel):
 
     job_name: str
     backend: Literal["aws", "gce", "azure", "docker", "oci"]
+    # CPU architecture the job's DB nodes run on — images are published per architecture,
+    # so ARM jobs must declare it to have their version resolved against ARM images.
+    # Left empty it is inferred from the job's labels — see job_arch().
     arch: str = ""
 
     @field_validator("arch")
@@ -480,6 +743,19 @@ class JobConfig(BaseModel):
     collect_results: list[str] = Field(default_factory=list)
 
 
+def job_arch(job: JobConfig) -> str:
+    """The architecture a job's DB nodes run on.
+
+    Jobs that predate the `arch` field only say so through an "aarch64" label, so fall back
+    to that before assuming the default. Used both to filter jobs against a supplied image's
+    architecture and to look up per-backend images for version resolution — the two must
+    agree on what a job's architecture is.
+    """
+    if job.arch:
+        return job.arch
+    return "aarch64" if "aarch64" in job.labels else DEFAULT_ARCH
+
+
 class MatrixConfig(BaseModel):
     """Full trigger matrix configuration loaded from YAML."""
 
@@ -488,6 +764,7 @@ class MatrixConfig(BaseModel):
     jobs: list[JobConfig]
     defaults: dict = Field(default_factory=dict)
     default_scylla_version: str = ""
+    version_resolution: VersionResolution = DEFAULT_VERSION_RESOLUTION
     cron_triggers: list[CronTriggerConfig] = Field(default_factory=list)
     email_recipients: list[str] = Field(default_factory=list)
     jenkinsfiles: list[JenkinsfileEntry] = Field(default_factory=list)
@@ -788,12 +1065,12 @@ def filter_jobs(
 
         # Skip by architecture (derived from supplied image)
         if image_arch:
-            job_arch = job.arch or ("aarch64" if "aarch64" in job.labels else "x86_64")
-            if image_arch == "aarch64" and job_arch != "aarch64":
-                logger.debug("Skipping job '%s': ARM image but job arch is %s", job.job_name, job_arch)
+            this_job_arch = job_arch(job)
+            if image_arch == "aarch64" and this_job_arch != "aarch64":
+                logger.debug("Skipping job '%s': ARM image but job arch is %s", job.job_name, this_job_arch)
                 continue
-            if image_arch == "x86_64" and job_arch == "aarch64":
-                logger.debug("Skipping job '%s': x86_64 image but job arch is %s", job.job_name, job_arch)
+            if image_arch == "x86_64" and this_job_arch == "aarch64":
+                logger.debug("Skipping job '%s': x86_64 image but job arch is %s", job.job_name, this_job_arch)
                 continue
 
         # Skip by version inclusion (prefix match — only run for listed versions)
@@ -909,6 +1186,153 @@ def _extract_branch_from_version(scylla_version: str) -> str:
         return "master"
 
     return ""
+
+
+@dataclass(frozen=True, order=True)
+class BackendTarget:
+    """A backend/region/arch combination that matrix jobs need an image for."""
+
+    backend: str
+    region: str = ""
+    arch: str = DEFAULT_ARCH
+
+    def __str__(self) -> str:
+        return "/".join(part for part in (self.backend, self.region, self.arch) if part)
+
+
+def target_for_job(job: JobConfig, defaults: dict | None = None, region_override: str | None = None) -> BackendTarget:
+    """Backend/region/arch combination a job's images are looked up in.
+
+    The region is picked the way `build_job_parameters` picks it: a job that pins its own
+    `params.region` keeps it, and `region_override` (the CLI `--region`) only fills in for
+    jobs that don't — otherwise a multi-DC job would be resolved against a single region
+    it does not actually run in (SCT-693).
+    """
+    region = job.params.get("region") or region_override or (defaults or {}).get("region", "")
+    return BackendTarget(job.backend, _backend_region(job.backend, region), job_arch(job))
+
+
+def job_uses_scylla_version(job: JobConfig, defaults: dict, overrides: dict | None = None) -> bool:
+    """Whether a job's Scylla build comes from `scylla_version` (and thus from an image).
+
+    Rolling-upgrade jobs get an empty `scylla_version` (they install from `new_scylla_repo`)
+    and PGO jobs install a `unified_package`, so neither needs a per-backend image.
+    """
+    merged = dict(defaults)
+    merged.update(job.params)
+    merged.update({k: v for k, v in (overrides or {}).items() if v is not None})
+
+    if str(merged.get("rolling_upgrade_test", "")).lower() == "true":
+        return False
+    return not merged.get("unified_package")
+
+
+def _version_build_date(version: str) -> str:
+    """Extract the YYYYMMDD build date from a full version tag (empty when absent)."""
+    match = re.search(r"[.-](\d{8})[.-]", version)
+    return match.group(1) if match else ""
+
+
+def resolve_versions_for_targets(
+    original_version: str,
+    reference_version: str,
+    targets: list[BackendTarget],
+    strategy: VersionResolution = DEFAULT_VERSION_RESOLUTION,
+) -> tuple[dict[BackendTarget, str], dict[BackendTarget, str]]:
+    """Pick the scylla_version to trigger with, per backend/region, following `strategy`.
+
+    Args:
+        original_version: What the trigger was asked for (e.g. "master:latest", or a full tag).
+        reference_version: `original_version` resolved against AWS — used as-is by `aws-strict`
+            and for versions that don't need resolving at all.
+        targets: Backend/region pairs the filtered jobs run on.
+        strategy: per-backend | common | aws-strict (see VersionResolution).
+
+    Returns:
+        (version per target, reason per target that must not be triggered).
+
+    Raises:
+        TriggerMatrixError: For an unknown strategy, or when `common` finds no build that is
+            published on every target.
+    """
+    if strategy not in VERSION_RESOLUTION_STRATEGIES:
+        raise TriggerMatrixError(
+            f"Unknown version resolution strategy '{strategy}'. Valid: {', '.join(VERSION_RESOLUTION_STRATEGIES)}"
+        )
+
+    reference_version = reference_version or original_version
+    resolvable = is_resolvable_partial_version(original_version)
+    versions: dict[BackendTarget, str] = {}
+    unavailable: dict[BackendTarget, str] = {}
+
+    if strategy == "per-backend":
+        for target in targets:
+            if not resolvable or target.backend not in VALID_IMAGE_BACKENDS:
+                # Nothing to resolve against — pass the request through as the downstream
+                # job would have received it before backend-aware resolution existed.
+                versions[target] = reference_version if not resolvable else original_version
+                continue
+            if version := _resolve_latest_version_for_backend(
+                original_version, target.backend, target.region, target.arch
+            ):
+                # The build was found in the target's first region — a multi-DC job also needs
+                # it in the others, which the image copy may not have reached yet.
+                other_regions = split_regions(target.region)[1:]
+                if any(
+                    not _version_exists_in_region(version, target.backend, other, target.arch)
+                    for other in other_regions
+                ):
+                    unavailable[target] = f"build '{version}' is not published in every region"
+                    continue
+                versions[target] = version
+            else:
+                unavailable[target] = f"no image found for '{original_version}'"
+        return versions, unavailable
+
+    if strategy == "aws-strict":
+        for target in targets:
+            if version_exists_for_backend(reference_version, target.backend, target.region, target.arch):
+                versions[target] = reference_version
+            else:
+                unavailable[target] = f"build '{reference_version}' is not published"
+        return versions, unavailable
+
+    # common — every job must run the exact same build, so take the newest build that is
+    # published on all targets (i.e. the lowest of the per-backend latest builds).
+    candidates: list[str] = []
+    if resolvable:
+        for target in targets:
+            if target.backend not in VALID_IMAGE_BACKENDS:
+                continue
+            version = _resolve_latest_version_for_backend(original_version, target.backend, target.region, target.arch)
+            if version and version not in candidates:
+                candidates.append(version)
+        candidates.sort(key=_version_build_date, reverse=True)
+    elif reference_version:
+        candidates = [reference_version]
+
+    if not candidates:
+        raise TriggerMatrixError(
+            f"Cannot resolve '{original_version}' to a build on any of: "
+            f"{', '.join(str(t) for t in targets)}. Check that images were published."
+        )
+
+    for candidate in candidates:
+        missing = [t for t in targets if not version_exists_for_backend(candidate, t.backend, t.region, t.arch)]
+        if not missing:
+            logger.info("Common version for %s: %s", ", ".join(str(t) for t in targets), candidate)
+            return {target: candidate for target in targets}, {}
+        logger.info(
+            "Build '%s' is not published on %s — trying an older build",
+            candidate,
+            ", ".join(str(t) for t in missing),
+        )
+
+    raise TriggerMatrixError(
+        f"No build of '{original_version}' is published on all of: {', '.join(str(t) for t in targets)} "
+        f"(tried: {', '.join(candidates)}). Use version_resolution=per-backend to let every backend "
+        f"run its own latest build, or aws-strict to trigger only the backends that have the AWS build."
+    )
 
 
 def _branch_directory_id(branch: str) -> str:
@@ -1463,6 +1887,7 @@ def trigger_matrix(  # noqa: PLR0914
     dry_run: bool = False,
     email_recipients: list[str] | None = None,
     image_arch: str | None = None,
+    version_resolution: str | None = None,
     **overrides,
 ) -> dict:
     """Main entry point: load matrix, filter, build params, trigger jobs.
@@ -1471,22 +1896,26 @@ def trigger_matrix(  # noqa: PLR0914
         matrix_file: Path to the YAML matrix file.
         scylla_version: Full version tag or branch:qualifier.
         filter_version: Original version string before resolution (e.g., "master:latest").
-            Used for job folder determination and as branch_source_version for
-            {branch}/{branch_id} template resolution. When None, scylla_version is used
-            for both.
+            Used for job folder determination, for backend-aware version resolution, and as
+            branch_source_version for {branch}/{branch_id} template resolution. When None,
+            scylla_version is used for all three.
         job_folder: Override auto-detected job folder.
         labels_selector: Comma-separated labels to filter jobs.
         backend: Filter by backend.
         skip_jobs: Comma-separated job names to skip.
         dry_run: If True, print what would be triggered.
+        version_resolution: Override the matrix' version_resolution strategy
+            (per-backend | common | aws-strict).
         **overrides: Additional parameter overrides (e.g., stress_duration, region).
 
     Returns:
-        Dict with 'triggered', 'skipped', and 'failed' job lists.
+        Dict with 'triggered', 'skipped', 'failed' job lists and the 'versions' each job
+        was triggered with, keyed by job path.
 
     Raises:
         MatrixValidationError: If the YAML matrix file is invalid.
-        TriggerMatrixError: If the version cannot be mapped to a job folder.
+        TriggerMatrixError: If the version cannot be mapped to a job folder, or when
+            version_resolution=common finds no build shared by all backends.
         JenkinsTriggerError: If Jenkins credentials are missing (non-dry-run).
     """
     config = load_matrix_config(matrix_file)
@@ -1524,9 +1953,36 @@ def trigger_matrix(  # noqa: PLR0914
     if not filtered:
         logger.warning("No jobs matched the filters. Check your version, labels, backend, and skip_jobs settings.")
 
-    results = {"triggered": [], "skipped": [], "failed": [], "waited": []}
+    results = {"triggered": [], "skipped": [], "failed": [], "waited": [], "versions": {}}
     filtered_names = {j.job_name for j in filtered}
     results["skipped"] = [j.job_name for j in config.jobs if j.job_name not in filtered_names]
+
+    # Resolve the version every job gets, per backend/region, so a job never receives a
+    # build that was only published on some other backend (SCT-665).
+    strategy = version_resolution or config.version_resolution
+
+    def job_target(job: JobConfig) -> BackendTarget | None:
+        # Not keyed by job_name: the same job runs in the matrix more than once, on
+        # different regions/architectures.
+        if not job_uses_scylla_version(job, config.defaults, overrides):
+            return None
+        return target_for_job(job, config.defaults, region_override=overrides.get("region"))
+
+    matrix_targets = sorted({target for target in map(job_target, filtered) if target})
+    versions_by_target: dict[BackendTarget, str] = {}
+    unavailable_targets: dict[BackendTarget, str] = {}
+    if scylla_version and matrix_targets:
+        logger.info("Resolving scylla_version with strategy '%s'", strategy)
+        versions_by_target, unavailable_targets = resolve_versions_for_targets(
+            original_version=version_for_filtering,
+            reference_version=scylla_version,
+            targets=matrix_targets,
+            strategy=strategy,
+        )
+        for target, version in sorted(versions_by_target.items()):
+            logger.info("  %s → %s", target, version)
+        for target, reason in sorted(unavailable_targets.items()):
+            logger.warning("  %s → not triggered: %s", target, reason)
 
     # Step 1: Trigger all jobs, deduplicating by resolved path to prevent
     # the same Jenkins job from being triggered twice (e.g. when both x86
@@ -1539,9 +1995,19 @@ def trigger_matrix(  # noqa: PLR0914
         if full_path in triggered_paths:
             logger.debug("Skipping duplicate trigger for %s", full_path)
             continue
+
+        job_version = scylla_version
+        if target := job_target(job):
+            if reason := unavailable_targets.get(target):
+                logger.warning("Skipping job '%s' on %s: %s", job.job_name, target, reason)
+                results["skipped"].append(job.job_name)
+                continue
+            job_version = versions_by_target.get(target, scylla_version)
+
         params = build_job_parameters(
-            job, config.defaults, scylla_version, overrides, branch_source_version=filter_version
+            job, config.defaults, job_version, overrides, branch_source_version=filter_version
         )
+        results["versions"][full_path] = params.get("scylla_version", "")
 
         if job.wait:
             try:

--- a/unit_tests/trigger_matrix/conftest.py
+++ b/unit_tests/trigger_matrix/conftest.py
@@ -14,7 +14,36 @@
 import pytest
 import yaml
 
+from sdcm.utils import trigger_matrix
 from sdcm.utils.trigger_matrix import JobConfig
+
+
+# Version the stubbed cloud lookups report for every backend, so tests that don't care about
+# version resolution get a deterministic full tag instead of reaching a cloud image API.
+STUB_RESOLVED_VERSION = "2025.4.1-0.20250601.abc123def456-1"
+
+
+@pytest.fixture(autouse=True)
+def stub_image_lookups(monkeypatch):
+    """Keep version resolution offline — no unit test may query a cloud image API.
+
+    Tests that exercise resolution patch these same names themselves; `unittest.mock.patch`
+    inside a test takes precedence over this fixture.
+    """
+    monkeypatch.setattr(
+        trigger_matrix, "_resolve_version_via_branched_ami", lambda *args, **kwargs: STUB_RESOLVED_VERSION
+    )
+    monkeypatch.setattr(
+        trigger_matrix, "_resolve_version_via_branched_gce_image", lambda *args, **kwargs: STUB_RESOLVED_VERSION
+    )
+    monkeypatch.setattr(
+        trigger_matrix, "_resolve_version_via_branched_azure_image", lambda *args, **kwargs: STUB_RESOLVED_VERSION
+    )
+    monkeypatch.setattr(
+        trigger_matrix, "_resolve_version_via_branched_oci_image", lambda *args, **kwargs: STUB_RESOLVED_VERSION
+    )
+    monkeypatch.setattr(trigger_matrix, "version_exists_for_backend", lambda *args, **kwargs: True)
+    monkeypatch.setattr(trigger_matrix, "_version_exists_in_region", lambda *args, **kwargs: True)
 
 
 @pytest.fixture()

--- a/unit_tests/trigger_matrix/test_resolve_version.py
+++ b/unit_tests/trigger_matrix/test_resolve_version.py
@@ -60,17 +60,17 @@ def test_branch_qualifier_version_passes_as_is(mock_resolve):
     result = resolve_to_full_version("master:latest")
 
     assert result == FULL_TAG
-    mock_resolve.assert_called_once_with("master:latest", "eu-west-1")
+    mock_resolve.assert_called_once_with("master:latest", "eu-west-1", "x86_64")
 
 
 @patch("sdcm.utils.trigger_matrix._resolve_version_via_branched_ami")
-def test_simple_version_passed_as_is_not_with_latest(mock_resolve):
+def test_simple_version_looked_up_as_release_branch(mock_resolve):
     mock_resolve.return_value = FULL_TAG
 
     result = resolve_to_full_version("2025.4")
 
     assert result == FULL_TAG
-    mock_resolve.assert_called_once_with("2025.4", "eu-west-1")
+    mock_resolve.assert_called_once_with("branch-2025.4:latest", "eu-west-1", "x86_64")
 
 
 @patch("sdcm.utils.trigger_matrix._resolve_version_via_branched_ami")
@@ -80,7 +80,45 @@ def test_custom_region_forwarded(mock_resolve):
     result = resolve_to_full_version("2025.4", region="us-east-1")
 
     assert result == FULL_TAG
-    mock_resolve.assert_called_once_with("2025.4", "us-east-1")
+    mock_resolve.assert_called_once_with("branch-2025.4:latest", "us-east-1", "x86_64")
+
+
+@patch("sdcm.utils.trigger_matrix._resolve_version_via_branched_gce_image")
+def test_gce_backend_resolved_against_gce_images(mock_resolve):
+    mock_resolve.return_value = FULL_TAG
+
+    result = resolve_to_full_version("master:latest", backend="gce")
+
+    assert result == FULL_TAG
+    mock_resolve.assert_called_once_with("master:latest", "x86_64")
+
+
+@patch("sdcm.utils.trigger_matrix._resolve_version_via_branched_azure_image")
+def test_azure_backend_defaults_to_eastus(mock_resolve):
+    mock_resolve.return_value = FULL_TAG
+
+    result = resolve_to_full_version("master:latest", backend="azure")
+
+    assert result == FULL_TAG
+    mock_resolve.assert_called_once_with("master:latest", "eastus", "x86_64")
+
+
+@patch("sdcm.utils.trigger_matrix._resolve_version_via_branched_ami")
+def test_arch_forwarded_to_lookup(mock_resolve):
+    mock_resolve.return_value = FULL_TAG
+
+    result = resolve_to_full_version("master:latest", arch="aarch64")
+
+    assert result == FULL_TAG
+    mock_resolve.assert_called_once_with("master:latest", "eu-west-1", "aarch64")
+
+
+@patch("sdcm.utils.trigger_matrix._resolve_version_via_branched_gce_image")
+def test_error_mentions_the_backend_that_failed(mock_resolve):
+    mock_resolve.return_value = ""
+
+    with pytest.raises(TriggerMatrixError, match="on backend 'gce'"):
+        resolve_to_full_version("master:latest", backend="gce")
 
 
 @patch("sdcm.utils.trigger_matrix._resolve_version_via_branched_ami")

--- a/unit_tests/trigger_matrix/test_version_resolution.py
+++ b/unit_tests/trigger_matrix/test_version_resolution.py
@@ -1,0 +1,429 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2026 ScyllaDB
+
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from sdcm.utils.trigger_matrix import (
+    BackendTarget,
+    JobConfig,
+    TriggerMatrixError,
+    _as_branch_qualifier,
+    _gce_label_to_version,
+    is_resolvable_partial_version,
+    job_uses_scylla_version,
+    resolve_versions_for_targets,
+    split_regions,
+    target_for_job,
+    trigger_matrix,
+    version_exists_for_backend,
+)
+
+
+AWS_BUILD = "2026.4.0~dev-0.20260804.9a3aba9e452a"
+GCE_BUILD = "2026.4.0~dev-0.20260803.1122334455aa"
+
+AWS_TARGET = BackendTarget("aws", "eu-west-1")
+GCE_TARGET = BackendTarget("gce")
+AZURE_TARGET = BackendTarget("azure", "eastus")
+
+
+@pytest.mark.parametrize(
+    ("label", "expected"),
+    [
+        pytest.param("2026-4-0-dev-0-20260804-9a3aba9e452a", "2026.4.0~dev-0.20260804.9a3aba9e452a", id="dev"),
+        pytest.param("2026-3-0-rc1-0-20260730-726f67a532e2", "2026.3.0.rc1.0.20260730.726f67a532e2", id="rc"),
+        pytest.param("2025-4-10-0-20260609-99f4121cd8e1", "2025.4.10-0.20260609.99f4121cd8e1", id="release"),
+        pytest.param("2025-4-10", "", id="not_a_build"),
+        pytest.param("garbage", "", id="garbage"),
+    ],
+)
+def test_gce_label_converted_back_to_version_tag(label, expected):
+    assert _gce_label_to_version(label) == expected
+
+
+@pytest.mark.parametrize(
+    ("version", "expected"),
+    [
+        pytest.param("master:latest", "master:latest", id="branch_qualifier"),
+        pytest.param("2025.4", "branch-2025.4:latest", id="two_part_version"),
+        pytest.param("2025.4.0", "branch-2025.4:latest", id="three_part_version"),
+        pytest.param("master", "master", id="bare_branch_left_alone"),
+    ],
+)
+def test_partial_version_normalized_to_branch_qualifier(version, expected):
+    assert _as_branch_qualifier(version) == expected
+
+
+@pytest.mark.parametrize(
+    ("version", "expected"),
+    [
+        pytest.param("master:latest", True, id="branch_qualifier"),
+        pytest.param("2025.4", True, id="simple_version"),
+        pytest.param(AWS_BUILD, False, id="full_tag"),
+        pytest.param("2026.1.8", False, id="release_version"),
+        pytest.param("master", False, id="bare_branch"),
+        pytest.param("", False, id="empty"),
+    ],
+)
+def test_only_open_ended_versions_need_resolution(version, expected):
+    assert is_resolvable_partial_version(version) is expected
+
+
+def test_per_backend_gives_every_backend_its_own_build():
+    with patch("sdcm.utils.trigger_matrix._resolve_latest_version_for_backend") as mock_resolve:
+        mock_resolve.side_effect = lambda version, backend, region, arch: (AWS_BUILD if backend == "aws" else GCE_BUILD)
+        versions, unavailable = resolve_versions_for_targets(
+            original_version="master:latest",
+            reference_version=AWS_BUILD,
+            targets=[AWS_TARGET, GCE_TARGET],
+            strategy="per-backend",
+        )
+
+    assert versions == {AWS_TARGET: AWS_BUILD, GCE_TARGET: GCE_BUILD}
+    assert not unavailable
+
+
+def test_per_backend_skips_a_backend_without_images():
+    with patch("sdcm.utils.trigger_matrix._resolve_latest_version_for_backend") as mock_resolve:
+        mock_resolve.side_effect = lambda version, backend, region, arch: AWS_BUILD if backend == "aws" else ""
+        versions, unavailable = resolve_versions_for_targets(
+            original_version="master:latest",
+            reference_version=AWS_BUILD,
+            targets=[AWS_TARGET, GCE_TARGET],
+            strategy="per-backend",
+        )
+
+    assert versions == {AWS_TARGET: AWS_BUILD}
+    assert list(unavailable) == [GCE_TARGET]
+    assert "no image found for 'master:latest'" in unavailable[GCE_TARGET]
+
+
+def test_per_backend_leaves_an_explicit_build_alone():
+    """A version that already points at one build is passed through, no lookups needed."""
+    with patch("sdcm.utils.trigger_matrix._resolve_latest_version_for_backend") as mock_resolve:
+        versions, unavailable = resolve_versions_for_targets(
+            original_version=AWS_BUILD,
+            reference_version=AWS_BUILD,
+            targets=[AWS_TARGET, GCE_TARGET],
+            strategy="per-backend",
+        )
+
+    assert versions == {AWS_TARGET: AWS_BUILD, GCE_TARGET: AWS_BUILD}
+    assert not unavailable
+    mock_resolve.assert_not_called()
+
+
+def test_per_backend_passes_the_request_through_for_backends_without_images():
+    """Docker jobs have no image to resolve against — they get the original request."""
+    docker_target = BackendTarget("docker")
+    with patch("sdcm.utils.trigger_matrix._resolve_latest_version_for_backend", return_value=AWS_BUILD):
+        versions, unavailable = resolve_versions_for_targets(
+            original_version="master:latest",
+            reference_version=AWS_BUILD,
+            targets=[AWS_TARGET, docker_target],
+            strategy="per-backend",
+        )
+
+    assert versions == {AWS_TARGET: AWS_BUILD, docker_target: "master:latest"}
+    assert not unavailable
+
+
+def test_aws_strict_drops_backends_missing_the_aws_build():
+    with patch("sdcm.utils.trigger_matrix.version_exists_for_backend") as mock_exists:
+        mock_exists.side_effect = lambda version, backend, region, arch: backend == "aws"
+        versions, unavailable = resolve_versions_for_targets(
+            original_version="master:latest",
+            reference_version=AWS_BUILD,
+            targets=[AWS_TARGET, GCE_TARGET],
+            strategy="aws-strict",
+        )
+
+    assert versions == {AWS_TARGET: AWS_BUILD}
+    assert list(unavailable) == [GCE_TARGET]
+    assert AWS_BUILD in unavailable[GCE_TARGET]
+
+
+def test_common_picks_the_newest_build_published_everywhere():
+    """AWS is one nightly ahead of GCE, so everyone runs the older build both have."""
+    with (
+        patch("sdcm.utils.trigger_matrix._resolve_latest_version_for_backend") as mock_resolve,
+        patch("sdcm.utils.trigger_matrix.version_exists_for_backend") as mock_exists,
+    ):
+        mock_resolve.side_effect = lambda version, backend, region, arch: (AWS_BUILD if backend == "aws" else GCE_BUILD)
+        # only the older build exists on both backends
+        mock_exists.side_effect = lambda version, backend, region, arch: (version == GCE_BUILD or backend == "aws")
+        versions, unavailable = resolve_versions_for_targets(
+            original_version="master:latest",
+            reference_version=AWS_BUILD,
+            targets=[AWS_TARGET, GCE_TARGET],
+            strategy="common",
+        )
+
+    assert versions == {AWS_TARGET: GCE_BUILD, GCE_TARGET: GCE_BUILD}
+    assert not unavailable
+
+
+def test_common_raises_when_no_build_is_shared():
+    with (
+        patch("sdcm.utils.trigger_matrix._resolve_latest_version_for_backend") as mock_resolve,
+        patch("sdcm.utils.trigger_matrix.version_exists_for_backend", return_value=False),
+    ):
+        mock_resolve.side_effect = lambda version, backend, region, arch: (AWS_BUILD if backend == "aws" else GCE_BUILD)
+        with pytest.raises(TriggerMatrixError, match="is published on all of"):
+            resolve_versions_for_targets(
+                original_version="master:latest",
+                reference_version=AWS_BUILD,
+                targets=[AWS_TARGET, GCE_TARGET],
+                strategy="common",
+            )
+
+
+def test_common_raises_when_nothing_resolves():
+    with patch("sdcm.utils.trigger_matrix._resolve_latest_version_for_backend", return_value=""):
+        with pytest.raises(TriggerMatrixError, match="Cannot resolve 'master:latest'"):
+            resolve_versions_for_targets(
+                original_version="master:latest",
+                reference_version="",
+                targets=[AWS_TARGET, GCE_TARGET],
+                strategy="common",
+            )
+
+
+def test_common_verifies_an_explicit_build_on_every_backend():
+    with patch("sdcm.utils.trigger_matrix.version_exists_for_backend", return_value=True) as mock_exists:
+        versions, unavailable = resolve_versions_for_targets(
+            original_version=AWS_BUILD,
+            reference_version=AWS_BUILD,
+            targets=[AWS_TARGET, GCE_TARGET, AZURE_TARGET],
+            strategy="common",
+        )
+
+    assert set(versions.values()) == {AWS_BUILD}
+    assert not unavailable
+    assert mock_exists.call_count == 3
+
+
+def test_unknown_strategy_is_rejected():
+    with pytest.raises(TriggerMatrixError, match="Unknown version resolution strategy"):
+        resolve_versions_for_targets(
+            original_version="master:latest",
+            reference_version=AWS_BUILD,
+            targets=[AWS_TARGET],
+            strategy="whatever",
+        )
+
+
+def test_docker_backend_is_always_considered_available():
+    assert version_exists_for_backend(AWS_BUILD, "docker") is True
+
+
+def test_target_carries_backend_region_and_arch():
+    job = JobConfig(job_name="perf-i8g", backend="aws", params={"region": "eu-west-2"}, arch="aarch64")
+    assert target_for_job(job) == BackendTarget("aws", "eu-west-2", "aarch64")
+    assert str(target_for_job(job)) == "aws/eu-west-2/aarch64"
+
+
+def test_target_arch_falls_back_to_the_aarch64_label():
+    """Jobs predating the `arch` field only say so through a label — resolve them on ARM images."""
+    job = JobConfig(job_name="job", backend="aws", params={"region": "eu-west-2"}, labels=["aarch64"])
+    assert target_for_job(job).arch == "aarch64"
+    assert target_for_job(JobConfig(job_name="job", backend="aws")).arch == "x86_64"
+
+
+def test_the_job_region_wins_over_the_region_override():
+    """SCT-693: `--region` fills in for jobs that don't pin one, it never overwrites one."""
+    pinned = JobConfig(job_name="job", backend="aws", params={"region": "eu-west-1"})
+    assert target_for_job(pinned, region_override="us-east-1").region == "eu-west-1"
+
+    unpinned = JobConfig(job_name="job", backend="aws")
+    assert target_for_job(unpinned, region_override="us-east-1").region == "us-east-1"
+
+
+def test_target_region_falls_back_to_the_matrix_defaults():
+    job = JobConfig(job_name="job", backend="aws")
+    assert target_for_job(job, {"region": "eu-west-2"}).region == "eu-west-2"
+
+
+@pytest.mark.parametrize(
+    ("region", "expected"),
+    [
+        pytest.param("eu-west-1", ["eu-west-1"], id="single"),
+        pytest.param('["eu-west-1", "eu-west-2"]', ["eu-west-1", "eu-west-2"], id="json_list"),
+        pytest.param("eu-west-1,eu-west-2", ["eu-west-1", "eu-west-2"], id="comma_separated"),
+        pytest.param("", [], id="empty"),
+        pytest.param("[not json", ["[not", "json"], id="broken_list_falls_back"),
+    ],
+)
+def test_region_values_are_split(region, expected):
+    assert split_regions(region) == expected
+
+
+def test_multi_dc_job_keeps_all_its_regions():
+    job = JobConfig(job_name="multidc", backend="aws", params={"region": '["eu-west-1", "eu-west-2"]'})
+    assert target_for_job(job) == BackendTarget("aws", "eu-west-1,eu-west-2")
+
+
+def test_multi_dc_build_must_exist_in_every_region():
+    """SCTConfiguration looks up an AMI per region, so one missing region is a no-go."""
+    with patch("sdcm.utils.trigger_matrix._version_exists_in_region") as mock_exists:
+        mock_exists.side_effect = lambda version, backend, region, arch: region == "eu-west-1"
+        assert version_exists_for_backend(AWS_BUILD, "aws", "eu-west-1") is True
+        assert version_exists_for_backend(AWS_BUILD, "aws", '["eu-west-1", "eu-west-2"]') is False
+
+
+def test_multi_dc_latest_resolved_in_the_first_region():
+    with patch("sdcm.utils.trigger_matrix._resolve_version_via_branched_ami", return_value=AWS_BUILD) as mock_resolve:
+        versions, unavailable = resolve_versions_for_targets(
+            original_version="master:latest",
+            reference_version=AWS_BUILD,
+            targets=[BackendTarget("aws", "eu-west-1,eu-west-2")],
+            strategy="per-backend",
+        )
+
+    assert not unavailable
+    assert set(versions.values()) == {AWS_BUILD}
+    mock_resolve.assert_called_once_with("master:latest", "eu-west-1", "x86_64")
+
+
+def test_multi_dc_job_skipped_until_the_build_reaches_every_region():
+    multi_dc = BackendTarget("aws", "eu-west-1,eu-west-2")
+    with (
+        patch("sdcm.utils.trigger_matrix._resolve_version_via_branched_ami", return_value=AWS_BUILD),
+        patch("sdcm.utils.trigger_matrix._version_exists_in_region") as mock_exists,
+    ):
+        mock_exists.side_effect = lambda version, backend, region, arch: region == "eu-west-1"
+        versions, unavailable = resolve_versions_for_targets(
+            original_version="master:latest",
+            reference_version=AWS_BUILD,
+            targets=[multi_dc],
+            strategy="per-backend",
+        )
+
+    assert not versions
+    assert "not published in every region" in unavailable[multi_dc]
+
+
+def test_gce_target_has_no_region():
+    """GCE images are global — resolving them per region would only duplicate lookups."""
+    job = JobConfig(job_name="job", backend="gce", params={"region": "us-east1"})
+    assert target_for_job(job) == BackendTarget("gce", "", "x86_64")
+
+
+@pytest.mark.parametrize(
+    ("defaults", "params", "expected"),
+    [
+        pytest.param({}, {}, True, id="regular_job"),
+        pytest.param({"rolling_upgrade_test": "true"}, {}, False, id="rolling_upgrade_from_defaults"),
+        pytest.param({}, {"rolling_upgrade_test": "true"}, False, id="rolling_upgrade_from_job"),
+        pytest.param({}, {"unified_package": "http://example.com/x.tar.gz"}, False, id="pgo_unified_package"),
+    ],
+)
+def test_jobs_that_dont_install_from_an_image_need_no_version(defaults, params, expected):
+    job = JobConfig(job_name="job", backend="aws", params={"region": "eu-west-1"} | params)
+    assert job_uses_scylla_version(job, defaults) is expected
+
+
+def _write_matrix(tmp_path, version_resolution=None):
+    data = {
+        "defaults": {"provision_type": "on_demand"},
+        "jobs": [
+            {"job_name": "tier1/aws-test", "backend": "aws", "params": {"region": "eu-west-1"}},
+            {"job_name": "tier1/gce-test", "backend": "gce", "params": {"region": "us-east1"}},
+        ],
+    }
+    if version_resolution:
+        data["version_resolution"] = version_resolution
+    path = tmp_path / "matrix.yaml"
+    path.write_text(yaml.dump(data))
+    return path
+
+
+def test_trigger_matrix_stamps_each_backend_with_its_own_build(tmp_path):
+    """SCT-665: a GCE job must not be handed a version that only AWS published."""
+    matrix_file = _write_matrix(tmp_path)
+
+    with patch("sdcm.utils.trigger_matrix._resolve_latest_version_for_backend") as mock_resolve:
+        mock_resolve.side_effect = lambda version, backend, region, arch: (AWS_BUILD if backend == "aws" else GCE_BUILD)
+        results = trigger_matrix(
+            matrix_file=str(matrix_file),
+            scylla_version=AWS_BUILD,
+            filter_version="master:latest",
+            job_folder="scylla-master",
+            dry_run=True,
+        )
+
+    assert results["versions"] == {
+        "scylla-master/tier1/aws-test": AWS_BUILD,
+        "scylla-master/tier1/gce-test": GCE_BUILD,
+    }
+    assert len(results["triggered"]) == 2
+
+
+def test_trigger_matrix_aws_strict_skips_backends_without_the_build(tmp_path):
+    matrix_file = _write_matrix(tmp_path, version_resolution="aws-strict")
+
+    with patch("sdcm.utils.trigger_matrix.version_exists_for_backend") as mock_exists:
+        mock_exists.side_effect = lambda version, backend, region, arch: backend == "aws"
+        results = trigger_matrix(
+            matrix_file=str(matrix_file),
+            scylla_version=AWS_BUILD,
+            filter_version="master:latest",
+            job_folder="scylla-master",
+            dry_run=True,
+        )
+
+    assert results["triggered"] == ["scylla-master/tier1/aws-test"]
+    assert "tier1/gce-test" in results["skipped"]
+    assert results["versions"] == {"scylla-master/tier1/aws-test": AWS_BUILD}
+
+
+def test_trigger_matrix_common_runs_one_build_everywhere(tmp_path):
+    matrix_file = _write_matrix(tmp_path, version_resolution="common")
+
+    with (
+        patch("sdcm.utils.trigger_matrix._resolve_latest_version_for_backend") as mock_resolve,
+        patch("sdcm.utils.trigger_matrix.version_exists_for_backend") as mock_exists,
+    ):
+        mock_resolve.side_effect = lambda version, backend, region, arch: (AWS_BUILD if backend == "aws" else GCE_BUILD)
+        mock_exists.side_effect = lambda version, backend, region, arch: (version == GCE_BUILD or backend == "aws")
+        results = trigger_matrix(
+            matrix_file=str(matrix_file),
+            scylla_version=AWS_BUILD,
+            filter_version="master:latest",
+            job_folder="scylla-master",
+            dry_run=True,
+        )
+
+    assert set(results["versions"].values()) == {GCE_BUILD}
+    assert len(results["triggered"]) == 2
+
+
+def test_cli_strategy_overrides_the_matrix_file(tmp_path):
+    matrix_file = _write_matrix(tmp_path, version_resolution="common")
+
+    with patch("sdcm.utils.trigger_matrix.version_exists_for_backend") as mock_exists:
+        mock_exists.side_effect = lambda version, backend, region, arch: backend == "aws"
+        results = trigger_matrix(
+            matrix_file=str(matrix_file),
+            scylla_version=AWS_BUILD,
+            filter_version="master:latest",
+            job_folder="scylla-master",
+            dry_run=True,
+            version_resolution="aws-strict",
+        )
+
+    # `common` would have raised — aws-strict just drops the GCE job
+    assert results["triggered"] == ["scylla-master/tier1/aws-test"]

--- a/unit_tests/unit/test_gce_image_filter.py
+++ b/unit_tests/unit/test_gce_image_filter.py
@@ -15,7 +15,22 @@
 
 import pytest
 
-from sdcm.utils.common import build_gce_image_filter
+from sdcm.utils.common import build_gce_image_filter, gce_image_version_label
+
+
+@pytest.mark.parametrize(
+    "version,expected",
+    [
+        pytest.param("2026.4.0~dev-0.20260804.9a3aba9e452a", "2026-4-0-dev-0-20260804-9a3aba9e452a", id="dev"),
+        pytest.param("2025.4.10-0.20260609.99f4121cd8e1-1", "2025-4-10-0-20260609-99f4121cd8e1", id="release"),
+        pytest.param("2026.3.0.rc1.0.20260730.726f67a532e2", "2026-3-0-rc1-0-20260730-726f67a532e2", id="rc"),
+        pytest.param("2025.4", "", id="open-ended-version"),
+        pytest.param("master:latest", "", id="branch"),
+        pytest.param("", "", id="empty"),
+    ],
+)
+def test_gce_image_version_label(version, expected):
+    assert gce_image_version_label(version) == expected
 
 
 class TestGceImageFilterConstruction:
@@ -51,22 +66,31 @@ class TestGceImageFilterConstruction:
         assert "(labels.environment eq 'production')" in filters
 
     @pytest.mark.parametrize(
-        "version",
+        "version,expected_label",
         [
-            pytest.param("2024.2.5-0.20250221.cb9e2a54ae6d-1", id="full-enterprise-tag"),
-            pytest.param("5.4.8-0.20250221.9cc3d32e35b4-1", id="full-oss-tag"),
+            pytest.param(
+                "2024.2.5-0.20250221.cb9e2a54ae6d-1", "2024-2-5-0-20250221-cb9e2a54ae6d", id="full-enterprise-tag"
+            ),
+            pytest.param("5.4.8-0.20250221.9cc3d32e35b4-1", "5-4-8-0-20250221-9cc3d32e35b4", id="full-oss-tag"),
+            pytest.param(
+                "2026.4.0~dev-0.20260804.9a3aba9e452a", "2026-4-0-dev-0-20260804-9a3aba9e452a", id="dev-nightly-tag"
+            ),
+            pytest.param("2026.3.0.rc1.0.20260730.726f67a532e2", "2026-3-0-rc1-0-20260730-726f67a532e2", id="rc-tag"),
         ],
     )
-    def test_full_version_tag_filter_construction(self, version):
-        """Test that full version tags use exact matching."""
+    def test_full_version_tag_filter_construction(self, version, expected_label):
+        """Full version tags match one exact build, whatever environment it was promoted to.
+
+        Nightly images are labeled `environment=daily` and fresh release candidates
+        `environment=candidate`, so filtering on `production` would hide the very build that
+        was asked for (SCT-665). The `-N` packaging revision AWS tags carry is not part of
+        the GCE label either.
+        """
         filters = build_gce_image_filter(version)
 
-        # Should contain production environment filter (always present in production code)
-        assert "(labels.environment eq 'production')" in filters
-
-        # Should contain normalized version label
-        normalized = version.replace(".", "-").replace("~", "-")
-        assert f"(labels.scylla_version eq '{normalized}')" in filters
+        assert "(labels.environment eq 'production')" not in filters
+        assert f"(labels.scylla_version eq '{expected_label}')" in filters
+        assert "(name ne debug-.*)" in filters
 
     def test_no_version_filter(self):
         """Test filter when no version is specified."""
@@ -86,6 +110,11 @@ class TestGceImageFilterConstruction:
         """Test that all filters start with the family filter."""
         for version in ["2025.1", "5.2.1", None, "all", "2024.2.5-0.20250221.cb9e2a54ae6d-1"]:
             filters = build_gce_image_filter(version)
-            assert filters.startswith("(family eq 'scylla(-enterprise)?')(labels.environment eq 'production')"), (
-                f"Filter for version={version} should start with family+production filter: {filters}"
+            assert filters.startswith("(family eq 'scylla(-enterprise)?')"), (
+                f"Filter for version={version} should start with the family filter: {filters}"
             )
+
+    def test_open_ended_versions_stay_on_released_images(self):
+        """Only exact builds skip the production filter — "give me 2025.1" still means released."""
+        for version in ["2025.1", "5.2.1", None, "all"]:
+            assert "(labels.environment eq 'production')" in build_gce_image_filter(version)

--- a/vars/triggerMatrixPipeline.groovy
+++ b/vars/triggerMatrixPipeline.groovy
@@ -79,6 +79,12 @@ def call(Map pipelineParams = [:]) {
                    description: 'Billing project for resource tagging')
             string(name: 'email_recipients', defaultValue: 'qa@scylladb.com',
                    description: 'Comma-separated email recipients for wait-mode results report')
+            choice(name: 'version_resolution', choices: ['', 'per-backend', 'common', 'aws-strict'],
+                   description: '''Overrides the matrix YAML. How the version passed to the jobs is picked:
+                                   per-backend - every backend runs its own latest build;
+                                   common - all jobs run the newest build published on every backend in the matrix;
+                                   aws-strict - the AWS build for everyone, backends missing that build are not triggered.
+                                   Empty keeps whatever the matrix YAML defines.''')
             booleanParam(name: 'use_job_throttling', defaultValue: true,
                    description: 'If true, use job throttling to limit the number of concurrent builds')
             booleanParam(name: 'dry_run', defaultValue: false,
@@ -135,6 +141,7 @@ def call(Map pipelineParams = [:]) {
                             'requested_by_user': params.requested_by_user,
                             'billing_project': params.billing_project,
                             'email_recipients': params.email_recipients,
+                            'version_resolution': params.version_resolution,
                         ]
 
                         if (!params.matrix_file?.trim()) {
@@ -204,6 +211,9 @@ def call(Map pipelineParams = [:]) {
                         }
                         if (params.email_recipients?.trim()) {
                             cmd += " --email-recipients '${params.email_recipients}'"
+                        }
+                        if (params.version_resolution?.trim()) {
+                            cmd += " --version-resolution '${params.version_resolution}'"
                         }
                         if (params.use_job_throttling) {
                             cmd += " --use-job-throttling"


### PR DESCRIPTION
## What

Fixes [SCT-665](https://scylladb.atlassian.net/browse/SCT-665) — tier1 GCE jobs aborting during config validation with `ValueError: GCE image for scylla_version='...' was not found` — and makes the trigger matrix resolve the Scylla build per backend, with strategies for triggers that need every job on the same build.

## Two root causes

**1. GCE couldn't find nightly images at all** (`sdcm/utils/common.py`)

`get_scylla_gce_images_versions()` always filtered on `labels.environment eq 'production'`, but nightly GCE images are labeled `daily` and freshly built release candidates `candidate`. A full version tag — the only way a nightly can be requested — therefore never matched, no matter which backend triggered the job. Checked against the real project: the GCE image for the exact build in the ticket (`2026.3.0~dev-0.20260717.3f9d1c16c708`) existed all along, the filter just hid it.

The environment filter is now dropped when the version names one exact build (debug images excluded by name instead), and the GCE label is built from the parsed tag components, so the `-N` packaging revision AWS carries on release tags (`2025.4.10-0.20260609.99f4121cd8e1-1`) no longer breaks the match either. Open-ended versions (`2025.4`, no version) still resolve to released images only.

**2. One AWS-resolved build was stamped on every job** (`sdcm/utils/trigger_matrix.py`)

`resolve_to_full_version()` resolved `master:latest` once via an AWS AMI lookup and `build_job_parameters()` stamped that tag on every job in the matrix, regardless of backend, region or architecture. Nightly images are built per backend and per architecture, so GCE/Azure/ARM jobs regularly got a build only AWS had published.

## Version resolution strategies

Resolution is now per **backend/region/architecture**, picked by `version_resolution` in the matrix YAML and overridable per run with `--version-resolution` (also exposed as a Jenkins job parameter):

| strategy | every job gets | use it when |
|---|---|---|
| `per-backend` (default) | each backend/region/arch resolves its own latest build | jobs are independent |
| `common` | the newest build published on **every** target — the lowest of their latest builds | results must be comparable across jobs |
| `aws-strict` | the AWS build; jobs whose backend lacks that exact build are **not triggered** | you want the AWS build or nothing |

`common` fails the trigger run when no build is shared; the other two skip only the jobs they can't serve and report them as skipped. `configurations/triggers/perf-regression.yaml` is set to `common` — perf numbers are only comparable when every job measures the same build; the rest keep `per-backend`.

Availability is checked with the same lookups `SCTConfiguration` runs downstream (`get_scylla_ami_versions`, `get_scylla_gce_images_versions`, `azure_utils.get_scylla_images`, `oci_utils.get_scylla_images_by_version`), so a version that passes here can't abort provisioning later.

## Also handled

- **Multi-DC jobs** (`region: '["eu-west-1", "eu-west-2"]'`) — the build must exist in every region the job provisions in, mirroring what the downstream config requires.
- **Architecture** — new `arch: "aarch64"` field on matrix jobs (defaults to `x86_64`), set on the i8g/arm64 perf jobs and the scylla-doctor ARM job. AWS names that architecture `arm64`, which is now mapped correctly for both AMI lookups.
- **Simple versions** — `2025.4` is looked up as `branch-2025.4:latest` instead of being passed verbatim to a branch lookup that always failed.
- Jobs that don't install from an image (rolling-upgrade via `new_scylla_repo`, PGO via `unified_package`) are left out of resolution entirely.
- The AWS reference resolution in `sct.py` is no longer fatal when it fails — per-backend resolution takes over — except under `aws-strict`, where the AWS build *is* the contract.

## Testing

- `unit_tests/trigger_matrix/` — 189 tests, 37 new in `test_version_resolution.py` covering each strategy, GCE label round-tripping, multi-region, arch, and the end-to-end stamping through `trigger_matrix()`. An autouse conftest fixture stubs the cloud lookups: the existing tests started hitting AWS/GCE for real once resolution moved into `trigger_matrix()`.
- `unit_tests/unit/` — 2834 passed.
- Real dry runs against AWS/GCE/Azure: tier1 with `per-backend` and `aws-strict`, perf-regression with `common` across x86_64 + aarch64 targets. Two bugs surfaced there and were fixed before this PR: the ARM AMI arch naming, and the multi-DC JSON region list.

Docs: `docs/testing/trigger-matrix.md`.


[SCT-665]: https://scylladb.atlassian.net/browse/SCT-665?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ