### PR TITLE
test(microbenchmark): add perf-cql-raw weekly microbenchmark tests

### DIFF
--- a/configurations/performance/perf_cql_raw/latency-decorator-error-thresholds-perf-cql-raw-microbenchmark_arm64.yaml
+++ b/configurations/performance/perf_cql_raw/latency-decorator-error-thresholds-perf-cql-raw-microbenchmark_arm64.yaml
@@ -1,0 +1,29 @@
+# Thresholds are deliberately null until perf-cql-raw has a baseline of its own.
+#
+# The numbers this file started from were copied from the perf-simple-query thresholds, and they
+# do not carry over: perf-simple-query drives the query processor in process, while perf-cql-raw
+# talks the CQL protocol to an embedded server over a socket, so it does strictly more work per
+# operation. It also runs with different resources (--smp 2 -m 2G against --smp 1 -m 1G).
+#
+# Null is not the same as deleting this file. sdcm/argus_results.py falls back to
+# ValidationRule(best_pct=5) when a metric has no entry at all, which would flag every run
+# against a baseline that does not exist yet. An explicit null produces a ValidationRule with no
+# limit, so results are recorded in Argus without being validated.
+#
+# To set real values: let the weekly jobs collect a few runs, take the stable numbers from the
+# Argus graphs for this test, and replace each null with a fixed_limit slightly above them.
+latency_decorator_error_thresholds:
+  write:
+      allocs_per_op:
+        fixed_limit: null
+      cpu_cycles_per_op:
+        fixed_limit: null
+      instructions_per_op:
+        fixed_limit: null
+  read:
+      allocs_per_op:
+        fixed_limit: null
+      cpu_cycles_per_op:
+        fixed_limit: null
+      instructions_per_op:
+        fixed_limit: null

--- a/configurations/performance/perf_cql_raw/latency-decorator-error-thresholds-perf-cql-raw-microbenchmark_x86_64.yaml
+++ b/configurations/performance/perf_cql_raw/latency-decorator-error-thresholds-perf-cql-raw-microbenchmark_x86_64.yaml
@@ -1,0 +1,29 @@
+# Thresholds are deliberately null until perf-cql-raw has a baseline of its own.
+#
+# The numbers this file started from were copied from the perf-simple-query thresholds, and they
+# do not carry over: perf-simple-query drives the query processor in process, while perf-cql-raw
+# talks the CQL protocol to an embedded server over a socket, so it does strictly more work per
+# operation. It also runs with different resources (--smp 2 -m 2G against --smp 1 -m 1G).
+#
+# Null is not the same as deleting this file. sdcm/argus_results.py falls back to
+# ValidationRule(best_pct=5) when a metric has no entry at all, which would flag every run
+# against a baseline that does not exist yet. An explicit null produces a ValidationRule with no
+# limit, so results are recorded in Argus without being validated.
+#
+# To set real values: let the weekly jobs collect a few runs, take the stable numbers from the
+# Argus graphs for this test, and replace each null with a fixed_limit slightly above them.
+latency_decorator_error_thresholds:
+  write:
+      allocs_per_op:
+        fixed_limit: null
+      cpu_cycles_per_op:
+        fixed_limit: null
+      instructions_per_op:
+        fixed_limit: null
+  read:
+      allocs_per_op:
+        fixed_limit: null
+      cpu_cycles_per_op:
+        fixed_limit: null
+      instructions_per_op:
+        fixed_limit: null

--- a/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-cql-raw-weekly-microbenchmark_arm64-write.jenkinsfile
+++ b/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-cql-raw-weekly-microbenchmark_arm64-write.jenkinsfile
@@ -1,0 +1,13 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    region: 'eu-west-1',
+    provision_type: 'on_demand',
+    test_name: 'microbenchmarking_test.PerfCqlRawTest.test_write',
+    test_config: """[ 'test-cases/microbenchmarking/amazon_perf_cql_raw_ARM.yaml', 'configurations/performance/perf_cql_raw/latency-decorator-error-thresholds-perf-cql-raw-microbenchmark_arm64.yaml' ]""",
+    email_recipients: "scylla-perf-results@scylladb.com",
+)

