### PR TITLE
fix(unit_tests): point config tests at internal_test_data on this branch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,7 +95,7 @@ export SCT_REUSE_CLUSTER=$(cat ~/sct-results/latest/test_id)
   `unit_tests/integration/conftest.py`.
 - `unit_tests/lib/` - Shared test utilities: `fake_remoter.py`, `fake_events.py`,
   `fake_provisioner.py`, `dummy_remote.py`, `s3_utils.py`, etc.
-- `unit_tests/test_data/` and `unit_tests/test_configs/` - Shared test data files
+- `unit_tests/test_data/` and `internal_test_data/` - Shared test data files
 - `unit_tests/conftest.py` - Shared fixtures (events, params, prom_address)
 
 **Key Test Categories:**

--- a/unit_tests/integration/test_config_get_version_based_on_conf.py
+++ b/unit_tests/integration/test_config_get_version_based_on_conf.py
@@ -46,7 +46,7 @@ def latest_release():
 
 @pytest.fixture(scope="function", autouse=True)
 def function_setup(monkeypatch):
-    monkeypatch.setenv("SCT_CONFIG_FILES", "unit_tests/test_configs/minimal_test_case.yaml")
+    monkeypatch.setenv("SCT_CONFIG_FILES", "internal_test_data/minimal_test_case.yaml")
 
 
 @pytest.mark.parametrize(
@@ -189,7 +189,7 @@ def test_unified_package_aws_sets_ubuntu_user(monkeypatch):
         ),
     )
     monkeypatch.setenv("SCT_AMI_ID_DB_SCYLLA", "ami-test123")
-    monkeypatch.setenv("SCT_CONFIG_FILES", "unit_tests/test_configs/minimal_test_case.yaml")
+    monkeypatch.setenv("SCT_CONFIG_FILES", "internal_test_data/minimal_test_case.yaml")
 
     conf = sct_config.SCTConfiguration()
     conf.verify_configuration()

--- a/unit_tests/test_utils__operator__multitenant_common.py
+++ b/unit_tests/test_utils__operator__multitenant_common.py
@@ -88,7 +88,7 @@ class UtilsOperatorMultitenantCommonTests(unittest.TestCase):
         self.setup_default_env()
 
     def setup_default_env(self):
-        self.monkeypatch.setenv("SCT_CONFIG_FILES", "unit_tests/test_configs/minimal_test_case.yaml")
+        self.monkeypatch.setenv("SCT_CONFIG_FILES", "internal_test_data/minimal_test_case.yaml")
         self.monkeypatch.setenv("SCT_CLUSTER_BACKEND", "k8s-eks")
 
     def _multitenant_class_with_shared_options(self, klass):


### PR DESCRIPTION
Found while triaging the 40 integration failures on #15691 — this accounts for **30 of them**, and is entirely independent of that PR.

## Problem

Every test in `unit_tests/integration/test_config_get_version_based_on_conf.py` fails before reaching a single assertion:

```
FAILED unit_tests/integration/test_config_get_version_based_on_conf.py::test_docker[latest]
  - FileNotFoundError: Couldn't find config file:
    /home/ubuntu/scylla-cluster-tests/unit_tests/test_configs/minimal_test_case.yaml
```

`unit_tests/test_configs/` does not exist on this branch. Master moved the fixtures with `c16e41a55c` *"improvement(treewide): Move internal_test_data into unit_tests"*, which was never backported here — the yamls still live in `internal_test_data/`. The test file arrived by cherry-pick carrying master's path, so it could never have passed on this branch.

The two files are **byte-identical** (`diff` of `branch-2025.1:internal_test_data/minimal_test_case.yaml` against `master:unit_tests/test_configs/minimal_test_case.yaml` is empty), so the path is the only thing wrong.

## Verification

Run inside the branch's own hydra image, `scylladb/hydra:v1.91-2025.1-pytest-xdist`:

| | before | after |
| --- | --- | --- |
| `Couldn't find config file` occurrences | 33 | **0** |
| result | 33 failed, 0 passed | 30 failed, **3 passed** |

The config now loads and the tests proceed into real validation. I am deliberately **not** claiming this turns 30 tests green: the remaining failures are live-lookup rot of the same class master fixed in #15670/#15671 — `Azure Image for scylla_version='master:latest' not found in eastus`, `GCE image for scylla_version='2026.2' was not found`, `KeyError: 'docker-image-name'` — plus, in my local run only, 15 failures from absent AWS credentials that CI does have. What this PR fixes is the blanket blocker that stopped every one of them from even getting that far.

## Also in this change

* `unit_tests/test_utils__operator__multitenant_common.py` carried the same stale path. It is **latent**: `setup_default_env` sets it, but `_multitenant_class_with_shared_options` overwrites `SCT_CONFIG_FILES` before anything loads it. Confirmed neutral — that file gives an identical 4 failed / same reasons (`Unable to locate credentials`, local-only) with and without the change.
* `AGENTS.md` layout description updated to name `internal_test_data/` instead of master's `unit_tests/test_configs/`.

## Deliberately untouched

`unit_tests/test_config_get_version_based_on_conf.py` — the stale pre-rename duplicate that #15691 deletes. Fixing the path there too would create a modify/delete conflict between the two PRs.