### PR TITLE
fix(fill_db_data): stop a slow TRUNCATE from silently voiding later verification

### DIFF
--- a/sdcm/fill_db_data.py
+++ b/sdcm/fill_db_data.py
@@ -40,6 +40,18 @@ from sdcm.utils.issues import SkipPerIssues
 
 LOGGER = logging.getLogger(__name__)
 
+# Applied on both sides of a TRUNCATE: as the server-side USING TIMEOUT and as the driver's
+# per-request timeout. They have to agree - the client timing out first is what made the
+# server-side value cosmetic.
+TRUNCATE_TIMEOUT = 300
+# A truncate pass covers ~100 tables, and every failure costs a full TRUNCATE_TIMEOUT. Bound how
+# much of the test budget a cluster that cannot truncate is allowed to consume.
+MAX_TRUNCATE_FAILURES = 5
+
+
+class TruncateTablesError(Exception):
+    """Raised when truncate_tables() could not clear every table it was asked to."""
+
 
 class FillDatabaseData(ClusterTester):
     """
@@ -262,10 +274,15 @@ class FillDatabaseData(ClusterTester):
                 ],
                 [[24], [12], [128], [24], [12], [42]],
             ],
-            "invalid_queries": [
-                # Error from server: code=2200 [Invalid query] message="Missing PRIMARY KEY part url"
-                "INSERT INTO dynamic_cf_test (userid, url, time) VALUES (810e8500-e29b-41d4-a716-446655440000, '', 42)"
-            ],
+            # No invalid_queries here on purpose. This used to carry
+            #   INSERT INTO dynamic_cf_test (userid, url, time) VALUES (810e8500-..., '', 42)
+            # expecting 'Missing PRIMARY KEY part url', but an empty string is a legal clustering
+            # key value and Scylla accepts the insert. _run_invalid_queries() only logs when a
+            # query it expected to be rejected succeeds, so the row stayed in the table - and the
+            # unrestricted "SELECT time FROM dynamic_cf_test" above then returned a 7th row on any
+            # later stage whose truncate had not cleared it. A data-mutating statement does not
+            # belong in invalid_queries at all: when the expectation goes stale it does not just
+            # fail to assert, it corrupts the dataset every other stage is verified against.
             "min_version": "1.0",
             "max_version": "",
             "skip": "",
@@ -3604,12 +3621,16 @@ class FillDatabaseData(ClusterTester):
         """Check is tablets enabled on cluster"""
         return is_tablets_feature_enabled(self.db_cluster.nodes[0])
 
+    # Deliberately not retrying OperationTimedOut: the timeout is already TRUNCATE_TIMEOUT long, so
+    # a retry would cost another full timeout for something that has just shown it is not moving.
     @retrying(n=3, sleep_time=20, allowed_exceptions=ProtocolException)
     def truncate_table(self, session, truncate):
         if "using timeout" not in truncate.lower():
-            truncate = f"{truncate} USING TIMEOUT 300s"
+            truncate = f"{truncate} USING TIMEOUT {TRUNCATE_TIMEOUT}s"
         LOGGER.debug(truncate)
-        session.execute(truncate)
+        # The driver's own request timeout defaults to well under the server-side USING TIMEOUT, so
+        # without this the client gives up first and the server-side value never applies.
+        session.execute(truncate, timeout=TRUNCATE_TIMEOUT)
 
     @contextlib.contextmanager
     def _execute_and_log(self, message):
@@ -3620,12 +3641,39 @@ class FillDatabaseData(ClusterTester):
     def truncate_tables(self, session):
         # Run through the list of items and create all tables
         self.log.info("Start table truncation")
+        failed = []
+        gave_up = False
         for test_num, item in enumerate(self.all_verification_items):
+            if gave_up:
+                break
             test_name = item.get("name", "Test #" + str(test_num))
             if not item["skip"] and ("skip_condition" not in item or eval(str(item["skip_condition"]))):
                 for truncate in item["truncates"]:
-                    with self._execute_and_log(f'Truncated table for test "{test_name}" in {{}} seconds'):
-                        self.truncate_table(session, truncate)
+                    # Per-table rather than per-loop: one slow TRUNCATE used to abort the whole
+                    # pass, so every table after it kept the previous stage's rows and the next
+                    # verify_db_data() compared against stale data. Keep going and report at the
+                    # end - a skipped truncate has to be visible, not inferred from a later
+                    # assertion on some unrelated table.
+                    try:
+                        with self._execute_and_log(f'Truncated table for test "{test_name}" in {{}} seconds'):
+                            self.truncate_table(session, truncate)
+                    except Exception as ex:  # noqa: BLE001 - one table must not stop the rest
+                        LOGGER.error("Failed to truncate '%s' for test %r: %s", truncate, test_name, ex)
+                        failed.append(test_name)
+                        # Each failure costs a full TRUNCATE_TIMEOUT, so carrying on through every
+                        # remaining table on a cluster that clearly cannot truncate would burn hours
+                        # of the test's budget to learn nothing new. Stop once it is established.
+                        if len(failed) >= MAX_TRUNCATE_FAILURES:
+                            gave_up = True
+                            break
+        if failed:
+            summary = f"{len(failed)} table(s) were not truncated"
+            if gave_up:
+                summary += f" (gave up after {MAX_TRUNCATE_FAILURES}; later tables were not attempted)"
+            raise TruncateTablesError(
+                f"{summary}, so they still hold the previous stage's rows and any verification "
+                f"against them is meaningless: {', '.join(sorted(set(failed)))}"
+            )
 
     def cql_insert_data_to_tables(self, session, default_fetch_size):
         self.log.info("Start to populate data into tables")
@@ -3755,7 +3803,12 @@ class FillDatabaseData(ClusterTester):
                 session.set_keyspace(self.base_ks)
                 self.truncate_tables(session)
             except Exception as ex:  # noqa: BLE001
-                LOGGER.debug("Found error in truncate tables: '%s'", ex)
+                # Deliberately non-fatal - the first fill_db_data() of a run has nothing to truncate
+                # yet. But a truncate that silently does nothing leaves the previous stage's rows in
+                # place, and the next verify_db_data() then fails on whichever table happens to have
+                # kept a row, far from the cause. WARNING, not DEBUG, so it is in the log when that
+                # assertion is being read.
+                LOGGER.warning("Truncate before re-populating did not complete: %s", ex)
 
             # Insert data to the tables according to the "inserts" and flush to disk in several cases (nodetool flush)
             self.cql_insert_data_to_tables(session, session.default_fetch_size)

--- a/unit_tests/unit/test_fill_db_data_truncate.py
+++ b/unit_tests/unit/test_fill_db_data_truncate.py
@@ -1,0 +1,132 @@
+"""Tests for truncate_tables(): one slow TRUNCATE must not silently skip the rest.
+
+The failure this guards against is indirect. truncate_tables() used to abort on the first
+exception, so a single timeout left every later table holding the previous stage's rows;
+fill_db_data() then re-inserted on top and the next verify_db_data() failed an assertion on
+whichever table happened to keep a row - nowhere near the truncate that actually broke.
+"""
+
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+from cassandra import OperationTimedOut
+
+from sdcm.fill_db_data import (
+    FillDatabaseData,
+    TruncateTablesError,
+    MAX_TRUNCATE_FAILURES,
+    TRUNCATE_TIMEOUT,
+)
+
+
+class _Harness:
+    """Minimal stand-in for FillDatabaseData: truncate_tables() only needs these members."""
+
+    def __init__(self, items, failing=()):
+        self.all_verification_items = items
+        self.log = logging.getLogger(__name__)
+        self.failing = set(failing)
+        self.truncated = []
+        self._execute_and_log = FillDatabaseData._execute_and_log.__get__(self)
+
+    def truncate_table(self, session, truncate):
+        if truncate in self.failing:
+            raise OperationTimedOut(f"simulated client timeout for {truncate}")
+        self.truncated.append(truncate)
+
+
+def _item(name, table, skip=""):
+    return {"name": name, "truncates": [f"TRUNCATE {table}"], "skip": skip}
+
+
+def _truncate_tables(harness, session=None):
+    return FillDatabaseData.truncate_tables(harness, session or MagicMock())
+
+
+def test_all_tables_truncated_when_nothing_fails():
+    harness = _Harness([_item("a", "t_a"), _item("b", "t_b"), _item("c", "t_c")])
+
+    _truncate_tables(harness)
+
+    assert harness.truncated == ["TRUNCATE t_a", "TRUNCATE t_b", "TRUNCATE t_c"]
+
+
+def test_one_failure_does_not_skip_the_remaining_tables():
+    """The regression: a timeout on the first table used to abort the whole pass."""
+    harness = _Harness([_item("a", "t_a"), _item("b", "t_b"), _item("c", "t_c")], failing=["TRUNCATE t_a"])
+
+    with pytest.raises(TruncateTablesError):
+        _truncate_tables(harness)
+
+    # t_b and t_c must still have been truncated despite t_a failing first.
+    assert harness.truncated == ["TRUNCATE t_b", "TRUNCATE t_c"]
+
+
+def test_error_names_every_table_left_untruncated():
+    harness = _Harness(
+        [_item("alpha", "t_a"), _item("beta", "t_b"), _item("gamma", "t_c")],
+        failing=["TRUNCATE t_a", "TRUNCATE t_c"],
+    )
+
+    with pytest.raises(TruncateTablesError) as excinfo:
+        _truncate_tables(harness)
+
+    message = str(excinfo.value)
+    assert "alpha" in message and "gamma" in message
+    assert "beta" not in message
+    assert "2 table(s)" in message
+
+
+def test_skipped_items_are_not_truncated():
+    harness = _Harness([_item("a", "t_a"), _item("b", "t_b", skip="disabled for a reason")])
+
+    _truncate_tables(harness)
+
+    assert harness.truncated == ["TRUNCATE t_a"]
+
+
+def test_gives_up_after_the_failure_cap_instead_of_burning_the_budget():
+    """Every failure costs a full TRUNCATE_TIMEOUT, so a hopeless cluster must not run ~100 of them."""
+    items = [_item(f"t{i}", f"t_{i}") for i in range(MAX_TRUNCATE_FAILURES + 5)]
+    harness = _Harness(items, failing=[f"TRUNCATE t_{i}" for i in range(len(items))])
+
+    with pytest.raises(TruncateTablesError) as excinfo:
+        _truncate_tables(harness)
+
+    assert "gave up" in str(excinfo.value)
+    assert f"{MAX_TRUNCATE_FAILURES} table(s)" in str(excinfo.value)
+
+
+def test_no_early_exit_while_under_the_failure_cap():
+    items = [_item(f"t{i}", f"t_{i}") for i in range(MAX_TRUNCATE_FAILURES + 3)]
+    # One fewer failure than the cap, so every remaining table still gets attempted.
+    failing = [f"TRUNCATE t_{i}" for i in range(MAX_TRUNCATE_FAILURES - 1)]
+    harness = _Harness(items, failing=failing)
+
+    with pytest.raises(TruncateTablesError) as excinfo:
+        _truncate_tables(harness)
+
+    assert "gave up" not in str(excinfo.value)
+    assert len(harness.truncated) == len(items) - len(failing)
+
+
+def test_truncate_table_applies_the_timeout_on_both_sides():
+    """A server-side USING TIMEOUT is cosmetic if the driver gives up first."""
+    session = MagicMock()
+    harness = MagicMock()
+
+    FillDatabaseData.truncate_table(harness, session, "TRUNCATE t_a")
+
+    query, kwargs = session.execute.call_args[0][0], session.execute.call_args[1]
+    assert query == f"TRUNCATE t_a USING TIMEOUT {TRUNCATE_TIMEOUT}s"
+    assert kwargs["timeout"] == TRUNCATE_TIMEOUT
+
+
+def test_truncate_table_keeps_an_explicit_using_timeout():
+    session = MagicMock()
+    harness = MagicMock()
+
+    FillDatabaseData.truncate_table(harness, session, "TRUNCATE t_a USING TIMEOUT 30s")
+
+    assert session.execute.call_args[0][0] == "TRUNCATE t_a USING TIMEOUT 30s"


### PR DESCRIPTION
A rolling upgrade failed on an assertion that had nothing to do with the code under test:

```
upgrade_test.py:662: in fill_and_verify_db_data -> verify_db_data -> run_db_queries
E AssertionError: Lists differ:
E   [[24], [12], [128], [24], [12], [42], [42]] != [[24], [12], [128], [24], [12], [42]]
```

An extra row from `SELECT time FROM dynamic_cf_test`, in a mixed-version cluster, 11 seconds after a node rollback. That reads like a Scylla correctness bug. It is not one — it is two independent SCT bugs compounding.

## 1. A stale `invalid_queries` entry plants a row

`dynamic_cf_test` carried:

```sql
INSERT INTO dynamic_cf_test (userid, url, time) VALUES (810e8500-..., '', 42)
-- expecting: [Invalid query] message="Missing PRIMARY KEY part url"
```

An empty string is a legal clustering key value, so Scylla accepts the insert and a 7th row appears with `time = 42`. `_run_invalid_queries()` only logs when a query it expected to be rejected succeeds (`query '...' is valid`, at ERROR) — the `self.fail(...)` beside it is commented out — so the row stays.

Corroboration from the failing run: queries `[0]` and `[1]` on that item are partition-restricted and both passed; only the unrestricted scan saw the extra row, exactly as a stray row in a third partition (`810e8500`) would look.

The entry is removed. A data-mutating statement does not belong in `invalid_queries` at all: once the expectation goes stale it does not merely fail to assert, it corrupts the dataset every other stage is verified against.

## 2. The truncate that normally cleans it up had stopped working

`fill_and_verify_db_data` verifies, then calls `fill_db_data()`, which truncates every table before re-inserting. That cleanup is what hid the stray row on the two earlier passes. On the third:

```
DEBUG > Found error in truncate tables: 'errors={'10.128.0.10:9042':
  'Client request timeout...'} (timeout=60.0s
```

Four things made that maximally damaging:

- `truncate_table()` appends `USING TIMEOUT 300s`, but the driver's request timeout is 60 s — **the client always gave up first, so the server-side value never applied.**
- `@retrying(n=3, allowed_exceptions=ProtocolException)` does not cover `OperationTimedOut`, so no retry.
- `truncate_tables()` was a bare loop with no per-item handling, so the first failure aborted the pass — **3 of 106 tables truncated**, the other 103 keeping the previous stage's rows.
- `fill_db_data()` swallowed it at **DEBUG** and re-inserted into un-truncated tables.

So the assertion was reading data ~8 minutes stale, on a table nobody had touched.

Changes:

- one `TRUNCATE_TIMEOUT` applied on both sides, so the server-side value is real
- per-table error handling: the pass keeps going and raises `TruncateTablesError` naming every table left untruncated
- `WARNING` rather than `DEBUG` where `fill_db_data()` tolerates a failed truncate

Continuing has a cost of its own — each failure burns a full `TRUNCATE_TIMEOUT`, and running that over ~100 tables would spend hours to learn nothing — so the pass gives up after `MAX_TRUNCATE_FAILURES` and says so in the error. `OperationTimedOut` is deliberately **not** added to the retry list for the same reason: the request already waited the full timeout.

## Testing

`unit_tests/unit/test_fill_db_data_truncate.py` — 8 tests covering continue-on-failure, the failure cap in both directions, skip handling, and the timeout applied on both sides.

End-to-end on `upgrade_test.UpgradeTest.test_rolling_upgrade` (minicloud/GCE, 3 nodes, 2026.1 → master): full pass, all 10 steps in ~62 min, no ERROR or CRITICAL events. All 5 `fill_and_verify_db_data` passes clean — including *"after rollback the second node"*, the one that produced the assertion above — with `dynamic_cf_test` verified 5 times and zero `is valid` surprises anywhere.

Being precise about what that run did and did not prove: it exercised the `invalid_queries` fix, but **not** the truncate-failure handling. All 582 truncates completed in under a second and there were no server-side `Timeout during TRUNCATE TABLE` warnings, so the continue-on-failure and give-up paths are covered by unit tests only. Whether the 60 s → 300 s alignment removes the timeouts seen on slower clusters is still open, and is tracked in SCT-817 along with the question of whether TRUNCATE genuinely needs >300 s there.

Refs SCT-817.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
