### PR TITLE
docs(test-metadata): add test_metadata to Storage QA test cases

### DIFF
--- a/docs/pipeline-labels/taxonomy.yaml
+++ b/docs/pipeline-labels/taxonomy.yaml
@@ -102,6 +102,7 @@ features:
     - twcs
     - zero-token-nodes
     - alternator-streams
+    - elasticity
 
 team_ownership:
   description: "QA team responsible for maintaining this test"

--- a/sdcm/utils/lint/docs_linter.py
+++ b/sdcm/utils/lint/docs_linter.py
@@ -65,11 +65,11 @@ def lint_test_metadata(config_path: Path, taxonomy_path: Path | None = None) -> 
     elif len(meta.description.strip()) < 20:
         result.errors.append(f"TD-002: 'description' is too short ({len(meta.description.strip())} chars, minimum 20)")
 
-    # TD-004: test_type should match directory name
+    # TD-004: test_type should match one of the directory names in the path
     if meta.test_type:
-        parent_dir = config_path.parent.name
-        if meta.test_type not in parent_dir and parent_dir not in meta.test_type:
-            result.warnings.append(f"TD-004: test_type '{meta.test_type}' may not match directory '{parent_dir}'")
+        ancestor_dirs = [p.name for p in config_path.parents if p.name and p.name != "test-cases"]
+        if not any(meta.test_type in d or d in meta.test_type for d in ancestor_dirs):
+            result.warnings.append(f"TD-004: test_type '{meta.test_type}' may not match directory path '{config_path}'")
 
     # TD-010: tier appropriate for duration
     if meta.tier and meta.duration_class:

--- a/skills/labeling-pipelines/references/taxonomy-values.md
+++ b/skills/labeling-pipelines/references/taxonomy-values.md
@@ -29,7 +29,7 @@ cassandra-stress, cql-stress-cassandra-stress, scylla-bench, ycsb, latte, gemini
 Any class from NemesisRegistry + NemesisRunner (124 values). See `docs/pipeline-labels/taxonomy.yaml` nemesis_labels section for the full list.
 
 ## features
-tls-ssl, multi-dc, cdc, tablets, vnodes, alternator, encryption-at-rest, ldap, authorization, ipv6, counters, large-partitions, materialized-views, secondary-indexes, lwt, schema-changes, tombstone-gc, twcs, ... (see taxonomy.yaml for full list)
+tls-ssl, multi-dc, cdc, tablets, vnodes, alternator, encryption-at-rest, ldap, authorization, ipv6, counters, large-partitions, materialized-views, secondary-indexes, lwt, schema-changes, tombstone-gc, twcs, elasticity, ... (see taxonomy.yaml for full list)
 
 ## supported_backends
 aws, gce, azure, docker, k8s-eks, k8s-gke, k8s-local-kind, baremetal, xcloud, oci

--- a/test-cases/enterprise-features/ics/longevity/ics-longevity-100gb-4h.yaml
+++ b/test-cases/enterprise-features/ics/longevity/ics-longevity-100gb-4h.yaml
@@ -1,3 +1,16 @@
+test_metadata:
+  description: >-
+    Enterprise ICS longevity overlay running ~4 hours of IncrementalCompactionStrategy cassandra-
+    stress write and read workloads on a ~100GB dataset. Note: this test has not been run in a while.
+  test_type: longevity
+  tier: ondemand
+  duration_class: short
+  stress_tools:
+    - cassandra-stress
+  workload: mixed
+  features: []
+  team_ownership: storage-qa
+
 prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=20971520 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=IncrementalCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..20971520 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5"
 
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=240m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=IncrementalCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..20971520 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5",

--- a/test-cases/enterprise-features/ics/longevity/ics-longevity-10gb-3h.yaml
+++ b/test-cases/enterprise-features/ics/longevity/ics-longevity-10gb-3h.yaml
@@ -1,2 +1,15 @@
+test_metadata:
+  description: >-
+    Enterprise ICS longevity overlay running a basic ~3-hour IncrementalCompactionStrategy
+    cassandra-stress write workload on a ~10GB dataset. Note: this test has not been run in a while.
+  test_type: longevity
+  tier: ondemand
+  duration_class: short
+  stress_tools:
+    - cassandra-stress
+  workload: write
+  features: []
+  team_ownership: storage-qa
+
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=180m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=IncrementalCompactionStrategy)' -mode cql3 native -rate threads=1000 -pop seq=1..10000000 -log interval=5"
              ]

