### PR TITLE
feature(perf): add optional c-s loader JVM safepoint logging

### DIFF
--- a/configurations/arm_instance_types/i8g_4xlarge.yaml
+++ b/configurations/arm_instance_types/i8g_4xlarge.yaml
@@ -1,1 +1,2 @@
 instance_type_db: 'i8g.4xlarge'
+cs_safepoint_logging: true

--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -434,6 +434,7 @@ agent:
 
 c_s_driver_version: '3'
 cs_extra_jvm_opts: ''
+cs_safepoint_logging: false
 test_metadata: null
 
 # KeyStore backend for credential retrieval.

--- a/docs/collected-logs.md
+++ b/docs/collected-logs.md
@@ -50,6 +50,8 @@ Each loader node directory contains:
 | `cloud-init.log` | Cloud-init execution log |
 | `cloud-init-output.log` | Cloud-init stdout/stderr |
 | `console_output.log` | Serial console output (when kernel panic checker is enabled) |
+| `hdrh-cs-*.hdr` | cassandra-stress HDR histogram files |
+| `cs-safepoint-*.log` | cassandra-stress JVM safepoint log (when `cs_safepoint_logging` is enabled) |
 
 ## Monitor Node Logs
 

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -3656,6 +3656,15 @@ Extra JVM options passed to cassandra-stress via JVM_OPTS environment variable. 
 **type:** str (appendable)
 
 
+## **cs_safepoint_logging** / SCT_CS_SAFEPOINT_LOGGING
+
+Enable JVM safepoint logging (-Xlog:safepoint) for the cassandra-stress loaders. The log is written on the loader host, pulled into the loader log directory and collected into the run log archive. Use it to tell a loader JVM pause (including non-GC safepoints) apart from a server-side or network stall behind a latency-step failure. Not supported for k8s backends and prepared loaders.
+
+**default:** False
+
+**type:** bool
+
+
 ## **stress_cmd_mv** / SCT_STRESS_CMD_MV
 
 cassandra-stress commands. You can specify everything but the -node parameter, which is going to be provided by the test suite infrastructure. Multiple commands can be passed as a list

--- a/docs/performance-tests.md
+++ b/docs/performance-tests.md
@@ -38,3 +38,89 @@ Main options:
 - --hdr-folder: Path to local folder with HDR files (optional).
 
 This utility is useful for performance engineers and developers investigating latency issues in distributed database clusters.
