### PR TITLE
feature(xcloud): derive rack-aware topology from availability zones

### DIFF
--- a/defaults/cloud_config.yaml
+++ b/defaults/cloud_config.yaml
@@ -2,6 +2,10 @@ n_db_nodes: 3
 n_loaders: 1
 n_monitor_nodes: 1
 
+# xcloud uses real racks from availability zones, so rack simulation is disabled.
+# this also prevents fake rack spread for AWS loaders and monitors.
+simulated_racks: 0
+
 # disable it since it need ssh access to db nodes
 # TODO: remove it once we have such access by default
 run_commit_log_check_thread: false
@@ -13,3 +17,5 @@ xcloud_vpc_peering:
   cidr_subnet_size: 24
 
 xcloud_scaling_config: {}
+
+xcloud_availability_zones: ''

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -4864,6 +4864,9 @@ Forces GossipingPropertyFileSnitch (regardless `endpoint_snitch`) to simulate ra
 
 **type:** int
 
+**backend overrides:**
+- `0`: xcloud
+
 
 ## **rack_aware_loader** / SCT_RACK_AWARE_LOADER
 
@@ -4917,6 +4920,15 @@ Replication factor for Scylla Cloud cluster
 **default:** N/A
 
 **type:** int
+
+
+## **xcloud_availability_zones** / SCT_XCLOUD_AVAILABILITY_ZONES
+
+Comma-separated availability zones for Scylla Cloud DB placement.<br>AWS values are AZ IDs (e.g., 'use1-az1,use1-az2,use1-az3'); GCE values are zone names<br>(e.g., 'us-east1-b,us-east1-c'). When set, SCT sends 'availabilityZoneIdsOverride' and forces placement.<br>Provide one zone per DB node, or provide a shorter list to cycle round-robin (node count must divide evenly).<br>Repeat the same zone to keep all nodes in one AZ. Leave empty (default) to let Scylla Cloud choose placement<br>(multi-AZ spread). Cannot be used with 'xcloud_scaling_config'.
+
+**default:** N/A
+
+**type:** str (appendable)
 
 
 ## **xcloud_vpc_peering** / SCT_XCLOUD_VPC_PEERING

--- a/docs/new-hydra-commands.md
+++ b/docs/new-hydra-commands.md
@@ -15,6 +15,11 @@ hydra conf unit_tests/test_configs/minimal_test_case.yaml --backend gce
 # listing resource used in cloud (AWS/GCE)
 hydra list-resources --test-id n3vik6-ssu84ld --user bentsi
 
+# list ScyllaDB Cloud availability zones of a region, to pick AZ ids for xcloud_availability_zones
+hydra list-cloud-zones --xcloud-env staging --cloud-provider aws --region us-east-1
+# only the zones where a given instance type can be deployed
+hydra list-cloud-zones --xcloud-env staging --cloud-provider aws --region us-east-1 --instance-type i4i.large
+
 
 # cleanup resources
 hydra clean-resources --post-behavior

--- a/sct.py
+++ b/sct.py
@@ -49,7 +49,7 @@ from argus.common.sct_types import RawEventPayload
 import sct_sizing
 import sct_ssh
 import sct_scan_issues
-from sdcm.cloud_api_client import ScyllaCloudAPIClient
+from sdcm.cloud_api_client import ScyllaCloudAPIClient, CloudProviderType
 from sdcm.cluster_cloud import extract_short_test_id_from_name
 from sdcm.keystore import KeyStore
 from sdcm.localhost import LocalHost
@@ -1519,6 +1519,55 @@ def list_repos(dist_type, dist_version):
         tbl.add_row(version_prefix, repo_url)
 
     click.echo(rich_table_to_string(tbl, title="Scylla Repos"))
+
+
+@cli.command("list-cloud-zones", help="List ScyllaDB Cloud availability zones of a provider region")
+@click.option(
+    "--xcloud-env",
+    type=str,
+    default="staging",
+    help="ScyllaDB Cloud environment to query. Defaults to staging",
+)
+@click.option("--cloud-provider", type=click.Choice(["aws", "gce"]), default="aws", help="Cloud provider to query")
+@click.option("--region", type=str, required=True, help="Region to query, eg: us-east-1, us-east1")
+@click.option(
+    "--instance-type",
+    type=str,
+    default=None,
+    help="Only list zones where this instance type can be deployed, eg: i4i.large",
+)
+def list_cloud_zones(xcloud_env, cloud_provider, region, instance_type):
+    add_file_logger()
+
+    credentials = KeyStore().get_cloud_rest_credentials(xcloud_env)
+    api_client = ScyllaCloudAPIClient(api_url=credentials["base_url"], auth_token=credentials["api_token"])
+
+    provider_id = api_client.cloud_provider_ids[CloudProviderType.from_sct_backend(cloud_provider)]
+    region_id = api_client.get_region_id_by_name(cloud_provider_id=provider_id, region_name=region)
+
+    instance_type_id = None
+    if instance_type:
+        instance_type_id = api_client.get_instance_id_by_name(
+            cloud_provider_id=provider_id, region_id=region_id, instance_type_name=instance_type
+        )
+    zones = api_client.get_availability_zones(
+        cloud_provider_id=provider_id, region_id=region_id, instance_type_id=instance_type_id
+    )
+
+    if not zones:
+        click.secho(f"No availability zones found for '{cloud_provider}' region '{region}'!", fg="yellow")
+        return
+
+    # the AZ id is what 'xcloud_availability_zones' expects; the name is the account-specific alias
+    tbl = Table("AZ ID", "AZ name", show_lines=False)
+    for zone in zones:
+        tbl.add_row(zone["id"], zone["name"])
+
+    title = f"ScyllaDB Cloud availability zones ({xcloud_env}, {cloud_provider}, {region})"
+    if instance_type:
+        title += f" for {instance_type}"
+    click.echo(rich_table_to_string(tbl, title=title))
+    click.secho(f"Use the AZ ID column as SCT_XCLOUD_AVAILABILITY_ZONES, eg: {zones[0]['id']}", fg="green")
 
 
 @cli.command("get-scylla-base-versions", help="Get Scylla base versions of upgrade")

--- a/sdcm/cloud_api_client.py
+++ b/sdcm/cloud_api_client.py
@@ -264,6 +264,7 @@ class ScyllaCloudAPIClient:
         prom_proxy: bool,
         vector_search: dict | None,
         tablets: str | None,
+        availability_zone_ids: list[str] | None = None,
     ) -> dict[str, Any]:
         """
         Create cluster-create request.
@@ -291,9 +292,16 @@ class ScyllaCloudAPIClient:
         :param prom_proxy: whether to enable Prometheus proxy for the cluster (default: False)
         :param vector_search: Vector Search configuration
         :param tablets: tablets configuration, should be set to "enforced" for XCloud cluster
+        :param availability_zone_ids: optional per-node AZ placement. AWS expects AZ IDs
+            (e.g., 'use1-az1'); GCE expects zone names (e.g., 'us-east1-b').
+            Provide one value per node to force placement. Use None to let Scylla Cloud choose placement.
 
         :return: created cluster details
         """
