### PR TITLE
Introduce Manager 3.12

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -11,7 +11,7 @@ ip_ssh_connections: 'private'
 scylla_repo: ''
 unified_package: ''
 
-manager_version: '3.11'
+manager_version: '3.12'
 manager_scylla_backend_version: '2025.4'
 # Notice: that centos (default monitor), ubuntu 22, ubuntu 20 and debian 11 monitors use 2024, while debian 10 ubuntu 18 use 2023, since we support both
 
@@ -186,8 +186,8 @@ jepsen_test_count: 1
 jepsen_test_run_policy: all
 
 max_events_severities: ""
-scylla_mgmt_agent_version: '3.11.0'
-mgmt_docker_image: 'scylladb/scylla-manager:3.11.0'
+scylla_mgmt_agent_version: '3.12.0'
+mgmt_docker_image: 'scylladb/scylla-manager:3.12.0'
 k8s_log_api_calls: false
 k8s_deploy_monitoring: false
 k8s_minio_storage_size: '10Gi'

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -414,7 +414,7 @@ Url to the repo of scylla manager agent version to install for management tests
 
 Version of Scylla Manager server and agent to install
 
-**default:** 3.11
+**default:** 3.12
 
 **type:** str
 
@@ -441,7 +441,7 @@ Version of ScyllaDB to install as Manager backend
 
 Version of Scylla Manager agent to install for management tests
 
-**default:** 3.11.0
+**default:** 3.12.0
 
 **type:** str
 
@@ -3012,7 +3012,7 @@ Number of nodes in the monitoring pool that will be used for scylla-operator's d
 
 Scylla manager docker image, i.e. 'scylladb/scylla-manager:2.2.1'
 
-**default:** scylladb/scylla-manager:3.11.0
+**default:** scylladb/scylla-manager:3.12.0
 
 **type:** str (appendable)
 

--- a/jenkins-pipelines/manager/debian12-manager-install.jenkinsfile
+++ b/jenkins-pipelines/manager/debian12-manager-install.jenkinsfile
@@ -9,5 +9,5 @@ managerPipeline(
     test_name: 'mgmt_cli_test.ManagerInstallationTests.test_manager_installed_and_functional',
     test_config: '''["test-cases/manager/manager-installation-set-distro.yaml", "configurations/manager/debian12.yaml"]''',
 
-    scylla_version: '2025.4'
+    scylla_version: '2026.1'
 )

--- a/jenkins-pipelines/manager/debian12-manager-sanity.jenkinsfile
+++ b/jenkins-pipelines/manager/debian12-manager-sanity.jenkinsfile
@@ -9,7 +9,7 @@ managerPipeline(
     test_name: 'mgmt_cli_test.ManagerSanityTests.test_manager_sanity',
     test_config: '''["test-cases/manager/manager-regression-singleDC-set-distro.yaml", "configurations/manager/debian12.yaml", "configurations/disable_kms_key_rotation.yaml", "configurations/disable_client_encrypt.yaml"]''',
 
-    scylla_version: '2025.4',
+    scylla_version: '2026.1',
 
     downstream_jobs_to_run: 'debian12-upgrade-test'
 )

--- a/jenkins-pipelines/manager/debian12-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/debian12-manager-upgrade.jenkinsfile
@@ -7,9 +7,9 @@ managerPipeline(
     backend: 'aws',
     region: 'eu-west-1',
 
-    scylla_version: '2025.4',
+    scylla_version: '2026.1',
 
-    manager_version: '3.8',
+    manager_version: '3.10',
     target_manager_version: 'master_latest',
 
     test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',

--- a/jenkins-pipelines/manager/ubuntu22-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu22-manager-upgrade.jenkinsfile
@@ -10,7 +10,7 @@ managerPipeline(
     scylla_version: '2026.1',
 
     // Upgrade from the previous minor release (the last one)
-    manager_version: '3.10',
+    manager_version: '3.11',
     target_manager_version: 'master_latest',
 
     test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',

--- a/jenkins-pipelines/manager/ubuntu24-manager-older-enterprise-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu24-manager-older-enterprise-upgrade.jenkinsfile
@@ -11,7 +11,7 @@ managerPipeline(
 
     // Upgrade from some old Manager release which is still used in production
     // Use Metabase to check it (https://scylladb.metabaseapp.com/question/1685-manager-version)
-    manager_version: '3.7',
+    manager_version: '3.8',
     target_manager_version: 'master_latest',
 
     test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',

--- a/jenkins-pipelines/manager/ubuntu24-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu24-manager-upgrade.jenkinsfile
@@ -8,7 +8,7 @@ managerPipeline(
     region: 'us-east-1',
 
     // Upgrade from the latest patch release
-    manager_version: '3.11',
+    manager_version: '3.12',
     target_manager_version: 'master_latest',
 
     test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',

--- a/unit_tests/unit/test_sdcm_mgmt_common.py
+++ b/unit_tests/unit/test_sdcm_mgmt_common.py
@@ -32,14 +32,14 @@ class TestManagerVersions:
         "version, distro, expected_url",
         [
             (
-                "3.11",
+                "3.12",
                 Distro.UBUNTU24,
-                "https://downloads.scylladb.com/deb/debian/scylladb-manager-3.11.list",
+                "https://downloads.scylladb.com/deb/debian/scylladb-manager-3.12.list",
             ),
             (
-                "3.11",
+                "3.12",
                 Distro.CENTOS9,
-                "https://downloads.scylladb.com/rpm/centos/scylladb-manager-3.11.repo",
+                "https://downloads.scylladb.com/rpm/centos/scylladb-manager-3.12.repo",
             ),
             (
                 "3.8.1",

--- a/vars/longevityPipeline.groovy
+++ b/vars/longevityPipeline.groovy
@@ -156,7 +156,7 @@ def call(Map pipelineParams) {
             // Manager Configuration
             separator(name: 'MANAGER_CONFIG', sectionHeader: 'Manager Configuration')
             string(defaultValue: "${pipelineParams.get('manager_version', '')}",
-                   description: 'master_latest|3.11|3.10',
+                   description: 'master_latest|3.12|3.11',
                    name: 'manager_version')
 
             string(defaultValue: '',

--- a/vars/managerPipeline.groovy
+++ b/vars/managerPipeline.groovy
@@ -124,7 +124,7 @@ def call(Map pipelineParams) {
                    name: 'ip_ssh_connections')
             separator(name: 'MANAGER_CONFIG', sectionHeader: 'Manager Configuration')
             string(defaultValue: "${pipelineParams.get('manager_version', 'master_latest')}",
-                   description: 'master_latest|3.11|3.10',
+                   description: 'master_latest|3.12|3.11',
                    name: 'manager_version')
 
             string(defaultValue: "${pipelineParams.get('scylla_mgmt_address', '')}",
@@ -140,7 +140,7 @@ def call(Map pipelineParams) {
                    name: 'scylla_mgmt_pkg')
 
             string(defaultValue: "${pipelineParams.get('target_manager_version', '')}",
-                   description: 'master_latest|3.11|3.10. Only for upgrade test',
+                   description: 'master_latest|3.12|3.11. Only for upgrade test',
                    name: 'target_manager_version')
 
             string(defaultValue: "${pipelineParams.get('target_scylla_mgmt_server_address', '')}",


### PR DESCRIPTION
Closes https://scylladb.atlassian.net/browse/CLOUD-3493

### Changes

- bump default Manager version to 3.12 across framework

### PR pre-checks (self review)
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code