### PR TITLE
fix(gce provision): misleading error on GCE incompatible disk type

### DIFF
--- a/sdcm/provision/gce/capacity_errors.py
+++ b/sdcm/provision/gce/capacity_errors.py
@@ -30,8 +30,31 @@ TYPE_NOT_AVAILABLE_MARKERS: list[str] = [
 ]
 
 
+# GCE reports an unsupported machine-type / disk-type / image combination with the very same
+# ZONE_RESOURCE_POOL_EXHAUSTED_WITH_DETAILS code it uses for a genuine capacity shortage, e.g.
+# "Error 400: [pd-standard, pd-ssd, n4-standard-16] features are not compatible for creating
+# instance., badRequest". Retrying such a request in another zone or region can never succeed,
+# so these markers veto the capacity classification. Matched case-insensitively.
+CONFIG_ERROR_MARKERS: list[str] = [
+    "not compatible for creating instance",
+    "not compatible with machine type architecture",
+]
+
+
+def is_config_error(exception: BaseException) -> bool:
+    """Return True if `exception` reports an unsupported machine-type / disk / image combination."""
+    error_str = str(exception).lower()
+    return any(marker in error_str for marker in CONFIG_ERROR_MARKERS)
+
+
 def is_zone_capacity_error(exception: BaseException) -> bool:
-    """Return True if `exception` is a transient GCE zone capacity exhaustion error."""
+    """Return True if `exception` is a transient GCE zone capacity exhaustion error.
+
+    Configuration errors are excluded even when they carry a capacity marker: they are not
+    transient, so relocating the cluster to another zone or region only reproduces the failure.
+    """
+    if is_config_error(exception):
+        return False
     error_str = str(exception)
     return any(marker in error_str for marker in CAPACITY_ERROR_MARKERS)
 
@@ -51,8 +74,10 @@ def is_type_unavailable_error(exception: BaseException) -> bool:
 def classify_provisioning_error(exception: BaseException) -> str:
     """Classify a GCE provisioning error for fallback routing.
 
-    Returns one of: "capacity", "quota", "type_unavailable", "unknown".
+    Returns one of: "config", "capacity", "quota", "type_unavailable", "unknown".
     """
+    if is_config_error(exception):
+        return "config"
     if is_zone_capacity_error(exception):
         return "capacity"
     if is_quota_error(exception):

--- a/sdcm/provision/gce/instance_provider.py
+++ b/sdcm/provision/gce/instance_provider.py
@@ -21,11 +21,14 @@ import google.api_core.exceptions
 from google.cloud import compute_v1
 
 from sdcm.provision.provisioner import (
+    InstanceConfigurationError,
     InstanceDefinition,
     PricingModel,
     ProvisionError,
+    ProvisionUnrecoverableError,
     ZoneResourcesExhaustedError,
 )
+from sdcm.provision.gce.capacity_errors import is_config_error
 from sdcm.provision.gce.disk_provider import DiskProvider
 from sdcm.provision.gce.network_provider import NetworkProvider
 from sdcm.provision.gce.constants import DISK_TYPE_PD_STANDARD, DISK_TYPE_LOCAL_SSD
@@ -44,6 +47,16 @@ ZONE_EXHAUSTED_MARKER = "ZONE_RESOURCE_POOL_EXHAUSTED"
 
 
 def _is_zone_exhausted(error: BaseException) -> bool:
+    """True only for a genuine zone capacity shortage.
+
+    A configuration error (e.g. a disk type the machine type does not support) carries the same
+    ZONE_RESOURCE_POOL_EXHAUSTED code, so it is vetoed here - and, identically, in
+    :func:`sdcm.provision.gce.capacity_errors.is_zone_capacity_error`, which the region-level
+    fallback classifies with. Both must agree, otherwise the region loop would relocate the whole
+    cluster on an error that fails the same way everywhere.
+    """
+    if is_config_error(error):
+        return False
     return ZONE_EXHAUSTED_MARKER in str(error)
 
 