+        # 'placement' is a string enum ("true"/"false"/"") in the API, not a JSON boolean
+        placement_overrides = (
+            {"availabilityZoneIdsOverride": availability_zone_ids, "placement": "true"} if availability_zone_ids else {}
+        )
         response = self.request(
             "POST",
             f"/account/{account_id}/cluster",
@@ -318,6 +326,7 @@ class ScyllaCloudAPIClient:
             promProxy=prom_proxy,
             vectorSearch=vector_search,
             tablets=tablets,
+            **placement_overrides,
         )
         return self._parse_response_data(response)
 

--- a/sdcm/cloud_api_client.py
+++ b/sdcm/cloud_api_client.py
@@ -174,6 +174,24 @@ class ScyllaCloudAPIClient:
         )
         return {instance["externalId"]: instance["id"] for instance in response["instances"]}
 
+    def get_availability_zones(
+        self, *, cloud_provider_id: int, region_id: int, instance_type_id: int | None = None
+    ) -> list[dict[str, str]]:
+        """
+        Get availability zones of a given cloud provider region, sorted by zone id.
+
+        AWS returns a distinct 'id' ('use1-az1', stable per physical zone) and 'name' ('us-east-1c',
+        an account-specific alias); GCE returns the zone name in both.
+        Passing instance_type_id narrows the list to zones where that instance type can be deployed.
+        """
+        account_id = self.get_current_account_id()
+        cloud_account_id = self.get_cloud_account_id(account_id=account_id, cloud_provider_id=cloud_provider_id)
+        params = {"instanceTypeId": instance_type_id} if instance_type_id else None
+        zones = self.request(
+            "GET", f"/account/{account_id}/cloud-account/{cloud_account_id}/region/{region_id}/zones", params=params
+        )
+        return sorted(zones or [], key=lambda zone: zone["id"])
+
     @cached_property
     def cloud_provider_ids(self) -> dict[CloudProviderType, int]:
         """Get a mapping of cloud provider names to their IDs"""
@@ -216,6 +234,14 @@ class ScyllaCloudAPIClient:
     def get_active_accounts(self, *, account_id: int) -> list[dict[str, Any]]:
         """From given account list active cloud-accounts for all cloud-providers"""
         return self.request("GET", f"/account/{account_id}/cloud-account")
+
+    def get_cloud_account_id(self, *, account_id: int, cloud_provider_id: int) -> int:
+        """Get the ID of the active cloud account tied to a given cloud provider"""
+        for account in self.get_active_accounts(account_id=account_id):
+            if account["cloudProviderId"] == cloud_provider_id and account.get("state") == "ACTIVE":
+                return account["id"]
+
+        raise ScyllaCloudAPIError(f"No active cloud account found for cloud_provider_id: {cloud_provider_id}")
 
     def get_account_details(self) -> dict[str, Any]:
         """Get details of the account tied to the authorized user"""

--- a/sdcm/cluster_cloud.py
+++ b/sdcm/cluster_cloud.py
@@ -34,6 +34,8 @@ from sdcm.utils.cloud_api_utils import (
     compute_cluster_exp_hours,
     build_cloud_cluster_name,
     apply_keep_tag_to_name,
+    parse_availability_zones,
+    expand_availability_zones,
     CLOUD_KEEP_ALIVE_HOURS,
 )
 from sdcm.utils.gce_region import GceRegion
@@ -171,6 +173,22 @@ def download_vector_locally(arch="amd64", dest_dir="downloads"):
     return dest
 
 
+def get_node_az(node_data: dict[str, Any]) -> str | None:
+    """Return node availability zone from cloud API data."""
+    return node_data.get("azName") or node_data.get("azId")
+
+
+def map_azs_to_rack_indexes(nodes_data: list[dict[str, Any]]) -> dict[str, int]:
+    """Build a stable AZ-to-rack index map from cloud node payloads."""
+    unique_azs: set[str] = set()
+    for node_data in nodes_data:
+        az = get_node_az(node_data)
+        if az:
+            unique_azs.add(az)
+
+    return {az: index for index, az in enumerate(sorted(unique_azs))}
+
+
 class ScyllaCloudError(Exception):
     """Exception for Scylla Cloud related errors"""
 
@@ -228,7 +246,9 @@ class CloudNode(cluster.BaseNode):
 
     def _refresh_instance_state(self):
         try:
-            node_details = self._api_client.get_cluster_nodes(account_id=self._account_id, cluster_id=self._cluster_id)
+            node_details = self._api_client.get_cluster_nodes(
+                account_id=self._account_id, cluster_id=self._cluster_id, enriched=True
+            )
             for node_data in node_details:
                 if node_data.get("id") == self._node_id:
                     self._cloud_instance_data = node_data
@@ -255,7 +275,8 @@ class CloudNode(cluster.BaseNode):
 
     @property
     def vm_region(self):
-        return self._cloud_instance_data.get("region", {}).get("name", "unknown")
+        region_info = self._cloud_instance_data.get("region", {})
+        return region_info.get("externalId") or region_info.get("name", "unknown")
 
     @property
     def region(self):
@@ -264,6 +285,10 @@ class CloudNode(cluster.BaseNode):
     @property
     def datacenter(self):
         return f"datacenter{self.dc_idx + 1}"
+
+    @property
+    def availability_zone(self) -> str:
+        return get_node_az(self._cloud_instance_data) or ""
 
     def _get_ipv6_ip_address(self):
         return None
@@ -592,9 +617,14 @@ class VectorStoreSetCloud(VectorStoreClusterMixin, cluster.BaseCluster):
 
     @property
     def vs_nodes_data(self) -> list[dict]:
-        """Fetch active Vector Search nodes data"""
+        """Fetch active Vector Search nodes data with each node availability zone attached"""
         vs_info = self._get_vs_info()
-        all_nodes = [node for az in (vs_info.get("availabilityZones") or []) for node in az.get("nodes", [])]
+        all_nodes = [
+            # the VS endpoint spells it 'azid'; normalize to the 'azId' key get_node_az() reads
+            node | {"azId": az.get("azid")}
+            for az in (vs_info.get("availabilityZones") or [])
+            for node in az.get("nodes", [])
+        ]
         return [node for node in all_nodes if node.get("status", "").upper() not in ("DELETED", "PENDING_DELETE")]
 
     def init_vs_nodes_from_cluster(self) -> None:
