### PR TITLE
alternator: add tablets_initial_scale_factor=1 to a test

### DIFF
--- a/test-cases/longevity/longevity-alternator-3h-multidc.yaml
+++ b/test-cases/longevity/longevity-alternator-3h-multidc.yaml
@@ -29,7 +29,7 @@ stress_cmd: [
 
 round_robin: true
 n_db_nodes: '3 3'
-instance_type_db: 'i4i.4xlarge'
+instance_type_db: 'i8g.large'
 n_loaders: '2 2'
 
 rack_aware_loader: true
@@ -47,3 +47,9 @@ alternator_port: 8080
 dynamodb_primarykey_type: HASH_AND_RANGE
 
 docker_network: 'ycsb_net'
+
+append_scylla_yaml:
+  # Needed because cluster has small amount of data (~50GB), which generates a lot of small (~100MB) tablets
+  # which hurt performance and cause timing (things take too much time) issues in the test. Workaround,
+  # problem is known to tablets team.
+  tablets_initial_scale_factor: 1


### PR DESCRIPTION
Add `tablets_initial_scale_factor: 1` entry to Alternator's longevity test. The test contains small (~50GB) cluster and does time tablet move throughput. The default (10) value for scale factor creates large pool of small tablets, which prevents scylla from reaching "normal" performance and thus fails the test.
The solution here is preferred to simply increase cluster's data size, which would increase test duration unnecesarily.

### Testing
Run a test here (https://jenkins.scylladb.com/job/scylla-2026.3/job/alternator/job/longevity-alternator-3h-test/7/).
