### PR TITLE
fix(minicloud): collect guest serial consoles and the container log's ending

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -124,6 +124,7 @@ from sdcm.utils.common import (
     get_hdr_tags,
     download_and_unpack_logs,
     find_equivalent_ami,
+    get_testrun_dir,
 )
 from sdcm.nemesis.generator import generate_nemesis_yaml, NemesisJobGenerator
 from sdcm.utils.open_with_diff import OpenWithDiff, ErrorCarrier
@@ -139,6 +140,7 @@ from sdcm.utils.minicloud import (
     MinicloudConfig,
     MinicloudManager,
     check_minicloud_reachability,
+    collect_minicloud_guest_serial_logs,
     collect_minicloud_logs,
     ensure_minicloud_ready,
     get_minicloud_endpoint,
@@ -2490,23 +2492,35 @@ def collect_logs(test_id=None, logdir=None, backend=None, config_file=None):
 
     config = SCTConfiguration()
 
+    if not test_id:
+        test_id = config.get("test_id")
+        if test_id:
+            LOGGER.info("Using test_id from SCT configuration: %s", test_id)
+
     if is_minicloud_active(config):
         # After SCTConfiguration so yaml-only activation is seen, and the SDK endpoint
         # is exported before Collector runs — in a fresh collect-logs process
         # SCT_MINICLOUD_ENDPOINT_URL alone is invisible to the AWS/GCE SDKs, so
         # collection would otherwise query the real cloud.
         set_minicloud_endpoint_env(get_minicloud_endpoint(config), _minicloud_backend(backend))
+        minicloud_config = MinicloudConfig.from_env(params=config)
+        # Write into the run's own logdir — the one Collector globs — not
+        # get_test_config().logdir(), which in this fresh process is a brand-new
+        # timestamped dir that Collector never looks at, so everything landed there was
+        # silently dropped. Resolve it the same way Collector does (sdcm/logcollector.py
+        # Collector.sct_result_dir / run), so the two cannot drift apart; fall back to the
+        # fresh logdir only when the run dir cannot be located at all.
+        minicloud_logdir = (
+            get_testrun_dir(logdir or os.path.join(os.environ.get("HOME"), "sct-results"), test_id)
+            or get_test_config().logdir()
+        )
         # Collect only — never ensure_minicloud_ready() here: its auto-start does
         # `docker rm -f` on a crashed container, destroying the very evidence
         # (exit code, container logs) this command exists to collect.
-        collect_minicloud_logs(
-            get_test_config().logdir(), container_name=MinicloudConfig.from_env(params=config).container_name
-        )
-
-    if not test_id:
-        test_id = config.get("test_id")
-        if test_id:
-            LOGGER.info("Using test_id from SCT configuration: %s", test_id)
+        collect_minicloud_logs(minicloud_logdir, container_name=minicloud_config.container_name)
+        # The guests' serial consoles: the only record of a node SCT could never reach,
+        # and the emulator keeps them after the instance is gone.
+        collect_minicloud_guest_serial_logs(minicloud_logdir, state_dir=minicloud_config.state_dir)
 
     collector = Collector(test_id=test_id, params=config, test_dir=logdir)
 

--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -1279,10 +1279,17 @@ class BaseSCTLogCollector(LogCollector):
         FileLog(name="junit.xml", search_locally=True),
         FileLog(name="cdc-replicator.log", search_locally=True),
         FileLog(name="minicloud.log", search_locally=True),
+        # the complete container log, pulled at collection time. minicloud.log above is the
+        # manager's streamed copy and always stops where its streamer was killed, so this is
+        # the only one carrying the teardown ending
+        FileLog(name="minicloud-teardown.log", search_locally=True),
         # the emulator's crash evidence: stderr and the (credential-redacted) container
         # state snapshot carrying the exit code and OOMKilled flag
         FileLog(name="minicloud-stderr.log", search_locally=True),
         FileLog(name="minicloud-inspect.json", search_locally=True),
+        # each emulated guest's serial console — the only view inside a node SCT never
+        # managed to SSH into, where every per-node archive comes back empty
+        FileLog(name="minicloud-serial-*.log", search_locally=True),
     ]
     cluster_log_type = "sct-runner-events"
     cluster_dir_prefix = "sct-runner-events"