@@ -604,7 +634,6 @@ class VectorStoreSetCloud(VectorStoreClusterMixin, cluster.BaseCluster):
             node_class=CloudVSNode,
             node_prefix=self.node_prefix,
             dc_idx=0,
-            rack=0,
         )
         self.nodes.extend(created_nodes)
 
@@ -716,10 +745,11 @@ class ScyllaCloudCluster(cluster.BaseScyllaCluster, cluster.BaseCluster):
             node_prefix=node_prefix,
             n_nodes=n_nodes,
             params=params,
-            region_names=params.cloud_provider_params.get("region"),
+            region_names=[params.cloud_provider_params.get("region")],
             node_type=node_type,
             add_nodes=add_nodes,
         )
+        self._update_racks_count()
 
     @property
     def parallel_startup(self):
@@ -810,10 +840,13 @@ class ScyllaCloudCluster(cluster.BaseScyllaCluster, cluster.BaseCluster):
         if self.test_config.REUSE_CLUSTER:
             self._cluster_id = self._resolve_cluster_id()
             self._reuse_existing_cluster()
+            self._update_racks_count()
             return self.nodes
 
         self.log.info("Adding %s nodes to Scylla Cloud cluster", count)
-        return self._create_cluster(count, dc_idx, rack, enable_auto_bootstrap, instance_type)
+        nodes = self._create_cluster(count, dc_idx, rack, enable_auto_bootstrap, instance_type)
+        self._update_racks_count()
+        return nodes
 
     def _init_vector_store_cluster(self) -> None:
         """Initialize Vector Store cluster object"""
@@ -888,22 +921,32 @@ class ScyllaCloudCluster(cluster.BaseScyllaCluster, cluster.BaseCluster):
         dc_idx: int = 0,
         rack: int = 0,
     ) -> list[CloudNode]:
-        """Create cloud node objects from API data"""
+        """Create cloud node objects from API data, deriving each node rack from its AZ"""
         if not nodes_data:
             return []
 
         self.log.info("Initializing %s %s objects", len(nodes_data), node_class.__name__)
 
+        az_to_rack = map_azs_to_rack_indexes(nodes_data)
+        if az_to_rack:
+            self.log.info("AZ to rack index mapping: %s", az_to_rack)
+        else:
+            self.log.warning(
+                "No availability zone data in the cloud nodes payload; all %s nodes fall back to rack %s. "
+                "Rack-aware features and RackawareValidator are inoperative.",
+                len(nodes_data),
+                rack,
+            )
         return [
             self._create_node(
                 cloud_instance_data=node_data,
-                node_index=i,
+                node_index=index,
                 dc_idx=dc_idx,
-                rack=rack,
+                rack=az_to_rack.get(get_node_az(node_data), rack),
                 node_class=node_class,
                 node_prefix=node_prefix,
             )
-            for i, node_data in enumerate(nodes_data, start=1)
+            for index, node_data in enumerate(nodes_data, start=1)
         ]
 
     def _init_nodes_from_cluster(self, count: int, dc_idx: int, rack: int) -> list[CloudNode]:
@@ -921,6 +964,25 @@ class ScyllaCloudCluster(cluster.BaseScyllaCluster, cluster.BaseCluster):
         )
         self.nodes.extend(created_nodes)
         return created_nodes
+
+    def _update_racks_count(self) -> None:
+        """Set racks_count from real AZ topology instead of simulated/config-derived values"""
+        configured_zones = parse_availability_zones(self.params.get("xcloud_availability_zones"))
+        configured_zone_count = len(set(configured_zones))
+
+        if self.nodes:
+            self.racks_count = len({node.rack for node in self.nodes})
+            if configured_zones and self.racks_count < configured_zone_count:
+                self.log.warning(
+                    "xcloud_availability_zones configures %s distinct zone(s), but only %s distinct rack(s) were "
+                    "derived from the cluster nodes. Rack-aware features and RackawareValidator may not be "
+                    "exercising all configured zones.",
+                    configured_zone_count,
+                    self.racks_count,
+                )
+            return
+
+        self.racks_count = configured_zone_count if configured_zones else 1
 
     def _init_manager_node(self, wait_for_install: bool = True) -> None:
         localhost = TestConfig().tester_obj().localhost
@@ -1029,9 +1091,10 @@ class ScyllaCloudCluster(cluster.BaseScyllaCluster, cluster.BaseCluster):
             instance_id = 0
             tablets_mode = "enforced"
         else:
-            instance_type_name = instance_type or self.params.cloud_provider_params.get("instance_type_db")
             instance_id = self._api_client.get_instance_id_by_name(
-                cloud_provider_id=self.provider_id, region_id=self.region_id, instance_type_name=instance_type_name
+                cloud_provider_id=self.provider_id,
+                region_id=self.region_id,
+                instance_type_name=instance_type or self.params.cloud_provider_params.get("instance_type_db"),
             )
             tablets_mode = None
 
@@ -1069,6 +1132,15 @@ class ScyllaCloudCluster(cluster.BaseScyllaCluster, cluster.BaseCluster):
                 "nodeCount": int(self.params.get("n_vector_store_nodes")),
                 "defaultInstanceTypeId": vs_instance_types[vs_instance_type_name],
             }
+
+        availability_zone_ids = (
+            expand_availability_zones(
+                parse_availability_zones(self.params.get("xcloud_availability_zones")), node_count
+            )
+            or None
+        )
+        if availability_zone_ids:
+            self.log.info("Forcing DB node AZ placement: %s", availability_zone_ids)
 
         expiration_hours = compute_cluster_exp_hours(
             self.test_config.TEST_DURATION, self.test_config.should_keep_alive(self.node_type)
@@ -1108,6 +1180,7 @@ class ScyllaCloudCluster(cluster.BaseScyllaCluster, cluster.BaseCluster):
             "scaling": self.xcloud_scaling_config,
             "vector_search": vs_config,
             "tablets": tablets_mode,
+            "availability_zone_ids": availability_zone_ids,
         }
 
     def _get_cluster_diagnostic_info(self) -> tuple[str, str]:

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -46,7 +46,12 @@ from sdcm.test_metadata import TestMetadata
 import sdcm.provision.azure.utils as azure_utils
 from sdcm.cloud_api_client import ScyllaCloudAPIClient, CloudProviderType
 from sdcm.keystore import KeyStore
-from sdcm.utils.cloud_api_utils import get_cloud_rest_credentials_from_file
+from sdcm.utils.cloud_api_utils import (
+    get_cloud_rest_credentials_from_file,
+    aws_region_to_az_id_prefix,
+    expand_availability_zones,
+    parse_availability_zones,
+)
 from sdcm.provision.aws.capacity_reservation import SCTCapacityReservation
 from sdcm.provision.aws.capacity_errors import RegionAMINotFoundError
 from sdcm.provision.aws.dedicated_host import SCTDedicatedHosts
