### PR TITLE
fix(sla-test): stress commands must be passed as list

### DIFF
--- a/sla_per_user_system_test.py
+++ b/sla_per_user_system_test.py
@@ -87,7 +87,7 @@ class SlaPerUserTest(LongevityTest):
             n=self.num_of_partitions, user=self.DEFAULT_USER, password=self.DEFAULT_USER_PASSWORD, threads=250
         )
         self.run_stress_and_verify_threads(
-            params={"stress_cmd": write_cmd, "prefix": "preload-", "stats_aggregate_cmds": False}
+            params={"stress_cmd": [write_cmd], "prefix": "preload-", "stats_aggregate_cmds": False}
         )
 
         self.wait_no_compactions_running(n=120)


### PR DESCRIPTION
a84bac551d0972e4e109f3a50f8f55ecbb04de6a removed this code, so passing a non list fails.
Fix the test to pass a list.
```diff
index ae32c1f2f..fe0a135c5 100644
--- a/sdcm/utils/loader_utils.py
+++ b/sdcm/utils/loader_utils.py
@@ -98,8 +98,6 @@ class LoaderUtilsMixin:
 
     def _run_all_stress_cmds(self, stress_queue, params):
         stress_cmds = params["stress_cmd"]
-        if not isinstance(stress_cmds, list):
-            stress_cmds = [stress_cmds]
         # In some cases we want the same stress_cmd to run several times (can be used with round_robin or not).
         stress_multiplier = self.params.get("stress_multiplier")
         if stress_multiplier > 1:
``` 

Example failure:
https://argus.scylladb.com/tests/scylla-cluster-tests/41357a58-00c2-4d1a-a7a8-7e1bf1e02bda/sct-events

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