--- a/test-cases/enterprise-features/ics/longevity/ics-longevity-1TB-7days-authorization-and-tls-ssl.yaml
+++ b/test-cases/enterprise-features/ics/longevity/ics-longevity-1TB-7days-authorization-and-tls-ssl.yaml
@@ -1,3 +1,19 @@
+test_metadata:
+  description: >-
+    Enterprise ICS longevity overlay validating IncrementalCompactionStrategy with multiple
+    compression algorithms (LZ4/Snappy/Deflate), an MV profile, plus TLS and role-based
+    authorization, on a ~1TB dataset over ~7 days. Note: this test has not been run in a while.
+  test_type: longevity
+  tier: ondemand
+  duration_class: long
+  stress_tools:
+    - cassandra-stress
+  workload: mixed
+  features:
+    - tls-ssl
+    - authorization
+  team_ownership: storage-qa
+
 prepare_write_cmd: ["cassandra-stress write cl=QUORUM n=1100200300 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=IncrementalCompactionStrategy)' -mode cql3 native  -rate threads=1000 -col 'size=FIXED(200) n=FIXED(5)' -pop seq=1..1100200300"]
 
 stress_cmd: ["cassandra-stress mixed cl=QUORUM duration=6800m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=IncrementalCompactionStrategy)' -mode cql3 native -rate threads=20 -pop seq=1..1100200300  -log interval=5 -col 'size=FIXED(200) n=FIXED(5)'",

--- a/test-cases/enterprise-features/ics/longevity/ics-longevity-200GB-48h-verifier-LimitedMonkey-tls.yaml
+++ b/test-cases/enterprise-features/ics/longevity/ics-longevity-200GB-48h-verifier-LimitedMonkey-tls.yaml
@@ -1,3 +1,18 @@
+test_metadata:
+  description: >-
+    Enterprise ICS longevity overlay running ~48 hours of IncrementalCompactionStrategy cassandra-
+    stress write/read workloads over TLS on a ~200GB dataset, intended to run with a LimitedMonkey
+    nemesis and data verifier. Note: this test has not been run in a while.
+  test_type: longevity
+  tier: ondemand
+  duration_class: long
+  stress_tools:
+    - cassandra-stress
+  workload: mixed
+  features:
+    - tls-ssl
+  team_ownership: storage-qa
+
 prepare_write_cmd: "cassandra-stress write cl=ALL n=200200300  -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=IncrementalCompactionStrategy)' -mode cql3 native -rate threads=1000 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..200200300 -log interval=15"
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=2860m  -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=IncrementalCompactionStrategy)' -mode cql3 native -rate threads=250  -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=400200300..600200300 -log interval=15"]
 stress_read_cmd: ["cassandra-stress read cl=ONE duration=2860m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=IncrementalCompactionStrategy)' -mode cql3 native -rate threads=250  -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..200200300 -log interval=5"]

