### PR TITLE
fix(aws): tolerate elastic IP release failures on node destroy

### DIFF
--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -49,9 +49,10 @@ from sdcm.provision.provisioner import ProvisionError
 from sdcm.sct_provision.aws.cluster import PlacementGroup
 
 from sdcm.remote import LocalCmdRunner, shell_script_cmd, NETWORK_EXCEPTIONS
+from sdcm.sct_events import Severity
 from sdcm.sct_events.database import DatabaseLogEvent
 from sdcm.sct_events.filters import DbEventsFilter
-from sdcm.sct_events.system import SpotTerminationEvent
+from sdcm.sct_events.system import SpotTerminationEvent, TestFrameworkEvent
 from sdcm.utils.aws_utils import tags_as_ec2_tags, ec2_instance_wait_public_ip
 from sdcm.utils.common import list_instances_aws
 from sdcm.kernel_panic_checker import AWSKernelPanicChecker
@@ -75,8 +76,21 @@ INSTANCE_STORE = "instance_store"
 
 SPOT_TERMINATION_CHECK_DELAY = 0
 
+# transient AWS errors that can happen right after instance termination
+TRANSIENT_EIP_RELEASE_ERRORS = ("InvalidNetworkInterfaceID.NotFound", "InvalidIPAddress.InUse")
+EIP_RELEASE_RETRIES = 8
+EIP_RELEASE_BACKOFF_THRESHOLD = 10
+
 P = ParamSpec("P")
 R = TypeVar("R")
+
+
+class TransientEipReleaseError(Exception):
+    """Releasing an elastic IP failed with an AWS error that is expected to clear on a retry."""
+
+    def __init__(self, client_error: botocore.exceptions.ClientError):
+        super().__init__(str(client_error))
+        self.client_error = client_error
 
 
 class AWSCluster(cluster.BaseCluster):
@@ -1088,26 +1102,62 @@ class AWSNode(cluster.BaseNode):
         self._instance.wait_until_terminated()
 
         client: EC2Client = boto3.client("ec2", region_name=self.parent_cluster.region_names[self.dc_idx])
-        try:
-            client.release_address(AllocationId=self.eip_allocation_id)
-        except botocore.exceptions.ClientError as exc:
-            if exc.response["Error"]["Code"] == "InvalidAllocationID.NotFound":
-                self.log.warning(
-                    "Ignoring InvalidAllocationID.NotFound error when releasing address: %s. "
-                    "The allocation ID '%s' does not exist, likely already released.",
-                    exc,
-                    self.eip_allocation_id,
-                )
-            else:
+
+        def release_address_once():
+            try:
+                client.release_address(AllocationId=self.eip_allocation_id)
+            except botocore.exceptions.ClientError as exc:
+                error_code = exc.response["Error"]["Code"]
+                if error_code == "InvalidAllocationID.NotFound":
+                    self.log.warning(
+                        "Ignoring InvalidAllocationID.NotFound error when releasing address: %s. "
+                        "The allocation ID '%s' does not exist, likely already released.",
+                        exc,
+                        self.eip_allocation_id,
+                    )
+                    return
+                if error_code in TRANSIENT_EIP_RELEASE_ERRORS:
+                    raise TransientEipReleaseError(exc) from exc
+
                 raise
+
+        try:
+            exponential_retry(
+                func=release_address_once,
+                exceptions=TransientEipReleaseError,
+                threshold=EIP_RELEASE_BACKOFF_THRESHOLD,
+                retries=EIP_RELEASE_RETRIES,
+                logger=self.log,
+            )
+        except tenacity.RetryError as retry_error:
+            raise retry_error.last_attempt.exception().client_error from None
 
     def destroy(self):
         self.stop_task_threads()
         self.wait_till_tasks_threads_are_stopped()
         self._instance.terminate()
         self._instance.wait_until_terminated()
-        if self.eip_allocation_id:
+
+        if not self.eip_allocation_id:
+            super().destroy()
+            return
+
+        try:
             self.release_address()
+        except Exception as exc:  # noqa: BLE001
+            # the instance is already terminated, so keep teardown going and let test cleanup release the EIP
+            self.log.error("Failed to release elastic IP '%s': %s", self.eip_allocation_id, exc)
+            TestFrameworkEvent(
+                source=self.__class__.__name__,
+                source_method="release_address",
+                message=(
+                    f"Failed to release elastic IP '{self.eip_allocation_id}' of node {self.name}. "
+                    "It is left for the cleanup at the end of the test."
+                ),
+                exception=exc,
+                severity=Severity.WARNING,
+            ).publish_or_dump()
+
         super().destroy()
 
     def get_console_output(self):

--- a/unit_tests/unit/test_cluster_aws.py
+++ b/unit_tests/unit/test_cluster_aws.py
@@ -9,6 +9,20 @@ from unittest.mock import Mock, patch
 import botocore.exceptions
 
 from sdcm.cluster_aws import AWSNode