@@ -126,6 +139,10 @@ class VirtualMachineProvider:
                 )
                 pending_instance_creations.append((definition, operation, normalized_name, user_data, startup_script))
             except google.api_core.exceptions.GoogleAPIError as err:
+                if is_config_error(err):
+                    raise InstanceConfigurationError(
+                        f"Failed to create instance {normalized_name} due to configuration error: {err}"
+                    ) from err
                 if _is_zone_exhausted(err):
                     LOGGER.error(
                         "Zone %s resource pool exhausted during insert request for %s",
@@ -143,9 +160,9 @@ class VirtualMachineProvider:
                     definition, operation, normalized_name, pricing_model, user_data, startup_script
                 )
                 instances.append(instance)
-            except ZoneResourcesExhaustedError:
-                # Zone exhaustion is unrecoverable; let it propagate immediately.
-                # Successfully-created instances remain in self._cache so callers
+            except ProvisionUnrecoverableError:
+                # Zone exhaustion and configuration errors are unrecoverable; let them propagate
+                # immediately. Successfully-created instances remain in self._cache so callers
                 # can clean them up before retrying in a different zone.
                 raise
             except google.api_core.exceptions.GoogleAPIError as err:
@@ -153,6 +170,10 @@ class VirtualMachineProvider:
                 error_to_raise = err
 
         if error_to_raise:
