### PR TITLE
ci(tier1): run tier 1 jobs with ScyllaDB automatic repair every hour

### DIFF
--- a/configurations/auto-repair-1h.yaml
+++ b/configurations/auto-repair-1h.yaml
@@ -1,0 +1,17 @@
+# ScyllaDB built-in Automatic Repair with a 1-hour repair period.
+#
+# A tablet becomes eligible for repair once more than the threshold has elapsed
+# since its own last repair; ScyllaDB spreads the work over time, nodes and
+# shards, so this is a repair period rather than a synchronised hourly burst.
+#
+# Requires ScyllaDB 2026.1 or newer and tablet-enabled keyspaces. On vnode
+# tables it does nothing, and on older releases the two options are logged as
+# "Unknown option" at warn level without affecting startup.
+#
+# Both values have to be identical on every node, which is what
+# append_scylla_yaml guarantees.
+#
+# https://docs.scylladb.com/manual/master/features/automatic-repair.html
+append_scylla_yaml:
+  auto_repair_enabled_default: true
+  auto_repair_threshold_default_in_seconds: 3600

--- a/jenkins-pipelines/oss/tier1/elasticity-90-percent-with-nemesis.jenkinsfile
+++ b/jenkins-pipelines/oss/tier1/elasticity-90-percent-with-nemesis.jenkinsfile
@@ -7,5 +7,5 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: """["test-cases/features/elasticity/elasticity-90-percent-with-nemesis.yaml", "configurations/compression/zstd_dict_compression.yaml"]""",
+    test_config: """["test-cases/features/elasticity/elasticity-90-percent-with-nemesis.yaml", "configurations/compression/zstd_dict_compression.yaml", "configurations/auto-repair-1h.yaml"]""",
 )

--- a/jenkins-pipelines/oss/tier1/longevity-150gb-asymmetric-cluster-12h.jenkinsfile
+++ b/jenkins-pipelines/oss/tier1/longevity-150gb-asymmetric-cluster-12h.jenkinsfile
@@ -7,5 +7,5 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: '''["test-cases/longevity/longevity-150GB-12h-autorization-LimitedMonkey-cql-stress.yaml", "configurations/db-nodes-shards-random.yaml", "configurations/auth_cassandra.yaml"]'''
+    test_config: '''["test-cases/longevity/longevity-150GB-12h-autorization-LimitedMonkey-cql-stress.yaml", "configurations/db-nodes-shards-random.yaml", "configurations/auth_cassandra.yaml", "configurations/auto-repair-1h.yaml"]'''
 )

--- a/jenkins-pipelines/oss/tier1/longevity-2tb-5days.jenkinsfile
+++ b/jenkins-pipelines/oss/tier1/longevity-2tb-5days.jenkinsfile
@@ -8,6 +8,6 @@ longevityPipeline(
     region: 'us-east-1',
     availability_zone: 'b',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: '''["test-cases/longevity/longevity-1TB-5days-authorization-and-tls-ssl.yaml", "configurations/2TB_high_disk_used_capacity.yaml", "configurations/auth_cassandra.yaml"]'''
+    test_config: '''["test-cases/longevity/longevity-1TB-5days-authorization-and-tls-ssl.yaml", "configurations/2TB_high_disk_used_capacity.yaml", "configurations/auth_cassandra.yaml", "configurations/auto-repair-1h.yaml"]'''
 
 )

--- a/jenkins-pipelines/oss/tier1/longevity-large-partition-200k-pks-4days-gce.jenkinsfile
+++ b/jenkins-pipelines/oss/tier1/longevity-large-partition-200k-pks-4days-gce.jenkinsfile
@@ -7,6 +7,6 @@ longevityPipeline(
     backend: 'gce',
     region: 'us-east1',
     test_name: 'longevity_large_partition_test.LargePartitionLongevityTest.test_large_partition_longevity',
-    test_config: 'test-cases/longevity/longevity-large-partition-200k_pks-4days.yaml'
+    test_config: '''["test-cases/longevity/longevity-large-partition-200k_pks-4days.yaml", "configurations/auto-repair-1h.yaml"]'''
 
 )