+from sdcm.sct_events import Severity
+
+
+def make_client_error(code: str, message: str = "") -> botocore.exceptions.ClientError:
+    """Build a botocore ClientError for the ReleaseAddress operation."""
+    error_response = {"Error": {"Code": code, "Message": message}}
+    return botocore.exceptions.ClientError(error_response, "ReleaseAddress")
+
+
+@pytest.fixture
+def no_retry_backoff():
+    """Make exponential_retry's backoff instant, so retry tests don't sleep for the whole budget."""
+    with patch("tenacity.nap.time.sleep") as mock_sleep:
+        yield mock_sleep
 
 
 @pytest.fixture
@@ -28,6 +42,7 @@ def mock_aws_node():
     aws_node.dc_idx = 0
     aws_node.eip_allocation_id = "eipalloc-05bed6a4528b5369f"
     aws_node.log = Mock()
+    aws_node.name = "longevity-test-db-node-1"
 
     # Bind the actual release_address method from AWSNode to our mock
     aws_node.release_address = AWSNode.release_address.__get__(aws_node, AWSNode)
@@ -97,3 +112,62 @@ class TestAWSNodeReleaseAddress:
         mock_aws_node._instance.wait_until_terminated.assert_called_once()
         # Verify that warning was NOT logged for other errors
         mock_aws_node.log.warning.assert_not_called()
+
+
+@patch("boto3.client")
+def test_release_address_retries_transient_network_interface_error(mock_boto3_client, mock_aws_node, no_retry_backoff):
+    """The EIP is released once AWS cleans up the stale association of the already deleted ENI."""
+    mock_client = Mock()
+    mock_boto3_client.return_value = mock_client
+    transient_error = make_client_error(
+        "InvalidNetworkInterfaceID.NotFound", "The networkInterface ID 'eni-00bc825c56fb32e96' does not exist"
+    )
+    mock_client.release_address.side_effect = [transient_error, transient_error, None]
+
+    mock_aws_node.release_address()
+
+    assert mock_client.release_address.call_count == 3
+    mock_boto3_client.assert_called_once_with("ec2", region_name="us-east-1")
+
+
+@patch("boto3.client")
+def test_release_address_raises_original_error_when_retries_exhausted(
+    mock_boto3_client, mock_aws_node, no_retry_backoff
+):
+    """When the transient error never clears, the AWS error is surfaced, not tenacity's RetryError wrapper."""
+    mock_client = Mock()
+    mock_boto3_client.return_value = mock_client
+    mock_client.release_address.side_effect = make_client_error("InvalidIPAddress.InUse", "Address is in use")
+
+    with pytest.raises(botocore.exceptions.ClientError) as exc_info:
+        mock_aws_node.release_address()
+
+    assert exc_info.value.response["Error"]["Code"] == "InvalidIPAddress.InUse"
+    assert mock_client.release_address.call_count == 8
+    assert sum(call.args[0] for call in no_retry_backoff.call_args_list) == pytest.approx(54)
+
+
+@pytest.mark.parametrize(
+    "release_error",
+    [
+        make_client_error("InvalidNetworkInterfaceID.NotFound", "does not exist"),
+        botocore.exceptions.EndpointConnectionError(endpoint_url="https://ec2.us-east-1.amazonaws.com"),
+    ],
+    ids=["transient_error", "connection_error"],
+)
+def test_destroy_continues_when_release_address_fails(mock_aws_node, release_error):
+    """A failed EIP release must not abort destroy() after instance termination."""
+    mock_aws_node.destroy = AWSNode.destroy.__get__(mock_aws_node, AWSNode)
+    mock_aws_node.release_address = Mock(side_effect=release_error)
+
+    with (
+        patch("sdcm.cluster.BaseNode.destroy") as mock_base_destroy,
+        patch("sdcm.cluster_aws.TestFrameworkEvent") as mock_event,
+    ):
+        mock_aws_node.destroy()
+
+    mock_base_destroy.assert_called_once()
+    mock_event.assert_called_once()
+    assert mock_event.call_args.kwargs["severity"] is Severity.WARNING
+    assert "eipalloc-05bed6a4528b5369f" in mock_event.call_args.kwargs["message"]
+    mock_event.return_value.publish_or_dump.assert_called_once()


### PR DESCRIPTION
EC2 clears the elastic IP association with the deleted network interface asynchronously, so ReleaseAddress fails with InvalidNetworkInterfaceID.NotFound right after the instance is terminated.
If raised from destroy(), it can abort the nemesis before 'nodetool removenode' and leave the node dead, but not removed from the topology.

The fix adds retries for the transient codes, and doesn't let an elastic IP failure fail destroy(): it is reported as a WARNING event and the address is released by the cleanup at the end of the test.

Fixes: SCT-229

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :green_circle: [longevity-5gb-1h test config executed for 8 hours](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/longevity-5gb-1h-gce-test/14/)
The test was executed with `'configurations/nemesis/TerminateAndRemoveNodeMonkey.yaml', 'configurations/network_config/scylla_addresses_on_different_interfaces.yaml'` overrides. The transient AWS error itself did not reproduce (it is a timing race on EC2 clearing the address association; in the original issue the failure occurred once in 14 terminations).
But the retry and error handling are covered and executed by unit tests.
