### PR TITLE
docs(test-metadata): label cassandra/platform/spark test cases

### DIFF
--- a/docs/pipeline-labels/taxonomy.yaml
+++ b/docs/pipeline-labels/taxonomy.yaml
@@ -19,6 +19,8 @@ test_type:
     - platform-migration
     - vector-search
     - cdc
+    - cassandra
+    - spark-migrator
 
 tier:
   description: "Test priority tier"

--- a/skills/labeling-pipelines/references/taxonomy-values.md
+++ b/skills/labeling-pipelines/references/taxonomy-values.md
@@ -4,7 +4,7 @@ All valid values are defined in `docs/pipeline-labels/taxonomy.yaml` (single sou
 The pydantic model in `sdcm/test_metadata.py` loads and enforces them at runtime.
 
 ## test_type
-longevity, performance, upgrade, artifacts, manager, functional, scale, jepsen, gemini, features, platform-migration, vector-search, cdc, operator, cassandra, kafka, microbenchmarking, load
+longevity, performance, upgrade, artifacts, manager, functional, scale, jepsen, gemini, features, platform-migration, vector-search, cdc, operator, cassandra, spark-migrator, kafka, microbenchmarking, load
 
 ## tier
 sanity, tier1, tier2, release, ondemand

--- a/skills/reviewing-pipeline-docs/references/taxonomy-values.md
+++ b/skills/reviewing-pipeline-docs/references/taxonomy-values.md
@@ -4,7 +4,7 @@ All valid values are defined in `docs/pipeline-labels/taxonomy.yaml` (single sou
 The pydantic model in `sdcm/test_metadata.py` loads and enforces them at runtime.
 
 ## test_type
-longevity, performance, upgrade, artifacts, manager, functional, scale, jepsen, gemini, features, platform-migration, vector-search, cdc, operator, cassandra, kafka, microbenchmarking, load
+longevity, performance, upgrade, artifacts, manager, functional, scale, jepsen, gemini, features, platform-migration, vector-search, cdc, operator, cassandra, spark-migrator, kafka, microbenchmarking, load
 
 ## tier
 sanity, tier1, tier2, release, ondemand

--- a/test-cases/cassandra/cassandra-preload-1tb-latte.yaml
+++ b/test-cases/cassandra/cassandra-preload-1tb-latte.yaml
@@ -1,3 +1,21 @@
+test_metadata:
+  description: >-
+    Apache Cassandra 4.1 baseline on a 3-node cluster: preloads 1TB (1B rows of
+    ~1KB, RF=1) with four parallel latte write streams, then measures a 30-minute
+    gauss-distributed latte read workload over the full key range. Establishes the
+    reference numbers that the scylla-migrator and platform-migration suites compare
+    against; runs Cassandra rather than ScyllaDB, so no nemesis is used.
+  test_type: cassandra
+  tier: ondemand
+  duration_class: medium
+  supported_backends:
+    - aws
+  stress_tools:
+    - latte
+  workload: read
+  features: []
+  team_ownership: core-test-infra
+
 test_duration: 960
 n_db_nodes: 3
 n_loaders: 2

--- a/test-cases/cassandra/cassandra-preload-2tb-latte.yaml
+++ b/test-cases/cassandra/cassandra-preload-2tb-latte.yaml
@@ -1,3 +1,21 @@
+test_metadata:
+  description: >-
+    Apache Cassandra 4.1 baseline on a 3-node cluster: preloads 2TB (2B rows of
+    ~1KB, RF=1) with four parallel latte write streams, then measures a 30-minute
+    gauss-distributed latte read workload over the full key range. Establishes the
+    reference numbers that the scylla-migrator and platform-migration suites compare
+    against; runs Cassandra rather than ScyllaDB, so no nemesis is used.
+  test_type: cassandra
+  tier: ondemand
+  duration_class: medium
+  supported_backends:
+    - aws
+  stress_tools:
+    - latte
+  workload: read
+  features: []
+  team_ownership: core-test-infra
+
 test_duration: 1440
 n_db_nodes: 3
 n_loaders: 4

--- a/test-cases/cassandra/cassandra-preload-500gb-latte.yaml
+++ b/test-cases/cassandra/cassandra-preload-500gb-latte.yaml
@@ -1,3 +1,21 @@
+test_metadata:
+  description: >-
+    Apache Cassandra 4.1 baseline on a 3-node cluster: preloads 500GB (500M rows
+    of ~1KB, RF=1) with four parallel latte write streams, then measures a 30-minute
+    gauss-distributed latte read workload over the full key range. Establishes the
+    reference numbers that the scylla-migrator and platform-migration suites compare
+    against; runs Cassandra rather than ScyllaDB, so no nemesis is used.
+  test_type: cassandra
+  tier: ondemand
+  duration_class: medium
+  supported_backends:
+    - aws
+  stress_tools:
+    - latte
+  workload: read
+  features: []
+  team_ownership: core-test-infra
+
 test_duration: 480
 n_db_nodes: 3
 n_loaders: 2

--- a/test-cases/cassandra/cassandra-preload-5tb-latte.yaml
+++ b/test-cases/cassandra/cassandra-preload-5tb-latte.yaml
@@ -1,3 +1,21 @@
+test_metadata:
+  description: >-
+    Largest Apache Cassandra 4.1 baseline: preloads 5TB (5.5B rows of ~1KB, RF=1)
+    onto a 6-node cluster with four parallel latte write streams, then measures a
+    30-minute gauss-distributed latte read workload over the full key range.
+    Establishes the reference numbers that the scylla-migrator and platform-migration
+    suites compare against; runs Cassandra rather than ScyllaDB, so no nemesis is used.
+  test_type: cassandra
+  tier: ondemand
+  duration_class: long
+  supported_backends:
+    - aws
+  stress_tools:
+    - latte
+  workload: read
+  features: []
+  team_ownership: core-test-infra
+
 test_duration: 2880
 n_db_nodes: 6
 n_loaders: 4

--- a/test-cases/platform-migration/x86-to-arm-batched.yaml
+++ b/test-cases/platform-migration/x86-to-arm-batched.yaml
@@ -1,3 +1,19 @@
+# overlay on x86-to-arm-single-dc-50-perc.yaml - only the keys that differ are set,
+# the rest of test_metadata is inherited from the base config on config merge
+test_metadata:
+  description: >-
+    Overlay on x86-to-arm-single-dc-50-perc.yaml that switches the x86-to-ARM migration
+    to batched per-rack mode: the 6 nodes are spread across 3 simulated racks and each
+    rack is migrated as a unit (add target nodes, update seeds, decommission source
+    nodes) before the next rack starts. Composed with the base config this is the
+    variant that the weekly platform-migration trigger runs every Saturday.
+  test_type: platform-migration
+  tier: tier1
+  features:
+    - tablets
+    - rack-aware
+  team_ownership: core-test-infra
+
 n_db_nodes: 6
 simulated_racks: 3
 

--- a/test-cases/platform-migration/x86-to-arm-multi-dc.yaml
+++ b/test-cases/platform-migration/x86-to-arm-multi-dc.yaml
@@ -1,3 +1,24 @@
+# overlay on x86-to-arm-single-dc-50-perc.yaml - only the keys that differ are set,
+# the rest of test_metadata is inherited from the base config on config merge
+test_metadata:
+  description: >-
+    Overlay on x86-to-arm-single-dc-50-perc.yaml that turns the x86-to-ARM migration
+    into a two-DC run: 3 nodes each in eu-west-1 and us-east-1 holding 900M rows of
+    ~1KB at RF=3. Target nodes are added across both DCs simultaneously and source
+    nodes are then decommissioned in parallel across DCs, one per DC at a time, under
+    a LOCAL_QUORUM 9:1 read/write workload driven by rack- and region-aware loaders.
+  test_type: platform-migration
+  tier: ondemand
+  duration_class: medium
+  stress_tools:
+    - cassandra-stress
+    - scylla-bench
+  workload: mixed
+  features:
+    - tablets
+    - multi-dc
+  team_ownership: core-test-infra
+
 test_duration: 480
 n_db_nodes: '3 3'
 region_name: 'eu-west-1 us-east-1'

--- a/test-cases/platform-migration/x86-to-arm-single-dc-10-perc.yaml
+++ b/test-cases/platform-migration/x86-to-arm-single-dc-10-perc.yaml
@@ -1,3 +1,21 @@
+# overlay on x86-to-arm-single-dc-50-perc.yaml - only the keys that differ are set,
+# the rest of test_metadata is inherited from the base config on config merge
+test_metadata:
+  description: >-
+    Overlay on x86-to-arm-single-dc-50-perc.yaml that shrinks the dataset to ~10% disk
+    utilization (360M rows of ~1KB at RF=3) and the run to 4 hours, for quick validation
+    of the x86-to-ARM migration procedure. Only the cassandra-stress prepare and
+    continuous workload are resized; the base topology and the scylla-bench
+    pre/post-migration validation datasets are inherited unchanged.
+  test_type: platform-migration
+  tier: ondemand
+  duration_class: short
+  stress_tools:
+    - cassandra-stress
+    - scylla-bench
+  workload: mixed
+  team_ownership: core-test-infra
+
 test_duration: 240
 
 prepare_write_cmd: [

--- a/test-cases/platform-migration/x86-to-arm-single-dc-50-perc.yaml
+++ b/test-cases/platform-migration/x86-to-arm-single-dc-50-perc.yaml
@@ -1,3 +1,27 @@
+test_metadata:
+  description: >-
+    Migrates a 6-node single-DC cluster filled to ~50% disk utilization (1.8B rows of
+    ~1KB at RF=3) from x86 to ARM (i8g.2xlarge) by adding target-platform nodes and
+    decommissioning the source nodes, all under a continuous QUORUM 9:1 read/write
+    cassandra-stress workload, with scylla-bench validation datasets
+    written before and re-read after the migration. This is the base of the
+    platform-migration suite and the only config here that runs standalone: it alone
+    defines instance_type_db_target, which the test requires. The other files in this
+    directory are overlays on it that select the migration mode (batched per-rack),
+    the topology (multi-DC), the dataset size (10-perc) or vnodes instead of tablets.
+  test_type: platform-migration
+  tier: tier1
+  duration_class: medium
+  supported_backends:
+    - aws
+  stress_tools:
+    - cassandra-stress
+    - scylla-bench
+  workload: mixed
+  features:
+    - tablets
+  team_ownership: core-test-infra
+
 test_duration: 480
 
 sizing_db:  # no OCI match (DenseIO min 16 vCPUs)

--- a/test-cases/platform-migration/x86-to-arm-single-dc-vnodes.yaml
+++ b/test-cases/platform-migration/x86-to-arm-single-dc-vnodes.yaml
@@ -1,3 +1,17 @@
+# overlay on x86-to-arm-single-dc-50-perc.yaml - only the keys that differ are set,
+# the rest of test_metadata is inherited from the base config on config merge
+test_metadata:
+  description: >-
+    Overlay on x86-to-arm-single-dc-50-perc.yaml that disables tablets, so the
+    x86-to-ARM migration is exercised against vnode-based keyspaces and covers the
+    pre-tablets topology-change path. Base topology, dataset and workload are
+    inherited unchanged.
+  test_type: platform-migration
+  tier: ondemand
+  features:
+    - vnodes
+  team_ownership: core-test-infra
+
 append_scylla_yaml:
   enable_tablets: false
   tablets_mode_for_new_keyspaces: 'disabled'

--- a/test-cases/spark-migrator/cs-to-scylla-500gb.yaml
+++ b/test-cases/spark-migrator/cs-to-scylla-500gb.yaml
@@ -1,3 +1,22 @@
+test_metadata:
+  description: >-
+    Scale-out Cassandra-to-ScyllaDB migration: preloads 500GB (500M rows of ~1KB, RF=1)
+    into a 3-node Apache Cassandra 4.1 source cluster with four parallel latte write
+    streams, then migrates the table onto a 3-node ScyllaDB target with a spark-migrator
+    job on a native Spark 4 EMR cluster (emr-spark-8.0.0), reports migration throughput
+    to Argus and finally runs the migrator's own validator job to compare source and
+    target row by row.
+  test_type: spark-migrator
+  tier: ondemand
+  duration_class: medium
+  supported_backends:
+    - aws
+  stress_tools:
+    - latte
+  workload: write
+  features: []
+  team_ownership: core-test-infra
+
 test_duration: 720
 
 db_type: mixed_cassandra

--- a/test-cases/spark-migrator/cs-to-scylla-small.yaml
+++ b/test-cases/spark-migrator/cs-to-scylla-small.yaml
@@ -1,3 +1,20 @@
+test_metadata:
+  description: >-
+    Smallest Cassandra-to-ScyllaDB migration case: preloads 100K rows into a
+    single-node Apache Cassandra 4.1 source cluster over CQL, replicates the source
+    schema onto a single-node ScyllaDB target via dump_schema, then migrates the table
+    with a spark-migrator job on a native Spark 4 EMR cluster (emr-spark-8.0.0) and
+    checks the migrated row count. Provisions no loaders and skips the post-migration
+    validator job, which makes it the quickest end-to-end check of the migrator path.
+  test_type: spark-migrator
+  tier: ondemand
+  duration_class: short
+  supported_backends:
+    - aws
+  stress_tools: []
+  features: []
+  team_ownership: core-test-infra
+
 test_duration: 120
 
 db_type: mixed_cassandra

--- a/test-cases/spark-migrator/spark-migrator-basic.yaml
+++ b/test-cases/spark-migrator/spark-migrator-basic.yaml
@@ -1,3 +1,20 @@
+test_metadata:
+  description: >-
+    Smoke test for the scylla-migrator plumbing: creates a small source table on a
+    3-node ScyllaDB cluster, submits a spark-migrator job on an auxiliary EMR cluster
+    to copy it into a target table on the same cluster, then verifies the migrated row
+    count. Uses the legacy EMR path, where Spark 4.x is installed by a bootstrap action
+    on an emr-7.x release, which keeps that fallback exercised alongside the native
+    emr-spark-8.0.0 releases used by the cs-to-scylla configs.
+  test_type: spark-migrator
+  tier: ondemand
+  duration_class: short
+  supported_backends:
+    - aws
+  stress_tools: []
+  features: []
+  team_ownership: core-test-infra
+
 test_duration: 120
 
 n_db_nodes: 3


### PR DESCRIPTION
Add test_metadata to test-cases/cassandra/ (4 configs), platform-migration/ (5) and spark-migrator/ (3). Also add missing cassandra and spark-migrator test_type taxonomy values.

Platform migration `50-perc` and `batched` configs are tier1, they are what the weekly trigger runs; the rest is ondemand. The four platform-migration overlays set only the keys that differ from the 50-perc base and inherit the rest on config merge.

Fixes: SCT-637

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] executed `sct.py conf` dry run for each of the updated config
```
❯ configs=(
  # standalone configs
  "test-cases/cassandra/cassandra-preload-500gb-latte.yaml"
  "test-cases/cassandra/cassandra-preload-1tb-latte.yaml"
  "test-cases/cassandra/cassandra-preload-2tb-latte.yaml"
  "test-cases/cassandra/cassandra-preload-5tb-latte.yaml"
  "test-cases/spark-migrator/spark-migrator-basic.yaml"
  "test-cases/spark-migrator/cs-to-scylla-small.yaml"
  "test-cases/spark-migrator/cs-to-scylla-500gb.yaml"
  "test-cases/platform-migration/x86-to-arm-single-dc-50-perc.yaml"
  # composed combinations
  '["test-cases/platform-migration/x86-to-arm-single-dc-50-perc.yaml", "test-cases/platform-migration/x86-to-arm-batched.yaml"]'
  '["test-cases/platform-migration/x86-to-arm-single-dc-50-perc.yaml", "test-cases/platform-migration/x86-to-arm-single-dc-10-perc.yaml", "test-cases/platform-migration/x86-to-arm-batched.yaml"]'
  '["test-cases/platform-migration/x86-to-arm-single-dc-50-perc.yaml", "test-cases/platform-migration/x86-to-arm-single-dc-vnodes.yaml"]'
  '["test-cases/platform-migration/x86-to-arm-single-dc-50-perc.yaml", "test-cases/platform-migration/x86-to-arm-multi-dc.yaml"]'
)

❯ failed=()
for cfg in "${configs[@]}"; do
  echo "=== $cfg"
  if SCT_SCYLLA_VERSION=master:latest uv run sct.py conf -b aws "$cfg" >/tmp/sct_conf.log 2>&1; then
    echo "    OK"
  else
    echo "    FAILED:"
    tail -20 /tmp/sct_conf.log
    failed+=("$cfg")
  fi
done

echo "\n${#failed[@]} failed"
for f in "${failed[@]}"; do echo "  ! $f"; done
=== test-cases/cassandra/cassandra-preload-500gb-latte.yaml
    OK
=== test-cases/cassandra/cassandra-preload-1tb-latte.yaml
    OK
=== test-cases/cassandra/cassandra-preload-2tb-latte.yaml
    OK
=== test-cases/cassandra/cassandra-preload-5tb-latte.yaml
    OK
=== test-cases/spark-migrator/spark-migrator-basic.yaml
    OK
=== test-cases/spark-migrator/cs-to-scylla-small.yaml
    OK
=== test-cases/spark-migrator/cs-to-scylla-500gb.yaml
    OK
=== test-cases/platform-migration/x86-to-arm-single-dc-50-perc.yaml
    OK
=== ["test-cases/platform-migration/x86-to-arm-single-dc-50-perc.yaml", "test-cases/platform-migration/x86-to-arm-batched.yaml"]
    OK
=== ["test-cases/platform-migration/x86-to-arm-single-dc-50-perc.yaml", "test-cases/platform-migration/x86-to-arm-single-dc-10-perc.yaml", "test-cases/platform-migration/x86-to-arm-batched.yaml"]
    OK
=== ["test-cases/platform-migration/x86-to-arm-single-dc-50-perc.yaml", "test-cases/platform-migration/x86-to-arm-single-dc-vnodes.yaml"]
    OK
=== ["test-cases/platform-migration/x86-to-arm-single-dc-50-perc.yaml", "test-cases/platform-migration/x86-to-arm-multi-dc.yaml"]
    OK

0 failed
```