### PR TITLE
fix(test): fix config in the scale-schema-5000-tables-latte-vnodes test

### DIFF
--- a/jenkins-pipelines/oss/vnodes/tier1/scale-schema-5000-tables-latte-vnodes.jenkinsfile
+++ b/jenkins-pipelines/oss/vnodes/tier1/scale-schema-5000-tables-latte-vnodes.jenkinsfile
@@ -7,5 +7,5 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: 'test-cases/scale/longevity-5000-tables-latte-vnodes.yaml',
+    test_config: '''["test-cases/scale/longevity-5000-tables-latte-vnodes.yaml", "configurations/tablets_disabled.yaml"]'''
 )


### PR DESCRIPTION
It was missing the "configurations/tablets_disabled.yaml" making
non-latte related code assess the tablets enablement as "true".
It led to running tablets-only nemesis on vnodes tables created by latte.

So, fix it by properly disabling tablets for the test run.

Ref: https://argus.scylladb.com/tests/scylla-cluster-tests/419a4fbe-9ff6-49db-b533-2ffca2d592bd/discuss ([scylla-2026.3/customer-cases/longevity-gce-custom-d1-worklod2-hybrid-raid-test#4](https://argus.scylladb.com/tests/scylla-cluster-tests/59f8aaa7-2e3e-4efe-98ff-13927a238b0e))

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