--- a/test-cases/enterprise-features/ics/longevity/ics-longevity-50GB-4days-authorization-and-tls-ssl.yaml
+++ b/test-cases/enterprise-features/ics/longevity/ics-longevity-50GB-4days-authorization-and-tls-ssl.yaml
@@ -1,3 +1,19 @@
+test_metadata:
+  description: >-
+    Enterprise ICS longevity overlay validating IncrementalCompactionStrategy with multiple
+    compression algorithms, an MV profile, plus TLS and role-based authorization, on a ~50GB
+    dataset over ~4 days. Note: this test has not been run in a while.
+  test_type: longevity
+  tier: ondemand
+  duration_class: long
+  stress_tools:
+    - cassandra-stress
+  workload: mixed
+  features:
+    - tls-ssl
+    - authorization
+  team_ownership: storage-qa
+
 prepare_write_cmd: ["cassandra-stress write cl=QUORUM n=100000000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=IncrementalCompactionStrategy)' -mode cql3 native  -rate threads=500 -pop seq=1..100000000"]
 
 stress_cmd: ["cassandra-stress mixed cl=QUORUM duration=5760m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=IncrementalCompactionStrategy)' -mode cql3 native  -rate threads=20 -pop seq=1..100000000 -log interval=5",

--- a/test-cases/enterprise-features/ics/longevity/ics-longevity-large-partition-4days.yaml
+++ b/test-cases/enterprise-features/ics/longevity/ics-longevity-large-partition-4days.yaml
@@ -1,1 +1,14 @@
+test_metadata:
+  description: >-
+    Enterprise ICS (Incremental Compaction Strategy) longevity overlay that sets the compaction
+    strategy to IncrementalCompactionStrategy for a large-partition longevity scenario running over
+    ~4 days. Note: this test has not been run in a while.
+  test_type: longevity
+  tier: ondemand
+  duration_class: long
+  stress_tools: []
+  features:
+    - large-partitions
+  team_ownership: storage-qa
+
 compaction_strategy: 'IncrementalCompactionStrategy'

--- a/test-cases/enterprise-features/ics/longevity/ics-longevity-mv-si-4days.yaml
+++ b/test-cases/enterprise-features/ics/longevity/ics-longevity-mv-si-4days.yaml
@@ -1,3 +1,17 @@
+test_metadata:
+  description: >-
+    Enterprise ICS longevity overlay running materialized-view and secondary-index cassandra-stress
+    user-profile workloads (inserts plus MV/SI reads) for ~4 days to validate ICS behavior with
+    MV/SI under sustained mixed load. Note: this test has not been run in a while.
+  test_type: longevity
+  tier: ondemand
+  duration_class: long
+  stress_tools:
+    - cassandra-stress
+  workload: mixed
+  features: []
+  team_ownership: storage-qa
+
 prepare_write_cmd: ["cassandra-stress user profile=/tmp/ics_c-s_profile_4mv_5queries.yaml ops'(insert=15,read1=1,read2=1,read3=1,read4=1,read5=1)' cl=QUORUM n=100000000 -mode cql3 native -rate threads=10",
                     "cassandra-stress user profile=/tmp/ics_c-s_profile_3si_5queries.yaml ops'(insert=25,si_read1=1,si_read2=1,si_read3=1,si_read4=1,si_read5=1)' cl=QUORUM n=100000000 -mode cql3 native -rate threads=10"
                    ]

--- a/test-cases/enterprise-features/ics/longevity/ics-longevity-toggle-strategy-large-partitions-24h.yaml
+++ b/test-cases/enterprise-features/ics/longevity/ics-longevity-toggle-strategy-large-partitions-24h.yaml
@@ -1,3 +1,18 @@
+test_metadata:
+  description: >-
+    Enterprise ICS longevity test that toggles a table's compaction strategy via
+    ToggleTableIcsMonkey nemesis while running scylla-bench large-partition write/read workloads
+    for ~27 hours. Note: this test has not been run in a while.
+  test_type: longevity
+  tier: ondemand
+  duration_class: long
+  stress_tools:
+    - scylla-bench
+  workload: mixed
+  features:
+    - large-partitions
+  team_ownership: storage-qa
+
 test_duration: 1600
 
 nemesis_class_name: "SisyphusMonkey"

--- a/test-cases/features/elasticity/elasticity-90-percent-i4i-2xlarge-drop.yaml
+++ b/test-cases/features/elasticity/elasticity-90-percent-i4i-2xlarge-drop.yaml
@@ -1,3 +1,21 @@
+test_metadata:
+  description: >-
+    Elasticity feature test that fills a cluster to ~90% disk utilization, drops one of the
+    populated keyspaces, then runs a mixed cassandra-stress workload to validate space reclamation
+    and stability at high disk utilization.
+  test_type: features
+  tier: ondemand
+  duration_class: medium
+  supported_backends:
+    - aws
+  stress_tools:
+    - cassandra-stress
+  workload: mixed
+  features:
+    - elasticity
+    - tablets
+  team_ownership: storage-qa
+
 # Test case for ScyllaDB elasticity at 90% utilization
 # The test writes approximately 1.5 TB of data to fill the cluster at around 90% utilization.
 # A 3rd of the data is written to a keyspace that is dropped after all writes are done.

--- a/test-cases/features/elasticity/elasticity-90-percent-i4i-2xlarge-truncate.yaml
+++ b/test-cases/features/elasticity/elasticity-90-percent-i4i-2xlarge-truncate.yaml
@@ -1,3 +1,21 @@
+test_metadata:
+  description: >-
+    Elasticity feature test that fills a cluster to ~90% disk utilization, truncates one of the
+    populated keyspaces, then runs a mixed cassandra-stress workload to validate space reclamation
+    and stability at high disk utilization.
+  test_type: features
+  tier: ondemand
+  duration_class: medium
+  supported_backends:
+    - aws
+  stress_tools:
+    - cassandra-stress
+  workload: mixed
+  features:
+    - elasticity
+    - tablets
+  team_ownership: storage-qa
+
 # Test case for ScyllaDB elasticity at 90% utilization
 # The test writes approximately 1.5 TB of data to fill the cluster at around 90% utilization.
 # A 3rd of the data is written to a keyspace that is truncated after all writes are done.

--- a/test-cases/features/elasticity/elasticity-90-percent-i4i-2xlarge-ttl.yaml
+++ b/test-cases/features/elasticity/elasticity-90-percent-i4i-2xlarge-ttl.yaml
@@ -1,3 +1,22 @@
+test_metadata:
+  description: >-
+    Elasticity feature test that fills a cluster to ~90% disk utilization with data written under a
+    12000-second TTL and TWCS expiration, then runs a mixed cassandra-stress workload with major-
+    compaction nemesis to validate space reclamation via TTL expiry.
+  test_type: features
+  tier: ondemand
+  duration_class: medium
+  supported_backends:
+    - aws
+  stress_tools:
+    - cassandra-stress
+  workload: mixed
+  features:
+    - elasticity
+    - twcs
+    - tablets
+  team_ownership: storage-qa
+
 # Test case for ScyllaDB elasticity at 90% utilization
 # The test writes approximately 1.5 TB of data to fill the cluster at around 90% utilization.
 # A 3rd of the data is written to a keyspace with a 12,000 seconds TTL (chosen to be more than the time it takes to write the data).

--- a/test-cases/features/elasticity/elasticity-90-percent-perf-i4i-4xlarge-grow-i4i-large.yaml
+++ b/test-cases/features/elasticity/elasticity-90-percent-perf-i4i-4xlarge-grow-i4i-large.yaml
@@ -1,3 +1,21 @@
+test_metadata:
+  description: >-
+    Elasticity performance test that fills a cluster to ~90% disk utilization, runs a mixed
+    workload at ~50% load, then scales the cluster out and back in using smaller instance types
+    (i4i.4xlarge -> i4i.large) to measure elasticity behavior under shrink.
+  test_type: features
+  tier: ondemand
+  duration_class: medium
+  supported_backends:
+    - aws
+  stress_tools:
+    - cassandra-stress
+  workload: mixed
+  features:
+    - elasticity
+    - tablets
+  team_ownership: storage-qa
+
 # Test case for ScyllaDB elasticity at 90% utilization
 # The test writes approximately 3 TB of data to fill the cluster at around 90% utilization.
 # After the cluster is filled, a mixed workload is run at approximately 50% load.

--- a/test-cases/features/elasticity/elasticity-90-percent-perf-i4i-large-grow-i4i-4xlarge.yaml
+++ b/test-cases/features/elasticity/elasticity-90-percent-perf-i4i-large-grow-i4i-4xlarge.yaml
@@ -1,3 +1,21 @@
+test_metadata:
+  description: >-
+    Elasticity performance test that fills a cluster to ~90% disk utilization, runs a mixed
+    workload at ~50% load, then scales the cluster out and back in using larger instance types
+    (i4i.large -> i4i.4xlarge) to measure elasticity behavior under growth.
+  test_type: features
+  tier: ondemand
+  duration_class: medium
+  supported_backends:
+    - aws
+  stress_tools:
+    - cassandra-stress
+  workload: mixed
+  features:
+    - elasticity
+    - tablets
+  team_ownership: storage-qa
+
 # Test case for ScyllaDB elasticity at 90% utilization
 # The test writes approximately 0.4 TB of data to fill the cluster at around 90% utilization.
 # After the cluster is filled, a mixed workload is run at approximately 50% load.

--- a/test-cases/features/elasticity/elasticity-90-percent-with-nemesis.yaml
+++ b/test-cases/features/elasticity/elasticity-90-percent-with-nemesis.yaml
@@ -1,3 +1,22 @@
+test_metadata:
+  description: >-
+    Elasticity feature test running a tablets-enabled keyspace at high disk utilization for 50
+    hours with concurrent read/write cassandra-stress load and SisyphusMonkey nemesis restricted to
+    disk-utilization-safe disruptions, validating elasticity nemesis interaction under sustained
+    load.
+  test_type: features
+  tier: tier1
+  duration_class: long
+  supported_backends:
+    - aws
+  stress_tools:
+    - cassandra-stress
+  workload: mixed
+  features:
+    - elasticity
+    - tablets
+  team_ownership: storage-qa
+
 # Maintained by Storage QA
 test_duration: 3000
 prepare_stress_duration: 720

--- a/test-cases/features/elasticity/longevity-elasticity-many-small-tables.yaml
+++ b/test-cases/features/elasticity/longevity-elasticity-many-small-tables.yaml
@@ -1,3 +1,21 @@
+test_metadata:
+  description: >-
+    Elasticity feature test validating cluster behavior at ~90% disk utilization spread across 500
+    small tables, populated and stressed in 4 batches of 125 tables with combined write/read load
+    via a templated cassandra-stress user profile.
+  test_type: features
+  tier: ondemand
+  duration_class: medium
+  supported_backends:
+    - aws
+  stress_tools:
+    - cassandra-stress
+  workload: mixed
+  features:
+    - elasticity
+    - tablets
+  team_ownership: storage-qa
+
 # This is a test case for having 90% disk utilization with a lot of small tables.
 # The data is split equally among 500 tables.
 # The dataset size is aligned with 'i4i.xlarge' and RF = 3 = number-of-DB-nodes.

--- a/test-cases/features/ics_space_amplification_goal_test.yaml
+++ b/test-cases/features/ics_space_amplification_goal_test.yaml
@@ -1,3 +1,19 @@
+test_metadata:
+  description: >-
+    Longevity-style feature test validating the Incremental Compaction Strategy (ICS) space
+    amplification goal by writing ~1B rows with ICS and measuring disk space amplification under
+    continued QUORUM writes on a 3-node cluster. Note: this test has not been run in a while.
+  test_type: features
+  tier: ondemand
+  duration_class: long
+  supported_backends:
+    - aws
+  stress_tools:
+    - cassandra-stress
+  workload: write
+  features: []
+  team_ownership: storage-qa
+
 test_duration: 3600
 
 

--- a/test-cases/features/out-of-space-prevention/longevity-out-of-space-prevention-compaction.yaml
+++ b/test-cases/features/out-of-space-prevention/longevity-out-of-space-prevention-compaction.yaml
@@ -1,3 +1,19 @@
+test_metadata:
+  description: >-
+    Out-of-space prevention feature test that fills a cluster to ~90% disk usage plus an extra ~15%
+    write burst, validating that compaction continues to function safely as the cluster approaches
+    disk capacity.
+  test_type: features
+  tier: ondemand
+  duration_class: medium
+  supported_backends:
+    - aws
+  stress_tools:
+    - cassandra-stress
+  workload: write
+  features: []
+  team_ownership: storage-qa
+
 # Maintained by Storage QA
 
 test_duration: 1440

--- a/test-cases/features/out-of-space-prevention/longevity-out-of-space-prevention-reject-writes.yaml
+++ b/test-cases/features/out-of-space-prevention/longevity-out-of-space-prevention-reject-writes.yaml
@@ -1,3 +1,19 @@
+test_metadata:
+  description: >-
+    Out-of-space prevention feature test that fills a cluster to ~90% disk usage plus an extra ~15%
+    write burst, validating that the cluster correctly rejects writes rather than crashing as it
+    approaches disk capacity.
+  test_type: features
+  tier: ondemand
+  duration_class: medium
+  supported_backends:
+    - aws
+  stress_tools:
+    - cassandra-stress
+  workload: write
+  features: []
+  team_ownership: storage-qa
+
 # Maintained by Storage QA
 
 test_duration: 1440

--- a/test-cases/features/out-of-space-prevention/longevity-out-of-space-prevention-repair.yaml
+++ b/test-cases/features/out-of-space-prevention/longevity-out-of-space-prevention-repair.yaml
@@ -1,3 +1,19 @@
+test_metadata:
+  description: >-
+    Out-of-space prevention feature test that fills a cluster to ~90% disk usage plus an extra ~15%
+    write burst, then runs read validation, checking that repair-adjacent operations behave safely
+    as the cluster approaches disk capacity.
+  test_type: features
+  tier: ondemand
+  duration_class: medium
+  supported_backends:
+    - aws
+  stress_tools:
+    - cassandra-stress
+  workload: mixed
+  features: []
+  team_ownership: storage-qa
+
 # Maintained by Storage QA
 
 test_duration: 1440

--- a/test-cases/features/out-of-space-prevention/longevity-out-of-space-prevention-restart.yaml
+++ b/test-cases/features/out-of-space-prevention/longevity-out-of-space-prevention-restart.yaml
@@ -1,3 +1,19 @@
+test_metadata:
+  description: >-
+    Out-of-space prevention feature test that fills a cluster to ~90% disk usage plus an extra ~15%
+    write burst, validating that nodes restart safely and recover as the cluster approaches disk
+    capacity.
+  test_type: features
+  tier: ondemand
+  duration_class: medium
+  supported_backends:
+    - aws
+  stress_tools:
+    - cassandra-stress
+  workload: write
+  features: []
+  team_ownership: storage-qa
+
 # Maintained by Storage QA
 
 test_duration: 1440

--- a/test-cases/features/out-of-space-prevention/longevity-out-of-space-prevention-secondary-index.yaml
+++ b/test-cases/features/out-of-space-prevention/longevity-out-of-space-prevention-secondary-index.yaml
@@ -1,3 +1,20 @@
+test_metadata:
+  description: >-
+    Out-of-space prevention feature test that fills a tablets-enabled cluster to ~90% disk usage
+    plus an extra ~15% write burst, validating secondary index (views-with-tablets) creation and
+    behavior as the cluster approaches disk capacity.
+  test_type: features
+  tier: ondemand
+  duration_class: medium
+  supported_backends:
+    - aws
+  stress_tools:
+    - cassandra-stress
+  workload: write
+  features:
+    - tablets
+  team_ownership: storage-qa
+
 # Maintained by Storage QA
 
 test_duration: 1440

--- a/test-cases/features/size-based-load-balancing/size-based-load-balancing.yaml
+++ b/test-cases/features/size-based-load-balancing/size-based-load-balancing.yaml
@@ -1,3 +1,21 @@
+test_metadata:
+  description: >-
+    Feature test validating tablets size-based load balancing on a heterogeneous cluster: populates
+    ~1.2TB of data with varied partition sizes, scales out with a different instance type per rack,
+    and checks per-rack disk usage stays balanced within a 5% threshold during scale-out and scale-
+    in.
+  test_type: features
+  tier: ondemand
+  duration_class: medium
+  supported_backends:
+    - aws
+  stress_tools:
+    - scylla-bench
+  workload: write
+  features:
+    - tablets
+  team_ownership: storage-qa
+
 # Size-based load balancing test.
 # This test ensures storage utilization within each rack stays within the allowed threshold.
 # - Work with a heterogenous cluster: add 'nemesis_add_node_cnt' nodes of type 'nemesis_grow_shrink_instance_type' to the base cluster (n_db_nodes = 6).

--- a/test-cases/features/tombstone_gc/longevity-tombstone-gc-modes.yaml
+++ b/test-cases/features/tombstone_gc/longevity-tombstone-gc-modes.yaml
@@ -1,3 +1,21 @@
+test_metadata:
+  description: >-
+    Feature test validating tombstone GC modes by writing a scylla-bench timeseries workload
+    against a TWCS table configured with a short (4-minute) TTL, gc_grace_seconds, compaction
+    window, and disabled tombstone_gc propagation delay.
+  test_type: features
+  tier: ondemand
+  duration_class: short
+  supported_backends:
+    - aws
+  stress_tools:
+    - scylla-bench
+  workload: write
+  features:
+    - tombstone-gc
+    - twcs
+  team_ownership: storage-qa
+
 # Maintained by Storage QA
 test_duration: 200
 

--- a/test-cases/longevity/longevity-azure-kms-10gb-3h.yaml
+++ b/test-cases/longevity/longevity-azure-kms-10gb-3h.yaml
@@ -1,3 +1,20 @@
+test_metadata:
+  description: >-
+    Longevity test validating KMS (Key Management Service) encryption at rest on Azure, including
+    key rotation, while running a cassandra-stress write workload with SisyphusMonkey nemesis on a
+    6-node single-DC cluster for ~4 hours.
+  test_type: longevity
+  tier: ondemand
+  duration_class: short
+  supported_backends:
+    - azure
+  stress_tools:
+    - cassandra-stress
+  workload: write
+  features:
+    - kms
+  team_ownership: storage-qa
+
 test_duration: 255
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=180m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=1000 -pop seq=1..10000000 -log interval=5"
              ]