--- a/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-cql-raw-weekly-microbenchmark_arm64.jenkinsfile
+++ b/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-cql-raw-weekly-microbenchmark_arm64.jenkinsfile
@@ -1,0 +1,13 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    region: 'eu-west-1',
+    provision_type: 'on_demand',
+    test_name: 'microbenchmarking_test.PerfCqlRawTest.test_read',
+    test_config: """[ 'test-cases/microbenchmarking/amazon_perf_cql_raw_ARM.yaml', 'configurations/performance/perf_cql_raw/latency-decorator-error-thresholds-perf-cql-raw-microbenchmark_arm64.yaml' ]""",
+    email_recipients: "scylla-perf-results@scylladb.com",
+)

--- a/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-cql-raw-weekly-microbenchmark_x86_64-write.jenkinsfile
+++ b/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-cql-raw-weekly-microbenchmark_x86_64-write.jenkinsfile
@@ -1,0 +1,13 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    region: 'eu-west-1',
+    provision_type: 'on_demand',
+    test_name: 'microbenchmarking_test.PerfCqlRawTest.test_write',
+    test_config: """[ 'test-cases/microbenchmarking/amazon_perf_cql_raw_ARM.yaml', 'test-cases/microbenchmarking/amazon_perf_cql_raw_x86.yaml', 'configurations/performance/perf_cql_raw/latency-decorator-error-thresholds-perf-cql-raw-microbenchmark_x86_64.yaml' ]""",
+    email_recipients: "scylla-perf-results@scylladb.com",
+)

--- a/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-cql-raw-weekly-microbenchmark_x86_64.jenkinsfile
+++ b/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-cql-raw-weekly-microbenchmark_x86_64.jenkinsfile
@@ -1,0 +1,13 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    region: 'eu-west-1',
+    provision_type: 'on_demand',
+    test_name: 'microbenchmarking_test.PerfCqlRawTest.test_read',
+    test_config: """[ 'test-cases/microbenchmarking/amazon_perf_cql_raw_ARM.yaml', 'test-cases/microbenchmarking/amazon_perf_cql_raw_x86.yaml', 'configurations/performance/perf_cql_raw/latency-decorator-error-thresholds-perf-cql-raw-microbenchmark_x86_64.yaml' ]""",
+    email_recipients: "scylla-perf-results@scylladb.com",
+)

--- a/microbenchmarking_test.py
+++ b/microbenchmarking_test.py
@@ -12,24 +12,132 @@
 # Copyright (c) 2023 ScyllaDB
 import json
 
-from sdcm.argus_results import send_perf_simple_query_result_to_argus
+from sdcm.argus_results import send_microbenchmark_result_to_argus
 from sdcm.tester import ClusterTester
 
 
-class PerfSimpleQueryTest(ClusterTester):
-    def test_perf_simple_query(self):
-        perf_simple_query_extra_command = self.params.get("perf_simple_query_extra_command") or ""
-        node = self.db_cluster.nodes[0]
-        scylla_bin = node.add_install_prefix("/usr/bin/scylla")
-        result = node.remoter.run(
-            f"{scylla_bin} perf-simple-query --json-result=perf-simple-query-result.txt --smp 1 -m 1G {perf_simple_query_extra_command}"
-        )
-        if result.ok:
-            output = node.remoter.run("cat perf-simple-query-result.txt").stdout
-            results = json.loads(output)
+class MicrobenchmarkTest(ClusterTester):
+    """
+    Base for the scylla microbenchmark tests, each of which runs one `scylla perf-*` tool on a
+    single DB node and reports the JSON it writes to Argus.
 
-            error_thresholds = self.params.get("latency_decorator_error_thresholds")
-            send_perf_simple_query_result_to_argus(self.test_config.argus_client(), results, error_thresholds)
+    Note for the tools' command lines: options must be passed as "--name value", never
+    "--name=value". A tool that strips its own options out of argv before handing the rest to
+    scylla (perf-cql-raw does) compares each argument verbatim, so the "=" form is not recognised,
+    stays in argv and reaches scylla as an unknown option.
+    """
+
+    def submit_results(self, node, result_file: str, benchmark_name: str) -> None:
+        results = json.loads(node.remoter.run(f"cat {result_file}").stdout)
+        send_microbenchmark_result_to_argus(
+            argus_client=self.test_config.argus_client(),
+            result=results,
+            error_thresholds=self.params.get("latency_decorator_error_thresholds"),
+            benchmark_name=benchmark_name,
+        )
 
     def update_test_with_errors(self):
         self.log.info("update_test_with_errors: Using Argus for performance results")
