### PR TITLE
improvement(perf-weekly-status-report): add uninvestigated failures table, argus events, re-run detection, build type selection

### DIFF
--- a/skills/perf-weekly-status-report/SKILL.md
+++ b/skills/perf-weekly-status-report/SKILL.md
@@ -13,13 +13,32 @@ description: >-
 
 Generate Gmail-compatible HTML reports summarizing ScyllaDB Enterprise performance test results from the past week using the Argus CLI.
 
+## First Step: Ask the User Which Build Type to Report
+
+**Before collecting any data, ask the user which build type to report on.**
+
+Use the interactive question tool to present two options:
+1. **Master (~dev)** -- Filter to dev versions matching `^\d{4}\.\d+\.\d+.+dev$`. These are builds from the master/development branch.
+2. **Release** -- Filter to release versions matching `^\d{4}\.\d+\.\d+$` (no `dev` suffix). These are builds from stable release branches.
+
+The chosen build type determines:
+- The version filter regex applied in Phase 2
+- The header subtitle text ("Master (~dev) builds only" vs "Release builds only")
+- The output filename (`perf-weekly-status-report.html` vs `perf-weekly-status-report-release.html`)
+
+If the user has already specified the build type in their prompt (e.g., "generate report for release versions"), skip the question and proceed with that choice.
+
 ## Essential Principles
 
-### Master (~dev) Builds Only
+### Version Filtering by Build Type
 
-**Filter to dev versions matching `^\d{4}\.\d+\.\d+.+dev$` -- exclude release builds.**
+**Master mode:** Filter to dev versions matching `^\d{4}\.\d+\.\d+.+dev$` -- exclude release builds.
 
-Release builds (`2026.1.5`) run on stable branches and represent prior releases. The weekly report must only include master/dev versions (e.g., `2026.3.0~dev`) because these represent the latest development state being validated. Mixing release and dev data would produce misleading conclusions about the current master branch performance.
+Release builds (`2026.1.5`) run on stable branches and represent prior releases. The master report only includes master/dev versions (e.g., `2026.3.0~dev`) because these represent the latest development state being validated.
+
+**Release mode:** Filter to release versions matching `^\d{4}\.\d+\.\d+$` -- exclude dev builds.
+
+Dev builds run on the master branch and represent unreleased code. The release report only includes release versions (e.g., `2026.2.3`, `2026.1.10`) because these represent validated stable releases. Note that release reports often span multiple versions (e.g., `2026.2.3` and `2026.1.10` in the same week).
 
 ### Use Argus CLI Directly
 
@@ -51,20 +70,29 @@ Gmail only supports inline CSS styles on elements. Never use `<style>` tags, `<l
 
 ### Overview Table: Group by Workload
 
-**The overview table shows each workload as its own row. Columns: Category | Test | Workload | Status | Link.**
+**The overview table shows each workload as its own row. Columns: Category | Test | Workload | Status | Issues | Link.**
 
 - Category column shows the category name only on the first row of that category group (empty on subsequent rows)
 - Test column shows the test name only on the first workload row for that test (empty on subsequent rows)
 - Workload column shows the actual workload name (mixed, read, write, read_disk_only). **For microbenchmarks use "-"** since they don't have separate workloads
-- Status column shows just the status badge (PASSED/FAILED/ERROR) of the latest run -- no counts
+- Status column shows just the status badge (PASSED/FAILED/ERROR/RUNNING) of the latest run -- no counts
+- Issues column shows linked Jira issue keys as clickable links (comma-separated if multiple); empty for runs with no linked issues
 - Link column shows an Argus link to the specific run for that workload
 - Each run covers a single workload, so each workload has its own run(s)
+
+**Per-version tables:** When the report spans multiple versions, create a separate Overview table for each version with a version label above it (e.g., "Version 2026.2.3"). When only a single version is present, show one table without a version label.
 
 **Microbenchmark handling**: Microbenchmarks don't report results in the same table structure as performance tests. When a microbenchmark run has no workload-specific tables, use "-" as the workload value. Each microbenchmark test appears as a single row in the overview with workload="-".
 
 **Runs column format:** Removed. Status column shows just the badge.
 
-**Status column format:** Show just the status badge (PASSED/FAILED/ERROR) of the latest run for that workload. No counts.
+**Status column format:** Show just the status badge (PASSED/FAILED/ERROR/RUNNING) of the latest run for that workload. No counts.
+
+### Running Tests
+
+**Include runs with status `running` in the report if they match the version filter.**
+
+Running tests should appear in the Overview table with a RUNNING status badge (blue, `#17a2b8`). They are counted separately in the Summary (not as passed or failed). Determine the workload from partial results (`argus run results`) if available, or from Jenkins `sub_tests` positional mapping. Do not include running tests in Detailed Results or Uninvestigated Failures.
 
 ### Runs With No Results: Recover the Workload From Jenkins
 
@@ -82,13 +110,49 @@ Recover the workload from the Jenkins build that produced the run:
 
 Map sub-test names to workload labels: `test_read_gradual_increase_load` -> `read`, `test_write_gradual_increase_load` -> `write`, `test_mixed_gradual_increase_load` -> `mixed`, `test_read_disk_only_gradual_increase_load` -> `read_disk_only`, `test_latency_mixed_with_nemesis` -> `mixed`.
 
-Also determine *why* the run produced nothing, and say so in the Conclusion -- a provisioning abort is not a performance result. Grep the Jenkins console for the cause; the common one is AWS capacity:
+Also determine *why* the run produced nothing using `argus run events`:
+
+```bash
+argus run events --run-id <RUN_UUID> --url https://argus.scylladb.com
+```
+
+This returns CRITICAL and ERROR events for the run. The common cause is AWS capacity:
 
 ```
-sdcm.exceptions.CapacityReservationError: Failed to create capacity reservation in any availability zone.
+(TestFrameworkEvent Severity.CRITICAL) Failed to provision aws resources: CapacityReservationError: Failed to create capacity reservation in any availability zone.
 ```
 
-State the real reason (e.g. `InsufficientInstanceCapacity` for a given instance type and region) rather than reporting a bare `ERROR`. Do **not** list these runs as rows in the Failed Results table -- they have no metrics to show; the Conclusion carries them.
+State the real reason (e.g. `CapacityReservationError`) rather than reporting a bare `ERROR`.
+
+### CapacityReservationError Runs: Detect Re-runs and Exclude
+
+**If a `test_error` run caused by CapacityReservationError was successfully re-run, exclude it from the report entirely.**
+
+To detect re-runs:
+1. Group runs by test name + version.
+2. Within each group, sort by `build_number`.
+3. If a later build exists for the same test + version, and it has runs with matching workloads that passed, the earlier CapacityReservationError run was re-run successfully.
+4. Exclude the original CapacityReservationError run from all report sections (overview, detailed results, counts).
+5. If the re-run also failed with CapacityReservationError, exclude the intermediate attempts and keep only the latest one. Note this in the Uninvestigated Failures table cause column (e.g., "CapacityReservationError, re-run also failed (builds #57,#59,#61)").
+
+Note: There is no explicit "re-run of build #X" field in Argus. The link is inferred by matching test + version + sequential build numbers.
+
+**CapacityReservationError runs that were NOT re-run** (or whose re-run also failed) should appear in the **Uninvestigated Failures** table with the cause noted as "CapacityReservationError, not re-run". Do **not** list them in the Failed Results table -- they have no metrics to show.
+
+### Uninvestigated Failures Table
+
+**Show a table of all failed/test_error runs that have no linked Argus issue, placed between the Conclusion and Issues sections.**
+
+This table helps the user quickly identify runs that need investigation. Columns: Test | Workload | Version | Status | Cause | Link.
+
+- **Include**: Any run with status `failed` or `test_error` where `argus issue list` returns `[]`
+- **Exclude**: CapacityReservationError runs that were successfully re-run (same test + version, later build passed)
+- **Cause column**: Show the specific failure reason:
+  - For `test_error` runs: the error from `argus run events` (e.g. "CapacityReservationError, not re-run")
+  - For `failed` runs with failed tables: the specific metric failure (e.g. "P99 ERROR at 750K step")
+  - For `failed` runs where all tables pass: "All tables PASS, run marked failed"
+- The table heading is "Uninvestigated Failures (no issue linked)"
+- Print this table to the user during the conclusion review step so they can investigate before finalizing the report
 
 ### Version Display
 