--- a/test-cases/longevity/longevity-encryption-at-rest-200GB-6h.yaml
+++ b/test-cases/longevity/longevity-encryption-at-rest-200GB-6h.yaml
@@ -1,3 +1,21 @@
+test_metadata:
+  description: >-
+    Longevity test validating encryption-at-rest (server_encrypt) with a ~200GB dataset, running
+    mixed cassandra-stress write/read workloads plus a full-scan check for ~6 hours on a 6-node
+    single-DC cluster with SisyphusMonkey nemesis.
+  test_type: longevity
+  tier: ondemand
+  duration_class: medium
+  supported_backends:
+    - aws
+  stress_tools:
+    - cassandra-stress
+  workload: mixed
+  features:
+    - encryption-at-rest
+    - tls-ssl
+  team_ownership: storage-qa
+
 test_duration: 550
 prepare_write_cmd: "cassandra-stress write cl=ALL n=200200300  -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=1000 -col 'size=FIXED(200) n=FIXED(5)' -pop seq=1..200200300 -log interval=15"
 

--- a/test-cases/longevity/longevity-encryption-at-rest-20GB-6h-multidc.yaml
+++ b/test-cases/longevity/longevity-encryption-at-rest-20GB-6h-multidc.yaml
@@ -1,3 +1,22 @@
+test_metadata:
+  description: >-
+    Longevity test validating encryption-at-rest (server_encrypt) on a multi-DC cluster (2x3
+    nodes), running cassandra-stress write/read workloads for ~6 hours with SisyphusMonkey nemesis
+    and rack-aware/region-aware loaders.
+  test_type: longevity
+  tier: ondemand
+  duration_class: medium
+  supported_backends:
+    - aws
+  stress_tools:
+    - cassandra-stress
+  workload: mixed
+  features:
+    - encryption-at-rest
+    - tls-ssl
+    - multi-dc
+  team_ownership: storage-qa
+
 test_duration: 550
 
 prepare_write_cmd:  [

--- a/test-cases/longevity/longevity-encryption-at-rest-50GB-1day-authorization-and-tls-ssl.yaml
+++ b/test-cases/longevity/longevity-encryption-at-rest-50GB-1day-authorization-and-tls-ssl.yaml
@@ -1,3 +1,22 @@
+test_metadata:
+  description: >-
+    Longevity test validating encryption-at-rest combined with client/server TLS and role-based
+    authorization on a ~50GB dataset, running mixed cassandra-stress workloads (including an MV
+    profile) for ~1 day on a 6-node single-DC cluster with SisyphusMonkey nemesis.
+  test_type: longevity
+  tier: ondemand
+  duration_class: long
+  supported_backends:
+    - aws
+  stress_tools:
+    - cassandra-stress
+  workload: mixed
+  features:
+    - encryption-at-rest
+    - tls-ssl
+    - authorization
+  team_ownership: storage-qa
+
 test_duration: 1940
 prepare_write_cmd: ["cassandra-stress write cl=QUORUM n=100000000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=100 -pop seq=1..100000000"]
 

--- a/test-cases/longevity/longevity-gcp-kms-10gb-3h.yaml
+++ b/test-cases/longevity/longevity-gcp-kms-10gb-3h.yaml
@@ -1,3 +1,20 @@
+test_metadata:
+  description: >-
+    Longevity test validating KMS (Key Management Service) encryption at rest on GCE, including key
+    rotation, while running a cassandra-stress write workload with SisyphusMonkey nemesis on a
+    3-node single-DC cluster for ~4 hours.
+  test_type: longevity
+  tier: ondemand
+  duration_class: short
+  supported_backends:
+    - gce
+  stress_tools:
+    - cassandra-stress
+  workload: write
+  features:
+    - kms
+  team_ownership: storage-qa
+
 test_duration: 255
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=180m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=1000 -pop seq=1..10000000 -log interval=5"
              ]