+
+## Loader JVM safepoint logging
+
+Throttled perf steps sometimes fail a fixed P99 threshold because of a short (~1-2s) stall that the aggregate
+tail magnifies through coordinated-omission correction. The cassandra-stress JVM frequently shows **0 GC** in
+those runs, so the GC log cannot explain the pause and there is no way to tell a **non-GC safepoint** in the
+loader JVM (biased lock revocation, JIT deoptimization, thread dump, class redefinition, monitor deflation, the
+periodic "guaranteed safepoint") apart from a server-side or network stall.
+
+`cs_safepoint_logging` makes every cassandra-stress JVM log all of its safepoints, so the loaders can be
+implicated or exonerated within a single run.
+
+### Enabling it
+
+```yaml
+cs_safepoint_logging: true
+```
+
+or `SCT_CS_SAFEPOINT_LOGGING=true`. It is off by default; enable it for the pipeline that is being diagnosed.
+Before turning it on for a throughput-sensitive baseline, do one control run and compare the tail latency -
+`-Xlog:safepoint` only emits at safepoints that happen anyway and is cheap, but `safepoint+stats` is a bit
+heavier.
+
+The flag appends the unified logging options to whatever `cs_extra_jvm_opts` already carries (the ZGC and heap
+flags used by the perf pipelines are kept), so both end up in the `JVM_OPTS` of the c-s container:
+
+```
+-Xlog:safepoint*=info:file=/cs-safepoint-<operation>-<log-id>.log:time,uptime,level,tags:filecount=0
+```
+
+`safepoint*=info` selects both the `safepoint` and the `safepoint+stats` tag sets; a bare `safepoint=info`
+would match the exact tag set only and drop the stats.
+
+Not supported for k8s backends or `use_prepared_loaders: true` - `JVM_OPTS` is only injected into the c-s
+docker container, so the configuration is rejected at validation time.
+
+### Where the log ends up
+
+The log file is bind mounted into the c-s container from the loader host (the container is removed as soon as
+the stress command finishes), pulled into the loader log directory when the stress thread is over, and
+collected into the run log archive as `cs-safepoint-<operation>-l<loader_idx>-c<cpu_idx>-k<keyspace_idx>-<timestamp>-<uuid>.log`
+next to the `hdrh-*.hdr` files - one file per stress thread, sharing the log id with the `cassandra-stress-*.log`
+and `hdrh-*.hdr` files of the same thread. Empty logs are dropped instead of being collected.
+
+### Reading it
+
+Each safepoint is one line:
+
+```
+[2026-06-09T17:10:55.207+0000][0.278s][info][safepoint] Safepoint "G1CollectForAllocation", Time since last: 64444016 ns, Reaching safepoint: 3047 ns, Cleanup: 34865 ns, At safepoint: 2472966 ns, Leaving safepoint: 2519 ns, Total: 2513397 ns
+```
+
+- the quoted name is the operation/reason: `G1CollectForAllocation` / `ZMarkStart` (GC), `Deoptimize`,
+  `ICBufferFull`, `ThreadDump`, `RevokeBias`, `Cleanup`, `no vm operation` = the periodic guaranteed safepoint;
+- **`Total`** is the stop-the-world time, what the application actually lost;
+- **`Reaching safepoint`** is the TTSP - how long it took to bring all threads to the safepoint;
+- the `time`/`uptime` decorators map every line to a UTC wall clock.
+
+`safepoint+stats` adds, at JVM exit, a per-operation table plus a `Maximum sync time` / `Maximum cleanup time` /
+`Maximum vm operation time` summary - a one-line answer to "was there any long safepoint in this run at all".
+
+To attribute a latency-step ERROR that happened at, say, `2026-06-09 17:10:55 UTC`:
+
+1. Find the failing interval in the c-s HDR histograms - `hydra hdr-investigate` (see above) reports the
+   intervals whose P99 crosses the threshold.
+2. Check the `Maximum vm operation time` summary line of every loader log first - if the worst safepoint of
+   the whole run is a couple of ms, the loaders are out of the picture already.
+3. Otherwise grep the safepoint logs of all loaders around that wall clock second:
+
+   ```bash
+   grep '17:10:5' cs-safepoint-*.log | sort
+   ```
+
+4. Interpret what shows up at that second:
+   - **A pause of comparable magnitude** (hundreds of ms up to ~2s) - the loader JVM is the cause. A large
+     `Total` with a small `Reaching safepoint` means a long VM operation, and the quoted operation name says
+     which one.
+   - **A small `Total` but a large `Reaching safepoint`** - threads were slow to reach the safepoint: a
+     blocked/JNI thread, page faults or swap, CPU steal. Cross-check the loader `node_exporter` CPU steal and
+     memory metrics.
+   - **Nothing aligned with the stall** - the loader JVM is exonerated. Move to the server side
+     (`scylla_reactor_stalls_*`, `scylla_database_queued_reads` per shard on the DB nodes at that second) or to
+     the network.
+
+Because the stall is usually visible on all loaders at once, compare the loaders against each other: a
+synchronized pause across independent JVMs points away from the loaders and towards the cluster or the network.

--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -1166,6 +1166,7 @@ class LoaderLogCollector(LogCollector):
         FileLog(name="kcl-l*.log", search_locally=True),
         FileLog(name="*cassandra-harry*.log", search_locally=True),
         FileLog(name="hdrh-*.hdr", search_locally=True),