@@ -131,7 +195,7 @@ Note: A run may have status `"failed"` but its individual tables may show `ERROR
 **The entire "Detailed Results" section is ONLY shown when there are actual failures (run status `failed` or `test_error`).** When all tests pass, the Detailed Results section is completely omitted from the report.
 
 When failures exist, the section includes:
-- **Failed Results table**: Lists individual failed/error steps with workload, step name, P99, throughput, version, and Argus link
+- **Failed Results table**: Lists individual failed/error steps with workload, step name, P99, throughput, version, and Argus link. Only tests that have actual failed result tables (status `FAIL` or `ERROR`) are shown. Tests where the run is marked `failed` but all result tables show `PASS`, or `test_error` runs with no result tables, are excluded from Detailed Results -- they belong in the Uninvestigated Failures table instead.
 - **Max Throughput table** (only for `predefined-throughput-steps` tests where the **unthrottled step itself** has status `FAIL` or `ERROR`): Shows per-workload max throughput from the latest run. If the unthrottled steps all pass (status `PASS`), the Max Throughput table is **omitted** even if other throttled steps failed -- the throughput is as expected.
 
 This means:
@@ -199,6 +263,7 @@ Do not treat a mostly-empty result as a collection failure, and do not list test
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
+| Build type | (ask user) | Master (~dev) or Release. Controls version filter regex. If not specified, ask the user before collecting data. |
 | Time window (days) | 7 | Number of days to look back for runs. Controls `--after` timestamp in `argus run list`. User can specify a different period (e.g., "last 14 days", "last 30 days"). |
 
 Example user prompts with time window:
@@ -244,6 +309,20 @@ Returns JSON array of result tables. Each table has:
   - `"P99 <op>"` -- 99th percentile latency in ms
   - `"Throughput <op>"` -- Actual throughput in op/s
 
+### Fetch events (errors) for a run
+
+```bash
+argus run events \
+  --run-id <RUN_UUID> \
+  --url https://argus.scylladb.com
+```
+
+Returns JSON array of CRITICAL and ERROR event objects. Key fields:
+- `severity` -- "CRITICAL" or "ERROR"
+- `message` -- Event message text (contains the error description)
+
+Use this to determine why a `test_error` run failed (e.g., CapacityReservationError). This is more reliable than fetching Jenkins console output, which often requires authentication.
+
 ### Fetch issues for a run
 
 ```bash
@@ -276,12 +355,13 @@ Use `status` / `resolution` for the State column, and to support any "no progres
 The output HTML file must contain:
 
 1. **Header** -- Report title, date range, "Master (~dev) builds only" indicator
-2. **Summary** -- Title format: "Summary for Scylla version {full_version}" where full_version includes build date and revision hash (e.g., "2026.3.0.dev.20260612.91ada5517d59"). Body: Total tests run, passed count, failed count, error count. **Counts are per run, not per test group.** Each workload is a separate run, so a test with 4 workloads (mixed, read, write, read_disk_only) counts as 4 runs. Microbenchmark tests count as 1 run each. This ensures that Total = Passed + Failed/Error always holds.
-3. **Conclusion** -- Hierarchical bullet-point lines summarizing weekly results. Structure: top-level items are test names in bold (prefixed with `- `), sub-items are specific observations (prefixed with `&#8226;`). The agent MUST print the generated conclusion text to the user and ask for confirmation or edits BEFORE saving it into the final HTML report file. This ensures the user can review and adjust the conclusion wording.
-4. **New Issues - Regression** -- Shown after Conclusion when new issues exist. Lists Jira issues whose tickets were created during the report period (i.e., newly filed regressions). Classify by fetching each issue's `created` date from Jira (Atlassian MCP `getJiraIssue`) and comparing it to the report window; only ask the user if Jira is unreachable. If no new issues, this section is omitted.
-5. **Reproduced Issues** -- Always shown after New Issues (or after Conclusion if no new issues). Lists issues linked to runs whose Jira tickets were created before the report period. If no reproduced issues, displays "No reproduced issues in this period."
-6. **Overview Table** -- Grouped by category, then test, then workload. Columns: Category | Test | Workload | Status | Link. Microbenchmarks use "-" as workload.
-7. **Detailed Results** -- **ONLY shown when there are actual failures.** When all tests pass, this section is completely omitted. When failures exist, shows per-category breakdown of failed steps with P99/throughput, and optionally a Max Throughput table for failed predefined-throughput-steps tests where the unthrottled step itself has FAIL/ERROR status.
+2. **Summary** -- Title format: "Summary for Scylla version {full_version}" where full_version includes build date and revision hash (e.g., "2026.3.0.dev.20260612.91ada5517d59"). Body: Total tests run, passed count, failed count, error count, running count. **Counts are per run, not per test group.** Each workload is a separate run, so a test with 4 workloads (mixed, read, write, read_disk_only) counts as 4 runs. Microbenchmark tests count as 1 run each. Running tests are counted separately and not included in passed/failed totals.
+3. **Conclusion** -- Hierarchical bullet-point lines summarizing weekly results. Structure: top-level items are test names in bold (prefixed with `- `), sub-items are specific observations (prefixed with `&#8226;`). Version numbers must be bold. Do NOT mention CapacityReservationError runs (those are in the Uninvestigated Failures table). Do NOT mention issue numbers per test in the conclusion body -- issue references belong only in the warning banner; the Issues column in Overview and the Known Issues table provide the per-run linkage. **Per-version grouping:** When the report spans multiple versions, create a separate list per version with a bold version header (e.g., "Version 2026.2.3:"). When only a single version is present, omit the version header and list tests directly. **Warning banner** (optional): After collecting all issues, present the de-duplicated list to the user and ask which issues (if any) should be highlighted in a warning banner at the top of the Conclusion. If the user selects issues, render a yellow/red banner with `&#9888;` icon stating "No updates on [issues] during last week." **Issue numbers in the banner must be clickable links** (e.g., `<a href="...">SCYLLADB-3459</a>`), not plain text. If the user selects none, omit the banner entirely. The agent MUST print the generated conclusion text to the user and ask for confirmation or edits BEFORE saving it into the final HTML report file. This ensures the user can review and adjust the conclusion wording.
+4. **Uninvestigated Failures** -- Table of failed/test_error runs with no linked Argus issue. Shown after Conclusion when such runs exist. Columns: Test | Workload | Version | Status | Cause | Link. Excludes CapacityReservationError runs that were successfully re-run. Printed to the user during conclusion review for investigation before finalizing.
+5. **New Issues - Regression** -- Shown after Uninvestigated Failures when new issues exist. Lists Jira issues whose tickets were created during the report period (i.e., newly filed regressions). Classify by fetching each issue's `created` date from Jira (Atlassian MCP `getJiraIssue`) and comparing it to the report window; only ask the user if Jira is unreachable. If no new issues, this section is omitted.
+6. **Reproduced Issues** -- Always shown after New Issues (or after Uninvestigated Failures if no new issues). Lists issues linked to runs whose Jira tickets were created before the report period. If no reproduced issues, displays "No reproduced issues in this period."
+7. **Overview Table** -- Grouped by category, then test, then workload. Columns: Category | Test | Workload | Status | Issues | Link. Issues column shows linked Jira keys as clickable links. Microbenchmarks use "-" as workload. **When multiple versions exist, create a separate table per version with a version label above it; when single version, show one table without a version label.**
+8. **Detailed Results** -- **ONLY shown when there are actual failures.** When all tests pass, this section is completely omitted. When failures exist, shows per-category breakdown of failed steps with P99/throughput, and optionally a Max Throughput table for failed predefined-throughput-steps tests where the unthrottled step itself has FAIL/ERROR status. **When multiple versions exist, group detailed results by version with version sub-headings; when single version, omit the version sub-heading.**
    - **Microbenchmarks**: Shown only when they have failures.
 
 ## Reference Index