--- a/test-cases/longevity/longevity-harry-2h.yaml
+++ b/test-cases/longevity/longevity-harry-2h.yaml
@@ -1,3 +1,17 @@
+test_metadata:
+  description: >-
+    Longevity test running the cassandra-harry fuzzing/verification tool for 2 hours on a 6-node
+    single-DC cluster with SisyphusMonkey nemesis (ENOSPC-safe selector), validating data
+    consistency under continuous chaos.
+  test_type: longevity
+  tier: ondemand
+  duration_class: short
+  supported_backends:
+    - aws
+  stress_tools: []
+  features: []
+  team_ownership: storage-qa
+
 test_duration: 240
 stress_cmd: ["cassandra-harry -run-time 2 -run-time-unit HOURS"]
 

--- a/test-cases/longevity/longevity-multidc-parallel-topology-schema-changes-12h.yaml
+++ b/test-cases/longevity/longevity-multidc-parallel-topology-schema-changes-12h.yaml
@@ -1,3 +1,22 @@
+test_metadata:
+  description: >-
+    Longevity test running concurrent per-user-role cassandra-stress workloads with service levels
+    on a multi-DC cluster (2x6 nodes) for 12 hours, while parallel topology-change and schema-
+    change SisyphusMonkey nemeses run per DC to validate cluster stability under concurrent
+    structural changes.
+  test_type: longevity
+  tier: tier1
+  duration_class: medium
+  stress_tools:
+    - cassandra-stress
+  workload: mixed
+  features:
+    - multi-dc
+    - tls-ssl
+    - authorization
+    - sla
+  team_ownership: storage-qa
+
 test_duration: 1200
 
 # `connectionsPerHost` - target a specific number of TCP connections per shard.

