### PR TITLE
chore(sizing): migrate cassandra/platform/spark to sizing constraints

### DIFF
--- a/test-cases/cassandra/cassandra-preload-1tb-latte.yaml
+++ b/test-cases/cassandra/cassandra-preload-1tb-latte.yaml
@@ -1,9 +1,15 @@
 test_duration: 960
 n_db_nodes: 3
 n_loaders: 2
-instance_type_db: 'i4i.4xlarge'
+sizing_db:  # no OCI match (DenseIO.E5 at 16 vCPUs caps at 96 GB)
+  vcpu: 16
+  memory: '>=128'
+  arch: x86_64
+  local_disk_gb: '>=800'
 root_disk_size_db: 100
-instance_type_loader: 'c6i.4xlarge'
+sizing_loader:
+  vcpu: 16
+  memory: '>=32'
 
 db_type: cassandra
 cassandra_version: '4.1'

--- a/test-cases/cassandra/cassandra-preload-2tb-latte.yaml
+++ b/test-cases/cassandra/cassandra-preload-2tb-latte.yaml
@@ -1,9 +1,15 @@
 test_duration: 1440
 n_db_nodes: 3
 n_loaders: 4
-instance_type_db: 'i4i.8xlarge'
+sizing_db:  # no OCI match (DenseIO.E5 at 32 vCPUs caps at 192 GB)
+  vcpu: 32
+  memory: '>=256'
+  arch: x86_64
+  local_disk_gb: '>=1500'
 root_disk_size_db: 100
-instance_type_loader: 'c6i.4xlarge'
+sizing_loader:
+  vcpu: 16
+  memory: '>=32'
 
 db_type: cassandra
 cassandra_version: '4.1'

--- a/test-cases/cassandra/cassandra-preload-500gb-latte.yaml
+++ b/test-cases/cassandra/cassandra-preload-500gb-latte.yaml
@@ -1,9 +1,15 @@
 test_duration: 480
 n_db_nodes: 3
 n_loaders: 2
-instance_type_db: 'i4i.4xlarge'
+sizing_db:  # no OCI match (DenseIO.E5 at 16 vCPUs caps at 96 GB)
+  vcpu: 16
+  memory: '>=128'
+  arch: x86_64
+  local_disk_gb: '>=400'
 root_disk_size_db: 100
-instance_type_loader: 'c6i.4xlarge'
+sizing_loader:
+  vcpu: 16
+  memory: '>=32'
 
 db_type: cassandra
 cassandra_version: '4.1'

--- a/test-cases/cassandra/cassandra-preload-5tb-latte.yaml
+++ b/test-cases/cassandra/cassandra-preload-5tb-latte.yaml
@@ -1,9 +1,15 @@
 test_duration: 2880
 n_db_nodes: 6
 n_loaders: 4
-instance_type_db: 'i4i.8xlarge'
+sizing_db:  # no OCI match (DenseIO.E5 at 32 vCPUs caps at 192 GB)
+  vcpu: 32
+  memory: '>=256'
+  arch: x86_64
+  local_disk_gb: '>=2000'
 root_disk_size_db: 100
-instance_type_loader: 'c6i.4xlarge'
+sizing_loader:
+  vcpu: 16
+  memory: '>=32'
 
 db_type: cassandra
 cassandra_version: '4.1'

--- a/test-cases/platform-migration/x86-to-arm-single-dc-50-perc.yaml
+++ b/test-cases/platform-migration/x86-to-arm-single-dc-50-perc.yaml
@@ -1,10 +1,15 @@
 test_duration: 480
 
-instance_type_db: 'i7i.2xlarge'
+sizing_db:  # no OCI match (DenseIO min 16 vCPUs)
+  vcpu: 8
+  memory: '>=64'
+  arch: x86_64
 instance_type_db_target: 'i8g.2xlarge'
 n_db_nodes: 6
 n_loaders: 2
