### PR TITLE
fix(events): exclude perf-collector's log line from BACKTRACE detection

### DIFF
--- a/sdcm/sct_events/database.py
+++ b/sdcm/sct_events/database.py
@@ -205,7 +205,7 @@ DatabaseLogEvent.add_subevent_type(
 )
 
 DatabaseLogEvent.add_subevent_type("DATABASE_ERROR", severity=Severity.ERROR, regex=r"(^ERROR|!\s*?ERR).*\[shard.*\]")
-DatabaseLogEvent.add_subevent_type("BACKTRACE", severity=Severity.ERROR, regex="^(?!.*audit:).*backtrace")
+DatabaseLogEvent.add_subevent_type("BACKTRACE", severity=Severity.ERROR, regex=r"^(?!.*audit:)(?!.*perf\[).*backtrace")
 
 DatabaseLogEvent.add_subevent_type("TABLET_SPLIT", severity=Severity.DEBUG, regex=r"Detected tablet split for table")
 DatabaseLogEvent.add_subevent_type("TABLET_MERGE", severity=Severity.DEBUG, regex=r"Detected tablet merge for table")


### PR DESCRIPTION
scylla-server's new perf-collector helper (scylladb/scylladb#30076) periodically restarts `perf record`, and each restart logs a benign startup banner:

    perf[14184] setup and enables call-graph (stack chain/backtrace):

The BACKTRACE regex matches on the word **"backtrace"** alone, so this message gets misclassified as a real crash backtrace, failing `artifacts_test.ArtifactsTest.test_scylla_service` on both **x86_64** and **aarch64** with `TestFailedByEvents`.
unified-deb failed on https://jenkins.scylladb.com/job/scylla-master/job/artifacts/job/artifacts-ubuntu2204-test/1525/

Add a negative lookahead for perf's own log lines, the same way `audit:` lines are already excluded.

Fixes: SCYLLADB-3611

### Testing
- [X] https://jenkins.scylladb.com/view/releng-testing/job/releng-testing/job/artifacts/job/artifacts-ubuntu2204-test/819/ - verification **passed successfully** from my branch on releng-testing

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [X] I added the relevant `backport` labels
- [X] I didn't leave commented-out/debugging code