+        FileLog(name="cs-safepoint-*.log", search_locally=True),
         FileLog(name="*latte*", search_locally=True),
         FileLog(
             name="test.crt",

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -2127,6 +2127,13 @@ class SCTConfiguration(BaseModel):
         "Recommended for low-latency: '-XX:+UseZGC -XX:+ZGenerational -Xms8g -Xmx8g -XX:+AlwaysPreTouch' "
         "(requires Java 21+, which cassandra-stress 3.20.6+ ships with).",
     )
+    cs_safepoint_logging: Boolean = SctField(
+        description="Enable JVM safepoint logging (-Xlog:safepoint) for the cassandra-stress loaders. "
+        "The log is written on the loader host, pulled into the loader log directory and collected into the "
+        "run log archive. Use it to tell a loader JVM pause (including non-GC safepoints) apart from a "
+        "server-side or network stall behind a latency-step failure. Not supported for k8s backends and "
+        "prepared loaders.",
+    )
     stress_cmd_mv: StringOrList = SctField(
         description="cassandra-stress commands. You can specify everything but the -node parameter, which is going to be provided by the test suite infrastructure. Multiple commands can be passed as a list",
     )
@@ -4183,6 +4190,7 @@ class SCTConfiguration(BaseModel):
         if backend == "xcloud":
             self._validate_cloud_backend_parameters()
         self._verify_data_volume_configuration(backend)
+        self._verify_cs_safepoint_logging(backend)
 
         if self.get("n_db_nodes"):
             self._validate_seeds_number()
@@ -5198,6 +5206,16 @@ class SCTConfiguration(BaseModel):
 
         if not self.get("data_volume_disk_size") or not self.get("data_volume_disk_type"):
             raise ValueError("Data volume configuration requires: data_volume_disk_type, data_volume_disk_size")
+
+    def _verify_cs_safepoint_logging(self, backend):
+        if not self.get("cs_safepoint_logging"):
+            return
+
+        if "k8s" in backend or self.get("use_prepared_loaders"):
+            raise ValueError(
+                "'cs_safepoint_logging' requires cassandra-stress to run in a docker container on the loader, "
+                "it is not supported for k8s backends or with 'use_prepared_loaders'"
+            )
 
     def _verify_scylla_bench_mode_and_workload_parameters(self):
         for param_name in self.stress_cmd_params:

--- a/sdcm/stress_thread.py
+++ b/sdcm/stress_thread.py
@@ -326,6 +326,31 @@ class CassandraStressThread(DockerBasedStressThread):
 
         return stress_cmd
 
+    @staticmethod
+    def _safepoint_jvm_opts(container_log_file: str) -> str:
+        """Build the unified logging options that make the c-s JVM log every safepoint.
+
+        `safepoint*=info` selects both the `safepoint` tag set - one line per safepoint with its
+        operation/reason, the stop-the-world time (`Total`) and the time it took to bring all threads to the
+        safepoint (`Reaching safepoint`) - and `safepoint+stats`, the per-operation table and the worst-case
+        times printed at JVM exit. A bare `safepoint=info` would match the exact tag set only and drop the stats.
+        Rotation is disabled on purpose - the log is bind mounted into the container as a single file.
+        """
+        return f"-Xlog:safepoint*=info:file={container_log_file}:time,uptime,level,tags:filecount=0"
+
+    @staticmethod
+    def _collect_safepoint_log(loader, remote_log_file: str, local_log_file: str) -> None:
+        """Pull the safepoint log from the loader, so that LoaderLogCollector finds it in the local logdir."""
+        try:
+            loader.remoter.receive_files(src=remote_log_file, dst=local_log_file)
+            if os.path.getsize(local_log_file) == 0:
+                LOGGER.debug("Safepoint log %s is empty, removing it", local_log_file)
+                os.remove(local_log_file)
+            else:
+                LOGGER.info("cassandra-stress safepoint log collected: %s", local_log_file)
+        except Exception:  # noqa: BLE001
+            LOGGER.warning("Failed to collect cassandra-stress safepoint log %s", remote_log_file, exc_info=True)
+
     def _run_stress(self, loader, loader_idx, cpu_idx):
         pass
 