+
+
+class PerfSimpleQueryTest(MicrobenchmarkTest):
+    """
+    Run the `scylla perf-simple-query` microbenchmark.
+
+    The tool drives the query processor in process, against a cql_test_env: it builds its own
+    db::config so it reads no config file, it starts no CQL server so it binds no ports, and its
+    data goes to a throwaway temp directory. Nothing about it collides with the scylla-server that
+    SCT runs on the node, so it needs no special handling here - unlike perf-cql-raw, see
+    PerfCqlRawTest.
+
+    The read workload is the default; `perf_simple_query_extra_command` passes `--write` for the
+    write workload.
+    """
+
+    def test_perf_simple_query(self):
+        extra_command = self.params.get("perf_simple_query_extra_command") or ""
+        node = self.db_cluster.nodes[0]
+        scylla_bin = node.add_install_prefix("/usr/bin/scylla")
+        result_file = "perf-simple-query-result.txt"
+        result = node.remoter.run(
+            f"{scylla_bin} perf-simple-query --json-result {result_file} --smp 1 -m 1G {extra_command}"
+        )
+        if result.ok:
+            self.submit_results(node, result_file, benchmark_name="Perf Simple Query")
+
+
+class PerfCqlRawTest(MicrobenchmarkTest):
+    """
+    Run the `scylla perf-cql-raw` microbenchmark, which exercises the full networking and protocol
+    parsing path using handcrafted CQL binary frames.
+
+    Unlike perf-simple-query, this tool boots a full scylla server in process - it calls
+    scylla_main and then speaks the CQL protocol to itself over a real socket - so it needs
+    everything a server needs, and each of those needs is handled below:
+
+    * A config file. scylla resolves its config as <cwd>/conf/scylla.yaml, and the test does not
+      run from a scylla source tree the way the tool's developers do, so it gets SCYLLA_CONFIG
+      written into its work directory and passed as --options-file.
+    * A data directory. --workdir keeps it off the live /var/lib/scylla. Note this only works
+      because SCYLLA_CONFIG lists no storage directories: scylla moves a directory under --workdir
+      only when the config file leaves it unset, so reusing the node's /etc/scylla/scylla.yaml
+      would silently put the benchmark on the running server's data.
+    * The standard ports, plus memory and cpus. The node's own scylla-server already holds
+      native_transport_port 9042 and api_port 10000, so it is stopped for the duration of the run
+      and started again afterwards.
+
+    The command line matches what the tool's developers run, so results stay comparable with
+    theirs. Changing RESOURCE_OPTIONS or DURATION invalidates the Argus baseline, which is why
+    they are constants here rather than config options.
+    """
+
+    WORKDIR = "/tmp/scylla-perf-cql-raw-workdir"
+    RESOURCE_OPTIONS = "--smp 2 --cpus 0,1 -m 2G"
+    DURATION = 60
+
+    # Only long standing options are set, so this stays valid across the scylla versions the
+    # weekly jobs run against; everything else falls back to scylla's built-in defaults. Storage
+    # directories are deliberately absent, so that --workdir relocates all of them.
+    SCYLLA_CONFIG = """\
+seed_provider:
+    - class_name: org.apache.cassandra.locator.SimpleSeedProvider
+      parameters:
+          - seeds: "127.0.0.1"
+listen_address: localhost
+rpc_address: localhost
+api_address: 127.0.0.1
+endpoint_snitch: SimpleSnitch
+"""
+
+    def run_workload(self, workload: str) -> None:
+        node = self.db_cluster.nodes[0]
+        scylla_bin = node.add_install_prefix("/usr/bin/scylla")
+        result_file = "perf-cql-raw-result.json"
+        conf_file = f"{self.WORKDIR}/conf/scylla.yaml"
+
+        node.remoter.run(f"rm -rf {self.WORKDIR}")
+        node.remoter.run(f"mkdir -p {self.WORKDIR}/conf")
+        node.remoter.run(f"cat > {conf_file} <<'SCYLLA_CONFIG'\n{self.SCYLLA_CONFIG}SCYLLA_CONFIG")
+
+        # The stop only has to free the ports, so a failing `systemctl stop` (the service is
+        # already down) is not a reason to abort the benchmark - ignore_status lets the run
+        # continue, and verify_down still confirms the ports are actually free. It is inside the
+        # try so that anything it does raise still goes through the finally below and leaves the
+        # node's scylla-server running.
+        try:
+            node.stop_scylla_server(ignore_status=True)
+            results = node.remoter.run(
+                f"{scylla_bin} perf-cql-raw --json-result {result_file}"
+                f" --workdir {self.WORKDIR} --options-file {conf_file}"
+                f" {self.RESOURCE_OPTIONS} --workload {workload} --duration {self.DURATION}"
+            )
+            if results.ok:
+                self.submit_results(node, result_file, benchmark_name="Perf CQL Raw")
+        finally:
+            node.start_scylla_server()
+
+    def test_read(self):
+        self.run_workload("read")
+
+    def test_write(self):
+        self.run_workload("write")

