### PR TITLE
improvement(performance): set error threshould for i8g predefined test

### DIFF
--- a/configurations/performance/latency-decorator-error-thresholds-steps-ent-i8g-tablets.yaml
+++ b/configurations/performance/latency-decorator-error-thresholds-steps-ent-i8g-tablets.yaml
@@ -1,0 +1,121 @@
+latency_decorator_error_thresholds:
+  write:
+    unthrottled:
+      P90 write:
+        fixed_limit: null
+      P99 write:
+        fixed_limit: null
+      Throughput write:
+        # Fixed throughput limit in operations per second (ops/sec).
+        # This value was determined based on performance testing: 10% below the avg. of 5 best results in the last 3 months.
+        fixed_limit: 720000
+
+  read:
+    "150000":
+      P90 read:
+        fixed_limit: null
+      P99 read:
+        fixed_limit: 1
+    "300000":
+      P90 read:
+        fixed_limit: null
+      P99 read:
+        fixed_limit: 1
+    "450000":
+      P90 read:
+        fixed_limit: null
+      P99 read:
+        fixed_limit: 3
+    "600000":
+      P90 read:
+        fixed_limit: null
+      P99 read:
+        fixed_limit: 40
+    "700000":
+      P90 read:
+        fixed_limit: null
+      P99 read:
+        fixed_limit: 50
+    unthrottled:
+      P90 read:
+        fixed_limit: null
+      P99 read:
+        fixed_limit: null
+      Throughput read:
+        # Fixed throughput limit in operations per second (ops/sec).
+        # This value was determined based on performance testing: 10% below the avg. of 5 best results in the last 3 months.
+        fixed_limit: 1670000
+
+
+  read_disk_only:
+    "80000":
+      P90 read:
+        fixed_limit: null
+      P99 read:
+        fixed_limit: null
+    "165000":
+      P90 read:
+        fixed_limit: null
+      P99 read:
+        fixed_limit: null
+    "250000":
+      P90 read:
+        fixed_limit: null
+      P99 read:
+        fixed_limit: null
+    "300000":
+      P90 read:
+        fixed_limit: null
+      P99 read:
+        fixed_limit: null
+    unthrottled:
+      P90 read:
+        fixed_limit: null
+      P99 read:
+        fixed_limit: null
+      Throughput read:
+        # Fixed throughput limit in operations per second (ops/sec).
+        # This value was determined based on performance testing: 10% below the avg. of 5 best results in the last 3 months.
+        fixed_limit: 580000
+
+  mixed:
+    "50000":
+      P90 write:
+        fixed_limit: null
+      P90 read:
+        fixed_limit: null
+      P99 write:
+        fixed_limit: 3
+      P99 read:
+        fixed_limit: 3
+    "150000":
+      P90 write:
+        fixed_limit: null
+      P90 read:
+        fixed_limit: null
+      P99 write:
+        fixed_limit: 3
+      P99 read:
+        fixed_limit: 3
+    "300000":
+      P90 write:
+        fixed_limit: null
+      P90 read:
+        fixed_limit: null
+      P99 write:
+        fixed_limit: 5
+      P99 read:
+        fixed_limit: 5
+    unthrottled:
+      P90 write:
+        fixed_limit: null
+      P90 read:
+        fixed_limit: null
+      P99 write:
+        fixed_limit: null
+      P99 read:
+        fixed_limit: null
+      Throughput write:
+        # Fixed throughput limit in operations per second (ops/sec).
+        # This value was determined based on performance testing: 10% below the avg. of 5 best results in the last 3 months.
+        fixed_limit: 440000

--- a/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-i8g-tablets.jenkinsfile
+++ b/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-i8g-tablets.jenkinsfile
@@ -8,6 +8,6 @@ perfRegressionParallelPipeline(
     region: "us-east-1",
     provision_type: 'on_demand',
     test_name: "performance_regression_gradual_grow_throughput.PerformanceRegressionPredefinedStepsTest",
-    test_config: '''["test-cases/performance/perf-regression-predefined-throughput-steps.yaml", "configurations/performance/cassandra_stress_gradual_load_steps_i8g.yaml", "configurations/c-s-driver-version-4.yaml", "configurations/disable_kms.yaml", "configurations/disable_speculative_retry.yaml", "configurations/performance/latency-decorator-error-thresholds-steps-ent-tablets.yaml", "configurations/arm_instance_types/i8g_4xlarge.yaml"]''',
+    test_config: '''["test-cases/performance/perf-regression-predefined-throughput-steps.yaml", "configurations/performance/cassandra_stress_gradual_load_steps_i8g.yaml", "configurations/c-s-driver-version-4.yaml", "configurations/disable_kms.yaml", "configurations/disable_speculative_retry.yaml", "configurations/performance/latency-decorator-error-thresholds-steps-ent-i8g-tablets.yaml", "configurations/arm_instance_types/i8g_4xlarge.yaml"]''',
     sub_tests: ["test_read_gradual_increase_load", "test_mixed_gradual_increase_load", "test_read_disk_only_gradual_increase_load", "test_write_gradual_increase_load"],
 )


### PR DESCRIPTION
Add latency-decorator-error-thresholds-steps-ent-i8g-tablets.yaml with Throughput fixed_limit values calibrated for i8g hardware: write 720000, read 1670000, read_disk_only 580000, mixed 440000.

Update the i8g tablets jenkinsfile to reference the new config.

Fixes: https://scylladb.atlassian.net/browse/SCT-620

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