@@ -346,6 +371,9 @@ class CassandraStressThread(DockerBasedStressThread):
         LOGGER.debug("cassandra-stress HDR local file %s", local_hdr_file_name)
 
         remote_hdr_file_name_full_path = remote_hdr_file_name
+        jvm_opts = ""
+        safepoint_log_name = ""
+        remote_safepoint_log_full_path = ""
         if "k8s" in self.params.get("cluster_backend"):
             cmd_runner = loader.remoter
             cmd_runner_name = loader.remoter.pod_name
@@ -359,11 +387,22 @@ class CassandraStressThread(DockerBasedStressThread):
             ).stdout.strip()
             cmd_runner_name = loader.ip_address
 
+            safepoint_volume_opt = ""
+            jvm_opts_value = self.params.get("cs_extra_jvm_opts") or ""
+            if self.params.get("cs_safepoint_logging"):
+                safepoint_log_name = f"cs-safepoint-{stress_cmd_opt}-{log_id}.log"
+                loader.remoter.run(f"touch $HOME/{safepoint_log_name}", ignore_status=False, verbose=False)
+                remote_safepoint_log_full_path = loader.remoter.run(
+                    f"realpath $HOME/{safepoint_log_name}", ignore_status=False, verbose=False
+                ).stdout.strip()
+                safepoint_volume_opt = f" -v {remote_safepoint_log_full_path}:/{safepoint_log_name}"
+                jvm_opts_value = f"{jvm_opts_value} {self._safepoint_jvm_opts(f'/{safepoint_log_name}')}".strip()
+                LOGGER.info("cassandra-stress safepoint log on %s: %s", loader.name, remote_safepoint_log_full_path)
+
             cpu_options = ""
-            jvm_opts = ""
-            if cs_extra_jvm_opts := self.params.get("cs_extra_jvm_opts"):
-                jvm_opts = f" -e JVM_OPTS='{cs_extra_jvm_opts}'"
-                LOGGER.info("Passing JVM_OPTS to cassandra-stress container: %s", cs_extra_jvm_opts)
+            if jvm_opts_value:
+                jvm_opts = f" -e JVM_OPTS='{jvm_opts_value}'"
+                LOGGER.info("Passing JVM_OPTS to cassandra-stress container: %s", jvm_opts_value)
             cmd_runner = cleanup_context = RemoteDocker(
                 loader,
                 self.docker_image_name,
@@ -375,6 +414,7 @@ class CassandraStressThread(DockerBasedStressThread):
                 f" --entrypoint /bin/bash"
                 f" -w /"
                 f" -v {remote_hdr_file_name_full_path}:/{remote_hdr_file_name}"
+                f"{safepoint_volume_opt}"
                 f"{jvm_opts}",
             )
 
@@ -409,7 +449,7 @@ class CassandraStressThread(DockerBasedStressThread):
 
         LOGGER.info("Stress command:\n%s", stress_cmd)
 
-        if self.params.get("cs_extra_jvm_opts"):
+        if jvm_opts:
             try:
                 env_check = cmd_runner.run("echo JVM_OPTS=$JVM_OPTS", ignore_status=True, verbose=False)
                 LOGGER.info("JVM_OPTS env inside container: %s", env_check.stdout.strip())
@@ -478,6 +518,11 @@ class CassandraStressThread(DockerBasedStressThread):
                     )
             except Exception as exc:  # noqa: BLE001
                 self.configure_event_on_failure(stress_event=cs_stress_event, exc=exc)
+
+        if remote_safepoint_log_full_path:
+            self._collect_safepoint_log(
+                loader, remote_safepoint_log_full_path, os.path.join(loader.logdir, safepoint_log_name)
+            )
 
         return loader, result, cs_stress_event
 

