### PR TITLE
fix(nemesis): handle new keyspace being written to during AddRemoveDCNemesis

### DIFF
--- a/sdcm/nemesis/monkey/add_remove_dc.py
+++ b/sdcm/nemesis/monkey/add_remove_dc.py
@@ -1,4 +1,4 @@
-from collections.abc import Iterator
+from collections.abc import Generator
 from contextlib import ExitStack, contextmanager
 
 from sdcm.cluster import BaseNode
@@ -51,7 +51,7 @@ class AddRemoveDcNemesis(NemesisBaseClass):
         if self.runner.cluster.is_features_enabled_on_node(
             node=self.runner.target_node, feature_list=["KEYSPACE_MULTI_RF_CHANGE"]
         ):
-            return 2
+            return 3
         return 1
 
     @property
@@ -65,7 +65,7 @@ class AddRemoveDcNemesis(NemesisBaseClass):
         return system_keyspaces
 
     @contextmanager
-    def temporary_system_keyspaces_network_topology_strategy(self) -> Iterator[None]:
+    def temporary_system_keyspaces_network_topology_strategy(self) -> Generator[None]:
         """Temporarily switch system keyspaces to NetworkTopologyStrategy."""
         with (
             temporary_replication_strategy_setter(self.runner.target_node) as ntrs_setter,
@@ -78,8 +78,45 @@ class AddRemoveDcNemesis(NemesisBaseClass):
                     ntrs_setter(**{keyspace: new_rs})
             yield
 
+    def _preserve_keyspaces_with_new_dc_replication(self, new_dc_setter: temporary_replication_strategy_setter) -> None:
+        """Add rollback records for keyspaces created while the temporary DC exists."""
+        new_dc_name = self.new_dc_name
+        if not new_dc_name:
+            return
+
+        try:
+            with self.runner.cluster.cql_connection_patient(self.runner.target_node) as session:
+                result = session.execute("SELECT keyspace_name, replication FROM system_schema.keyspaces")
+                keyspace_rows = result.current_rows
+        except Exception as exc:  # noqa: BLE001 - best-effort cleanup must not mask nemesis failure
+            self.runner.log.warning(f"Failed to discover keyspaces with replication to {new_dc_name}: {exc}")
+            return
+
+        for row in keyspace_rows:
+            keyspace = row.keyspace_name
+            replication = row.replication
+            self.runner.log.info(f"Found {keyspace=} with {replication=}")
+            if keyspace in new_dc_setter.preserved:
+                continue
+            if "NetworkTopologyStrategy" not in replication.get("class", ""):
+                continue
+            if new_dc_name not in replication:
+                continue
+
+            try:
+                strategy = ReplicationStrategy.get(self.runner.target_node, keyspace)
+                rollback_strategy = NetworkTopologyReplicationStrategy(
+                    **{**strategy.replication_factors_per_dc, new_dc_name: 0}
+                )
+            except Exception as exc:  # noqa: BLE001 - keep rollback of other keyspaces best-effort
+                self.runner.log.warning(f"Failed to preserve rollback strategy for keyspace {keyspace}: {exc}")
+                continue
+
+            self.runner.log.info(f"Preserve rollback strategy for keyspace {keyspace} with RF=0 in {new_dc_name}")
+            new_dc_setter.preserved[keyspace] = rollback_strategy
+
     @contextmanager
-    def temporary_new_dc_replication_factors(self) -> Iterator[None]:
+    def temporary_new_dc_replication_factors(self) -> Generator[None]:
         """Temporarily update replication factors for the new datacenter."""
         with (
             temporary_replication_strategy_setter(self.runner.target_node) as new_dc_setter,
@@ -99,7 +136,10 @@ class AddRemoveDcNemesis(NemesisBaseClass):
                     )
                     new_dc_setter.preserved[keyspace] = rollback_strategy
 
-            yield
+            try:
+                yield
+            finally:
+                self._preserve_keyspaces_with_new_dc_replication(new_dc_setter)
 
     @property
     def datacenters(self) -> list[str]:

--- a/sdcm/utils/replication_strategy_utils.py
+++ b/sdcm/utils/replication_strategy_utils.py
@@ -5,6 +5,8 @@ import re
 from contextlib import ContextDecorator
 from typing import Callable, Dict, TYPE_CHECKING
 
+from cassandra import InvalidRequest
+
 from sdcm.exceptions import DatacenterNotResolvedError
 from sdcm.utils.cql_utils import cql_quote_if_needed
 from sdcm.utils.database_query_utils import is_system_keyspace, LOGGER
@@ -126,8 +128,13 @@ class temporary_replication_strategy_setter(ContextDecorator):
 
     def __call__(self, **keyspaces: ReplicationStrategy) -> None:
         for keyspace, strategy in keyspaces.items():
-            self._preserve_replication_strategy(keyspace)
-            strategy.apply(self.node, keyspace)
+            try:
+                self._preserve_replication_strategy(keyspace)
+                strategy.apply(self.node, keyspace)
+            except InvalidRequest as exc:
+                # A concurrent nemesis may have dropped this keyspace in the meantime:
+                # skip it instead of aborting rollback of the remaining keyspaces.
+                LOGGER.warning("Skipping replication strategy update for keyspace %s: %s", keyspace, exc)
 
 
 class DataCenterTopologyRfControl:

--- a/unit_tests/unit/nemesis/monkey/test_add_remove_dc.py
+++ b/unit_tests/unit/nemesis/monkey/test_add_remove_dc.py
@@ -1,6 +1,7 @@
 """Tests for sdcm.nemesis.monkey.add_remove_dc module."""
 
 from threading import Event
+from types import SimpleNamespace
 from unittest.mock import MagicMock, call, patch
 
 import pytest
@@ -16,6 +17,11 @@ from sdcm.utils.replication_strategy_utils import (
 _MODULE = "sdcm.nemesis.monkey.add_remove_dc"
 
 pytestmark = pytest.mark.usefixtures("events")
+
+
+def _keyspace_row(name, replication):
+    """Build a system_schema.keyspaces row for replication discovery tests."""
+    return SimpleNamespace(keyspace_name=name, replication=replication)
 
 
 def _clone_strategy(strategy):
@@ -155,8 +161,31 @@ def test_disrupt_updates_replication_and_cleans_new_dc(runner):
     monkey = AddRemoveDcNemesis(runner)
     new_nodes = [MagicMock(name="node-new-1"), MagicMock(name="node-new-2")]
     events = []
+    created_keyspace = "created_during_nemesis"
     first_setter = FakeReplicationStrategySetter("system-keyspaces", events)
     second_setter = FakeReplicationStrategySetter("new-dc-rf", events)
+    session = runner.cluster.cql_connection_patient.return_value.__enter__.return_value
+    session.execute.side_effect = None
+    session.execute.return_value = MagicMock(
+        current_rows=[
+            _keyspace_row(
+                created_keyspace,
+                {
+                    "class": "org.apache.cassandra.locator.NetworkTopologyStrategy",
+                    monkey.initial_dc_name: str(monkey.new_ks_rf),
+                    "dc1_nemesis_dc": str(monkey.num_nodes_in_new_dc),
+                },
+            ),
+            _keyspace_row("local_strategy_keyspace", {"class": "org.apache.cassandra.locator.LocalStrategy"}),
+            _keyspace_row(
+                "other_dc_keyspace",
+                {
+                    "class": "org.apache.cassandra.locator.NetworkTopologyStrategy",
+                    monkey.initial_dc_name: str(monkey.new_ks_rf),
+                },
+            ),
+        ]
+    )
 
     def add_nodes():
         monkey.new_nodes = new_nodes
@@ -180,6 +209,10 @@ def test_disrupt_updates_replication_and_cleans_new_dc(runner):
             return NetworkTopologyReplicationStrategy(**{monkey.initial_dc_name: monkey.new_ks_rf})
         if keyspace in ("system_distributed", "system_traces"):
             return SimpleReplicationStrategy(monkey.new_ks_rf)
+        if keyspace == created_keyspace:
+            return NetworkTopologyReplicationStrategy(
+                **{monkey.initial_dc_name: monkey.new_ks_rf, "dc1_nemesis_dc": monkey.num_nodes_in_new_dc}
+            )
         return NetworkTopologyReplicationStrategy(**{monkey.initial_dc_name: monkey.new_ks_rf})
 
     with (
@@ -234,10 +267,54 @@ def test_disrupt_updates_replication_and_cleans_new_dc(runner):
         }
 
     assert len(second_setter.rollback_calls) == 1
-    assert list(second_setter.rollback_calls[0]) == updated_keyspaces
+    assert list(second_setter.rollback_calls[0]) == updated_keyspaces + [created_keyspace]
     assert events.index("new-dc-rf:rollback") < events.index("decommission")
 
     assert monkey.new_dc_name is None
+
+
+def test_temporary_new_dc_replication_factors_preserves_created_keyspaces_on_error(runner):
+    """Keyspaces created during the temporary DC window should be rolled back on errors too."""
+    monkey = AddRemoveDcNemesis(runner)
+    runner.status_by_dc["dc1_nemesis_dc"] = object()
+    created_keyspace = "created_during_error"
+    setter = FakeReplicationStrategySetter("new-dc-rf", [])
+    session = runner.cluster.cql_connection_patient.return_value.__enter__.return_value
+    session.execute.side_effect = None
+    session.execute.return_value = MagicMock(
+        current_rows=[
+            _keyspace_row(
+                created_keyspace,
+                {
+                    "class": "org.apache.cassandra.locator.NetworkTopologyStrategy",
+                    monkey.initial_dc_name: str(monkey.new_ks_rf),
+                    "dc1_nemesis_dc": str(monkey.num_nodes_in_new_dc),
+                },
+            )
+        ]
+    )
+
+    def fake_get(node, keyspace):
+        if keyspace == created_keyspace:
+            return NetworkTopologyReplicationStrategy(
+                **{monkey.initial_dc_name: monkey.new_ks_rf, "dc1_nemesis_dc": monkey.num_nodes_in_new_dc}
+            )
+        return NetworkTopologyReplicationStrategy(**{monkey.initial_dc_name: monkey.new_ks_rf})
+
+    with pytest.raises(RuntimeError, match="boom"):
+        with (
+            patch(f"{_MODULE}.temporary_replication_strategy_setter", return_value=setter),
+            patch(f"{_MODULE}.ReplicationStrategy.get", side_effect=fake_get),
+        ):
+            with monkey.temporary_new_dc_replication_factors():
+                raise RuntimeError("boom")
+
+    expected_keyspaces = ["system_distributed", "system_traces", monkey.new_ks_name, created_keyspace]
+    assert list(setter.rollback_calls[0]) == expected_keyspaces
+    assert setter.preserved[created_keyspace].replication_factors_per_dc == {
+        monkey.initial_dc_name: monkey.new_ks_rf,
+        "dc1_nemesis_dc": 0,
+    }
 
 
 def test_assert_new_dc_registered_retries_until_status_contains_new_dc(runner):
@@ -343,7 +420,7 @@ def test_finalizer_skips_decommission_when_no_new_nodes(runner):
 @pytest.mark.parametrize(
     "feature_enabled,expected_count",
     [
-        pytest.param(True, 2, id="multi-rf-change-enabled"),
+        pytest.param(True, 3, id="multi-rf-change-enabled"),
         pytest.param(False, 1, id="multi-rf-change-disabled"),
     ],
 )


### PR DESCRIPTION
If a new keyspace is created and written to by cassandra-stress while there is another DC, because the stress command only specifies `replication_factor=3`, it will try to  write to that DC and get a schema creation failure.

- change the number of nodes in the new DC to 3 (matches RF in most commands)
- look for keyspaces from outside the nemesis, and revert their RF if needed.

Closes: SCT-130

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://argus.scylladb.com/tests/scylla-cluster-tests/196a37b7-f5a4-4dc8-8f50-35f0b33eca26
Tested on another branch were I added a nemesis that runs in parallel and just creates and writes to some keyspaces

From sct.log, 4 instances where the keyspace created by the second nemesis was altered to have RF=0 on the new DC.
```
2026-08-14 10:48:48,990 ... Executing CQL 'ALTER KEYSPACE system_distributed WITH replication = {'class': 'NetworkTopologyStrategy', 'eu-west-1': 3}' ...
2026-08-14 10:49:10,761 ... Executing CQL 'ALTER KEYSPACE system_traces WITH replication = {'class': 'NetworkTopologyStrategy', 'eu-west-1': 2}' ...
2026-08-14 10:49:32,812 ... Executing CQL 'ALTER KEYSPACE system_distributed WITH replication = {'class': 'NetworkTopologyStrategy', 'eu-west-1': 3, 'add_remove_nemesis_dc': 3}' ...
2026-08-14 10:49:55,263 ... Executing CQL 'ALTER KEYSPACE system_traces WITH replication = {'class': 'NetworkTopologyStrategy', 'eu-west-1': 2, 'add_remove_nemesis_dc': 3}' ...
2026-08-14 10:50:02,385 ... Executing CQL 'ALTER KEYSPACE keyspace_new_dc WITH replication = {'class': 'NetworkTopologyStrategy', 'eu-west-1': ['RACK1', 'RACK2', 'RACK0'], 'add_remove_nemesis_dc': 3}' ...
2026-08-14 11:08:59,209 ... Executing CQL 'ALTER KEYSPACE system_distributed WITH replication = {'class': 'NetworkTopologyStrategy', 'eu-west-1': 3, 'add_remove_nemesis_dc': 0}' ...
2026-08-14 11:09:18,289 ... Executing CQL 'ALTER KEYSPACE system_traces WITH replication = {'class': 'NetworkTopologyStrategy', 'eu-west-1': 2, 'add_remove_nemesis_dc': 0}' ...
2026-08-14 11:09:23,177 ... Executing CQL 'ALTER KEYSPACE keyspace_new_dc WITH replication = {'class': 'NetworkTopologyStrategy', 'eu-west-1': ['RACK1', 'RACK2', 'RACK0'], 'add_remove_nemesis_dc': 0}' ...
2026-08-14 11:10:48,728 ... Executing CQL 'ALTER KEYSPACE "keyspace_stress_write_SFM9ZJ8D" WITH replication = {'class': 'NetworkTopologyStrategy', 'add_remove_nemesis_dc': 0, 'eu-west-1': ['RACK1', 'RACK2', 'RACK0']}' ...
2026-08-14 11:11:56,717 ... Executing CQL 'ALTER KEYSPACE "keyspace_stress_write_F5EDKP0N" WITH replication = {'class': 'NetworkTopologyStrategy', 'add_remove_nemesis_dc': 0, 'eu-west-1': ['RACK1', 'RACK2', 'RACK0']}' ...
2026-08-14 11:19:49,829 ... Executing CQL 'ALTER KEYSPACE system_distributed WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3}' ...
2026-08-14 11:19:53,403 ... Executing CQL 'ALTER KEYSPACE system_traces WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 2}' ...
2026-08-14 11:30:39,678 ... Executing CQL 'ALTER KEYSPACE system_distributed WITH replication = {'class': 'NetworkTopologyStrategy', 'eu-west-1': 3}' ...
2026-08-14 11:31:00,542 ... Executing CQL 'ALTER KEYSPACE system_traces WITH replication = {'class': 'NetworkTopologyStrategy', 'eu-west-1': 2}' ...
2026-08-14 11:31:07,602 ... Executing CQL 'ALTER KEYSPACE system_distributed WITH replication = {'class': 'NetworkTopologyStrategy', 'eu-west-1': 3, 'add_remove_nemesis_dc': 3}' ...
2026-08-14 11:31:30,574 ... Executing CQL 'ALTER KEYSPACE system_traces WITH replication = {'class': 'NetworkTopologyStrategy', 'eu-west-1': 2, 'add_remove_nemesis_dc': 3}' ...
2026-08-14 11:31:38,952 ... Executing CQL 'ALTER KEYSPACE keyspace_new_dc WITH replication = {'class': 'NetworkTopologyStrategy', 'eu-west-1': ['RACK1', 'RACK2', 'RACK0'], 'add_remove_nemesis_dc': 3}' ...
2026-08-14 11:48:51,538 ... Executing CQL 'ALTER KEYSPACE system_distributed WITH replication = {'class': 'NetworkTopologyStrategy', 'eu-west-1': 3, 'add_remove_nemesis_dc': 0}' ...
2026-08-14 11:49:11,815 ... Executing CQL 'ALTER KEYSPACE system_traces WITH replication = {'class': 'NetworkTopologyStrategy', 'eu-west-1': 2, 'add_remove_nemesis_dc': 0}' ...
2026-08-14 11:49:30,158 ... Executing CQL 'ALTER KEYSPACE keyspace_new_dc WITH replication = {'class': 'NetworkTopologyStrategy', 'eu-west-1': ['RACK1', 'RACK2', 'RACK0'], 'add_remove_nemesis_dc': 0}' ...
2026-08-14 11:50:08,799 ... Executing CQL 'ALTER KEYSPACE "keyspace_stress_write_S6CZ3IP8" WITH replication = {'class': 'NetworkTopologyStrategy', 'add_remove_nemesis_dc': 0, 'eu-west-1': ['RACK0', 'RACK2', 'RACK1']}' ...
2026-08-14 11:50:42,517 ... Executing CQL 'ALTER KEYSPACE "keyspace_stress_write_UC3DSMMF" WITH replication = {'class': 'NetworkTopologyStrategy', 'add_remove_nemesis_dc': 0, 'eu-west-1': ['RACK1', 'RACK2', 'RACK0']}' ...
2026-08-14 11:51:13,574 ... Executing CQL 'ALTER KEYSPACE system_distributed WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3}' ...
2026-08-14 11:51:17,417 ... Executing CQL 'ALTER KEYSPACE system_traces WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 2}' ...
```

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
