### PR TITLE
fix(manager): ignore listing oversized allocation for Scylla<=2026.3

### DIFF
--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -264,7 +264,7 @@ class ManagerBackupTests(ManagerRestoreTests):
 
         ctx = (
             ignore_snapshot_listing_oversized_allocation()
-            if ComparableScyllaVersion(self.db_cluster.nodes[0].scylla_version) <= "2026.2.0"
+            if ComparableScyllaVersion(self.db_cluster.nodes[0].scylla_version) <= "2026.3.0"
             else nullcontext()
         )
         with ctx:


### PR DESCRIPTION
Closes https://scylladb.atlassian.net/browse/CLOUD-3397

The fix is included in 2026.3.0-rc already, but not in 2026.2 as it was expected originally.

Refs:
https://github.com/scylladb/scylladb/issues/26736#issuecomment-5213956467