--- a/test-cases/performance/perf-regression-latency-2.5tb-elasticity.yaml
+++ b/test-cases/performance/perf-regression-latency-2.5tb-elasticity.yaml
@@ -53,3 +53,4 @@ parallel_node_operations: true
 cluster_health_check: false
 
 adaptive_timeout_store_metrics: false
+cs_safepoint_logging: true

--- a/unit_tests/integration/test_cassandra_stress_thread.py
+++ b/unit_tests/integration/test_cassandra_stress_thread.py
@@ -12,6 +12,7 @@
 # Copyright (c) 2022 ScyllaDB
 import subprocess
 import time
+from pathlib import Path
 
 import pytest
 
@@ -23,6 +24,17 @@ pytestmark = [
     pytest.mark.integration,
     pytest.mark.xdist_group("docker_heavy"),
 ]
+
+
+@pytest.fixture(autouse=True)
+def enable_safepoint_logging(params):
+    """Run every c-s integration test with safepoint logging on, instead of paying for a dedicated run.
+
+    It has to stay compatible with every way c-s is started here (user profiles, client encryption,
+    multi-region, compression, extra JVM opts), so exercising it everywhere is the point.
+    test_06 is the one that asserts what it actually produces.
+    """
+    params["cs_safepoint_logging"] = True
 
 
 def test_01_cassandra_stress(request, docker_scylla, params):
@@ -210,7 +222,10 @@ def test_06_cassandra_stress_with_extra_jvm_opts(request, docker_scylla, params)
         check=True,
     )
     actual_jvm_opts = result.stdout.strip()