+            if is_config_error(error_to_raise):
+                raise InstanceConfigurationError(
+                    f"Failed to create instances due to configuration error: {error_to_raise}"
+                ) from error_to_raise
             if _is_zone_exhausted(error_to_raise):
                 raise ZoneResourcesExhaustedError(
                     f"Zone {self.zone} resource pool exhausted: {error_to_raise}"
@@ -183,6 +204,18 @@ class VirtualMachineProvider:
             self._cache[normalized_name] = instance
             return instance
         except google.api_core.exceptions.GoogleAPIError as gce_error:
+            # Config first, then capacity: a config error carries the capacity code too, so the order
+            # matches the other two classification sites even though _is_zone_exhausted vetoes it.
+            if is_config_error(gce_error):
+                LOGGER.error(
+                    "Instance %s creation failed due to configuration error (not retryable): %s",
+                    normalized_name,
+                    gce_error,
+                )
+                self._cleanup_failed_instance(normalized_name, str(gce_error))
+                raise InstanceConfigurationError(
+                    f"Failed to create instance {normalized_name} due to configuration error: {gce_error}"
+                ) from gce_error
             if _is_zone_exhausted(gce_error):
                 LOGGER.error(
                     "Zone %s resource pool exhausted while creating %s; failing fast without retry",
@@ -227,6 +260,10 @@ class VirtualMachineProvider:
         except google.api_core.exceptions.GoogleAPIError as gce_error:
             LOGGER.warning("Instance %s creation failed: %s", normalized_name, gce_error)
             self._cleanup_failed_instance(normalized_name, str(gce_error))
+            if is_config_error(gce_error):
+                raise InstanceConfigurationError(
+                    f"Failed to create instance {normalized_name} due to configuration error: {gce_error}"
+                ) from gce_error
             if _is_zone_exhausted(gce_error):
                 raise ZoneResourcesExhaustedError(
                     f"Zone {self.zone} resource pool exhausted: {gce_error}"

--- a/sdcm/provision/provisioner.py
+++ b/sdcm/provision/provisioner.py
@@ -86,6 +86,13 @@ class ZoneResourcesExhaustedError(ProvisionUnrecoverableError):
     """Raised when the target availability zone has no capacity for the requested resources."""
 
 
+class InstanceConfigurationError(ProvisionUnrecoverableError):
+    """Raised when the requested instance configuration itself is invalid (e.g. a disk type the
+    machine type does not support). Deliberately *not* a `ProvisionError`, so the provisioning
+    retry in `sdcm.sct_provision.instances_provider` does not re-issue a request that can only
+    fail again, in this or any other zone/region."""
+
+
 class ProvisionerError(Exception):
     pass
 

--- a/sdcm/utils/decorators.py
+++ b/sdcm/utils/decorators.py
@@ -414,7 +414,10 @@ def skip_on_capacity_issues(func: Callable | None = None, db_cluster: BaseCluste
     def decorator(inner_func):
         @wraps(inner_func)
         def wrapper(*args, **kwargs):
-            from sdcm.provision.provisioner import ProvisionUnrecoverableError  # noqa: PLC0415
+            from sdcm.provision.provisioner import (  # noqa: PLC0415
+                InstanceConfigurationError,
+                ProvisionUnrecoverableError,
+            )
 
             cluster = db_cluster
             # Try to get db_cluster from inner_func's bound instance if not provided
@@ -449,6 +452,21 @@ def skip_on_capacity_issues(func: Callable | None = None, db_cluster: BaseCluste
                     ).publish()
                     raise
                 raise UnsupportedNemesis("Capacity Issue") from ex
+            except InstanceConfigurationError as ex:
+                # Unrecoverable, but not a capacity issue: the requested instance configuration is
+                # invalid (e.g. a disk type the machine type does not support), so it fails the same
+                # way in every zone and region. Deliberately never softened into a nemesis skip -
+                # that would hide a real misconfiguration behind "Capacity Issue".
+                if not check_cluster_layout(cluster):
+                    TestFrameworkEvent(
+                        source=inner_func.__name__,
+                        message=(
+                            f"Test failed due to an invalid instance configuration: {ex} cluster is unbalanced, "
+                            "continuing with test would yield unknown results"
+                        ),
+                        severity=Severity.CRITICAL,
+                    ).publish()
+                raise
             except ProvisionUnrecoverableError as ex:
                 # Azure stuck-VM recovery gave up - a capacity/provisioning issue
                 if check_cluster_layout(cluster):
@@ -479,7 +497,10 @@ def critical_on_capacity_issues(func: callable) -> callable:
 
     @wraps(func)
     def wrapper(*args, **kwargs):
-        from sdcm.provision.provisioner import ProvisionUnrecoverableError  # noqa: PLC0415
+        from sdcm.provision.provisioner import (  # noqa: PLC0415
+            InstanceConfigurationError,
+            ProvisionUnrecoverableError,
+        )
 
         try:
             return func(*args, **kwargs)
@@ -496,6 +517,16 @@ def critical_on_capacity_issues(func: callable) -> callable:
             TestFrameworkEvent(
                 source=func.__name__,
                 message=f"Test failed due to service availability issues: {ex} "
+                "cluster is probably unbalanced, continuing with test would yield unknown results",
+                severity=Severity.CRITICAL,
+            ).publish()
+            raise
+        except InstanceConfigurationError as ex:
+            # Unrecoverable like a capacity error, but a different cause - report it as what it is,
+            # otherwise an invalid instance configuration is filed as a capacity shortage.
+            TestFrameworkEvent(
+                source=func.__name__,
+                message=f"Test failed due to an invalid instance configuration: {ex} "
                 "cluster is probably unbalanced, continuing with test would yield unknown results",
                 severity=Severity.CRITICAL,
             ).publish()

--- a/unit_tests/unit/provisioner/test_gce_capacity_errors.py
+++ b/unit_tests/unit/provisioner/test_gce_capacity_errors.py
@@ -14,6 +14,7 @@
 import pytest
 
 from sdcm.provision.gce.capacity_errors import (
+    is_config_error,
     is_zone_capacity_error,
     is_quota_error,
     is_type_unavailable_error,
@@ -35,10 +36,33 @@ class _FakeError(Exception):
         ("PERMISSION_DENIED: cannot access", False),
         ("QUOTA_EXCEEDED", False),
         ("", False),
+        # GCE returns the capacity code for an unsupported machine-type/disk-type combination too;
+        # it must not be classified as capacity, or the region loop relocates the cluster for nothing.
+        (
+            "ZONE_RESOURCE_POOL_EXHAUSTED_WITH_DETAILS: Error 400: "
+            "[pd-standard, pd-ssd, n4-standard-16] features are not compatible for creating instance., badRequest",
+            False,
+        ),
     ],
 )
 def test_is_zone_capacity_error(message, expected):
     assert is_zone_capacity_error(_FakeError(message)) is expected
+
+
+@pytest.mark.parametrize(
+    "message,expected",
+    [
+        # Verbatim GCE wording - "are ... for", not "is ... with".
+        ("Error 400: [pd-standard, pd-ssd, n4-standard-16] features are not compatible for creating instance.", True),
+        ("[e2-medium, local-ssd] features are not compatible for creating instance.", True),
+        ("Requested boot disk architecture (X86_64) is not compatible with machine type architecture (ARM64).", True),
+        ("ZONE_RESOURCE_POOL_EXHAUSTED", False),
+        ("QUOTA_EXCEEDED", False),
+        ("", False),
+    ],
+)
+def test_is_config_error(message, expected):
+    assert is_config_error(_FakeError(message)) is expected
 
 
 @pytest.mark.parametrize(
@@ -71,6 +95,11 @@ def test_is_type_unavailable_error(message, expected):
     "message,expected_class",
     [
         ("ZONE_RESOURCE_POOL_EXHAUSTED", "capacity"),
+        (
+            "ZONE_RESOURCE_POOL_EXHAUSTED_WITH_DETAILS: [pd-standard, n4-standard-16] "
+            "features are not compatible for creating instance.",
+            "config",
+        ),
         ("QUOTA_EXCEEDED", "quota"),
         ("RESOURCE_NOT_FOUND", "type_unavailable"),
         ("PERMISSION_DENIED", "unknown"),

--- a/unit_tests/unit/provisioner/test_gce_region_fallback.py
+++ b/unit_tests/unit/provisioner/test_gce_region_fallback.py
@@ -20,13 +20,23 @@ from sdcm.provision.common.fallback import is_region_fallback_enabled
 from sdcm.provision.gce import region_fallback as rf
 from sdcm.provision.gce.constants import SUPPORTED_GCE_REGIONS
 from sdcm.provision.gce.zone_resolver import GceAZResolver
-from sdcm.provision.provisioner import ProvisionError, ProvisionUnrecoverableError, ZoneResourcesExhaustedError
+from sdcm.provision.provisioner import (
+    InstanceConfigurationError,
+    ProvisionError,
+    ProvisionUnrecoverableError,
+    ZoneResourcesExhaustedError,
+)
 from sdcm.sct_provision.instances_provider import provision_sct_resources
 from sdcm.tester import ClusterTester, CriticalTestFailure
 
 from unit_tests.lib.dot_dict import DotDict
 
 CAPACITY_MSG = "Operation failed: ZONE_RESOURCE_POOL_EXHAUSTED"
+# Verbatim GCE shape: an unsupported machine-type/disk-type pair reported under the capacity code.
+CONFIG_ERROR_MSG = (
+    "ZONE_RESOURCE_POOL_EXHAUSTED_WITH_DETAILS: Error 400: "
+    "[pd-standard, pd-ssd, n4-standard-16] features are not compatible for creating instance., badRequest"
+)
 
 
 class _GceParams(DotDict):
@@ -278,6 +288,45 @@ def test_loop_non_capacity_error_propagates_and_restores(monkeypatch):
     cleanup.assert_not_called()
     assert params["gce_datacenter"] == "us-east1"  # restored
     assert params["availability_zone"] == "b"
+
+
+def test_loop_does_not_relocate_on_config_error(monkeypatch):
+    """A config error wearing the capacity code must not relocate: it fails identically everywhere."""
+    monkeypatch.delenv("SCT_GCE_DATACENTER", raising=False)
+    params = _make_params()
+    provision_once = MagicMock(side_effect=InstanceConfigurationError(CONFIG_ERROR_MSG))
+    with patch.object(rf, "cleanup_region") as cleanup:
+        with pytest.raises(InstanceConfigurationError, match="not compatible for creating instance"):
+            rf.provision_with_region_fallback(
+                params=params,
+                test_id="t",
+                network_name="qa-vpc",
+                region_candidates=lambda: [("us-west1", ["a"])],
+                provision_once=provision_once,
+                error_factory=ProvisionUnrecoverableError,
+            )
+    assert provision_once.call_count == 1
+    cleanup.assert_not_called()
+    assert params["gce_datacenter"] == "us-east1"  # restored
+
+
+def test_loop_does_not_relocate_on_config_error_wrapped_in_provision_error(monkeypatch):
+    """Text-based classification agrees with the type-based one: no relocation on a config message."""
+    monkeypatch.delenv("SCT_GCE_DATACENTER", raising=False)
+    params = _make_params()
+    provision_once = MagicMock(side_effect=ProvisionError(CONFIG_ERROR_MSG))
+    with patch.object(rf, "cleanup_region") as cleanup:
+        with pytest.raises(ProvisionError, match="not compatible for creating instance"):
+            rf.provision_with_region_fallback(
+                params=params,
+                test_id="t",
+                network_name="qa-vpc",
+                region_candidates=lambda: [("us-west1", ["a"])],
+                provision_once=provision_once,
+                error_factory=ProvisionUnrecoverableError,
+            )
+    assert provision_once.call_count == 1
+    cleanup.assert_not_called()
 
 
 def test_loop_all_regions_exhausted_raises_via_error_factory(monkeypatch):

--- a/unit_tests/unit/provisioner/test_provision_retry.py
+++ b/unit_tests/unit/provisioner/test_provision_retry.py
@@ -1,0 +1,46 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2026 ScyllaDB
+
+"""Which provisioning failures the generic `provision_with_retry` wrapper re-issues."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from sdcm.provision.provisioner import (
+    InstanceConfigurationError,
+    PricingModel,
+    ProvisionError,
+)
+from sdcm.sct_provision.instances_provider import provision_with_retry
+
+
+def test_config_error_is_not_retried():
+    """An unsupported machine-type/disk-type combination can only fail again - issue the request once."""
+    provisioner = MagicMock()
+    provisioner.get_or_create_instances.side_effect = InstanceConfigurationError(
+        "[pd-standard, pd-ssd, n4-standard-16] features are not compatible for creating instance."
+    )
+    with pytest.raises(InstanceConfigurationError):
+        provision_with_retry(provisioner, definitions=[], pricing_model=PricingModel.ON_DEMAND)
+    assert provisioner.get_or_create_instances.call_count == 1
+
+
+def test_generic_provision_error_is_still_retried(monkeypatch):
+    """Guard the exemption above: ordinary ProvisionErrors keep their three attempts."""
+    monkeypatch.setattr("time.sleep", lambda _: None)
+    provisioner = MagicMock()
+    provisioner.get_or_create_instances.side_effect = ProvisionError("transient API failure")
+    with pytest.raises(ProvisionError):
+        provision_with_retry(provisioner, definitions=[], pricing_model=PricingModel.ON_DEMAND)
+    assert provisioner.get_or_create_instances.call_count == 3

--- a/unit_tests/unit/test_utils_decorators.py
+++ b/unit_tests/unit/test_utils_decorators.py
@@ -5,7 +5,7 @@ import pytest
 from google.api_core.exceptions import ServiceUnavailable
 
 from sdcm.exceptions import UnsupportedNemesis
-from sdcm.provision.provisioner import ProvisionUnrecoverableError
+from sdcm.provision.provisioner import InstanceConfigurationError, ProvisionUnrecoverableError
 from sdcm.sct_events import Severity
 from sdcm.utils.decorators import (
     _find_hdr_tags,
@@ -61,6 +61,13 @@ def _raise_service_unavailable():
     raise ServiceUnavailable("GCE capacity issue")
 
 
+def _raise_instance_configuration_error():
+    raise InstanceConfigurationError(
+        "Failed to create instance node-x due to configuration error: "
+        "[pd-standard, pd-ssd, n4-standard-16] features are not compatible for creating instance."
+    )
+
+
 def test_skip_on_capacity_issues_converts_stuck_vm_give_up_to_nemesis_skip():
     """Stuck VM recovery give-up on a balanced cluster must skip the nemesis, not fail it."""
     with patch("sdcm.utils.decorators.check_cluster_layout", return_value=True):
@@ -94,6 +101,43 @@ def test_critical_on_capacity_issues_publishes_critical_on_stuck_vm_give_up():
         with pytest.raises(ProvisionUnrecoverableError):
             critical_on_capacity_issues(_raise_stuck_vm_give_up)()
     assert event_mock.call_args.kwargs["severity"] == Severity.CRITICAL
+    event_mock.return_value.publish.assert_called_once()
+
+
+def test_skip_on_capacity_issues_does_not_skip_on_instance_configuration_error():
+    """An invalid instance configuration is not a capacity issue: it must fail, not skip the nemesis.
+
+    `InstanceConfigurationError` is a `ProvisionUnrecoverableError`, so without its own clause it
+    would be softened into `UnsupportedNemesis("Capacity Issue")` and the real misconfiguration
+    would never surface.
+    """
+    with patch("sdcm.utils.decorators.check_cluster_layout", return_value=True):
+        with patch("sdcm.utils.decorators.TestFrameworkEvent") as event_mock:
+            with pytest.raises(InstanceConfigurationError, match="not compatible for creating instance"):
+                skip_on_capacity_issues(db_cluster=MagicMock())(_raise_instance_configuration_error)()
+    event_mock.return_value.publish.assert_not_called()
+
+
+def test_skip_on_capacity_issues_reports_configuration_error_on_unbalanced_cluster():
+    """On an unbalanced cluster it still publishes CRITICAL and re-raises, but not as a capacity issue."""
+    with patch("sdcm.utils.decorators.check_cluster_layout", return_value=False):
+        with patch("sdcm.utils.decorators.TestFrameworkEvent") as event_mock:
+            with pytest.raises(InstanceConfigurationError):
+                skip_on_capacity_issues(db_cluster=MagicMock())(_raise_instance_configuration_error)()
+    assert event_mock.call_args.kwargs["severity"] == Severity.CRITICAL
+    assert "invalid instance configuration" in event_mock.call_args.kwargs["message"]
+    assert "capacity" not in event_mock.call_args.kwargs["message"]
+    event_mock.return_value.publish.assert_called_once()
+
+
+def test_critical_on_capacity_issues_reports_configuration_error_as_such():
+    """A must-succeed topology change still fails critically, with the actual cause in the message."""
+    with patch("sdcm.utils.decorators.TestFrameworkEvent") as event_mock:
+        with pytest.raises(InstanceConfigurationError):
+            critical_on_capacity_issues(_raise_instance_configuration_error)()
+    assert event_mock.call_args.kwargs["severity"] == Severity.CRITICAL
+    assert "invalid instance configuration" in event_mock.call_args.kwargs["message"]
+    assert "capacity" not in event_mock.call_args.kwargs["message"]
     event_mock.return_value.publish.assert_called_once()
 
 


### PR DESCRIPTION
When a machine type (e.g., c4-highcpu-32) does not support the configured disk type (e.g., pd-standard), GCE may return an error containing ZONE_RESOURCE_POOL_EXHAUSTED_WITH_DETAILS. This was incorrectly classified as a zone capacity issue, triggering futile retries in alternative zones and reporting a misleading ZoneResourcesExhaustedError.

Now configuration errors (disk type incompatibility) are detected and reported immediately as ProvisionError with the actual error message, without retrying.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] was tested with https://github.com/scylladb/scylla-cluster-tests/pull/14871

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