--- a/jenkins-pipelines/oss/tier1/longevity-multidc-schema-topology-changes-12h.jenkinsfile
+++ b/jenkins-pipelines/oss/tier1/longevity-multidc-schema-topology-changes-12h.jenkinsfile
@@ -8,7 +8,7 @@ longevityPipeline(
     availability_zone: 'a,b,c',
     region: '''["eu-west-1", "eu-west-2"]''',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: '''["test-cases/longevity/longevity-multidc-parallel-topology-schema-changes-12h.yaml", "configurations/network_config/all_addresses_ipv6_public.yaml", "configurations/auth_cassandra.yaml"]''',
+    test_config: '''["test-cases/longevity/longevity-multidc-parallel-topology-schema-changes-12h.yaml", "configurations/network_config/all_addresses_ipv6_public.yaml", "configurations/auth_cassandra.yaml", "configurations/auto-repair-1h.yaml"]''',
 
     timeout: [time: 820, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/oss/tier1/longevity-mv-si-4days-streaming.jenkinsfile
+++ b/jenkins-pipelines/oss/tier1/longevity-mv-si-4days-streaming.jenkinsfile
@@ -7,6 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: '''["test-cases/longevity/longevity-mv-si-4days.yaml", "configurations/disable_rbno.yaml", "configurations/adaptive_timeout_multipliers.yaml"]'''
+    test_config: '''["test-cases/longevity/longevity-mv-si-4days.yaml", "configurations/disable_rbno.yaml", "configurations/adaptive_timeout_multipliers.yaml", "configurations/auto-repair-1h.yaml"]'''
 
 )

--- a/jenkins-pipelines/oss/tier1/longevity-schema-topology-changes-12h.jenkinsfile
+++ b/jenkins-pipelines/oss/tier1/longevity-schema-topology-changes-12h.jenkinsfile
@@ -7,7 +7,7 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: '''["test-cases/longevity/longevity-parallel-schema-changes-12h-cql-stress.yaml", "configurations/network_config/scylla_addresses_on_different_interfaces.yaml"]''',
+    test_config: '''["test-cases/longevity/longevity-parallel-schema-changes-12h-cql-stress.yaml", "configurations/network_config/scylla_addresses_on_different_interfaces.yaml", "configurations/auto-repair-1h.yaml"]''',
 
     timeout: [time: 820, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/oss/tier1/longevity-twcs-48h.jenkinsfile
+++ b/jenkins-pipelines/oss/tier1/longevity-twcs-48h.jenkinsfile
@@ -7,6 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: 'us-east-1',
     test_name: 'longevity_twcs_test.TWCSLongevityTest.test_custom_time',
-    test_config: 'test-cases/longevity/longevity-twcs-48h.yaml'
+    test_config: '''["test-cases/longevity/longevity-twcs-48h.yaml", "configurations/auto-repair-1h.yaml"]'''
 
 )

--- a/jenkins-pipelines/oss/tier1/scale-schema-5000-tables-latte.jenkinsfile
+++ b/jenkins-pipelines/oss/tier1/scale-schema-5000-tables-latte.jenkinsfile
@@ -7,5 +7,5 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: 'test-cases/scale/longevity-5000-tables-latte.yaml',
+    test_config: '''["test-cases/scale/longevity-5000-tables-latte.yaml", "configurations/auto-repair-1h.yaml"]''',
 )


### PR DESCRIPTION
## What

Adds `configurations/auto-repair-1h.yaml` and layers it on the tier 1 pipelines that `configurations/triggers/tier1.yaml` actually fires for master, so those jobs run against a cluster ScyllaDB is repairing in the background once an hour.

```yaml
append_scylla_yaml:
  auto_repair_enabled_default: true
  auto_repair_threshold_default_in_seconds: 3600
```

## Why

ScyllaDB 2026.1 schedules and runs repairs itself, without Scylla Manager and without a nemesis driving them ([docs](https://docs.scylladb.com/manual/master/features/automatic-repair.html)). SCT never exercised that: every repair we run comes from a nemesis, and the weekly repair task Scylla Manager creates on `add_cluster` is deleted immediately (`sdcm/mgmt/cli.py:1271`). Production clusters are continuously being repaired; our tier 1 coverage was not.

## Which pipelines

| Job | Backend | Week |
| --- | --- | --- |
| `elasticity-90-percent-with-nemesis` | aws (x86 + aarch64) | a |
| `longevity-150gb-asymmetric-cluster-12h` | aws | b |
| `longevity-2tb-5days` | aws aarch64 | b |
| `longevity-large-partition-200k-pks-4days-gce` | gce | a |
| `longevity-multidc-schema-topology-changes-12h` | aws | b |
| `longevity-mv-si-4days-streaming` | aws | a |
| `longevity-schema-topology-changes-12h` | aws | a |
| `longevity-twcs-48h` | aws (x86 + aarch64) | b |
| `scale-schema-5000-tables-latte` | aws | b |

## Semantics

The threshold is a repair **period**, not a synchronised hourly burst. A tablet becomes eligible once more than an hour has elapsed since its *own* last repair, and ScyllaDB spreads the work over time, nodes and shards. A repair from any other source, e.g. `nodetool cluster repair` run by `MgmtRepair`, also updates a tablet's last repair time and resets its clock.

## Scope and limits

Automatic repair builds on incremental repair, so it covers **tablet tables only** and exists only in **ScyllaDB 2026.1 and newer** (upstream `7ba7b25bdda9`, contained in `branch-2026.1`, not in `branch-2025.4`). On older releases the two options are logged as `Unknown option` at warn level without affecting startup; on vnode keyspaces they do nothing.

Repair nemesis (`MgmtRepair`, `CorruptThenRepairMonkey`, …) are unaffected and keep running.

## Verification

- Resolved the trigger matrix with the real `load_matrix_config` + `filter_jobs` for `master:latest` on both cron entries, and asserted every edited jenkinsfile is in the triggered set — no pipeline is touched that master never runs.
- Ran the real `merge_dicts_append_strings` over each of the 9 pipelines' resolved config lists: every one yields both new keys **plus** the inherited `rf_rack_valid_keyspaces`, and `enable_repair_based_node_ops: False` survives on the `disable_rbno` job — the recursive merge stacks, nothing is clobbered.
- All 9 `test_config` values parse as JSON, every referenced path exists, and the overlay is last in each list.
- `pre-commit run --all-files` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)