@@ -296,7 +376,8 @@ The output HTML file must contain:
 
 A valid weekly status report:
 
-- [ ] Filters exclusively to master (~dev) versions (no release builds included)
+- [ ] User asked to choose build type (master or release) before data collection, unless already specified in prompt
+- [ ] Filters exclusively to the chosen build type (master ~dev or release -- no mixing)
 - [ ] Shows only tests that were actually run (no "NO_RUNS" entries)
 - [ ] Uses table-based layout with inline CSS only (no style blocks, no div layout, no border-radius)
 - [ ] Uses bgcolor attribute alongside background-color for Gmail compatibility
@@ -304,8 +385,12 @@ A valid weekly status report:
 - [ ] Summary title format: "Summary for Scylla version {full_version}" with build date and revision hash
 - [ ] Overview table: grouped by category/test/workload with Argus links in Link column
 - [ ] Overview table: microbenchmarks appear with "-" as workload
-- [ ] Overview Status column: just the status badge (PASSED/FAILED/ERROR) -- no counts
-- [ ] Overview columns: Category | Test | Workload | Status | Link (no Runs column, no Version column)
+- [ ] Overview Status column: just the status badge (PASSED/FAILED/ERROR/RUNNING) -- no counts
+- [ ] Running tests included in Overview with RUNNING badge (blue #17a2b8) when they match version filter
+- [ ] Overview columns: Category | Test | Workload | Status | Issues | Link (no Runs column, no Version column)
+- [ ] Overview Issues column: linked Jira keys as clickable links, comma-separated; empty for runs with no issues
+- [ ] Overview and Detailed Results: separate table per version with version header when multiple versions; no version header when single version
+- [ ] Conclusion grouped by version when multiple versions present; single list when only one version
 - [ ] Detailed results: ONLY shown when there are actual failures (completely omitted when all pass)
 - [ ] Detailed results: test sub-heading has full version, NO status badge
 - [ ] Detailed results: Failed Results table lists all failed steps with metrics
@@ -319,12 +404,24 @@ A valid weekly status report:
 - [ ] Output file is NOT saved into the SCT repository (scratchpad/temp dir or home dir)
 - [ ] Conclusion text is printed to the user for review/editing BEFORE being saved into the HTML report
 - [ ] Conclusion uses hierarchical format: bold test names as top-level items, specific observations as sub-bullets
+- [ ] Conclusion version numbers are bold (e.g., `<b>2026.2.3</b>`)
+- [ ] Conclusion does not mention CapacityReservationError runs (those are in the Uninvestigated Failures table)
+- [ ] Conclusion warning banner: user asked to select which issues to highlight from the found issues list; omitted if user selects none or no issues found
+- [ ] Conclusion warning banner: issue numbers rendered as clickable links, not plain text
+- [ ] CapacityReservationError re-runs that also failed: intermediate attempts excluded, only latest kept in Uninvestigated table with cause noting all build numbers
 - [ ] Issues are split into "New Issues - Regression" (created during period) and "Reproduced Issues" (pre-existing)
 - [ ] Issue classification comes from Jira `created` dates; the user is asked only for unlinked failures or if Jira is unreachable
 - [ ] `argus` resolved from PATH, not a hardcoded home directory; login handled by a pre-flight call
 - [ ] Every master run in the window is accounted for, including `test_error` runs with zero result tables
 - [ ] Workload for runs with no result tables recovered from the Jenkins `sub_tests` order and validated against runs that do have tables
 - [ ] Runs that produced nothing state the actual cause (e.g. `CapacityReservationError`) rather than a bare ERROR
+- [ ] Test error causes determined via `argus run events`, not Jenkins console
+- [ ] CapacityReservationError runs that were successfully re-run are excluded from the report entirely
+- [ ] Re-runs detected by matching same test + version with a later build number that passed
+- [ ] Uninvestigated Failures table shown for failed/test_error runs with no linked Argus issue
+- [ ] Uninvestigated Failures table includes Cause column with specific failure reason
+- [ ] Uninvestigated Failures table excludes CapacityReservationError runs that were successfully re-run
+- [ ] Uninvestigated Failures table printed to user during conclusion review for investigation
 - [ ] Categories with no master runs are named in the Conclusion, so "passed" is distinguishable from "never ran"
 - [ ] Summary version chosen by run count when the period spans multiple builds; per-run versions shown in Detailed Results
 - [ ] Data tables use `border="1"` plus per-cell borders (CSS-only cell borders get stripped)

--- a/skills/perf-weekly-status-report/references/argus-data-format.md
+++ b/skills/perf-weekly-status-report/references/argus-data-format.md
@@ -162,6 +162,49 @@ Microbenchmark tests have a different cell structure:
 | `tps` | float | Transactions per second |
 | `mad tps` | float | Median absolute deviation of TPS |
 
+## `argus run events` Output
+
+Returns CRITICAL and ERROR events for an SCT test run:
+
+```bash
+argus run events \
+  --run-id <RUN_UUID> \
+  --url https://argus.scylladb.com
+```
+
+```json
+[
+  {
+    "severity": "CRITICAL",
+    "message": "(TestFrameworkEvent Severity.CRITICAL) Failed to provision aws resources: CapacityReservationError: Failed to create capacity reservation in any availability zone.",
+        "ts": "2026-08-05T10:16:06.223Z"
+  }
+]
+```
+
+### Event Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `severity` | string | Event severity: "CRITICAL" or "ERROR" |
+| `message` | string | Full event message text |
+| `ts` | string | ISO-8601 timestamp of when the event occurred |
+
+### Common Error Patterns
+
+| Pattern in `message` | Meaning |
+|----------------------|---------|
+| `CapacityReservationError: Failed to create capacity reservation` | AWS instance capacity unavailable |
+| `InsufficientInstanceCapacity` | AWS cannot fulfill the instance request |
+| `Unable to provision` | General provisioning failure |
+
+### Usage Notes
+
+- Use `argus run events` instead of fetching Jenkins console output, which often requires authentication (403)
+- For `test_error` runs with empty results, events reveal why the run failed
+- The common pattern is `CapacityReservationError` -- check if the run was re-run by looking for a later build with the same test + version that passed
+- Time filtering is available with `--before` and `--after` flags but usually not needed for individual run queries
+
 ## `argus issue list` Output
 
 Returns array of issue objects linked to a run, test, or other entity:

--- a/skills/perf-weekly-status-report/references/html-template.md
+++ b/skills/perf-weekly-status-report/references/html-template.md
@@ -57,6 +57,10 @@ Only inline `style` attributes on supported elements survive. Use `<table>` for 
 </tr>
 ```
 
+Note: The subtitle text varies by build type:
+- Master mode: `Master (~dev) builds only`
+- Release mode: `Release builds only`
+
 ## Spacer Row
 
 Gmail ignores margin/padding between table rows. Use explicit spacer rows:
@@ -67,13 +71,13 @@ Gmail ignores margin/padding between table rows. Use explicit spacer rows:
 
 ## Summary Box
 
-Counts are **per run** (each workload = 1 run), not per test group. A test with 4 workloads counts as 4 runs. This ensures Total = Passed + Failed/Error always holds. Example: 1 throughput test (4 workloads) + 4 microbenchmarks = 8 total runs.
+Counts are **per run** (each workload = 1 run), not per test group. A test with 4 workloads counts as 4 runs. This ensures Total = Passed + Failed/Error + Running always holds. Example: 1 throughput test (4 workloads) + 4 microbenchmarks = 8 total runs.
 
 ```html
 <tr>
 <td bgcolor="#f8f9fa" style="background-color:#f8f9fa;border:1px solid #dee2e6;padding:15px;">
   <table width="100%" cellpadding="0" cellspacing="0" border="0" style="font-family:Arial,Helvetica,sans-serif;font-size:13px;color:#333333;">
-  <tr><td colspan="4" style="font-size:16px;font-weight:bold;padding-bottom:10px;">Summary</td></tr>
+  <tr><td colspan="4" style="font-size:16px;font-weight:bold;padding-bottom:10px;">Summary for Scylla versions <b>{version_1}</b> / <b>{version_2}</b></td></tr>
   <tr>
     <td style="padding:3px 15px 3px 0;"><strong>Total Tests:</strong></td>
     <td style="padding:3px 15px 3px 0;">{total_runs}</td>
@@ -92,10 +96,26 @@ Counts are **per run** (each workload = 1 run), not per test group. A test with 
 
 ## Conclusion Box (hierarchical bullet points)
 
-The Conclusion section uses a white-background box with a heading table and a content table.
-Structure: heading in one table, hierarchical bullets in a separate table (both inside the same `<td>`).
+The Conclusion section uses a white-background box with a heading table, an optional warning banner, and a content table (all inside the same `<td>`).
+
+Structure: heading in one table, optional warning banner in a separate table, hierarchical bullets in another table.
 
 The number of top-level items and sub-bullets varies per report -- include one row per test/category that had runs, and one sub-bullet per notable observation.
+
+### Warning Banner (optional)
+
+When the user selects issues to highlight (from the interactive Step 2 prompt), render a warning banner between the heading and the bullet points. If the user selects no issues, or there are no issues found, omit the banner entirely.
+
+```html
+<table width="100%" cellpadding="0" cellspacing="0" border="0" style="margin-bottom:10px;"><tr>
+<td bgcolor="#fff3cd" style="background-color:#fff3cd;border:2px solid #dc3545;padding:8px 12px;font-family:Arial,Helvetica,sans-serif;font-size:13px;color:#dc3545;font-weight:bold;">
+&#9888; {user_provided_message}
+</td></tr></table>
+```
+
+Key styling: yellow background (`#fff3cd`), red border (`2px solid #dc3545`), red bold text (`color:#dc3545`), warning icon (`&#9888;`). Uses `bgcolor` for Gmail fallback.
+
+### Full Conclusion Structure
 
 ```html
 <tr><td height="15" style="font-size:1px;line-height:1px;">&nbsp;</td></tr>
@@ -104,7 +124,12 @@ The number of top-level items and sub-bullets varies per report -- include one r
 <table width="100%" cellpadding="0" cellspacing="0" border="0" style="font-family:Arial,Helvetica,sans-serif;font-size:13px;color:#333333;">
 <tr><td style="font-size:16px;font-weight:bold;padding-bottom:10px;">Conclusion</td></tr>
 </table>
+<!-- optional warning banner here (see above) -->
 <table width="100%" cellpadding="0" cellspacing="0" border="0" style="font-family:Arial,Helvetica,sans-serif;font-size:12px;color:#555555;">
+<!-- Per-version header (when multiple versions; omit when single version) -->
+<tr><td style="padding:6px 0 2px 0;font-size:13px;font-weight:bold;color:#333333;">Version {version}:</td></tr>
+<!-- Subsequent version headers use extra top padding for visual separation -->
+<tr><td style="padding:10px 0 2px 0;font-size:13px;font-weight:bold;color:#333333;">Version {version}:</td></tr>
 <!-- Repeat this block for each test/category with runs -->
 <tr><td style="padding:2px 0 2px 15px;">- <b>{test_or_category_name}:</b></td></tr>
 <!-- Repeat this row for each observation under that test/category -->
@@ -117,9 +142,11 @@ The number of top-level items and sub-bullets varies per report -- include one r
 ```
 
 Key details:
+- Version header (first): `padding:6px 0 2px 0;font-size:13px;font-weight:bold;color:#333333;`
+- Version header (subsequent): `padding:10px 0 2px 0;` for extra visual separation
 - Top-level: `padding:2px 0 2px 15px;` with `- <b>test/category name:</b>` format
 - Sub-level: `padding:2px 0 2px 30px;` with `&#8226; observation.` format
-- The heading table and content table are siblings inside the same `<td>` container
+- The heading table, optional warning banner, and content table are siblings inside the same `<td>` container
 - The outer `<td>` has `bgcolor="#ffffff"` and `border:1px solid #dee2e6;padding:15px;`
 
 ## Section Headings (as table cells, not h-tags)
@@ -135,9 +162,14 @@ Key details:
 <tr><td style="font-family:Arial,Helvetica,sans-serif;font-size:15px;font-weight:bold;color:#333333;padding:15px 0 5px 0;border-bottom:2px solid #007bff;">{category_name}</td></tr>
 </table>
 
-<!-- Sub-heading (test name with full version, NO status badge) -->
+<!-- Version sub-heading (dark blue, used in both overview and detailed results) -->
 <table width="100%" cellpadding="0" cellspacing="0" border="0">
-<tr><td style="font-family:Arial,Helvetica,sans-serif;font-size:13px;font-weight:bold;color:#333333;padding:10px 0 5px 0;">{test_name} ({full_version})</td></tr>
+<tr><td style="font-family:Arial,Helvetica,sans-serif;font-size:14px;font-weight:bold;color:#1a237e;padding:10px 0 5px 0;">Version {version}</td></tr>
+</table>
+
+<!-- Sub-heading (test name, NO status badge) -->
+<table width="100%" cellpadding="0" cellspacing="0" border="0">
+<tr><td style="font-family:Arial,Helvetica,sans-serif;font-size:13px;font-weight:bold;color:#333333;padding:10px 0 5px 0;">{test_name}</td></tr>
 </table>
 ```
 
@@ -155,8 +187,9 @@ above requires.
   <td bgcolor="#28a745" align="center" style="background-color:#28a745;padding:3px 10px;font-size:11px;font-weight:bold;color:#ffffff;font-family:Arial,Helvetica,sans-serif;">PASSED</td>
 </tr></table>
 
-<!-- Failed: bgcolor="#dc3545" / background-color:#dc3545 -->
-<!-- Error:  bgcolor="#fd7e14" / background-color:#fd7e14 -->
+<!-- Failed:  bgcolor="#dc3545" / background-color:#dc3545 -->
+<!-- Error:   bgcolor="#fd7e14" / background-color:#fd7e14 -->
+<!-- Running: bgcolor="#17a2b8" / background-color:#17a2b8 -->
 <!-- No Runs: bgcolor="#6c757d" / background-color:#6c757d -->
 ```
 
@@ -165,7 +198,7 @@ it renders in most clients but has no fallback when the background is stripped.
 
 ## Data Tables
 
-### Overview Table (dark header, grouped by category/test/workload, with Link column)
+### Overview Table (dark header, grouped by category/test/workload, with Issues and Link columns)
 
 Number of rows varies: one row per workload per test that had runs. Categories and tests with no runs are omitted.
 
@@ -176,6 +209,7 @@ Number of rows varies: one row per workload per test that had runs. Categories a
   <th style="border:1px solid #dee2e6;padding:6px 10px;text-align:left;color:#ffffff;font-weight:bold;">Test</th>
   <th style="border:1px solid #dee2e6;padding:6px 10px;text-align:center;color:#ffffff;font-weight:bold;">Workload</th>
   <th style="border:1px solid #dee2e6;padding:6px 10px;text-align:center;color:#ffffff;font-weight:bold;">Status</th>
+  <th style="border:1px solid #dee2e6;padding:6px 10px;text-align:center;color:#ffffff;font-weight:bold;">Issues</th>
   <th style="border:1px solid #dee2e6;padding:6px 10px;text-align:center;color:#ffffff;font-weight:bold;">Link</th>
 </tr>
 <!-- First row of a category group: category name shown, test name shown -->
@@ -184,6 +218,7 @@ Number of rows varies: one row per workload per test that had runs. Categories a
   <td style="border:1px solid #dee2e6;padding:4px 8px;font-family:Arial,Helvetica,sans-serif;font-size:12px;">{test_name}</td>
   <td style="border:1px solid #dee2e6;padding:4px 8px;text-align:center;font-family:Arial,Helvetica,sans-serif;font-size:12px;">{workload}</td>
   <td style="border:1px solid #dee2e6;padding:4px 8px;text-align:center;font-family:Arial,Helvetica,sans-serif;font-size:12px;"><!-- status badge --></td>
+  <td style="border:1px solid #dee2e6;padding:4px 8px;text-align:center;font-family:Arial,Helvetica,sans-serif;font-size:12px;"><!-- issue keys or empty --></td>
   <td style="border:1px solid #dee2e6;padding:4px 8px;text-align:center;font-family:Arial,Helvetica,sans-serif;font-size:12px;"><a href="https://argus.scylladb.com/test/{test_id}/runs?additionalRuns[]={run_id}" style="color:#007bff;text-decoration:none;">Argus</a></td>
 </tr>
 <!-- Subsequent workload row within same test: category and test cells are empty -->
@@ -192,6 +227,7 @@ Number of rows varies: one row per workload per test that had runs. Categories a
   <td style="border:1px solid #dee2e6;padding:4px 8px;font-family:Arial,Helvetica,sans-serif;font-size:12px;"></td>
   <td style="border:1px solid #dee2e6;padding:4px 8px;text-align:center;font-family:Arial,Helvetica,sans-serif;font-size:12px;">{workload}</td>
   <td style="border:1px solid #dee2e6;padding:4px 8px;text-align:center;font-family:Arial,Helvetica,sans-serif;font-size:12px;"><!-- status badge --></td>
+  <td style="border:1px solid #dee2e6;padding:4px 8px;text-align:center;font-family:Arial,Helvetica,sans-serif;font-size:12px;"><!-- issue keys or empty --></td>
   <td style="border:1px solid #dee2e6;padding:4px 8px;text-align:center;font-family:Arial,Helvetica,sans-serif;font-size:12px;"><a href="https://argus.scylladb.com/test/{test_id}/runs?additionalRuns[]={run_id}" style="color:#007bff;text-decoration:none;">Argus</a></td>
 </tr>
 <!-- ... repeat rows for each workload, test, and category ... -->
@@ -202,33 +238,56 @@ NOTE: Each workload row has its own Argus link in the Link column. Version is in
 Argus URL format: `https://argus.scylladb.com/test/{test_id}/runs?additionalRuns[]={run_id}` (singular `/test/`, NOT `/tests/`)
 Status column: just the badge (PASSED/FAILED/ERROR) -- no counts.
 
-### Results Table (light header) -- Per-Workload with Argus Links
+### Overview Section Heading and Per-Version Label
 
-Number of rows varies: one per workload that has results.
+The overview section starts with a standalone heading row, followed by a version label (when multiple versions) and the table. Each version gets its own table.
+
+```html
+<!-- Section heading (standalone row in the main content table) -->
+<tr><td style="font-family:Arial,Helvetica,sans-serif;font-size:16px;font-weight:bold;color:#333333;padding-bottom:10px;">Test Overview</td></tr>
+
+<!-- Version label (when multiple versions; omit when single version) -->
+<tr><td style="font-family:Arial,Helvetica,sans-serif;font-size:14px;font-weight:bold;color:#1a237e;padding:10px 0 5px 0;">Version {version}</td></tr>
+
+<!-- Then the overview table wrapped in <tr><td>...</td></tr> -->
+<tr><td>
+<table width="100%" ...>
+<!-- ... overview table content ... -->
+</table>
+</td></tr>
+```
+
+### Failed Results Table (light header) -- Per-Workload with Argus Links
+
+Number of rows varies: one per failed/error step across all runs in the period.
 
 ```html
 <table width="100%" cellpadding="0" cellspacing="0" border="1" style="border-collapse:collapse;font-family:Arial,Helvetica,sans-serif;font-size:12px;border-color:#dee2e6;margin-bottom:5px;">
 <tr bgcolor="#f8f9fa" style="background-color:#f8f9fa;">
-  <th style="border:1px solid #dee2e6;padding:4px 8px;text-align:left;font-weight:bold;">Workload</th>
-  <th style="border:1px solid #dee2e6;padding:4px 8px;font-weight:bold;">Max Throughput (run)</th>
+  <th style="border:1px solid #dee2e6;padding:4px 8px;font-weight:bold;">Workload</th>
+  <th style="border:1px solid #dee2e6;padding:4px 8px;font-weight:bold;">Step</th>
   <th style="border:1px solid #dee2e6;padding:4px 8px;font-weight:bold;">P99 (ms)</th>
-  <th style="border:1px solid #dee2e6;padding:4px 8px;font-weight:bold;">Status</th>
+  <th style="border:1px solid #dee2e6;padding:4px 8px;font-weight:bold;">Throughput (op/s)</th>
+  <th style="border:1px solid #dee2e6;padding:4px 8px;font-weight:bold;">Version</th>
   <th style="border:1px solid #dee2e6;padding:4px 8px;font-weight:bold;">Link</th>
 </tr>
-<!-- Repeat for each workload -->
-<tr>
+<!-- Repeat for each failed step -->
+<tr bgcolor="#ffffff" style="background-color:#ffffff;">
   <td style="border:1px solid #dee2e6;padding:4px 8px;font-family:Arial,Helvetica,sans-serif;font-size:12px;">{workload}</td>
-  <td style="border:1px solid #dee2e6;padding:4px 8px;text-align:right;font-family:Arial,Helvetica,sans-serif;font-size:12px;">{max_throughput}</td>
-  <td style="border:1px solid #dee2e6;padding:4px 8px;text-align:right;font-family:Arial,Helvetica,sans-serif;font-size:12px;">{p99_value}</td>
-  <td style="border:1px solid #dee2e6;padding:4px 8px;text-align:center;font-family:Arial,Helvetica,sans-serif;font-size:12px;"><!-- status badge --></td>
+  <td style="border:1px solid #dee2e6;padding:4px 8px;font-family:Arial,Helvetica,sans-serif;font-size:12px;">{step}</td>
+  <td style="border:1px solid #dee2e6;padding:4px 8px;text-align:right;font-family:Arial,Helvetica,sans-serif;font-size:12px;color:#dc3545;font-weight:bold;">{p99_value}</td>
+  <td style="border:1px solid #dee2e6;padding:4px 8px;text-align:right;font-family:Arial,Helvetica,sans-serif;font-size:12px;">{throughput}</td>
+  <td style="border:1px solid #dee2e6;padding:4px 8px;font-family:Arial,Helvetica,sans-serif;font-size:12px;">{version}</td>
   <td style="border:1px solid #dee2e6;padding:4px 8px;text-align:center;font-family:Arial,Helvetica,sans-serif;font-size:12px;"><a href="https://argus.scylladb.com/test/{test_id}/runs?additionalRuns[]={run_id}" style="color:#007bff;text-decoration:none;">Argus</a></td>
 </tr>
 <!-- ... more rows as needed ... -->
 </table>
 ```
 
-NOTE: Each workload row has its own Argus link pointing to the specific run for that workload.
-Argus URL format: `https://argus.scylladb.com/test/{test_id}/runs?additionalRuns[]={run_id}` (singular `/test/`, NOT `/tests/`)
+Key details:
+- Failed P99 values are styled with `color:#dc3545;font-weight:bold;` (red bold)
+- Header uses light background `#f8f9fa` (not dark `#343a40`)
+- Each workload row has its own Argus link pointing to the specific run
 
 ## Bullet Lists (as table rows, not ul/li)
 
@@ -268,6 +327,49 @@ Key styling details:
 <a href="https://argus.scylladb.com/test/{test_id}/runs?additionalRuns[]={run_id}" style="color:#007bff;text-decoration:none;">Argus</a>
 ```
 
+## Uninvestigated Failures Table
+
+Shows failed/test_error runs with no linked Argus issue, placed between the Conclusion and Issues sections.
+Columns: Test | Workload | Version | Status | Cause | Link.
+Excludes CapacityReservationError runs that were successfully re-run.
+
+```html
+<tr><td height="15" style="font-size:1px;line-height:1px;">&nbsp;</td></tr>
+<tr>
+<td bgcolor="#ffffff" style="background-color:#ffffff;border:1px solid #dee2e6;padding:15px;">
+<table width="100%" cellpadding="0" cellspacing="0" border="0" style="font-family:Arial,Helvetica,sans-serif;font-size:13px;color:#333333;">
+<tr><td style="font-size:16px;font-weight:bold;padding-bottom:10px;">Uninvestigated Failures (no issue linked)</td></tr>
+</table>
+<table width="100%" cellpadding="0" cellspacing="0" border="1" style="border-collapse:collapse;font-family:Arial,Helvetica,sans-serif;font-size:12px;border-color:#dee2e6;">
+<tr bgcolor="#343a40" style="background-color:#343a40;">
+  <th style="border:1px solid #dee2e6;padding:6px 10px;text-align:left;color:#ffffff;font-weight:bold;">Test</th>
+  <th style="border:1px solid #dee2e6;padding:6px 10px;text-align:left;color:#ffffff;font-weight:bold;">Workload</th>
+  <th style="border:1px solid #dee2e6;padding:6px 10px;text-align:left;color:#ffffff;font-weight:bold;">Version</th>
+  <th style="border:1px solid #dee2e6;padding:6px 10px;text-align:left;color:#ffffff;font-weight:bold;">Status</th>
+  <th style="border:1px solid #dee2e6;padding:6px 10px;text-align:left;color:#ffffff;font-weight:bold;">Cause</th>
+  <th style="border:1px solid #dee2e6;padding:6px 10px;text-align:center;color:#ffffff;font-weight:bold;">Link</th>
+</tr>
+<!-- Repeat for each uninvestigated run, alternating bgcolor #ffffff / #f8f9fa -->
+<tr bgcolor="#ffffff" style="background-color:#ffffff;">
+  <td style="border:1px solid #dee2e6;padding:4px 8px;font-family:Arial,Helvetica,sans-serif;font-size:12px;">{test_name}</td>
+  <td style="border:1px solid #dee2e6;padding:4px 8px;font-family:Arial,Helvetica,sans-serif;font-size:12px;">{workload}</td>
+  <td style="border:1px solid #dee2e6;padding:4px 8px;font-family:Arial,Helvetica,sans-serif;font-size:12px;">{version}</td>
+  <td style="border:1px solid #dee2e6;padding:4px 8px;font-family:Arial,Helvetica,sans-serif;font-size:12px;"><!-- status badge --></td>
+  <td style="border:1px solid #dee2e6;padding:4px 8px;font-family:Arial,Helvetica,sans-serif;font-size:12px;">{cause}</td>
+  <td style="border:1px solid #dee2e6;padding:4px 8px;text-align:center;font-family:Arial,Helvetica,sans-serif;font-size:12px;"><a href="https://argus.scylladb.com/test/{test_id}/runs?additionalRuns[]={run_id}" style="color:#007bff;text-decoration:none;">Argus</a></td>
+</tr>
+<!-- ... more rows as needed ... -->
+</table>
+</td>
+</tr>
+```
+
+Key details:
+- Cause column values: "CapacityReservationError, not re-run", "P99 ERROR at <step>", "All tables PASS, run marked failed", etc.
+- Status column uses the standard status badge (FAILED/ERROR)
+- Only shown when uninvestigated failures exist
+- CapacityReservationError runs that were re-run successfully are excluded
+
 ## New Issues and Reproduced Issues Sections
 
 Issues are split into two sections based on Jira creation date (user-classified):
@@ -304,7 +406,9 @@ The "Status" column contains the Jira custom field "Status Description" value fo
 </tr>
 ```
 
-### Reproduced Issues (always shown)
+### Reproduced Issues / Known Issues (always shown)
+
+The section heading may be "Reproduced Issues" or "Known Issues" depending on context. When all issues are reproduced (pre-existing), "Known Issues" is preferred.
 
 ```html
 <tr><td height="15" style="font-size:1px;line-height:1px;">&nbsp;</td></tr>
@@ -380,6 +484,7 @@ Key details:
 | Passed/OK | #28a745 | Green badge |
 | Failed | #dc3545 | Red badge |
 | Error/Warning | #fd7e14 | Orange badge |
+| Running | #17a2b8 | Blue badge |
 | No data/neutral | #6c757d | Gray badge |
 | Link color | #007bff | Blue |
 | Table header (dark) | #343a40 | Dark gray |

--- a/skills/perf-weekly-status-report/workflows/generate-report.md
+++ b/skills/perf-weekly-status-report/workflows/generate-report.md
@@ -33,8 +33,13 @@ Step-by-step process for generating the Gmail-compatible HTML performance report
      --after $AFTER \
      --limit 200 \
      --full \
+     --no-cache \
      --url https://argus.scylladb.com
    ```
+
+   Use `--no-cache` to ensure fresh data. Run status and issue linkage can change between
+   refreshes (e.g., a run status updated from `failed` to `passed`, or an issue linked to a
+   previously uninvestigated run).
 
 3. Parse the JSON output. Each run object contains:
    - `id` (run UUID)
@@ -45,32 +50,49 @@ Step-by-step process for generating the Gmail-compatible HTML performance report
 
 **Exit criteria:** JSON data collected for all 16 tests.
 
-## Phase 2: Filter to Master (~dev) Builds
+## Phase 1a: Ask Build Type (if not specified)
 
-**Entry criteria:** Raw run data collected.
+**Entry criteria:** Raw run data collected (Phase 1 complete).
 
-1. Apply version regex filter: `^\d{4}\.\d+\.\d+.+dev$`
-2. This matches versions like `2026.3.0~dev`, `2025.2.0~dev`
-3. Excludes release versions like `2026.1.5`, `2025.1.13`, `None`
+If the user has not specified the build type in their prompt, ask them to choose:
+1. **Master (~dev)** -- dev builds from master branch
+2. **Release** -- stable release builds
+
+Use the interactive question tool. If the user already said "release" or "master" in their prompt, skip this step.
+
+**Exit criteria:** Build type is determined (master or release).
+
+## Phase 2: Filter by Build Type
+
+**Entry criteria:** Raw run data collected, build type determined.
+
+Apply the version regex filter based on the chosen build type:
+
+- **Master mode:** `^\d{4}\.\d+\.\d+.+dev$` -- matches `2026.3.0~dev`, `2025.2.0~dev`
+- **Release mode:** `^\d{4}\.\d+\.\d+$` -- matches `2026.2.3`, `2026.1.10`
 
 Example filter logic:
 ```python
 import re
 MASTER_RE = re.compile(r"^\d{4}\.\d+\.\d+.+dev$")
+RELEASE_RE = re.compile(r"^\d{4}\.\d+\.\d+$")
 
-master_runs = [
+version_re = MASTER_RE if build_type == "master" else RELEASE_RE
+filtered_runs = [
     run for run in all_runs
-    if MASTER_RE.match(run.get("scylla_version") or "")
+    if version_re.match(run.get("scylla_version") or "")
 ]
 ```
 
-**Exit criteria:** Only master (~dev) version runs remain per test.
+Also include runs with status `"running"`.
+
+**Exit criteria:** Only runs matching the chosen build type remain per test.
 
 ## Phase 3: Fetch Results Per Run
 
-**Entry criteria:** Filtered master runs identified.
+**Entry criteria:** Filtered runs identified (master or release).
 
-1. For each master run, fetch results:
+1. For each filtered run, fetch results:
    ```bash
    argus run results \
      --run-id <RUN_ID> \
@@ -149,16 +171,32 @@ master_runs = [
    tables -- their table-name workload must match their assigned position; if not, report the
    ambiguity instead of guessing.
 
-   Then find the failure cause for the Conclusion (`get_build_console_output` with a pattern such as
-   `InsufficientInstanceCapacity|CapacityReservationError|Unable to provision`) so the report can say
-   *why* nothing was produced rather than just `ERROR`.
+   Then find the failure cause using `argus run events`:
+
+   ```bash
+   argus run events --run-id <RUN_UUID> --url https://argus.scylladb.com
+   ```
+
+   This returns CRITICAL/ERROR events. Look for `CapacityReservationError` in the message text.
+   This is more reliable than Jenkins console output, which often requires authentication (403).
+
+6. **Detect re-runs for CapacityReservationError failures.**
+
+   Group runs by test name + version. Within each group, sort by `build_number`. If a later build
+   exists for the same test + version with runs that passed for the same workloads, the earlier
+   CapacityReservationError run was successfully re-run. Exclude it from all report sections
+   (overview, detailed results, counts, uninvestigated table).
+
+   Note: There is no explicit "re-run of build #X" field in Argus. The link is inferred by
+   matching test + version + sequential build numbers.
 
 **Exit criteria:** Data organized by category > test > workload > step, throughput tracker populated.
 Every master run in the window is accounted for -- including those with zero result tables.
+CapacityReservationError runs with successful re-runs are marked for exclusion.
 
 ## Phase 4a: Collect Issues
 
-**Entry criteria:** Filtered master runs identified (from Phase 2).
+**Entry criteria:** Filtered runs identified (from Phase 2).
 
 1. For each run with status `failed` or `test_error`, fetch linked issues:
    ```bash
@@ -200,6 +238,21 @@ Every master run in the window is accounted for -- including those with zero res
 
 6. Store the classification for use in the HTML report generation.
 
+7. **Build the Uninvestigated Failures list.** For each run with status `failed` or `test_error`
+   that has no linked issues (empty `argus issue list`), add it to the uninvestigated list with:
+   - Test name, workload, version, status
+   - Cause: determined from `argus run events` (e.g. "CapacityReservationError, not re-run") or
+     from failed result tables (e.g. "P99 ERROR at 750K step") or "All tables PASS, run marked failed"
+   - For CapacityReservationError re-runs that also failed, exclude intermediate attempts and keep
+     only the latest one, noting all build numbers in the cause (e.g. "CapacityReservationError,
+     re-run also failed (builds #57,#59,#61)")
+   - Argus link to the specific run
+   - Exclude CapacityReservationError runs that were successfully re-run (identified in Phase 4 step 6)
+
+   **Important:** Issue linkage in Argus is manual and may change between data refreshes. When
+   re-collecting data, always use `--no-cache` on `argus issue list` calls. A run that was previously
+   uninvestigated may now have an issue linked -- remove it from the uninvestigated list.
+
 **Exit criteria:** Issues collected and classified as new vs reproduced from Jira creation dates
 (user consulted only for unlinked failures or if Jira is unreachable).
 
@@ -208,9 +261,10 @@ Every master run in the window is accounted for -- including those with zero res
 **Entry criteria:** Data grouped and aggregated.
 
 1. Generate the HTML file with these sections:
-   - Header (solid navy background `#1a237e`, title, date range)
-   - Summary box (total/passed/failed counts per run + Scylla version). **Count individual runs, not test groups.** Each workload is a separate run (e.g., a test with mixed/read/write/read_disk_only = 4 runs). Microbenchmarks = 1 run each. Total must equal Passed + Failed/Error.
+   - Header (solid navy background `#1a237e`, title, date range). Subtitle text varies by build type: "Master (~dev) builds only" or "Release builds only".
+   - Summary box (total/passed/failed/running counts per run + Scylla version). **Count individual runs, not test groups.** Each workload is a separate run (e.g., a test with mixed/read/write/read_disk_only = 4 runs). Microbenchmarks = 1 run each. Total must equal Passed + Failed/Error + Running. **Exclude CapacityReservationError runs that were successfully re-run from all counts.**
    - Conclusion (auto-generated hierarchical text summary)
+   - Uninvestigated Failures table (failed/test_error runs with no linked issue)
    - New Issues - Regression (issues created during the period, if any)
    - Reproduced Issues (pre-existing issues seen again this week)
    - Overview table (grouped by workload, with Argus links in Link column)
@@ -218,12 +272,26 @@ Every master run in the window is accounted for -- including those with zero res
 
    **Conclusion section** (between Summary and Overview):
    - Heading "Conclusion" must use same style as "Summary" heading: `font-size:16px;font-weight:bold;padding-bottom:10px;`
+   - **Warning banner** (optional): After collecting all issues from failed runs, present the
+     de-duplicated list to the user and ask which issues (if any) should be highlighted in a
+     warning banner. If the user selects issues, render a banner stating those issues had no
+     updates during the report period. If the user selects none, omit the banner entirely.
+     Banner markup:
+     ```html
+     <table width="100%" cellpadding="0" cellspacing="0" border="0" style="margin-bottom:10px;"><tr>
+     <td bgcolor="#fff3cd" style="background-color:#fff3cd;border:2px solid #dc3545;padding:8px 12px;font-family:Arial,Helvetica,sans-serif;font-size:13px;color:#dc3545;font-weight:bold;">
+     &#9888; No updates on {issue_keys} during last week.
+     </td></tr></table>
+     ```
+     This banner uses yellow background with red border and red bold text to stand out visually.
    - Auto-generate **hierarchical** bullet-point lines summarizing the week's performance results
    - Structure uses two levels:
      - **Top-level items**: Test name in bold, prefixed with `- ` (indented 15px from left)
      - **Sub-items**: Specific observations, prefixed with `&#8226;` bullet (indented 30px from left)
    - Each top-level item and sub-item is rendered as its own table row
+   - **Version numbers must be bold** in sub-items (e.g., `<b>2026.2.3</b>`)
    - Include: which workloads failed/passed for each test, specific failure details (metric, value)
+   - Do NOT mention CapacityReservationError runs in the Conclusion -- they are covered in the Uninvestigated Failures table. If a test only had CapacityReservationError runs, omit it from the Conclusion entirely.
    - Do NOT mention registered tests with no runs
    - Example output structure:
      ```
@@ -252,11 +320,14 @@ Every master run in the window is accounted for -- including those with zero res
    **Important**: When fetching results for microbenchmark runs, if no workload-specific tables are found (e.g., no "workload - step - latencies" tables), treat the entire results array as belonging to workload="-". This ensures microbenchmarks appear in the overview table.
 
 3. **Detailed results structure (per category):**
-   - **CRITICAL**: The entire "Detailed Results" section is ONLY shown when there are actual failures (run status `failed` or `test_error`)
-   - When all tests pass, completely omit the Detailed Results section from the report
-   - When failures exist:
+   - **CRITICAL**: The entire "Detailed Results" section is ONLY shown when there are actual failed result tables (table status `FAIL` or `ERROR`)
+   - Runs where status is `failed` but all result tables show `PASS`, and `test_error` runs with no result tables, must NOT appear in Detailed Results -- they belong in the Uninvestigated Failures table
+   - When all tests pass (or failures have no failed tables), completely omit the Detailed Results section from the report
+   - When failures with actual failed tables exist:
+     - First collect all failed result tables across all runs, grouped by category and test
+     - Only render category headings and test sub-headings that have at least one failed table
      - Category heading with blue underline (`#007bff`)
-     - For each test with failures: sub-heading with test name and full version, NO status badge
+     - For each test with failed tables: sub-heading with test name and full version, NO status badge
        Example: `predefined-throughput-steps-i8g-tablets (2026.3.0.dev.20260612.91ada5517d59)`
       - **Failed Results table**:
         - Columns: Workload | Step | P99 (ms) | Throughput (op/s) | Version | Link
@@ -338,15 +409,16 @@ Only when the user asks for an email draft.
 
 **Entry criteria:** HTML report content is ready to be generated (all data collected and processed, issues collected from Phase 4a).
 
-Before writing the final HTML file, the agent MUST perform TWO interactive steps:
+Before writing the final HTML file, the agent MUST perform THREE interactive steps:
 
 ### Step 1: Conclusion Review
 
 1. Print the auto-generated Conclusion bullet points to the user in plain text format (hierarchical structure)
-2. Ask the user to confirm the conclusion or provide edits
-3. Wait for user response
-4. If the user approves: proceed to Step 2
-5. If the user provides changes: incorporate the edits
+2. Also print the **Uninvestigated Failures** table (failed/test_error runs with no linked issue, including cause)
+3. Ask the user to confirm the conclusion or provide edits, and to investigate the uninvestigated failures
+4. Wait for user response
+5. If the user approves: proceed to Step 2
+6. If the user provides changes: incorporate the edits
 
 Example interaction:
 ```
@@ -360,10 +432,37 @@ Here is the generated Conclusion for the report:
   * write tests (arm64 and x86_64) both failed with ERROR on instructions_per_op (~8% regression).
   * Read tests passed on both architectures.
 
+Uninvestigated failures (no issue linked):
+
+| Test | Workload | Version | Status | Cause | Link |
+|------|----------|---------|--------|-------|------|
+| predefined-throughput-steps-i8g-tablets | mixed | 2026.1.10 | failed | P99 ERROR at 750K step | Argus |
+| latency-650gb-with-nemesis-i8g-vnodes | mixed | 2026.2.3 | test_error | CapacityReservationError, not re-run | Argus |
+
 Would you like to use this conclusion as-is, or would you like to edit it?
 ```
 
-### Step 2: Issue Classification
+### Step 2: Warning Banner Selection
+
+1. Present the de-duplicated list of all issues found on failed/errored runs
+2. Ask the user which issues (if any) should be highlighted in a warning banner at the top of the Conclusion
+3. Wait for user response
+4. If the user selects issues: generate a warning banner stating those issues had no updates during the report period
+5. If the user selects none (or there are no issues): omit the warning banner entirely
+
+Example interaction:
+```
+I found the following issues linked to failed runs:
+
+1. SCYLLADB-2353: Tablet load-balancer oscillation causes P99 latency explosion...
+2. SCYLLADB-3459: Oversized allocation (262144 bytes) in circular_buffer...
+
+Which of these issues (if any) should be highlighted in a warning banner
+stating they had no updates this week? Provide the keys (e.g., "SCYLLADB-2353, SCYLLADB-3459"),
+or "none" to skip the banner.
+```
+
+### Step 3: Issue Classification
 
 1. Present the de-duplicated list of all issues found on failed/errored runs
 2. Ask the user to identify which issues are **new** (Jira ticket created during the report period)
@@ -384,7 +483,7 @@ Which of these are NEW issues (Jira ticket created this week)?
 Please provide the keys (e.g., "PROJECT-789"), or "none" if all are reproduced.
 ```
 
-This ensures the user has final control over both the conclusion wording and issue classification before they appear in the report.
+This ensures the user has final control over the conclusion wording, warning banner, and issue classification before they appear in the report.
 
 ## Phase 6: Verify Output
 
@@ -414,6 +513,11 @@ This ensures the user has final control over both the conclusion wording and iss
 22. Verify status badges use `bgcolor` on a `<td>`, not a bare `<span>` (`grep -c '<span[^>]*background-color'` must be 0)
 23. Verify the page was actually opened in a browser and the tables/badges checked visually
 24. Verify every master run in the window appears somewhere in the report, including runs with zero result tables
+25. Verify Uninvestigated Failures table is present when there are failed/test_error runs with no linked issues
+26. Verify Uninvestigated Failures table has columns: Test | Workload | Version | Status | Cause | Link
+27. Verify CapacityReservationError runs that were successfully re-run are excluded from all sections
+28. Verify test_error causes are determined via `argus run events`, not Jenkins console
+29. Verify Uninvestigated Failures table was printed to user during conclusion review
 
 **Exit criteria:** Report is ready for email distribution.
 
@@ -451,8 +555,16 @@ argus run results \
   --url https://argus.scylladb.com > "$OUT/results.json"
 
 # 4b. For runs whose results are empty (test_error), recover the workload from Jenkins
-#     sub_tests order (build_id + build_number on the run object) and grep the console
-#     for the abort cause, e.g. CapacityReservationError / InsufficientInstanceCapacity.
+#     sub_tests order (build_id + build_number on the run object).
+#     Determine error cause via argus run events (not Jenkins console):
+argus run events \
+  --run-id <RUN_ID> \
+  --url https://argus.scylladb.com
+#     Look for CapacityReservationError in event messages.
+
+# 4c. Detect re-runs: group runs by test+version, sort by build_number.
+#     If a later build passed the same workloads, exclude the earlier
+#     CapacityReservationError run from the report.
 
 # 5. Fetch issues for failed/errored runs (often returns [] -- linking is manual)
 argus issue list \
@@ -460,7 +572,7 @@ argus issue list \
   --url https://argus.scylladb.com
 
 # 6. Generate HTML report (output to $OUT, NOT to repo)
-# - Ask user to confirm conclusion text
+# - Ask user to confirm conclusion text + uninvestigated failures table
 # - Classify issues from Jira `created` dates (Atlassian MCP getJiraIssue)
 # - Write "$OUT/perf-weekly-status-report.html"
 


### PR DESCRIPTION
Enhance the perf-weekly-status-report skill with several improvements based on real-world report generation experience:

- Add build type selection (master vs release) as the first interactive step, allowing the same skill to generate reports for either build type
- Use `argus run events` to determine test_error causes instead of Jenkins console output (which requires authentication)
- Detect CapacityReservationError re-runs by matching test + version + sequential build numbers; exclude successfully re-run failures from all report sections; keep only the latest attempt when re-runs also failed
- Add "Uninvestigated Failures" table for failed/test_error runs with no linked Argus issue, including a Cause column with specific failure reason
- Add optional warning banner in Conclusion section: agent asks user which issues to highlight, renders yellow/red banner if selected
- Bold version numbers in Conclusion sub-bullets
- Do not mention CapacityReservationError runs in Conclusion text
- Exclude tests from Detailed Results when they have no actual failed result tables (e.g., run marked failed but all tables PASS)
- Use --no-cache on argus CLI calls to ensure fresh data on refresh
- Document `argus run events` output format in references

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] master report: 
[perf-weekly-status-report-master.html](https://github.com/user-attachments/files/31015735/perf-weekly-status-report-master.html)

- [x] releases report: 
[perf-weekly-status-report-release.html](https://github.com/user-attachments/files/31015755/perf-weekly-status-report-release.html)


### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