@@ -2659,6 +2664,14 @@ class SCTConfiguration(BaseModel):
     xcloud_replication_factor: int = SctField(
         description="Replication factor for Scylla Cloud cluster",
     )
+    xcloud_availability_zones: String = SctField(
+        description="""Comma-separated availability zones for Scylla Cloud DB placement.
+         AWS values are AZ IDs (e.g., 'use1-az1,use1-az2,use1-az3'); GCE values are zone names
+         (e.g., 'us-east1-b,us-east1-c'). When set, SCT sends 'availabilityZoneIdsOverride' and forces placement.
+         Provide one zone per DB node, or provide a shorter list to cycle round-robin (node count must divide evenly).
+         Repeat the same zone to keep all nodes in one AZ. Leave empty (default) to let Scylla Cloud choose placement
+         (multi-AZ spread). Cannot be used with 'xcloud_scaling_config'.""",
+    )
     xcloud_vpc_peering: Annotated[dict, BeforeValidator(dict_or_str)] = SctField(
         description="""Dictionary of VPC peering parameters for private connectivity between
          SCT infrastructure and Scylla Cloud. The following parameters are used:
@@ -5211,15 +5224,21 @@ class SCTConfiguration(BaseModel):
         if not self.get("rack_aware_loader"):
             raise ValueError("'rack_aware_loader' must be set to True for rackaware validator.")
 
-        regions = self.get("simulated_regions") or len(self.region_names)
-        availability_zone = self.get("availability_zone")
-        racks_count = (
-            simulated_racks
-            if (simulated_racks := self.get("simulated_racks"))
-            else len(availability_zone.split(","))
-            if availability_zone
-            else 1
-        )
+        if self.get("cluster_backend") == "xcloud":
+            # xcloud+gce keeps the region in gce_datacenters, not region_names
+            regions = self.get("simulated_regions") or len(self.region_names or self.gce_datacenters)
+            # deterministic placement is required: this is the only source of AZ layout
+            racks_count = len(set(parse_availability_zones(self.get("xcloud_availability_zones"))))
+            if racks_count < 2:
+                raise ValueError(
+                    "Rack-aware validation on the xcloud backend requires 'xcloud_availability_zones' "
+                    "with at least two distinct zones."
+                )
+        else:
+            regions = self.get("simulated_regions") or len(self.region_names)
+            availability_zone, simulated_racks = self.get("availability_zone"), self.get("simulated_racks")
+            racks_count = simulated_racks or (len(availability_zone.split(",")) if availability_zone else 1)
+
         if racks_count == 1 and regions == 1:
             raise ValueError(
                 "Rack-aware validation can only be performed in multi-availability zone or multi-region environments."
@@ -5230,6 +5249,37 @@ class SCTConfiguration(BaseModel):
         zones = racks_count * regions
         if loaders >= zones:
             raise ValueError("Rack-aware validation requires zones without loaders.")
+
+    def _validate_xcloud_availability_zones(self):
+        """Validate the AZ placement knob against node count, scaling config and the target region"""
+        zones = parse_availability_zones(self.get("xcloud_availability_zones"))
+        if not zones:
+            return
+        if self.get("xcloud_scaling_config"):
+            raise ValueError(
+                "'xcloud_availability_zones' cannot be combined with 'xcloud_scaling_config': "
+                "node count is managed by Scylla Cloud scaling."
+            )
+        expand_availability_zones(zones, self.get("n_db_nodes")[0])
+
+        # zones from another region are only rejected by Siren after provisioning starts, with an
+        # opaque "general error creating the cluster", so catch the mismatch here instead
+        cloud_provider = self.get("xcloud_provider")
+        is_aws = cloud_provider == "aws"
+        region_name = self.region_names[0] if is_aws else self.gce_datacenters[0]
+        expected_prefix = aws_region_to_az_id_prefix(region_name) if is_aws else region_name
+
+        if (not is_aws) or expected_prefix:
+            zone_prefix = f"{expected_prefix}-"
+            mismatched = [zone for zone in zones if not zone.startswith(zone_prefix)]
+            if mismatched:
+                provider = "AWS" if is_aws else "GCE"
+                zone_kind = "availability zone IDs" if is_aws else "zone names"
+                example = f"{expected_prefix}-az1" if is_aws else f"{region_name}-b"
+                raise ValueError(
+                    f"'xcloud_availability_zones' {mismatched} does not belong to region '{region_name}'. "
+                    f"{provider} {zone_kind} for this region start with '{zone_prefix}' (e.g. '{example}')."
+                )
 
     def _validate_cloud_backend_parameters(self):
         cloud_api_client = ScyllaCloudAPIClient(
@@ -5288,6 +5338,8 @@ class SCTConfiguration(BaseModel):
             self["xcloud_replication_factor"] = min(*n_nodes, 3)
         elif rf > min(n_nodes):
             raise ValueError(f"xcloud_replication_factor ({rf}) cannot be greater than n_db_nodes ({n_nodes})")
+
+        self._validate_xcloud_availability_zones()
 
         # validate Vector Search parameters for cloud backend
         # TODO: update after Vector Search moves out of Beta for Scylla Cloud and limitations are changed/no longer apply

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -48,7 +48,6 @@ from sdcm.cloud_api_client import ScyllaCloudAPIClient, CloudProviderType
 from sdcm.keystore import KeyStore
 from sdcm.utils.cloud_api_utils import (
     get_cloud_rest_credentials_from_file,
-    aws_region_to_az_id_prefix,
     expand_availability_zones,
     parse_availability_zones,
 )
@@ -5250,7 +5249,7 @@ class SCTConfiguration(BaseModel):
         if loaders >= zones:
             raise ValueError("Rack-aware validation requires zones without loaders.")
 
-    def _validate_xcloud_availability_zones(self):
+    def _validate_xcloud_availability_zones(self, cloud_api_client, provider_id: int, region_id: int):
         """Validate the AZ placement knob against node count, scaling config and the target region"""
         zones = parse_availability_zones(self.get("xcloud_availability_zones"))
         if not zones:
@@ -5262,24 +5261,27 @@ class SCTConfiguration(BaseModel):
             )
         expand_availability_zones(zones, self.get("n_db_nodes")[0])
 
-        # zones from another region are only rejected by Siren after provisioning starts, with an
-        # opaque "general error creating the cluster", so catch the mismatch here instead
-        cloud_provider = self.get("xcloud_provider")
-        is_aws = cloud_provider == "aws"
+        # zones outside the region, and zones that cannot host the DB instance type, are only rejected by Siren
+        # after provisioning starts, with a generic "general error creating the cluster" error.
+        # So checking them against the account real zone list here instead
+        is_aws = self.get("xcloud_provider") == "aws"
         region_name = self.region_names[0] if is_aws else self.gce_datacenters[0]
-        expected_prefix = aws_region_to_az_id_prefix(region_name) if is_aws else region_name
+        instance_type = self.get("instance_type_db" if is_aws else "gce_instance_type_db")
+        instance_type_id = cloud_api_client.get_instance_id_by_name(
+            cloud_provider_id=provider_id, region_id=region_id, instance_type_name=instance_type
+        )
+        available_zones = cloud_api_client.get_availability_zones(
+            cloud_provider_id=provider_id, region_id=region_id, instance_type_id=instance_type_id
+        )
 
-        if (not is_aws) or expected_prefix:
-            zone_prefix = f"{expected_prefix}-"
-            mismatched = [zone for zone in zones if not zone.startswith(zone_prefix)]
-            if mismatched:
-                provider = "AWS" if is_aws else "GCE"
-                zone_kind = "availability zone IDs" if is_aws else "zone names"
-                example = f"{expected_prefix}-az1" if is_aws else f"{region_name}-b"
-                raise ValueError(
-                    f"'xcloud_availability_zones' {mismatched} does not belong to region '{region_name}'. "
-                    f"{provider} {zone_kind} for this region start with '{zone_prefix}' (e.g. '{example}')."
-                )
+        available_zone_ids = {zone["id"] for zone in available_zones}
+        mismatched = [zone for zone in zones if zone not in available_zone_ids]
+        if mismatched:
+            available = ", ".join(f"{zone['id']} ({zone['name']})" for zone in available_zones)
+            raise ValueError(
+                f"'xcloud_availability_zones' {mismatched} cannot be used in region '{region_name}' with "
+                f"instance type '{instance_type}'. Available zones: {available}."
+            )
 
     def _validate_cloud_backend_parameters(self):
         cloud_api_client = ScyllaCloudAPIClient(
@@ -5339,7 +5341,7 @@ class SCTConfiguration(BaseModel):
         elif rf > min(n_nodes):
             raise ValueError(f"xcloud_replication_factor ({rf}) cannot be greater than n_db_nodes ({n_nodes})")
 
-        self._validate_xcloud_availability_zones()
+        self._validate_xcloud_availability_zones(cloud_api_client, provider_id, region_id)
 
         # validate Vector Search parameters for cloud backend
         # TODO: update after Vector Search moves out of Beta for Scylla Cloud and limitations are changed/no longer apply

--- a/sdcm/teardown_validators/rackaware.py
+++ b/sdcm/teardown_validators/rackaware.py
@@ -44,6 +44,13 @@ class RackawareValidator(TeardownValidator):  # pylint: disable=too-few-public-m
             LOGGER.info("No workloads were running under the rack-aware policy.")
             return
 
+        if self.tester.db_cluster is None or self.tester.loaders is None:
+            LOGGER.warning(
+                "Rackaware validation skipped: DB cluster or loaders were not created "
+                "(the run failed before setup completed)."
+            )
+            return
+
         validation_passed = set()
         # The case: multi-region cluster
         loaders_per_region = self.tester.loaders.nodes_by_region()

--- a/sdcm/utils/cloud_api_utils.py
+++ b/sdcm/utils/cloud_api_utils.py
@@ -78,3 +78,50 @@ def get_cloud_rest_credentials_from_file(file_path: str) -> dict:
     with path.open("r", encoding="utf-8") as creds_file:
         creds = json.load(creds_file)
     return creds
+
+
+def parse_availability_zones(value: str | None) -> list[str]:
+    """Parse a comma-separated availability zone list from config into a clean list"""
+    return [zone.strip() for zone in (value or "").split(",") if zone.strip()]
+
+
+# AWS compresses region names in AZ IDs, e.g.: 'us-east-1' -> 'use1-az1', 'ap-southeast-1' -> 'apse1-az1'
+AWS_AZ_ID_DIRECTIONS = {
+    "north": "n",
+    "south": "s",
+    "east": "e",
+    "west": "w",
+    "central": "c",
+    "northeast": "ne",
+    "northwest": "nw",
+    "southeast": "se",
+    "southwest": "sw",
+}
+
+
+def aws_region_to_az_id_prefix(region_name: str) -> str | None:
+    """Return AZ-ID region prefix (for example: 'us-east-1' -> 'use1')."""
+    try:
+        geo, direction, index = region_name.split("-")
+    except ValueError:
+        return None
+
+    short_direction = AWS_AZ_ID_DIRECTIONS.get(direction)
+    if short_direction is None:
+        return None
+    return f"{geo}{short_direction}{index}"
+
+
+def expand_availability_zones(zones: list[str], node_count: int) -> list[str]:
+    """Expand the configured AZ list to one entry per node."""
+    if not zones:
+        return []
+
+    zone_count = len(zones)
+    if node_count % zone_count:
+        raise ValueError(
+            f"Cannot spread {node_count} nodes evenly across {zone_count} availability zones {zones}. "
+            f"Provide one zone per node or a list that divides the node count evenly."
+        )
+
+    return zones * (node_count // zone_count)

--- a/sdcm/utils/cloud_api_utils.py
+++ b/sdcm/utils/cloud_api_utils.py
@@ -85,33 +85,6 @@ def parse_availability_zones(value: str | None) -> list[str]:
     return [zone.strip() for zone in (value or "").split(",") if zone.strip()]
 
 
-# AWS compresses region names in AZ IDs, e.g.: 'us-east-1' -> 'use1-az1', 'ap-southeast-1' -> 'apse1-az1'
-AWS_AZ_ID_DIRECTIONS = {
-    "north": "n",
-    "south": "s",
-    "east": "e",
-    "west": "w",
-    "central": "c",
-    "northeast": "ne",
-    "northwest": "nw",
-    "southeast": "se",
-    "southwest": "sw",
-}
-
-
-def aws_region_to_az_id_prefix(region_name: str) -> str | None:
-    """Return AZ-ID region prefix (for example: 'us-east-1' -> 'use1')."""
-    try:
-        geo, direction, index = region_name.split("-")
-    except ValueError:
-        return None
-
-    short_direction = AWS_AZ_ID_DIRECTIONS.get(direction)
-    if short_direction is None:
-        return None
-    return f"{geo}{short_direction}{index}"
-
-
 def expand_availability_zones(zones: list[str], node_count: int) -> list[str]:
     """Expand the configured AZ list to one entry per node."""
     if not zones:

--- a/unit_tests/unit/test_cluster_cloud.py
+++ b/unit_tests/unit/test_cluster_cloud.py
@@ -616,34 +616,64 @@ def test_rackaware_verification_non_xcloud_unchanged():
 )
 def test_xcloud_az_validation_rejects_bad_config(values, error):
     with pytest.raises(ValueError, match=error):
-        SCTConfiguration._validate_xcloud_availability_zones(_fake_conf(values))
+        SCTConfiguration._validate_xcloud_availability_zones(_fake_conf(values), MagicMock(), 1, 1)
 
 
 @pytest.mark.parametrize(
-    "region,zones,raises",
+    "zones,raises",
     [
-        ("eu-west-1", "use1-az1,use1-az2,use1-az4", True),
-        ("eu-west-1", "euw1-az1,euw1-az2,euw1-az3", False),
-        ("us-east-1", "use1-az1,use1-az2,use1-az4", False),
-        ("ap-southeast-1", "apse1-az1,apse1-az2,apse1-az3", False),
-        ("us-gov-west-1", "usgw1-az1,usgw1-az2,usgw1-az3", False),
+        ("use1-az1,use1-az2,use1-az4", False),  # all three can host the configured instance type
+        ("use1-az1,use1-az2,use1-az3", True),  # use1-az3 exists but cannot host the instance type
+        ("euw1-az1,euw1-az2,euw1-az3", True),  # zones of another region entirely
     ],
 )
-def test_xcloud_az_validation_checks_region_prefix(region, zones, raises):
+def test_xcloud_az_validation_checks_zones_are_available(zones, raises):
     conf = _fake_conf(
-        {"xcloud_availability_zones": zones, "n_db_nodes": [3], "xcloud_provider": "aws"},
-        region_names=(region,),
+        {
+            "xcloud_availability_zones": zones,
+            "n_db_nodes": [3],
+            "xcloud_provider": "aws",
+            "instance_type_db": "i4i.large",
+        }
     )
+    api_client = MagicMock()
+    api_client.get_availability_zones.return_value = [
+        {"id": "use1-az1", "name": "us-east-1c"},
+        {"id": "use1-az2", "name": "us-east-1d"},
+        {"id": "use1-az4", "name": "us-east-1a"},
+    ]
+
     if raises:
-        with pytest.raises(ValueError, match="does not belong to region"):
-            SCTConfiguration._validate_xcloud_availability_zones(conf)
+        with pytest.raises(ValueError, match="cannot be used in region"):
+            SCTConfiguration._validate_xcloud_availability_zones(conf, api_client, 1, 1)
     else:
-        SCTConfiguration._validate_xcloud_availability_zones(conf)
+        SCTConfiguration._validate_xcloud_availability_zones(conf, api_client, 1, 1)
 
 
 def _make_api_client():
     with patch.object(ScyllaCloudAPIClient, "_create_session", return_value=MagicMock()):
         return ScyllaCloudAPIClient(api_url="https://api.example.com", auth_token="token")
+
+
+def test_get_availability_zones_resolves_cloud_account_and_sorts():
+    client = _make_api_client()
+    active_accounts = [
+        {"id": 201, "cloudProviderId": 2, "state": "ACTIVE"},
+        {"id": 2, "cloudProviderId": 1, "state": "ACTIVE"},
+    ]
+    unsorted_zones = [{"id": "use1-az4", "name": "us-east-1a"}, {"id": "use1-az1", "name": "us-east-1c"}]
+
+    with (
+        patch.object(client, "get_current_account_id", return_value=7),
+        patch.object(client, "get_active_accounts", return_value=active_accounts),
+        patch.object(client, "request", return_value=unsorted_zones) as request_mock,
+    ):
+        zones = client.get_availability_zones(cloud_provider_id=1, region_id=3, instance_type_id=62)
+
+    assert [zone["id"] for zone in zones] == ["use1-az1", "use1-az4"]
+    request_mock.assert_called_once_with(
+        "GET", "/account/7/cloud-account/2/region/3/zones", params={"instanceTypeId": 62}
+    )
 
 
 def _minimal_create_kwargs():

--- a/unit_tests/unit/test_cluster_cloud.py
+++ b/unit_tests/unit/test_cluster_cloud.py
@@ -3,11 +3,13 @@
 import pytest
 from unittest.mock import MagicMock, patch
 
+from sdcm.cloud_api_client import ScyllaCloudAPIClient
 from sdcm.cluster_cloud import (
     xcloud_super_if_supported,
     ScyllaCloudCluster,
     ScyllaCloudError,
     CloudNode,
+    VectorStoreSetCloud,
 )
 from sdcm.sct_config import SCTConfiguration
 from sdcm.utils.cloud_api_utils import (
@@ -441,3 +443,306 @@ def test_configure_remote_logging_falls_back_to_self_install():
 
     ordered = [c[0] for c in node.mock_calls]
     assert ordered.index("_self_install_vector") < ordered.index("_apply_vector_target_config")
+
+
+def make_cloud_node_payload(
+    node_id=1, az_name="us-east-1a", az_id="use1-az1", public_ip="54.0.0.1", private_ip="10.0.0.1"
+):
+    """Payload shaped like NodeInfoEnriched from GET /account/{id}/cluster/{id}/nodes"""
+    return {
+        "id": node_id,
+        "azName": az_name,
+        "azId": az_id,
+        "rackName": az_id,
+        "publicIp": public_ip,
+        "privateIp": private_ip,
+        "status": "ACTIVE",
+        "state": "NORMAL",
+        "instance": {"externalId": "i4i.large"},
+        "region": {"externalId": "us-east-1", "name": "US East (N. Virginia)"},
+        "dcId": 1,
+    }
+
+
+@pytest.mark.parametrize(
+    "drop_external_id,expected",
+    [
+        # the (region, rack) join keys off the external id, not the display name
+        (False, "us-east-1"),
+        (True, "US East (N. Virginia)"),
+    ],
+)
+def test_cloud_node_region_prefers_external_id(drop_external_id, expected):
+    payload = make_cloud_node_payload()
+    if drop_external_id:
+        del payload["region"]["externalId"]
+    node = MagicMock(_cloud_instance_data=payload)
+    assert CloudNode.vm_region.fget(node) == expected
+
+
+def test_refresh_instance_state_requests_enriched_payload():
+    node = MagicMock(_node_id=1, _public_ip="54.0.0.1", _private_ip="10.0.0.1")
+    node._account_id, node._cluster_id = 1, 2
+    node._api_client = MagicMock()
+    node._api_client.get_cluster_nodes.return_value = [make_cloud_node_payload(node_id=1)]
+    CloudNode._refresh_instance_state(node)
+    node._api_client.get_cluster_nodes.assert_called_once_with(account_id=1, cluster_id=2, enriched=True)
+
+
+def test_init_nodes_from_data_mixed_az_and_azless_nodes():
+    """Racks are derived per node: AZ-bearing nodes by alphabetical AZ order, AZ-less ones from the caller's rack"""
+    mock_cluster = MagicMock(spec=ScyllaCloudCluster)
+    mock_cluster.log = MagicMock()
+    mock_cluster._create_node = MagicMock(side_effect=lambda **kwargs: kwargs)
+
+    nodes_data = [
+        make_cloud_node_payload(node_id=1, az_name="us-east-1c"),
+        make_cloud_node_payload(node_id=2, az_name="us-east-1a"),
+        {"id": 3, "publicIp": "54.0.0.3", "privateIp": "10.0.0.3", "status": "ACTIVE"},
+        make_cloud_node_payload(node_id=4, az_name="us-east-1b"),
+    ]
+    created = ScyllaCloudCluster._init_nodes_from_data(mock_cluster, nodes_data=nodes_data, rack=9)
+    assert [node["rack"] for node in created] == [2, 0, 9, 1]
+
+
+def test_vs_nodes_data_injects_az_id_from_group():
+    vs_set = MagicMock(spec=VectorStoreSetCloud)
+    vs_set._get_vs_info.return_value = {
+        "availabilityZones": [
+            {
+                "azid": "use1-az1",
+                "rackName": "use1-az1",
+                "nodes": [
+                    {"id": 1, "status": "ACTIVE"},
+                    {"id": 2, "status": "PENDING_DELETE"},
+                ],
+            },
+            {
+                "azid": "use1-az2",
+                "rackName": "use1-az2",
+                "nodes": [{"id": 3, "status": "ACTIVE"}],
+            },
+        ]
+    }
+
+    nodes = VectorStoreSetCloud.vs_nodes_data.fget(vs_set)
+    assert [(node["id"], node["azId"]) for node in nodes] == [(1, "use1-az1"), (3, "use1-az2")]
+
+
+def _build_real_cloud_cluster():
+    """Construct a real ScyllaCloudCluster with mocked externals (mirrors legacy fixture)"""
+    with (
+        patch("sdcm.cluster_cloud.TestConfig"),
+        patch.object(ScyllaCloudCluster, "init_log_directory"),
+        patch("sdcm.cluster.ScyllaClusterBenchmarkManager"),
+    ):
+        params = SCTConfiguration()
+        params.update(
+            {
+                "xcloud_provider": "aws",
+                "xcloud_vpc_peering": {"enabled": False},
+                "n_vector_store_nodes": 0,
+                "region_name": "us-east-1",
+            }
+        )
+        api_client = MagicMock(get_current_account_id=MagicMock(return_value=123))
+        return ScyllaCloudCluster(
+            cloud_api_client=api_client, user_prefix="test", n_nodes=0, params=params, add_nodes=False
+        )
+
+
+def test_cloud_cluster_datacenter_is_list():
+    cluster_obj = _build_real_cloud_cluster()
+    assert cluster_obj.datacenter == ["us-east-1"]
+
+
+def test_update_racks_count_from_nodes():
+    cluster_obj = _build_real_cloud_cluster()
+    cluster_obj.nodes = [MagicMock(rack=0), MagicMock(rack=1), MagicMock(rack=2)]
+    cluster_obj._update_racks_count()
+    assert cluster_obj.racks_count == 3
+
+
+def _fake_conf(values, region_names=("us-east-1",)):
+    conf = MagicMock(region_names=list(region_names))
+    conf.get.side_effect = values.get
+    return conf
+
+
+def _rackaware_conf(**overrides):
+    config = {
+        "rack_aware_loader": True,
+        "n_loaders": 1,
+    }
+    config.update(overrides)
+    return _fake_conf(config)
+
+
+@pytest.mark.parametrize("zones", ["", "use1-az1,use1-az1,use1-az1"])
+def test_rackaware_verification_xcloud_requires_two_distinct_zones(zones):
+    conf = _rackaware_conf(cluster_backend="xcloud", xcloud_availability_zones=zones)
+    with pytest.raises(ValueError, match="xcloud_availability_zones"):
+        SCTConfiguration._verify_rackaware_configuration(conf)
+
+
+def test_rackaware_verification_xcloud_passes_with_multi_az():
+    conf = _rackaware_conf(cluster_backend="xcloud", xcloud_availability_zones="use1-az1,use1-az2,use1-az3")
+    SCTConfiguration._verify_rackaware_configuration(conf)
+
+
+def test_rackaware_verification_non_xcloud_unchanged():
+    conf = _rackaware_conf(cluster_backend="aws", availability_zone="a,b,c", simulated_racks=0)
+    SCTConfiguration._verify_rackaware_configuration(conf)
+
+
+@pytest.mark.parametrize(
+    "values,error",
+    [
+        # node count is Cloud-managed under a scaling policy, so pinned zones cannot be honoured
+        (
+            {
+                "xcloud_availability_zones": "use1-az1,use1-az2",
+                "xcloud_scaling_config": {"Mode": "xcloud"},
+                "n_db_nodes": [3],
+            },
+            "xcloud_scaling_config",
+        ),
+        # 4 nodes cannot spread evenly over 3 zones
+        (
+            {"xcloud_availability_zones": "use1-az1,use1-az2,use1-az3", "n_db_nodes": [4]},
+            "Cannot spread 4 nodes evenly",
+        ),
+    ],
+)
+def test_xcloud_az_validation_rejects_bad_config(values, error):
+    with pytest.raises(ValueError, match=error):
+        SCTConfiguration._validate_xcloud_availability_zones(_fake_conf(values))
+
+
+@pytest.mark.parametrize(
+    "region,zones,raises",
+    [
+        ("eu-west-1", "use1-az1,use1-az2,use1-az4", True),
+        ("eu-west-1", "euw1-az1,euw1-az2,euw1-az3", False),
+        ("us-east-1", "use1-az1,use1-az2,use1-az4", False),
+        ("ap-southeast-1", "apse1-az1,apse1-az2,apse1-az3", False),
+        ("us-gov-west-1", "usgw1-az1,usgw1-az2,usgw1-az3", False),
+    ],
+)
+def test_xcloud_az_validation_checks_region_prefix(region, zones, raises):
+    conf = _fake_conf(
+        {"xcloud_availability_zones": zones, "n_db_nodes": [3], "xcloud_provider": "aws"},
+        region_names=(region,),
+    )
+    if raises:
+        with pytest.raises(ValueError, match="does not belong to region"):
+            SCTConfiguration._validate_xcloud_availability_zones(conf)
+    else:
+        SCTConfiguration._validate_xcloud_availability_zones(conf)
+
+
+def _make_api_client():
+    with patch.object(ScyllaCloudAPIClient, "_create_session", return_value=MagicMock()):
+        return ScyllaCloudAPIClient(api_url="https://api.example.com", auth_token="token")
+
+
+def _minimal_create_kwargs():
+    return dict(
+        account_id=1,
+        cluster_name="c",
+        scylla_version="2025.4.0",
+        cidr_block=None,
+        broadcast_type="PUBLIC",
+        allowed_ips=[],
+        cloud_provider_id=1,
+        region_id=1,
+        instance_id=1,
+        replication_factor=3,
+        number_of_nodes=3,
+        account_credential_id=1,
+        free_trial=False,
+        user_api_interface="CQL",
+        enable_dns_association=True,
+        jump_start=False,
+        encryption_at_rest=None,
+        maintenance_windows=[],
+        scaling={},
+        prom_proxy=True,
+        vector_search=None,
+        tablets=None,
+    )
+
+
+def test_create_cluster_request_without_az_override_keeps_payload():
+    client = _make_api_client()
+    client.request = MagicMock(return_value={"requestId": 1})
+    client.create_cluster_request(**_minimal_create_kwargs())
+    assert client.request.call_args.kwargs == {
+        "clusterName": "c",
+        "scyllaVersion": "2025.4.0",
+        "cidrBlock": None,
+        "broadcastType": "PUBLIC",
+        "allowedIPs": [],
+        "cloudProviderId": 1,
+        "regionId": 1,
+        "instanceId": 1,
+        "replicationFactor": 3,
+        "numberOfNodes": 3,
+        "accountCredentialId": 1,
+        "freeTier": False,
+        "userApiInterface": "CQL",
+        "enableDnsAssociation": True,
+        "jumpStart": False,
+        "encryptionAtRest": None,
+        "maintenanceWindows": [],
+        "scaling": {},
+        "promProxy": True,
+        "vectorSearch": None,
+        "tablets": None,
+    }
+
+
+def test_create_cluster_request_with_az_override_sets_placement():
+    client = _make_api_client()
+    client.request = MagicMock(return_value={"requestId": 1})
+    client.create_cluster_request(
+        **_minimal_create_kwargs(), availability_zone_ids=["use1-az1", "use1-az2", "use1-az3"]
+    )
+    body = client.request.call_args.kwargs
+    assert body["availabilityZoneIdsOverride"] == ["use1-az1", "use1-az2", "use1-az3"]
+    assert body["placement"] == "true"
+
+
+def _mock_cluster_for_prepare_config(az_knob=""):
+    mock_cluster = MagicMock(spec=ScyllaCloudCluster)
+    mock_cluster.log = MagicMock()
+    mock_cluster.xcloud_scaling_config = {}
+    mock_cluster.vpc_peering_enabled = False
+    mock_cluster._deploy_vs_nodes = False
+    mock_cluster._allowed_ips = []
+    mock_cluster._account_id = 1
+    mock_cluster.provider_id = 1
+    mock_cluster.region_id = 1
+    mock_cluster.shortid = "abc12345"
+    mock_cluster.node_type = "scylla-db"
+    mock_cluster.test_config = MagicMock(TEST_DURATION=60)
+    mock_cluster._api_client = MagicMock(client_ip="1.2.3.4", get_instance_id_by_name=MagicMock(return_value=42))
+    params = {
+        "xcloud_availability_zones": az_knob,
+        "xcloud_replication_factor": 3,
+        "xcloud_credential_id": 7,
+        "scylla_version": "2025.4.0",
+    }
+    mock_cluster.params = MagicMock()
+    mock_cluster.params.get = MagicMock(side_effect=params.get)
+    mock_cluster.params.cloud_provider_params = {"instance_type_db": "i4i.large", "region": "us-east-1"}
+    return mock_cluster
+
+
+@patch("sdcm.cluster_cloud.get_username", return_value="user")
+@patch("sdcm.cluster_cloud.get_test_name", return_value="test")
+def test_prepare_cluster_config_expands_knob_to_node_count(mock_test_name, mock_username):
+    az_ids = ["use1-az1", "use1-az2", "use1-az3"]
+    cluster = _mock_cluster_for_prepare_config(az_knob=",".join(az_ids))
+    config = ScyllaCloudCluster._prepare_cluster_config(cluster, node_count=6, instance_type=None)
+    assert config["availability_zone_ids"] == az_ids * 2

--- a/unit_tests/unit/test_teardown_validator.py
+++ b/unit_tests/unit/test_teardown_validator.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock, patch, mock_open
 import pytest
 
 from sdcm.teardown_validators.events import ErrorEventsValidator, Severity
+from sdcm.teardown_validators.rackaware import RackawareValidator
 from sdcm.sct_config import SCTConfiguration
 
 LOGGER = logging.getLogger(__name__)
@@ -136,3 +137,15 @@ def test_validate_with_failing_events_with_critical_events(
     with patch("builtins.open", open_mock):
         validator.validate()
     assert tester_mock.get_test_status() == "FAILED"
+
+
+def test_rackaware_validator_skips_when_cluster_was_not_created(tester_mock):
+    """Skip rack-aware validation when setup failed before creating cluster objects."""
+    params = SCTConfiguration()
+    params.update({"teardown_validators": {"rackaware": {"enabled": True}}})
+    tester_mock.is_rack_aware_policy = True
+    tester_mock.db_cluster = tester_mock.loaders = None
+
+    RackawareValidator(params, tester_mock).validate()
+    # reaching the traffic comparison would have replaced get_test_status
+    tester_mock.get_test_status.assert_not_called()


### PR DESCRIPTION
Currently every xcloud DB node ends up in a single rack. This leaves RackawareValidator, rack-aware loader pinning and rack-targeting nemeses unused on the backend.

The Cloud API returns azName/azId per node. The change adds logic to derive each node's rack index from its AZ (sorting zones alphabetically so indexes are aligned with the AWS-side loaders). Nodes without AZ data keep the caller's rack and log a warning. Vector-search nodes get real racks too - their AZ grouping was being flattened away.

Additionally, new config parameter xcloud_availability_zones is added to pin placement at creation (it's the only AZ control in public API). Empty by default.

Fixes: SCT-460

### Testing:
- [x] :green_circle: [xcloud test with pinned AZs and rack-aware topology](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/xcloud-test/16/)
3-node xcloud cluster pinned to AZs; each node landed in its own rack. All 2.4M reads went to the node in the loader rack and none to the others, so RackawareValidator passed on real traffic.
- [x] :green_circle: [xcloud test with VS nodes, with pinned AZs](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/xcloud-test/17/)
3-node cluster with 2 VS nodes, with pinned AZs. VS nodes also landed in their racks.
- [x] :red_circle: [xcloud test, 'bad' pinned AZs are rejected on config validation](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/xcloud-test/18/)
Attempt to pin eu-west-1 zones in a us-east-1 region cluster. The test run is rejected at config validation, without creating a single instance - preventing waste of time and cloud resources.
- [x] :green_circle: [xcloud test with VS nodes, and no pinned AZs](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/xcloud-test/20/)
Regression check for deployment without pinning any AZ (Scylla Cloud puts nodes across 3 AZs by default, as designed, the picked zones differ from the pinned runs - this is just another proof that the pinning used above works).