### PR TITLE
fix(cluster): stop node logging from running SSH and cloud API calls

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -414,6 +414,13 @@ class BaseNode(AutoSshContainerMixin):
     _instance_type = "N/A"
     scylla_network_configuration: Optional[ScyllaNetworkConfiguration] = None
 
+    # Class-level defaults, so that instances built by test fakes that bypass `__init__`
+    # (and any subclass that does the same) still resolve these attributes.
+    _public_ip_address_resolved = False
+    _private_ip_address_resolved = False
+    _ipv6_ip_address_resolved = False
+    destroyed = False
+
     GOSSIP_STATUSES_FILTER_OUT = [
         "LEFT",  # in case the node was decommissioned
         "removed",  # in case the node was removed by nodetool removenode
@@ -456,6 +463,10 @@ class BaseNode(AutoSshContainerMixin):
         self._public_ip_address_cached = None
         self._private_ip_address_cached = None
         self._ipv6_ip_address_cached = None
+        self._public_ip_address_resolved = False
+        self._private_ip_address_resolved = False
+        self._ipv6_ip_address_resolved = False
+        self.destroyed = False
         self._maximum_number_of_cores_to_publish = 10
 
         self.last_line_no = 1
@@ -567,6 +578,10 @@ class BaseNode(AutoSshContainerMixin):
     def init(self) -> None:
         if self.logdir:
             os.makedirs(self.logdir, exist_ok=True)
+        # `__str__` reads only the already-resolved addresses, so they are resolved once here:
+        # the log prefix built below is computed a single time and reused for every log record
+        # of this node.
+        self.resolve_ip_addresses()
         self.log = SDCMAdapter(self.log, extra={"prefix": str(self)})
         if self.ssh_login_info:
             self.ssh_login_info["hostname"] = self.external_address
@@ -749,6 +764,9 @@ class BaseNode(AutoSshContainerMixin):
         ssh_remoter.run(f"sudo bash -cxe {shlex.quote(script)}", verbose=True)
 
     def _init_remoter(self, ssh_login_info):
+        # A new remoter may point at a different host, so the MAC to device mapping cached from
+        # the previous one has to go.
+        self.invalidate_network_configuration_cache()
         agent_config = self.parent_cluster.params.get("agent")
         agent_enabled = agent_config.get("enabled", False) and self.parent_cluster.node_type in (
             "scylla-db",
@@ -901,7 +919,7 @@ class BaseNode(AutoSshContainerMixin):
 
     def refresh_ip_address(self):
         # Invalidate ip address cache
-        self._private_ip_address_cached = self._public_ip_address_cached = self._ipv6_ip_address_cached = None
+        self.invalidate_ip_address_cache()
         self.__dict__.pop("cql_address", None)
         self.__dict__.pop("public_dns_name", None)
         self.__dict__.pop("private_dns_name", None)
@@ -1276,9 +1294,13 @@ class BaseNode(AutoSshContainerMixin):
 
     @property
     def public_ip_address(self) -> Optional[str]:
-        # Primary network interface public IP
-        if self._public_ip_address_cached is None:
+        # Primary network interface public IP.
+        # A `None` result is cached as well: nodes provisioned without a public IP
+        # (`ip_ssh_connections: private`) would otherwise re-run the whole instance-state
+        # refresh - a cloud API call plus an `ip -j link` over SSH - on every single access.
+        if not self._public_ip_address_resolved:
             self._public_ip_address_cached = self._get_public_ip_address()
+            self._public_ip_address_resolved = True
         return self._public_ip_address_cached
 
     @property
@@ -1300,8 +1322,9 @@ class BaseNode(AutoSshContainerMixin):
     @property
     def private_ip_address(self) -> Optional[str]:
         # Primary network interface private IP
-        if self._private_ip_address_cached is None:
+        if not self._private_ip_address_resolved:
             self._private_ip_address_cached = to_inet_ntop_format(self._get_private_ip_address())
+            self._private_ip_address_resolved = True
         return self._private_ip_address_cached
 
     def _get_private_ip_address(self) -> Optional[str]:
@@ -1314,8 +1337,9 @@ class BaseNode(AutoSshContainerMixin):
     @property
     def ipv6_ip_address(self) -> Optional[str]:
         # Primary network interface public IPv6
-        if self._ipv6_ip_address_cached is None:
+        if not self._ipv6_ip_address_resolved:
             self._ipv6_ip_address_cached = to_inet_ntop_format(self._get_ipv6_ip_address())
+            self._ipv6_ip_address_resolved = True
         return self._ipv6_ip_address_cached
 
     def _get_ipv6_ip_address(self) -> Optional[str]:
@@ -1344,6 +1368,29 @@ class BaseNode(AutoSshContainerMixin):
                     ips.append(extra_address)
         return ips
 
+    def invalidate_ip_address_cache(self) -> None:
+        """Drop the cached addresses so that the next access resolves them again."""
+        self._private_ip_address_cached = self._public_ip_address_cached = self._ipv6_ip_address_cached = None
+        self._private_ip_address_resolved = self._public_ip_address_resolved = self._ipv6_ip_address_resolved = False
+
+    def resolve_ip_addresses(self) -> None:
+        """Populate the address cache, so that `__str__` has something to print.
+
+        `__str__` never resolves addresses on its own (it would run cloud API calls and SSH
+        commands from inside a log record), so the addresses are resolved here instead, while
+        the node is known to be reachable.
+        """
+        for ip_address_property in ("private_ip_address", "public_ip_address"):
+            try:
+                getattr(self, ip_address_property)
+            except Exception as exc:  # noqa: BLE001
+                self.log.debug("Node %s: failed to resolve %s: %s", self.name, ip_address_property, exc)
+        if self.test_config.IP_SSH_CONNECTIONS == "ipv6":
+            try:
+                self.ipv6_ip_address
+            except Exception as exc:  # noqa: BLE001
+                self.log.debug("Node %s: failed to resolve ipv6_ip_address: %s", self.name, exc)
+
     def _wait_public_ip(self):
         public_ips, _ = self._refresh_instance_state()
         while not public_ips:
@@ -1360,7 +1407,7 @@ class BaseNode(AutoSshContainerMixin):
     def network_configuration(self) -> dict[str, str]:
         """Query the MAC address to device name mapping from the node."""
         remoter = self.remoter
-        if not remoter:
+        if not remoter or self.destroyed:
             return {}
 
         network_devices = {}
@@ -1380,10 +1427,16 @@ class BaseNode(AutoSshContainerMixin):
         self.log.debug("Node %s ethernets: %s", self.name, network_devices)
         return network_devices
 
-    def refresh_network_interfaces_info(self):
-        # rebuild cached network mapping from the current remoter/node
+    def invalidate_network_configuration_cache(self) -> None:
+        """Drop the cached MAC address to device name mapping.
+
+        The mapping is a property of the node itself, so it only goes stale when the remoter is
+        replaced (see `_init_remoter`) - it must not be dropped on every instance-state refresh,
+        which would re-run `ip -j link` over SSH for each access (scylladb/scylla-cluster-tests#10217).
+        """
         self.__dict__.pop("network_configuration", None)
 
+    def refresh_network_interfaces_info(self):
         if self.scylla_network_configuration:
             self.scylla_network_configuration.network_interfaces = self.network_interfaces
 
@@ -1548,6 +1601,9 @@ class BaseNode(AutoSshContainerMixin):
         return AlertSilencer(self._alert_manager, alert_name, duration, start, end)
 
     def _dc_info_str(self):
+        # Called from `__str__` only, so it must stay I/O free: the cached values are read
+        # directly instead of the `datacenter`/`node_rack` properties, which run `nodetool`
+        # on the node when their cache is empty.
         dc_info = []
 
         # Example: `ManagerPodCluser` - the `params` is not needed and may be not passed there. Manager always created in the first DC
@@ -1568,18 +1624,22 @@ class BaseNode(AutoSshContainerMixin):
                 severity=Severity.ERROR,
             ).publish()
 
-        elif len(self.parent_cluster.params.region_names) > 1 and self.datacenter:
-            dc_info.append(f"dc name: {self.datacenter}")
+        elif len(self.parent_cluster.params.region_names) > 1 and self._datacenter_name:
+            dc_info.append(f"dc name: {self._datacenter_name}")
 
         # Workaround for 'k8s-local-kind*' backend.
         # "node.init()" is called in `sdcm.cluster_k8s.mini_k8s.LocalMinimalClusterBase.host_node` when Scylla cluster, that hold
         # "racks_count" parameter, is not created yet
-        if hasattr(self.parent_cluster, "racks_count") and self.parent_cluster.racks_count > 1 and self.node_rack:
-            dc_info.append(f"rack: {self.node_rack}")
+        if hasattr(self.parent_cluster, "racks_count") and self.parent_cluster.racks_count > 1 and self._node_rack:
+            dc_info.append(f"rack: {self._node_rack}")
 
         return f" ({', '.join(dc_info)})" if dc_info else ""
 
     def __str__(self):
+        # `__str__` is called from log records and event messages, so it must never perform
+        # cloud API calls or run commands over SSH: a node that is unreachable (terminated by
+        # a nemesis, for example) would make every log line that mentions it block for minutes
+        # and emit spurious errors. Only already-resolved addresses are used here.
         # If multiple network interface is defined on the node (AWS), private address in the `nodetool status`
         # is IP that defined in broadcast_address. Keep this output in correlation with `nodetool status`
         if (
@@ -1588,13 +1648,13 @@ class BaseNode(AutoSshContainerMixin):
         ):
             node_private_ip = self.scylla_network_configuration.broadcast_address
         else:
-            node_private_ip = self.private_ip_address
+            node_private_ip = self._private_ip_address_cached
 
         return "Node %s [%s | %s%s] (Type: %s)%s" % (
             self.name,
-            self.public_ip_address,
+            self._public_ip_address_cached,
             node_private_ip,
-            " | %s" % self.ipv6_ip_address if self.test_config.IP_SSH_CONNECTIONS == "ipv6" else "",
+            " | %s" % self._ipv6_ip_address_cached if self.test_config.IP_SSH_CONNECTIONS == "ipv6" else "",
             self._instance_type,
             self._dc_info_str(),
         )
@@ -1812,6 +1872,12 @@ class BaseNode(AutoSshContainerMixin):
         self.stop_task_threads()
         if self.remoter:
             self.remoter.stop()
+            # The instance is gone, so drop the remoter as well: it is kept reachable through
+            # `cluster.dead_nodes_list` and `nemesis.target_node`, and any later attempt to run
+            # a command on it would block until the SSH connect timeout expires, several times
+            # over, for every access.
+            self.remoter = None
+        self.destroyed = True
         ContainerManager.destroy_all_containers(self)
         self._terminate_node_in_argus()
         LOGGER.info("%s destroyed", self)

--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -2287,11 +2287,12 @@ class BaseScyllaPodContainer(BasePodContainer):
     def __str__(self):
         # TODO: when new network_configuration will be supported by all backends, copy this function from sdcm.cluster_aws.AWSNode.__str__
         #  to here
+        # Same as `BaseNode.__str__`: read the cached addresses only, never trigger a refresh.
         return "Node %s [%s | %s%s]%s" % (
             self.name,
-            self.public_ip_address,
-            self.private_ip_address,
-            " | %s" % self.ipv6_ip_address if self.test_config.IP_SSH_CONNECTIONS == "ipv6" else "",
+            self._public_ip_address_cached,
+            self._private_ip_address_cached,
+            " | %s" % self._ipv6_ip_address_cached if self.test_config.IP_SSH_CONNECTIONS == "ipv6" else "",
             self._dc_info_str(),
         )
 
@@ -2447,7 +2448,7 @@ class BaseScyllaPodContainer(BasePodContainer):
     def refresh_ip_address(self):
         # Invalidate ip address cache
         old_ip_info = (self.public_ip_address, self.private_ip_address)
-        self._private_ip_address_cached = self._public_ip_address_cached = self._ipv6_ip_address_cached = None
+        self.invalidate_ip_address_cache()
 
         if old_ip_info == (self.public_ip_address, self.private_ip_address):
             return

--- a/unit_tests/test_gce_use_dns_names.py
+++ b/unit_tests/test_gce_use_dns_names.py
@@ -113,6 +113,7 @@ def test_gce_node_network_interfaces_multiple_interfaces():
 def test_gce_network_configuration_parses_ip_json_link():
     node = MagicMock(spec=GCENode)
     node.remoter = MagicMock()
+    node.destroyed = False
     node.name = "test-node-1"
     ip_json_output = json.dumps(
         [
@@ -132,6 +133,7 @@ def test_gce_network_configuration_parses_ip_json_link():
 def test_gce_network_configuration_without_remoter():
     node = MagicMock(spec=GCENode)
     node.remoter = None
+    node.destroyed = False
     node.name = "test-node-2"
     node.log = MagicMock()
 
@@ -140,16 +142,33 @@ def test_gce_network_configuration_without_remoter():
     assert result == {}
 
 
+def test_gce_network_configuration_of_a_destroyed_node():
+    """A destroyed node's instance is gone, so `ip -j link` must not be attempted on it."""
+    node = MagicMock(spec=GCENode)
+    node.remoter = MagicMock()
+    node.destroyed = True
+    node.name = "test-node-3"
+    node.log = MagicMock()
+
+    result = GCENode.network_configuration.func(node)
+
+    assert result == {}
+    node.remoter.run.assert_not_called()
+
+
 def test_gce_refresh_network_interfaces_info():
     class FakeNode:
-        network_configuration = {"old": "data"}
         scylla_network_configuration = MagicMock()
         network_interfaces = [MagicMock()]
 
     node = FakeNode()
+    # the MAC to device mapping is not dropped here: it only goes stale when the remoter is
+    # replaced, and re-running `ip -j link` on every refresh is what makes an unreachable node
+    # cost minutes of SSH connect timeouts per access
+    node.__dict__["network_configuration"] = {"old": "data"}
     GCENode.refresh_network_interfaces_info(node)
 
-    assert not hasattr(node, "network_configuration") or "network_configuration" not in node.__dict__
+    assert node.__dict__["network_configuration"] == {"old": "data"}
     assert node.scylla_network_configuration.network_interfaces == node.network_interfaces
 
 

--- a/unit_tests/unit/test_cluster.py
+++ b/unit_tests/unit/test_cluster.py
@@ -1095,3 +1095,136 @@ def test_traffic_control_targets_the_secondary_interface():
         BaseNode.traffic_control(node, "--loss 5%")
     local_runner.run.assert_called_once_with("tcset ens5 --loss 5% --tc-command")
     node.remoter.run.assert_any_call('sudo bash -cxe "tc qdisc add dev ens5 root netem loss 5%"')
+
+
+def _node_for_str(instance_type="i4i.4xlarge", ip_ssh_connections="private"):
+    """A node stub whose only working attributes are the ones `__str__` is allowed to touch."""
+    node = unittest.mock.MagicMock()
+    node.name = "longevity-db-node-1"
+    node._instance_type = instance_type
+    node.scylla_network_configuration = None
+    node.test_config = unittest.mock.MagicMock(IP_SSH_CONNECTIONS=ip_ssh_connections)
+    node._public_ip_address_cached = None
+    node._private_ip_address_cached = "10.164.8.11"
+    node._ipv6_ip_address_cached = None
+    node._dc_info_str = unittest.mock.MagicMock(return_value="")
+    # any access to these must fail the test: they perform cloud API calls and SSH commands
+    for resolving_property in ("public_ip_address", "private_ip_address", "ipv6_ip_address"):
+        setattr(
+            type(node),
+            resolving_property,
+            unittest.mock.PropertyMock(side_effect=AssertionError(f"__str__ resolved {resolving_property}")),
+        )
+    return node
+
+
+def test_str_does_not_resolve_ip_addresses():
+    """`__str__` runs from log records, so it must never trigger cloud API calls or SSH commands.
+
+    A node terminated by a nemesis stays reachable through `dead_nodes_list` and
+    `nemesis.target_node`; resolving its addresses there blocks on the SSH connect timeout for
+    minutes per log line and raises spurious errors (scylladb/scylla-cluster-tests#10217).
+    """
+    node = _node_for_str()
+
+    assert BaseNode.__str__(node) == "Node longevity-db-node-1 [None | 10.164.8.11] (Type: i4i.4xlarge)"
+
+
+def test_str_uses_cached_ipv6_address():
+    node = _node_for_str(ip_ssh_connections="ipv6")
+    node._ipv6_ip_address_cached = "2a05:d018::1"
+
+    assert "| 2a05:d018::1]" in BaseNode.__str__(node)
+
+
+def test_dc_info_str_does_not_run_nodetool():
+    """`_dc_info_str` is only reachable from `__str__`, so it reads the cached values as well."""
+    node = unittest.mock.MagicMock()
+    params = SCTConfiguration()
+    params["region_name"] = "eu-west-1 eu-west-2"
+    node.parent_cluster.params = params
+    node.parent_cluster.racks_count = 2
+    node._datacenter_name = "eu-west-1"
+    node._node_rack = "RACK1"
+    for resolving_property in ("datacenter", "node_rack"):
+        setattr(
+            type(node),
+            resolving_property,
+            unittest.mock.PropertyMock(side_effect=AssertionError(f"_dc_info_str resolved {resolving_property}")),
+        )
+
+    assert BaseNode._dc_info_str(node) == " (dc name: eu-west-1, rack: RACK1)"
+
+
+def test_public_ip_address_caches_a_missing_address():
+    """`ip_ssh_connections: private` nodes have no public IP - that must be resolved only once.
+
+    Using `None` as the "not resolved yet" marker made every access re-run the full instance
+    state refresh: a cloud API call plus `ip -j link` over SSH.
+    """
+    node = unittest.mock.MagicMock()
+    node._public_ip_address_cached = None
+    node._public_ip_address_resolved = False
+    node._get_public_ip_address.return_value = None
+
+    for _ in range(3):
+        assert BaseNode.public_ip_address.fget(node) is None
+
+    node._get_public_ip_address.assert_called_once()
+
+
+def test_destroy_drops_the_remoter():
+    """A destroyed node must not keep a remoter around for later callers to connect with."""
+    node = unittest.mock.MagicMock()
+    node.destroyed = False
+    remoter = node.remoter
+
+    with unittest.mock.patch("sdcm.cluster.ContainerManager"):
+        BaseNode.destroy(node)
+
+    remoter.stop.assert_called_once()
+    assert node.remoter is None
+    assert node.destroyed is True
+
+
+def test_network_configuration_skips_a_destroyed_node():
+    """`ip -j link` must not be attempted against a node whose instance is already gone."""
+    node = unittest.mock.MagicMock()
+    node.destroyed = True
+
+    assert BaseNode.network_configuration.func(node) == {}
+
+    node.remoter.run.assert_not_called()
+
+
+def test_refresh_network_interfaces_info_keeps_the_cached_mapping():
+    """The MAC to device mapping only goes stale when the remoter is replaced.
+
+    Dropping it on every instance-state refresh re-runs `ip -j link` over SSH for each access
+    (scylladb/scylla-cluster-tests#10217), and turns a single log line about an unreachable node
+    into minutes of SSH connect timeouts.
+    """
+    node = unittest.mock.MagicMock()
+    node.__dict__["network_configuration"] = {"42:01:0a:80:00:02": "ens4"}
+
+    BaseNode.refresh_network_interfaces_info(node)
+
+    assert node.__dict__["network_configuration"] == {"42:01:0a:80:00:02": "ens4"}
+
+    BaseNode.invalidate_network_configuration_cache(node)
+
+    assert "network_configuration" not in node.__dict__
+
+
+def test_invalidate_ip_address_cache_allows_re_resolution():
+    """After an instance restart the addresses must be resolved again, `None` result included."""
+    node = unittest.mock.MagicMock()
+    node._get_public_ip_address.side_effect = [None, "34.1.2.3"]
+    node._public_ip_address_cached = None
+    node._public_ip_address_resolved = False
+
+    assert BaseNode.public_ip_address.fget(node) is None
+
+    BaseNode.invalidate_ip_address_cache(node)
+
+    assert BaseNode.public_ip_address.fget(node) == "34.1.2.3"


### PR DESCRIPTION
`BaseNode.__str__` performed live cloud-API and SSH I/O. Every log line or event message that
mentioned an unreachable node blocked on the SSH connect timeout (60s x 3 retries, ~190s) and
emitted a spurious `ERROR`.

Found while investigating [Argus run 3fbedddd](https://argus.scylladb.com/tests/scylla-cluster-tests/3fbedddd-5d3d-428b-9897-26707458f9d8):
`IsolateNodeWithIptableRuleNemesis` terminated `db-node-3fbedddd-5` at 11:04:42 UTC, and for the
next 34 minutes SCT logged ~15 `ip -j link` failures against the dead instance's address. The
real failure — `nodetool removenode` exiting 4 — was buried under them.

### Call chain

Every failure had the same stack, entered from a logging call:

```
logging/__init__.py:400  getMessage
sdcm/cluster.py          BaseNode.__str__
sdcm/cluster.py          public_ip_address
sdcm/cluster.py          _get_public_ip_address
sdcm/cluster_aws.py      _refresh_instance_state
sdcm/cluster.py          refresh_network_interfaces_info
sdcm/cluster_aws.py      network_interfaces
sdcm/cluster.py          remoter.run("ip -j link")   <- 3 x 60s connect timeout
```

The `removenode` failure path triggers it directly:

```python
self.log.debug(f"Remove failed node {node_to_remove} from dead node list {self.cluster.dead_nodes_list}")
```

### Changes

- **`__str__` and `_dc_info_str` no longer resolve anything.** They read the already-resolved
  values, so no cloud call, SSH command, or `nodetool` runs from inside a log record. The
  addresses are resolved once in `init()` (via `resolve_ip_addresses()`), while the node is
  known to be reachable, and the log prefix is built from them exactly as before.
- **`destroy()` drops the remoter and sets `destroyed`.** A terminated node stays reachable
  through `cluster.dead_nodes_list` and `nemesis.target_node`; clearing the remoter makes the
  existing `if not remoter: return {}` guard in `network_configuration` actually fire.
- **The address properties track resolution with a separate flag.** `None` was both the "not
  resolved yet" marker and a legitimate result, so a node with no public IP
  (`ip_ssh_connections: private` — as in this run) re-ran the full instance-state refresh on
  *every* access. All the ad-hoc cache resets now go through `invalidate_ip_address_cache()`.
- **`refresh_network_interfaces_info()` no longer evicts `network_configuration`.** The MAC to
  device mapping is a property of the node, so it only goes stale when the remoter is replaced —
  `_init_remoter` invalidates it via `invalidate_network_configuration_cache()` instead. The old
  eviction (added to fix stale connections from `id()` reuse in 66f5508c52) is also what makes
  `network_interfaces` re-run `ip -j link` thousands of times on a large cluster (#10217).

### Testing

- 8 new unit tests in `unit_tests/unit/test_cluster.py`: `__str__` fails if it resolves any
  address, `_dc_info_str` fails if it touches `datacenter`/`node_rack`, a missing public IP
  resolves once, `destroy()` drops the remoter, `network_configuration` skips a destroyed node,
  the mapping survives a refresh, and invalidation still allows re-resolution.
- 1 new test in `unit_tests/test_gce_use_dns_names.py` for the destroyed-node guard;
  `test_gce_refresh_network_interfaces_info` updated, since it asserted the removed eviction.
- Full `unit_tests/unit` suite: 3328 passed, 31 skipped.

Fixes: SCT-870
Refs: #10217