-    assert actual_jvm_opts == jvm_opts, f"JVM_OPTS not set correctly inside container: {actual_jvm_opts!r}"
+    assert actual_jvm_opts.startswith(jvm_opts), f"JVM_OPTS not set correctly inside container: {actual_jvm_opts!r}"
+    assert "-Xlog:safepoint*=info:file=/cs-safepoint-" in actual_jvm_opts, (
+        f"safepoint logging options not added to JVM_OPTS: {actual_jvm_opts!r}"
+    )
 
     result = subprocess.run(
         ["docker", "exec", container_id, "bash", "-c", "cat /proc/$(pgrep -x java | head -1)/cmdline | tr '\\0' ' '"],
@@ -222,6 +237,7 @@ def test_06_cassandra_stress_with_extra_jvm_opts(request, docker_scylla, params)
     assert "-XX:+UseZGC" in java_cmdline, f"ZGC flag not found in Java cmdline: {java_cmdline}"
     assert "-XX:+ZGenerational" in java_cmdline, f"ZGenerational flag not found in Java cmdline: {java_cmdline}"
     assert "-Xms512m" in java_cmdline, f"-Xms512m not found in Java cmdline: {java_cmdline}"
+    assert "-Xlog:safepoint" in java_cmdline, f"safepoint logging flag not found in Java cmdline: {java_cmdline}"
 
     output, _ = cs_thread.parse_results()
     assert "latency mean" in output[0]
@@ -229,3 +245,12 @@ def test_06_cassandra_stress_with_extra_jvm_opts(request, docker_scylla, params)
 
     assert "latency 99th percentile" in output[0]
     assert float(output[0]["latency 99th percentile"]) > 0
+
+    # the safepoint log is written into a file bind mounted from the loader - the container itself is gone
+    # once the stress command is over - and pulled into the loader log directory
+    logdir = Path(cs_thread.loaders[0].logdir)
+    safepoint_logs = list(logdir.glob("cs-safepoint-*.log"))
+    assert safepoint_logs, f"no safepoint log was collected into {logdir}"
+
+    content = safepoint_logs[0].read_text()
+    assert "[safepoint" in content, f"unexpected safepoint log content: {content[:500]}"

--- a/unit_tests/unit/test_config.py
+++ b/unit_tests/unit/test_config.py
@@ -1589,3 +1589,33 @@ def test_mixed_scylla_run_reserves_user_prefix_room_for_oracle_suffix(monkeypatc
     conf.verify_configuration()
 
     assert conf.user_prefix == user_prefix[:expected_len]
+
+
+@pytest.mark.parametrize(
+    "backend, use_prepared_loaders",
+    [
+        pytest.param("k8s-eks", False, id="k8s-backend"),
+        pytest.param("aws", True, id="prepared-loaders"),
+    ],
+)
+def test_cs_safepoint_logging_rejected_without_cs_docker_container(monkeypatch, backend, use_prepared_loaders):
+    """JVM_OPTS is only injected into the c-s docker container, so the flag would silently do nothing."""
+    monkeypatch.setenv("SCT_CLUSTER_BACKEND", backend)
+    monkeypatch.setenv("SCT_AMI_ID_DB_SCYLLA", "ami-dummy")
+    monkeypatch.setenv("SCT_USE_PREPARED_LOADERS", str(use_prepared_loaders))
+    monkeypatch.setenv("SCT_CS_SAFEPOINT_LOGGING", "true")
+
+    conf = sct_config.SCTConfiguration()
+
+    with pytest.raises(ValueError, match="cs_safepoint_logging"):
+        conf._verify_cs_safepoint_logging(backend)
+
+
+def test_cs_safepoint_logging_allowed_on_docker_based_loaders(monkeypatch):
+    monkeypatch.setenv("SCT_CLUSTER_BACKEND", "aws")
+    monkeypatch.setenv("SCT_AMI_ID_DB_SCYLLA", "ami-dummy")
+    monkeypatch.setenv("SCT_CS_SAFEPOINT_LOGGING", "true")
+
+    conf = sct_config.SCTConfiguration()
+
+    conf._verify_cs_safepoint_logging("aws")


### PR DESCRIPTION
Throttled perf steps intermittently fail a fixed P99 threshold because of a short (~1-2s) stall that the aggregate tail magnifies through coordinated-omission correction. The cassandra-stress JVM frequently shows 0 GC in those runs, so the GC log cannot explain the pause and there is no way to tell a non-GC safepoint in the loader JVM (biased lock revocation, JIT deoptimization, thread dump, monitor deflation, the periodic guaranteed safepoint) apart from a server-side or network stall without eliminating suspects over many reruns.

Add a cs_safepoint_logging flag that appends `-Xlog:safepoint `to the JVM_OPTS of the cassandra-stress container, on top of whatever cs_extra_jvm_opts already carries, so a single run can implicate or exonerate the loaders.

The log cannot simply be written inside the container - it is removed as soon as the stress command is over. It is written into a file bind mounted from the loader host, the same way the HDR file is, pulled into the loader log directory once the stress thread is done (dropped when empty) and collected into the run log archive by LoaderLogCollector next to the hdrh-*.hdr files.

The flag is off by default; enable it per pipeline for a diagnosis, after a control run confirms the added logging does not move the baseline tail latency. It is a no-op on k8s and prepared loaders, where JVM_OPTS is not injected, and it now warns instead of silently doing nothing. It requires a JDK 11+ loader image (the default one ships Temurin 21) - JDK 8 refuses to start a JVM with -Xlog at all.

docs/performance-tests.md documents how to correlate a latency-step ERROR with the safepoint log: the HDR interval, the safepoint+stats worst-case summary, then the wall-clock grep, reading a large Total with a small "Reaching safepoint" as a long VM operation and the reverse as threads slow to reach the safepoint.

fixes: [SCT-468]

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [perf-regression-predefined-throughput-steps-sanity-vnodes](https://argus.scylladb.com/tests/scylla-cluster-tests/eb75f19a-d15e-4e5a-88eb-e48e2578dd6b) - safepoint logs are collected and saved per every loader. zeus succeeded to analyse them

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)


[SCT-468]: https://scylladb.atlassian.net/browse/SCT-468?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