### PR TITLE
fix(node_exporter): add missing tar extraction before installing binary

### DIFF
--- a/sdcm/node_exporter_setup.py
+++ b/sdcm/node_exporter_setup.py
@@ -16,6 +16,7 @@ class NodeExporterSetup:
                 useradd -rs /bin/false node_exporter
             fi
             curl -L -f --connect-timeout 10 --retry 8 --retry-max-time 300 -O https://github.com/prometheus/node_exporter/releases/download/v{NODE_EXPORTER_VERSION}/node_exporter-{NODE_EXPORTER_VERSION}.linux-amd64.tar.gz
+            tar xzf node_exporter-{NODE_EXPORTER_VERSION}.linux-amd64.tar.gz
             mv node_exporter-{NODE_EXPORTER_VERSION}.linux-amd64/node_exporter /usr/local/bin
 
             if [ -e /etc/systemd/system/node_exporter.service ]; then


### PR DESCRIPTION
The install script downloads the node_exporter tarball but never extracts it before attempting to move the binary, causing 'No such file or directory' on all loader nodes and failing the test during setUp.

Fixes: https://scylladb.atlassian.net/browse/SCT-848

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] AWS provision test.
Provision step passed. It failed on the nemesis. This failure is not related to the PR change (fix for node_exporter tar extraction). The failure is from a pre-existing bug in the disrupt_nodetool_refresh nemesis at sdcm/utils/sstable/load_utils.py:124. It tries to run:
`sudo -u scylla tar xvfz /tmp/keyspace1.standard1.tar.gz -C .../upload/`
And fails with `Permission denied` because the scylla user cannot read /tmp/keyspace1.standard1.tar.gz. This is a known issue with file permissions in /tmp (likely due to sticky bit / private tmp on Ubuntu 24), and is unrelated to your node_exporter fix.

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
