### PR TITLE
fix(ldap): fix running stress command

### DIFF
--- a/test_add_remove_ldap_role_permission.py
+++ b/test_add_remove_ldap_role_permission.py
@@ -31,7 +31,7 @@ class AddRemoveLdapRolePermissionTest(LongevityTest, LdapUtilsMixin):
         stress_queue = []
         background_write_cmd = self.params.get("stress_cmd")
         InfoEvent(message=f"Starting C-S stress load: {background_write_cmd}").publish()
-        stress_queue.append(self.run_stress_thread(stress_cmd=background_write_cmd, round_robin=True))
+        self.assemble_and_run_all_stress_cmd(stress_queue, background_write_cmd, keyspace_num=1)
 
         if not node.is_enterprise:
             raise ValueError("Cluster is not enterprise. LDAP is supported only for enterprise. aborting.")


### PR DESCRIPTION
`stress_cmd` returns list[str], but the test was passing that list directly to `run_stress_thread`, which expects a single string and calls `.startswith()` on it.

Replace the direct `run_stress_thread` call with `assemble_and_run_all_stress_cmd` which already handles unwrapping the list and calling `run_stress_thread` per command.

Closes: SCT-792

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://argus.scylladb.com/tests/scylla-cluster-tests/cc405f72-37eb-41f7-8b26-406e69df3bed

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