--- a/test-cases/longevity/longevity-twcs-3h.yaml
+++ b/test-cases/longevity/longevity-twcs-3h.yaml
@@ -1,3 +1,21 @@
+test_metadata:
+  description: >-
+    Longevity test running a scylla-bench timeseries write/read workload against a
+    TimeWindowCompactionStrategy table with immediate tombstone GC for ~3 hours on a 6-node single-
+    DC cluster with SisyphusMonkey nemesis.
+  test_type: longevity
+  tier: ondemand
+  duration_class: short
+  supported_backends:
+    - aws
+  stress_tools:
+    - scylla-bench
+  workload: mixed
+  features:
+    - twcs
+    - tombstone-gc
+  team_ownership: storage-qa
+
 test_duration: 210
 
 stress_cmd: ["scylla-bench -workload=timeseries -mode=write -replication-factor=3 -partition-count=4000 -clustering-row-count=10000 -clustering-row-size=200 -concurrency=100 -rows-per-request=1 -start-timestamp=SET_WRITE_TIMESTAMP -connection-count 100 -max-rate 30000 --timeout 120s -retry-number=30 -retry-interval=80ms,1s -duration=170m"]

--- a/test-cases/longevity/longevity-twcs-48h.yaml
+++ b/test-cases/longevity/longevity-twcs-48h.yaml
@@ -1,3 +1,19 @@
+test_metadata:
+  description: >-
+    Longevity test running a 48-hour scylla-bench timeseries write/read workload against a
+    TimeWindowCompactionStrategy table with ZSTD dictionary compression and a 3-hour TTL,
+    validating TWCS compaction scheduling and compression stability under sustained ingestion.
+  test_type: longevity
+  tier: tier1
+  duration_class: long
+  stress_tools:
+    - scylla-bench
+  workload: mixed
+  features:
+    - twcs
+    - tombstone-gc
+  team_ownership: storage-qa
+
 # LONGEVITY TEST: TWCS 48H WITH ZSTD DICTIONARY COMPRESSION
 #
 # Purpose:


### PR DESCRIPTION
## Summary
- Adds `test_metadata:` sections to 32 test-case YAMLs (Tablets/Storage/KMS/LDAP/Encryption/Elasticity/OOS/TombstoneGC/Harry/TWCS).
- Adds `elasticity` to the `features` taxonomy enum and tags elasticity test cases with `elasticity` + `tablets`.
- Fixes TD-004 lint check to walk all ancestor directories (not just the immediate parent), removing false positives for test cases nested under a category dir (e.g. `test-cases/features/elasticity/`).

## Test plan
- [x] `uv run pytest unit_tests/unit/test_test_docs_linter.py` passes
- [x] Full-repo lint sweep via `lint_test_metadata` shows 0 errors/warnings on all 32 changed files
- [x] No new TD-004 warnings introduced elsewhere; pre-existing unrelated ones (`quarantined/gemini-*.yaml`, `minicloud-provision-test.yaml`) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Fixes https://scylladb.atlassian.net/browse/SCT-635