### PR TITLE
fix(trigger-matrix): Fix availability_zone for longevity-50gb-3days-test

### DIFF
--- a/configurations/triggers/tier1.yaml
+++ b/configurations/triggers/tier1.yaml
@@ -113,6 +113,7 @@ jobs:
     backend: "aws"
     params:
       region: "eu-west-1"
+      availability_zone: "a,b,c"
     labels:
       - "weekly"
       - "week-a"


### PR DESCRIPTION
The test needs 3 AZs (it has simutalted_racks=0) , and the default is just 1

Closes: SCT-757

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
