### PR TITLE
improvement(perf trigger): reduce perf tests frequency from weekly to bi-weekly

### DIFF
--- a/configurations/triggers/perf-regression.yaml
+++ b/configurations/triggers/perf-regression.yaml
@@ -19,11 +19,11 @@ cron_triggers:
       job_folder: "scylla-master"
       labels_selector: "alternator-weekly"
       requested_by_user: "radoslawcybulski"
-  - schedule: "00 6 * * 0"
+  - schedule: "00 6 */14 * *"
     params:
       scylla_version: "{branch}:latest"
       job_folder: "scylla-master"
-      labels_selector: "master-weekly"
+      labels_selector: "master-2weeks"
       requested_by_user: "juliayakovlev"
   - schedule: "0 23 */21 * *"
     params:
@@ -153,7 +153,7 @@ jobs:
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-simple-query-weekly-microbenchmark_arm64"
     backend: "aws"
     arch: "aarch64"
-    labels: ["master-weekly"]
+    labels: []
     params:
       region: "us-east-1"
       microbenchmark: "true"
@@ -161,21 +161,21 @@ jobs:
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-simple-query-weekly-microbenchmark_arm64-write"
     backend: "aws"
     arch: "aarch64"
-    labels: ["master-weekly"]
+    labels: []
     params:
       region: "us-east-1"
       microbenchmark: "true"
 
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-simple-query-weekly-microbenchmark_x86_64"
     backend: "aws"
-    labels: ["master-weekly"]
+    labels: []
     params:
       region: "us-east-1"
       microbenchmark: "true"
 
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-simple-query-weekly-microbenchmark_x86_64-write"
     backend: "aws"
-    labels: ["master-weekly"]
+    labels: []
     params:
       region: "us-east-1"
       microbenchmark: "true"
@@ -223,7 +223,7 @@ jobs:
     backend: "aws"
     arch: "aarch64"
     include_versions: ["master"]
-    labels: ["master-weekly"]
+    labels: ["master-2weeks"]
     job_throttle_category: "SCT-perf-us-east-1-i8g"
     params:
       region: "us-east-1"

--- a/jenkins-pipelines/master-triggers/sct_triggers/perf-regression-trigger.jenkinsfile
+++ b/jenkins-pipelines/master-triggers/sct_triggers/perf-regression-trigger.jenkinsfile
@@ -6,7 +6,7 @@ triggerMatrixPipeline(
     matrix_file: 'configurations/triggers/perf-regression.yaml',
     cron: '''0 8 * * * % scylla_version={branch}:latest;job_folder=scylla-master;labels_selector=alternator-daily;requested_by_user=radoslawcybulski
 0 8 * * 6 % scylla_version={branch}:latest;job_folder=scylla-master;labels_selector=alternator-weekly;requested_by_user=radoslawcybulski
-00 6 * * 0 % scylla_version={branch}:latest;job_folder=scylla-master;labels_selector=master-weekly;requested_by_user=juliayakovlev
+00 6 */14 * * % scylla_version={branch}:latest;job_folder=scylla-master;labels_selector=master-2weeks;requested_by_user=juliayakovlev
 0 23 */21 * * % scylla_version={branch}:latest;job_folder=scylla-master;labels_selector=master-3weeks;requested_by_user=juliayakovlev
 0 6 1 * * % scylla_version={branch}:latest;job_folder=scylla-master;labels_selector=master-monthly;requested_by_user=juliayakovlev
 13 6 8-14 * 2 % scylla_version={branch}:latest;job_folder=scylla-master;labels_selector=gce-custom-monthly;requested_by_user=valerii.ponomarov'''

--- a/unit_tests/trigger_matrix/test_perf_regression.py
+++ b/unit_tests/trigger_matrix/test_perf_regression.py
@@ -27,14 +27,14 @@ def perf_config():
     return load_matrix_config(PERF_YAML)
 
 
-def test_master_weekly_selects_expected_jobs(perf_config):
+def test_master_2weeks_selects_expected_jobs(perf_config):
     result = filter_jobs(
         perf_config.jobs,
         scylla_version="master:latest",
         resolved_version="2026.3.0~dev-0.20260525.69a5b417d1dc",
-        labels_selector="master-weekly",
+        labels_selector="master-2weeks",
     )
-    assert len(result) == 5
+    assert len(result) == 1
     names = {j.job_name for j in result}
     assert any("i8g-tablets" in n for n in names)
 


### PR DESCRIPTION
As part of cost reduction efforts in QA Tools & Infrastructure, reduce the frequency of performance tests from weekly to bi-weekly to save approximately K-2K per month. This change aims to optimize resource usage and reduce R&D core spending in AWS & GCP.

Microbenchmark tests are now triggered after PGO builds complete, so to run them weekly is no longer needed.

Fixes: https://scylladb.atlassian.net/browse/SCT-715

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