--- a/sdcm/utils/minicloud/__init__.py
+++ b/sdcm/utils/minicloud/__init__.py
@@ -26,7 +26,11 @@ from sdcm.utils.minicloud.config import (
     resolve_minicloud_regions,
 )
 from sdcm.utils.minicloud.endpoint import MINICLOUD_PORT, get_minicloud_endpoint, is_minicloud_active
-from sdcm.utils.minicloud.log_collection import collect_minicloud_logs, redact_docker_inspect
+from sdcm.utils.minicloud.log_collection import (
+    collect_minicloud_guest_serial_logs,
+    collect_minicloud_logs,
+    redact_docker_inspect,
+)
 from sdcm.utils.minicloud.manager import MinicloudManager
 
 __all__ = [
@@ -42,6 +46,7 @@ __all__ = [
     "MinicloudError",
     "MinicloudManager",
     "check_minicloud_reachability",
+    "collect_minicloud_guest_serial_logs",
     "collect_minicloud_logs",
     "default_minicloud_image",
     "ensure_minicloud_ready",

--- a/sdcm/utils/minicloud/log_collection.py
+++ b/sdcm/utils/minicloud/log_collection.py
@@ -1,12 +1,14 @@
 """Minicloud log/forensics collection into the test logdir, with credential redaction."""
 
+import glob
 import json
 import logging
 import os
 import re
+import shutil
 import subprocess
 
-from sdcm.utils.minicloud.config import MINICLOUD_CONTAINER_NAME
+from sdcm.utils.minicloud.config import MINICLOUD_CONTAINER_NAME, MINICLOUD_STATE_DIR_DEFAULT
 
 LOGGER = logging.getLogger(__name__)
 
@@ -50,15 +52,57 @@ def redact_docker_inspect(raw: bytes) -> bytes:
         return b'{"error": "docker inspect output could not be parsed for credential redaction"}\n'
 
 
+def collect_minicloud_guest_serial_logs(logdir: str, state_dir: str = MINICLOUD_STATE_DIR_DEFAULT) -> int:
+    """Copy every QEMU guest's serial console log out of the minicloud state dir.
+
+    minicloud runs each guest with `-serial file:<state_dir>/instances/<instance-id>/serial.log`
+    (scylladb/minicloud src/vm/mod.rs), and deliberately keeps that file when it removes the
+    guest's disks so it survives a terminated instance. It is the ONLY record of what happened
+    inside a guest that SCT could never SSH into: cloud-init output, sshd startup, kernel
+    messages. Everything else SCT collects needs a working SSH or SSM channel to the guest, so a
+    node that never came up produces empty per-node archives — exactly the case where the
+    console is the whole story.
+
+    Copied as ``minicloud-serial-<instance-id>.log`` into the test logdir, where
+    BaseSCTLogCollector's glob picks them up. Returns the number of files copied.
+
+    Never raises: this runs on the failure path, where losing the evidence is bad but breaking
+    the rest of log collection is worse.
+    """
+    instances_dir = os.path.join(os.path.expanduser(state_dir), "instances")
+    if not os.path.isdir(instances_dir):
+        LOGGER.debug("No minicloud instances dir at %s — nothing to collect", instances_dir)
+        return 0
+
+    os.makedirs(logdir, exist_ok=True)
+    copied = 0
+    for serial_log in sorted(glob.glob(os.path.join(instances_dir, "*", "serial.log"))):
+        instance_id = os.path.basename(os.path.dirname(serial_log))
+        destination = os.path.join(logdir, f"minicloud-serial-{instance_id}.log")
+        try:
+            shutil.copyfile(serial_log, destination)
+        except OSError as exc:
+            LOGGER.warning("Could not collect guest serial log %s: %s", serial_log, exc)
+            continue
+        copied += 1
+        LOGGER.info("Collected guest serial log %s (%d bytes)", destination, os.path.getsize(destination))
+
+    if not copied:
+        LOGGER.warning("No guest serial logs found under %s", instances_dir)
+    return copied
+
+
 def collect_minicloud_logs(logdir: str, container_name: str = MINICLOUD_CONTAINER_NAME) -> None:
     """Dump minicloud container logs and inspect state into the test logdir.
 
-    Produces: minicloud.log, minicloud-stderr.log, minicloud-inspect.json.
-    Never raises — each collector runs independently.
+    Produces: minicloud.log or minicloud-teardown.log, minicloud-stderr.log,
+    minicloud-inspect.json. Never raises — each collector runs independently.
 
-    Runs after the manager has already streamed the log and (on death or teardown)
-    recorded minicloud-inspect.json, so anything already written here wins: those files
-    were captured while the container still existed, this one runs after `docker rm -f`.
+    Runs after the manager has (on death or teardown) recorded minicloud-inspect.json, so
+    that snapshot wins: it was captured while the container still existed, this runs after
+    `docker rm -f`.
+
+    The container log is the exception — see the note on minicloud-teardown.log below.
 
     ``container_name`` defaults to the standard name because the log-collection entry points
     run without an SCTConfiguration; pass the configured ``minicloud_container_name`` from
@@ -67,28 +111,39 @@ def collect_minicloud_logs(logdir: str, container_name: str = MINICLOUD_CONTAINE
     os.makedirs(logdir, exist_ok=True)
 
     # 1. Collect container logs (works on stopped/exited containers, fails only if removed)
+    #
+    # The manager's `docker logs -f` streamer dies with the test process, so the copy it
+    # streamed into the run dir always stops short of teardown. `docker logs` here returns
+    # the container's whole log, so it must never be skipped just because that partial copy
+    # exists — that is precisely the run where the missing ending is worth having.
+    #
+    # It goes to its own name rather than over the streamed copy: the manager can adopt or
+    # restart a container mid-run, and then `docker logs` holds only the surviving
+    # container's output. Overwriting would trade one truncation for a worse one.
     log_path = os.path.join(logdir, "minicloud.log")
-    if os.path.exists(log_path) and os.path.getsize(log_path):
-        LOGGER.info("minicloud logs already streamed to %s, keeping the streamed copy", log_path)
-    else:
-        result = subprocess.run(["docker", "logs", container_name], capture_output=True, check=False)
-        if result.returncode == 0:
-            with open(log_path, "wb") as fh:
-                fh.write(result.stdout)
-                fh.write(result.stderr)
-            LOGGER.info("Collected minicloud logs to %s (%d bytes)", log_path, len(result.stdout) + len(result.stderr))
+    streamed_copy_exists = os.path.exists(log_path) and os.path.getsize(log_path)
+    if streamed_copy_exists:
+        log_path = os.path.join(logdir, "minicloud-teardown.log")
+        LOGGER.info("minicloud logs already streamed; collecting the complete log to %s", log_path)
 
-            # Write stderr separately for crash diagnostics
-            if result.stderr:
-                stderr_path = os.path.join(logdir, "minicloud-stderr.log")
-                with open(stderr_path, "wb") as fh:
-                    fh.write(result.stderr)
-                LOGGER.info("Collected minicloud stderr to %s (%d bytes)", stderr_path, len(result.stderr))
-        else:
-            LOGGER.warning(
-                "Failed to collect minicloud container logs (container removed?): %s",
-                result.stderr.decode(errors="replace").strip(),
-            )
+    result = subprocess.run(["docker", "logs", container_name], capture_output=True, check=False)
+    if result.returncode == 0:
+        with open(log_path, "wb") as fh:
+            fh.write(result.stdout)
+            fh.write(result.stderr)
+        LOGGER.info("Collected minicloud logs to %s (%d bytes)", log_path, len(result.stdout) + len(result.stderr))
+
+        # Write stderr separately for crash diagnostics
+        if result.stderr:
+            stderr_path = os.path.join(logdir, "minicloud-stderr.log")
+            with open(stderr_path, "wb") as fh:
+                fh.write(result.stderr)
+            LOGGER.info("Collected minicloud stderr to %s (%d bytes)", stderr_path, len(result.stderr))
+    else:
+        LOGGER.warning(
+            "Failed to collect minicloud container logs (container removed?): %s",
+            result.stderr.decode(errors="replace").strip(),
+        )
 
     # 2. Collect container inspect (state, exit code, health, config)
     inspect_path = os.path.join(logdir, "minicloud-inspect.json")

--- a/unit_tests/unit/minicloud/test_log_collection.py
+++ b/unit_tests/unit/minicloud/test_log_collection.py
@@ -1,6 +1,12 @@
-"""Tests for minicloud log collection: docker-inspect credential redaction."""
+"""Tests for minicloud log collection: guest serial consoles and docker-inspect redaction."""
 
-from sdcm.utils.minicloud import redact_docker_inspect
+import subprocess
+
+from sdcm.utils.minicloud import (
+    collect_minicloud_guest_serial_logs,
+    collect_minicloud_logs,
+    redact_docker_inspect,
+)
 
 
 def test_redact_docker_inspect_strips_credentials():
@@ -21,3 +27,88 @@ def test_redact_docker_inspect_drops_unparseable_output():
     """If the JSON cannot be parsed it must not be written verbatim — it may hold creds."""
     redacted = redact_docker_inspect(b"AWS_SECRET_ACCESS_KEY=verysecret \x00 not json")
     assert b"verysecret" not in redacted
+
+
+def test_collect_guest_serial_logs_copies_every_instance(tmp_path):
+    """Each guest's serial.log lands in the logdir under a name the SCT collector globs."""
+    state_dir = tmp_path / "state"
+    for instance_id, body in (("i-aaa", "node one console"), ("i-bbb", "node two console")):
+        instance_dir = state_dir / "instances" / instance_id
+        instance_dir.mkdir(parents=True)
+        (instance_dir / "serial.log").write_text(body)
+    logdir = tmp_path / "logdir"
+
+    copied = collect_minicloud_guest_serial_logs(str(logdir), state_dir=str(state_dir))
+
+    assert copied == 2
+    assert (logdir / "minicloud-serial-i-aaa.log").read_text() == "node one console"
+    assert (logdir / "minicloud-serial-i-bbb.log").read_text() == "node two console"
+
+
+def test_collect_guest_serial_logs_ignores_instances_without_a_console(tmp_path):
+    """A guest whose dir holds only disks (serial.log not yet created) is skipped, not fatal."""
+    state_dir = tmp_path / "state"
+    (state_dir / "instances" / "i-nodisk").mkdir(parents=True)
+    (state_dir / "instances" / "i-nodisk" / "root.qcow2").write_bytes(b"disk")
+    logdir = tmp_path / "logdir"
+
+    assert collect_minicloud_guest_serial_logs(str(logdir), state_dir=str(state_dir)) == 0
+
+
+def test_collect_guest_serial_logs_survives_a_missing_state_dir(tmp_path):
+    """Runner topology has no state dir on this host — collection must not raise."""
+    assert collect_minicloud_guest_serial_logs(str(tmp_path / "logdir"), state_dir=str(tmp_path / "absent")) == 0
+
+
+def _fake_docker_logs(stdout=b"", stderr=b"", returncode=0):
+    """Stand in for subprocess.run(['docker', 'logs', ...]) inside collect_minicloud_logs."""
+
+    def run(cmd, capture_output=False, check=False):  # noqa: ARG001
+        if cmd[:2] == ["docker", "logs"]:
+            return subprocess.CompletedProcess(cmd, returncode, stdout, stderr)
+        # docker inspect — irrelevant here, report it as unavailable
+        return subprocess.CompletedProcess(cmd, 1, b"", b"no such container")
+
+    return run
+
+
+def test_collect_logs_keeps_streamed_copy_and_still_captures_the_ending(tmp_path, monkeypatch):
+    """The streamed copy stops at teardown, so the full `docker logs` must still be collected.
+
+    Regression: pointing collect_minicloud_logs() at the run dir made the pre-existing streamed
+    minicloud.log suppress the `docker logs` dump entirely, so the ending never reached Argus.
+    """
+    logdir = tmp_path / "run"
+    logdir.mkdir()
+    (logdir / "minicloud.log").write_bytes(b"streamed up to teardown\n")
+    monkeypatch.setattr(subprocess, "run", _fake_docker_logs(stdout=b"streamed up to teardown\nplus the ending\n"))
+
+    collect_minicloud_logs(str(logdir))
+
+    # the streamed copy is left untouched — a restarted container would make the dump a subset
+    assert (logdir / "minicloud.log").read_bytes() == b"streamed up to teardown\n"
+    assert (logdir / "minicloud-teardown.log").read_bytes() == b"streamed up to teardown\nplus the ending\n"
+
+
+def test_collect_logs_writes_minicloud_log_when_nothing_was_streamed(tmp_path, monkeypatch):
+    """With no streamed copy (container adopted, or a bare collect-logs run) it keeps the plain name."""
+    logdir = tmp_path / "run"
+    monkeypatch.setattr(subprocess, "run", _fake_docker_logs(stdout=b"whole log\n"))
+
+    collect_minicloud_logs(str(logdir))
+
+    assert (logdir / "minicloud.log").read_bytes() == b"whole log\n"
+    assert not (logdir / "minicloud-teardown.log").exists()
+
+
+def test_collect_logs_leaves_streamed_copy_alone_when_container_is_gone(tmp_path, monkeypatch):
+    """`docker rm -f` already ran: keep what was streamed, write no empty teardown file."""
+    logdir = tmp_path / "run"
+    logdir.mkdir()
+    (logdir / "minicloud.log").write_bytes(b"streamed\n")
+    monkeypatch.setattr(subprocess, "run", _fake_docker_logs(returncode=1, stderr=b"No such container: minicloud"))
+
+    collect_minicloud_logs(str(logdir))
+
+    assert (logdir / "minicloud.log").read_bytes() == b"streamed\n"
+    assert not (logdir / "minicloud-teardown.log").exists()

--- a/vars/stopMinicloud.groovy
+++ b/vars/stopMinicloud.groovy
@@ -54,6 +54,25 @@ docker logs --tail 5000 minicloud > ./minicloud-logs/minicloud-container.log 2>&
 echo "--- last 50 lines of the minicloud container log ---"
 tail -50 ./minicloud-logs/minicloud-container.log
 
+# Every guest's serial console, straight off the builder's state dir. minicloud runs each VM
+# with `-serial file:<state_dir>/instances/<id>/serial.log` and keeps that file after the
+# instance is gone, so this is the only view inside a node SCT never managed to SSH into -
+# where every per-node archive comes back empty and the container log only shows the API side.
+# The state dir is read off the container's own bind mount, so a non-default
+# minicloud_state_dir is picked up without this needing to know about it.
+MINICLOUD_MOUNT_TEMPLATE='{{range .Mounts}}{{if eq .Destination "/root/.cache/minicloud"}}{{.Source}}{{end}}{{end}}'
+MINICLOUD_STATE_DIR="\$(docker inspect minicloud --format "\${MINICLOUD_MOUNT_TEMPLATE}" 2>/dev/null)"
+if [[ -d "\${MINICLOUD_STATE_DIR}/instances" ]] ; then
+    for serial in "\${MINICLOUD_STATE_DIR}"/instances/*/serial.log ; do
+        [[ -f "\$serial" ]] || continue
+        instance_id="\$(basename "\$(dirname "\$serial")")"
+        cp "\$serial" "./minicloud-logs/minicloud-serial-\${instance_id}.log"
+    done
+    echo "collected \$(ls -1 ./minicloud-logs/minicloud-serial-*.log 2>/dev/null | wc -l) guest serial log(s)"
+else
+    echo "no minicloud instances dir found (state dir: \${MINICLOUD_STATE_DIR:-unknown}) - no guest serial logs"
+fi
+
 if [[ "${keepGuests}" == "true" ]] ; then
     # The container is the cluster here: removing it would destroy the very nodes the
     # post_behavior_* settings asked to keep. Left running, and left for the next build's


### PR DESCRIPTION
Fixes the log-collection half of SCT-869.

On minicloud, an SSH-timeout failure currently leaves nothing to debug with. Every per-node collector needs the SSH/SSM channel that is precisely what is broken, so each node archive uploads empty, and the emulator's container log only records the API side — it says nothing about what happened inside the VM. Seen on [mc-pr-provision-test #6](https://jenkins.scylladb.com/job/scylla-staging/job/dimakr/job/mc/job/mc-pr-provision-test/6/) ([Argus](https://argus.scylladb.com/tests/scylla-cluster-tests/c50f1d59-fc04-400f-a544-8a68ada004fd)) and again on mc-longevity-10gb-1h #13.

Two independent gaps, both fixed here.

### 1. Guest serial consoles were never collected

minicloud runs every VM with `-serial file:<state_dir>/instances/<id>/serial.log` (`src/vm/mod.rs`) and deliberately *keeps* that file when it reaps the instance's disks — `cleanup_instance_disks` is commented "keep `serial.log` for post-mortem debugging". It is the only record of cloud-init output, sshd startup and kernel messages for a node SCT could never log into, and it was sitting on the builder being thrown away.

Collected now from both entry points:

- `collect_minicloud_guest_serial_logs()` on the SCT side, copying each console as `minicloud-serial-<instance-id>.log`, plus a `BaseSCTLogCollector` glob so they upload to Argus.
- `stopMinicloud.groovy` on the Jenkins builder side, which reads the state dir off the container's own bind mount — so a non-default `minicloud_state_dir` is picked up without the pipeline needing to know about it.

### 2. minicloud logs were written to a directory the Collector never scans

`collect_minicloud_logs()` wrote into `get_test_config().logdir()`. In a fresh `hydra collect-logs` process that is a brand-new timestamped dir, while `Collector` globs the *run's* dir resolved via `get_testrun_dir()`. From build #6:

```
Collected minicloud logs to /jenkins/sct-results/20260823-110846-983029/minicloud.log
Found sct result directory with logs: .../scylla-cluster-tests/20260823-103337-524117
```

Everything that command wrote was silently dropped. The `minicloud.log` that *did* reach Argus is the copy `MinicloudManager` streamed into the run dir during the test — 595,954 bytes, a byte-exact prefix of the 727,423-byte container log, truncated where the test gave up. The teardown-time tail, including all nine `QEMU process exited` lines, never made it. `minicloud-stderr.log` and `minicloud-inspect.json` were affected identically.

Now resolved the same way `Collector` does, so the two cannot drift apart, falling back to the fresh logdir only when the run dir cannot be found. `test_id` is resolved before this block, since the lookup needs it.

### 3. `minicloud.log` reached Argus without its ending

Caught in review by @dimakr. Two writers produce that file: the manager streams `docker logs -f` into the run dir, and that streamer dies with the test process — so the copy always stops short of teardown. `collect_minicloud_logs()` could dump the complete log, but skipped whenever `minicloud.log` already existed. Fixing (2) pointed it at the run dir, where the streamed copy *always* exists, so the dump became unreachable and the ending still never shipped.

The dump now always runs:

| situation | destination |
|---|---|
| no streamed copy (bare `collect-logs`, adopted container) | `minicloud.log` |
| streamed copy present | `minicloud-teardown.log` |
| container already `docker rm -f`'d | streamed copy kept, no empty file |

A separate name rather than overwriting `minicloud.log`, because the manager can adopt or restart a container mid-run — then `docker logs` holds only the surviving container's output, and overwriting would trade one truncation for a worse one. Both names are registered with `BaseSCTLogCollector`.

### Testing

- 3 unit tests for the serial collector (multiple guests, a guest with no console yet, absent state dir — the runner-topology case).
- 3 unit tests for the container-log destinations. The key one, `test_collect_logs_keeps_streamed_copy_and_still_captures_the_ending`, **fails against the pre-fix code and passes after**, so the regression is pinned rather than just fixed.
- Emitted teardown shell checked with `bash -n`, then **run against a real container** with a state-dir mount: both fake guests' consoles collected; and with no container present it degrades to a clean message and `exit 0`.
- `stopMinicloud.groovy` compiled in a `groovy:4.0-jdk17` container — `lint-pipelines` never parses `vars/*.groovy`, so a syntax error there fails at Jenkins startup instead.
- Full unit suite on the master base: 3527 passed, 31 skipped.

### Not in scope

The underlying SSH failure is still under investigation. Worth noting what the run already rules out: it is **not** connectivity. The traceback reaches `userauth_publickey_fromfile`, so TCP connect and the SSH handshake both succeeded and sshd is answering — the key just is not accepted. QEMU did not crash (all guests alive until teardown, exit status 0) and every guest got a DHCP lease. Whether cloud-init actually fetched `public-keys/0/openssh-key` from IMDS is exactly what these serial consoles will answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