-instance_type_loader: 'c7i.4xlarge'
+sizing_loader:
+  vcpu: 16
+  memory: '>=32'
 n_monitor_nodes: 1
 
 prepare_write_cmd: [

--- a/test-cases/spark-migrator/cs-to-scylla-500gb.yaml
+++ b/test-cases/spark-migrator/cs-to-scylla-500gb.yaml
@@ -4,20 +4,31 @@ db_type: mixed_cassandra
 
 # Scylla target cluster params
 n_db_nodes: 3
-instance_type_db: 'i4i.4xlarge'
+sizing_db:  # no OCI match (DenseIO.E5 at 16 vCPUs caps at 96 GB)
+  vcpu: 16
+  memory: '>=128'
+  local_disk_gb: '>=400'
 root_disk_size_db: 100
 
 # Cassandra source cluster params
 n_test_oracle_db_nodes: 3
-instance_type_db_oracle: 'i4i.4xlarge'
+sizing_db_oracle:  # no OCI match (DenseIO.E5 at 16 vCPUs caps at 96 GB)
+  vcpu: 16
+  memory: '>=128'
+  arch: x86_64
+  local_disk_gb: '>=400'
 cassandra_oracle_version: '4.1'
 ami_id_db_cassandra: 'resolve:ssm:/aws/service/canonical/ubuntu/server/22.04/stable/current/amd64/hvm/ebs-gp2/ami-id'
 
 n_loaders: 2
-instance_type_loader: 'c6i.4xlarge'
+sizing_loader:
+  vcpu: 16
+  memory: '>=32'
 
 n_monitor_nodes: 1
-instance_type_monitor: 'i4i.large'
+sizing_monitor:
+  vcpu: 2
+  memory: '>=16'
 
 emr_release_label: 'emr-spark-8.0.0'
 emr_instance_type_master: 'm5.xlarge'

--- a/test-cases/spark-migrator/cs-to-scylla-small.yaml
+++ b/test-cases/spark-migrator/cs-to-scylla-small.yaml
@@ -4,11 +4,16 @@ db_type: mixed_cassandra
 
 # Scylla target cluster params
 n_db_nodes: 1
-instance_type_db: 'i4i.large'
+sizing_db:  # no OCI match (DenseIO min 16 vCPUs)
+  vcpu: 2
+  memory: '>=16'
 
 # Cassandra source cluster params
 n_test_oracle_db_nodes: 1
-instance_type_db_oracle: 'i4i.large'
+sizing_db_oracle:  # no OCI match (DenseIO min 16 vCPUs)
+  vcpu: 2
+  memory: '>=16'
+  arch: x86_64
 cassandra_oracle_version: '4.1'
 ami_id_db_cassandra: 'resolve:ssm:/aws/service/canonical/ubuntu/server/22.04/stable/current/amd64/hvm/ebs-gp2/ami-id'
 
@@ -16,7 +21,6 @@ ami_id_db_cassandra: 'resolve:ssm:/aws/service/canonical/ubuntu/server/22.04/sta
 n_loaders: 0
 
 n_monitor_nodes: 1
-instance_type_monitor: 't3.large'
 
 emr_release_label: 'emr-spark-8.0.0'
 emr_instance_type_master: 'm5.xlarge'

--- a/test-cases/spark-migrator/spark-migrator-basic.yaml
+++ b/test-cases/spark-migrator/spark-migrator-basic.yaml
@@ -4,9 +4,9 @@ n_db_nodes: 3
 n_loaders: 1
 n_monitor_nodes: 1
 
-instance_type_db: 'i4i.large'
-instance_type_loader: 'c6i.xlarge'
-instance_type_monitor: 't3.large'
+sizing_db:  # no OCI match (DenseIO min 16 vCPUs)
+  vcpu: 2
+  memory: '>=16'
 
 # legacy fallback: Spark 4.x installed via bootstrap on an emr-7.x release
 emr_release_label: 'emr-7.12.0'


### PR DESCRIPTION
Replace literal instance_type params with sizing_db/sizing_db_oracle/ sizing_loader/sizing_monitor constraints:
- test-cases/cassandra/ (4 files): arch pinned to x86_64 because the Cassandra nodes boot amd64-only Ubuntu AMI; local_disk_gb pinned.
- test-cases/platform-migration/ (1 of 5 files): instance_type_db_target stays a literal - the pinned ARM target is the test subject and the sizing engine has no db_target role; the other four files are overlays with no instance params.
- test-cases/spark-migrator/ (3 files): loader/monitor params equal to the sizing defaults are dropped; arch pinned to x86_64 on the oracle (Cassandra source) side only; EMR instance types stay literal (no sizing-engine coverage for EMR).

Fixes: SCT-592

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :green_circle: [cassandra-preload-500gb-latte-test (with reduced load and test duration time)](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/cassandra-preload-500gb-latte-test/2/) - to validate changes in test-cases/cassandra/* configs
- [x] :green_circle: [scylla-migrator-test](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/scylla-migrator-test/38/) - to validate changes in test-cases/spark-migrator/* configs
- [x] :green_circle: [platform-migration test (x86-to-arm-single-dc-10-perc config, i.e. small dataset)](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/platform-migration/8/) - to validate changes in test-cases/platform-migration/* configs
- [x] `sizing preview` sct command was executed for the configs updated in this PR, the output is in the attached file
[sizing_preview_pr15738.txt](https://github.com/user-attachments/files/30946978/sizing_preview_pr15738.txt)
