### PR TITLE
fix(ci): make the hydra build trigger match this branch's layout

### DIFF
--- a/.github/workflows/build-docker-image.yaml
+++ b/.github/workflows/build-docker-image.yaml
@@ -4,10 +4,11 @@ on:
   pull_request_target:
     types: [labeled]
     paths:
-      - 'Dockerfile'
+      - 'docker/env/Dockerfile'
       - 'docker/env/build_n_push.sh'
-      - 'uv.lock'
       - 'pyproject.toml'
+      - 'requirements.in'
+      - 'requirements.txt'
 
 permissions:
   actions: write


### PR DESCRIPTION
Prerequisite for #15691.

## Problem

Applying the `New Hydra Version` label to a PR on `branch-2025.1` produces **no `build_image` run at all**. Verified on #15691: the label is present, the PR changes `requirements.in` / `requirements.txt`, and `gh run list --workflow build-docker-image.yaml` shows no run for its head branch, while the equivalent label toggle on `branch-perf-v17` (#15694) started a run immediately.

The cause is the `paths:` filter, none of whose entries correspond to files that drive the hydra image on this branch:

| entry | reality on `branch-2025.1` |
| --- | --- |
| `Dockerfile` | no root `Dockerfile`; the image is built from `docker/env/Dockerfile` |
| `uv.lock` | does not exist on this branch |
| `pyproject.toml` | 494 bytes of `[tool.ruff]` config only, no dependencies |

The image's Python dependencies come from `requirements.txt` — `docker/env/Dockerfile` does `ADD requirements.txt .` followed by `uv pip install --system --build-constraint build-constraints.txt -r requirements.txt` — and neither `requirements.in` nor `requirements.txt` is listed.

So any PR here that adds a dependency gets its label silently ignored. If `docker/env/version` was also bumped by hand (as renovate does, e.g. `bfdcb31bb3` for `1.90-2025.1-scylla-driver-v3.29.9`), the pinned tag is never published and *every* `hydra.sh` stage then dies with `failed to resolve reference "docker.io/scylladb/hydra:<tag>": not found` — precommit, unittests, lint_test_cases and integration-tests all report failure with no test output.

## Fix

Replace the dead entries with the paths that exist here, and add the two requirements files. `pyproject.toml` is kept: a tooling change there still warrants a rebuild, and that is how `852b5afab3` *"chore(hydra): create image 1.88-2025.1-ruff-PR12728"* — the one bot-built image on this branch — was produced.

## Note

Because this is a `pull_request_target` workflow, GitHub reads it from the **base** branch, so the fix cannot take effect on the PR that contains it. It has to land on `branch-2025.1` first; #15691 can then be re-labelled to get its image built.

Other branches are unaffected: `master` and `branch-perf-v17` both have a root `Dockerfile`, a `uv.lock` and dependencies in `pyproject.toml`, so their filter is already correct.