--- a/sdcm/argus_results.py
+++ b/sdcm/argus_results.py
@@ -211,9 +211,11 @@ class MigratorBenchmarkResult(StaticGenericResultTable):
         ]
 
 
-class PerfSimpleQueryResult(StaticGenericResultTable):
-    def __init__(self, workload: str, parameters: dict):
-        super().__init__(name=f"{workload} - Perf Simple Query", description=json.dumps(parameters))
+class MicrobenchmarkResult(StaticGenericResultTable):
+    # benchmark_name defaults to "Perf Simple Query" so that the perf-simple-query tables keep the
+    # name they have always had in Argus, and with it their history.
+    def __init__(self, workload: str, parameters: dict, benchmark_name: str = "Perf Simple Query"):
+        super().__init__(name=f"{workload} - {benchmark_name}", description=json.dumps(parameters))
 
     class Meta:
         Columns = [
@@ -428,7 +430,9 @@ def send_result_to_argus(  # noqa: PLR0914
         submit_results_to_argus(argus_client, result_table)
 
 
-def send_perf_simple_query_result_to_argus(argus_client: ArgusClient, result: dict, error_thresholds: dict):
+def send_microbenchmark_result_to_argus(
+    argus_client: ArgusClient, result: dict, error_thresholds: dict, benchmark_name: str = "Perf Simple Query"
+):
     def set_validation_rules(column_metadata):
         if column_threshold := error_thresholds.get(workload, {}).get(column_metadata, {}):
             LOGGER.debug("%s_threshold result: %s", column_metadata, column_threshold)
@@ -442,7 +446,9 @@ def send_perf_simple_query_result_to_argus(argus_client: ArgusClient, result: di
     validation_rules["instructions_per_op"] = set_validation_rules("instructions_per_op")
     validation_rules["allocs_per_op"] = set_validation_rules("allocs_per_op")
 
-    result_table = PerfSimpleQueryResult(workload=workload, parameters=result["parameters"])
+    result_table = MicrobenchmarkResult(
+        workload=workload, parameters=result["parameters"], benchmark_name=benchmark_name
+    )
     result_table.validation_rules = validation_rules
     LOGGER.debug("result_table.validation_rules result: %s", result_table.validation_rules)
     for key, value in stats.items():

--- a/test-cases/microbenchmarking/amazon_perf_cql_raw_ARM.yaml
+++ b/test-cases/microbenchmarking/amazon_perf_cql_raw_ARM.yaml
@@ -1,0 +1,17 @@
+test_duration: 60
+backtrace_decoding: false
+cluster_backend: 'aws'
+
+n_loaders: 0
+n_monitor_nodes: 0
+n_db_nodes: 1
+use_mgmt: false
+
+instance_type_db: 'c8g.large'
+data_volume_disk_num: 1
+user_prefix: 'perf-cql-raw-amazon-ARM'
+argus_email_report_template: email_report_performance_microbenchmarks.yaml
+instance_provision: "spot"
+instance_provision_fallback_on_demand: true
+
+email_recipients: ['scylla-perf-results@scylladb.com']

--- a/test-cases/microbenchmarking/amazon_perf_cql_raw_x86.yaml
+++ b/test-cases/microbenchmarking/amazon_perf_cql_raw_x86.yaml
@@ -1,0 +1,2 @@
+instance_type_db: 'c8i.large'
+user_prefix: 'perf-cql-raw-amazon-x86'


### PR DESCRIPTION
Add weekly x86_64 and arm64 read/write microbenchmarks for perf-cql-raw.

`perf-cql-raw` is implemented as a new `PerfCqlRawTest` class rather than modifying perf-simple-query. 
Because `perf-cql-raw` boots a full in-process Scylla server and talks to itself via CQL, it requires setup :

- Config: Generates a minimal scylla.yaml to ensure --workdir isn't bypassed by node default paths (e.g., /var/lib/scylla).

- Isolation: Wipes --workdir per run, and temporarily stops scylla-server to free ports (9042, 10000), CPU, and memory.

- CLI Arguments: Hardcodes key params (`--smp 2 --cpus 0,1 -m 2G`) to protect baseline integrity. 
- Passes options as` --key value` since perf::cut_arg() fails on `--key=value`.

Argus reporting logic is now shared between both tools using the benchmark name as the table label. 

`perf-cql-raw` starts with null error thresholds until baseline data is collected. 

`perf-simple-query` behaviour and history remain unchanged.

Fixes: https://scylladb.atlassian.net/browse/SCT-7

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
**perf-simple-query**
- [x] [scylla-enterprise-perf-simple-query-weekly-microbenchmark_x86_64](https://argus.scylladb.com/tests/scylla-cluster-tests/5ea0c008-33ff-4075-9e2b-384e8c3bec46)
- [x] [scylla-enterprise-perf-simple-query-weekly-microbenchmark_x86_64-write](https://argus.scylladb.com/tests/scylla-cluster-tests/81985574-8653-4bea-8750-a3e239c56255)
- [x] [scylla-enterprise-perf-simple-query-weekly-microbenchmark_arm64](https://argus.scylladb.com/tests/scylla-cluster-tests/f9403516-ccaa-463c-bd73-167d210f607a)
- [x] [scylla-enterprise-perf-simple-query-weekly-microbenchmark_arm64-write](https://argus.scylladb.com/tests/scylla-cluster-tests/f687852b-ec81-41f3-8db1-d36c81a12aec)

**perf-cql-raw**
- [x]  [scylla-enterprise-perf-cql-raw-weekly-microbenchmark_arm64](https://argus.scylladb.com/tests/scylla-cluster-tests/d3d6e0fa-3dc5-4e52-b4d9-992e2fc7400f)
- [x] [scylla-enterprise-perf-cql-raw-weekly-microbenchmark_arm64-write](https://argus.scylladb.com/tests/scylla-cluster-tests/94975012-6e57-4fc0-9916-c8d873089d2c)
- [x] [scylla-enterprise-perf-cql-raw-weekly-microbenchmark_x86_64](https://argus.scylladb.com/tests/scylla-cluster-tests/3a1ee1d3-0528-4d87-bae8-559a9edcec45)
- [x] [scylla-enterprise-perf-cql-raw-weekly-microbenchmark_x86_64-write](https://argus.scylladb.com/tests/scylla-cluster-tests/1464a022-849d-452d-a06b-72e451f8d8dc)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
