### PR TITLE
feat(adaptive_timeouts): report hard_timeout to Argus results table

### DIFF
--- a/sdcm/utils/adaptive_timeouts/__init__.py
+++ b/sdcm/utils/adaptive_timeouts/__init__.py
@@ -381,6 +381,7 @@ def adaptive_timeout(  # noqa: PLR0914
                     operation=operation.name,
                     duration=duration,
                     timeout=soft_timeout,
+                    hard_timeout=hard_timeout,
                     timeout_occurred=timeout_occurred,
                 )
         except Exception as exc:  # noqa: BLE001

--- a/sdcm/utils/adaptive_timeouts/load_info_store.py
+++ b/sdcm/utils/adaptive_timeouts/load_info_store.py
@@ -248,7 +248,13 @@ class AdaptiveTimeoutStore(metaclass=Singleton):
     Used for future reference/node operations time tracking and calculations optimization."""
 
     def store(
-        self, metrics: dict[str, Any], operation: str, duration: int | float, timeout: int, timeout_occurred: bool
+        self,
+        metrics: dict[str, Any],
+        operation: str,
+        duration: int | float,
+        timeout: int,
+        timeout_occurred: bool,
+        hard_timeout: int | float | None = None,
     ) -> None:
         pass
 
@@ -263,6 +269,7 @@ class ArgusAdaptiveTimeoutResult:
     operation: str
     duration: int
     timeout: int
+    hard_timeout: int | None
     timeout_occurred: bool
     end_time: str
     metrics: dict[str, Any]
@@ -277,6 +284,7 @@ class AdaptiveTimeoutResultsTable(StaticGenericResultTable):
         columns = [
             ColumnMetadata(name="duration", unit="HH:MM:SS", type=ResultType.DURATION, higher_is_better=False),
             ColumnMetadata(name="timeout", unit="HH:MM:SS", type=ResultType.DURATION),
+            ColumnMetadata(name="hard_timeout", unit="HH:MM:SS", type=ResultType.DURATION),
             ColumnMetadata(name="end_time", unit="", type=ResultType.TEXT),
             ColumnMetadata(name="cpu_load_5", unit="%", type=ResultType.FLOAT, visible=False),
             ColumnMetadata(name="shards_count", unit="", type=ResultType.INTEGER, visible=False),
@@ -318,6 +326,8 @@ class ArgusAdaptiveTimeoutStore(AdaptiveTimeoutStore):
             status=Status.PASS if not result.timeout_occurred else Status.ERROR,
         )
         table.add_result(column="timeout", row=f"#{cycle}", value=result.timeout, status=Status.UNSET)
+        if result.hard_timeout is not None:
+            table.add_result(column="hard_timeout", row=f"#{cycle}", value=result.hard_timeout, status=Status.UNSET)
         table.add_result(column="end_time", row=f"#{cycle}", value=result.end_time, status=Status.UNSET)
         table.add_result(
             column="cpu_load_5", row=f"#{cycle}", value=result.metrics.get("cpu_load_5"), status=Status.UNSET
@@ -366,11 +376,20 @@ class ArgusAdaptiveTimeoutStore(AdaptiveTimeoutStore):
         logging.debug("Submitting adaptive timeout results to Argus: %s", table.as_dict())
         submit_results_to_argus(argus_client, table)
 
-    def store(self, metrics: dict[str, Any], operation: str, duration: float, timeout: float, timeout_occurred: bool):
+    def store(
+        self,
+        metrics: dict[str, Any],
+        operation: str,
+        duration: float,
+        timeout: float,
+        timeout_occurred: bool,
+        hard_timeout: float | None = None,
+    ):
         result = ArgusAdaptiveTimeoutResult(
             operation=operation,
             duration=int(duration),
             timeout=int(timeout),
+            hard_timeout=int(hard_timeout) if hard_timeout is not None else None,
             timeout_occurred=timeout_occurred,
             end_time="N/A",
             metrics=metrics.copy(),

--- a/unit_tests/unit/test_adaptive_timeouts.py
+++ b/unit_tests/unit/test_adaptive_timeouts.py
@@ -22,8 +22,10 @@ from invoke import Result
 
 from sdcm.remote import RemoteCmdRunnerBase
 from sdcm.sct_config import AdaptiveTimeoutMultipliers, SCTConfiguration
+from sdcm.test_config import TestConfig
 from sdcm.utils.adaptive_timeouts.load_info_store import (
     AdaptiveTimeoutStore,
+    ArgusAdaptiveTimeoutStore,
     NodeLoadInfoService,
     NodeLoadInfoServices,
     _I4I_LARGE_BASELINE_THROUGHPUT_MB_PER_SEC,
@@ -56,10 +58,22 @@ class MemoryAdaptiveTimeoutStore(AdaptiveTimeoutStore):
         self._data = {}
 
     def store(
-        self, metrics: dict[str, Any], operation: str, duration: int, timeout: int, timeout_occurred: bool
+        self,
+        metrics: dict[str, Any],
+        operation: str,
+        duration: int,
+        timeout: int,
+        timeout_occurred: bool,
+        hard_timeout: int | None = None,
     ) -> None:
         metrics.update(
-            {"operation": operation, "duration": duration, "timeout": timeout, "timeout_occurred": timeout_occurred}
+            {
+                "operation": operation,
+                "duration": duration,
+                "timeout": timeout,
+                "hard_timeout": hard_timeout,
+                "timeout_occurred": timeout_occurred,
+            }
         )
         key = str(uuid.uuid4())
         self._data[key] = metrics
@@ -196,7 +210,9 @@ def test_decommission_timeout_is_calculated_and_stored(publish_or_dump, fake_nod
     ) as timeout:
         assert timeout == 7200  # based on data size
     publish_or_dump.assert_not_called()
-    assert adaptive_timeout_store.get(operation=Operations.DECOMMISSION.name, timeout_occurred=False)
+    metrics = adaptive_timeout_store.get(operation=Operations.DECOMMISSION.name, timeout_occurred=False)
+    assert metrics
+    assert metrics[0]["hard_timeout"] is None  # non-tablet decommission has no hard timeout
 
 
 @mock.patch("sdcm.sct_events.system.SoftTimeoutEvent.publish_or_dump")
@@ -219,6 +235,7 @@ def test_tablets_decommission_timeout_is_calculated_from_data_size(
     hard_timeout_mock.assert_not_called()
     metrics = adaptive_timeout_store.get(operation=Operations.DECOMMISSION.name)
     assert metrics[0].get("tablets_enabled") is True
+    assert metrics[0]["hard_timeout"] == expected_hard
 
 
 @mock.patch("sdcm.sct_events.system.SoftTimeoutEvent.publish_or_dump")
@@ -552,3 +569,48 @@ def test_sct_config_with_multipliers_is_json_serializable(monkeypatch):
     # Verify the multipliers are present and correctly serialized in the output
     parsed = json.loads(json_str)
     assert parsed["adaptive_timeout_multipliers"] == {"decommission": 5.0, "new_node": 5.0}
+
+
+# ===== ArgusAdaptiveTimeoutStore hard_timeout reporting tests =====
+
+
+@mock.patch("sdcm.utils.adaptive_timeouts.load_info_store.submit_results_to_argus")
+def test_argus_store_reports_hard_timeout_when_set(mock_submit):
+    with (
+        mock.patch.object(TestConfig, "argus_client_ready", return_value=True),
+        mock.patch.object(TestConfig, "argus_client", return_value=mock.Mock()),
+    ):
+        ArgusAdaptiveTimeoutStore().store(
+            metrics={"cpu_load_5": 1.5},
+            operation="DECOMMISSION",
+            duration=100.4,
+            timeout=200.6,
+            timeout_occurred=False,
+            hard_timeout=400.9,
+        )
+
+    mock_submit.assert_called_once()
+    table = mock_submit.call_args[0][1]
+    hard_timeout_cells = [cell for cell in table.results if cell.column == "hard_timeout"]
+    assert len(hard_timeout_cells) == 1
+    assert hard_timeout_cells[0].value == 400  # truncated to int, like the soft timeout column
+
+
+@mock.patch("sdcm.utils.adaptive_timeouts.load_info_store.submit_results_to_argus")
+def test_argus_store_reports_no_hard_timeout_when_not_set(mock_submit):
+    with (
+        mock.patch.object(TestConfig, "argus_client_ready", return_value=True),
+        mock.patch.object(TestConfig, "argus_client", return_value=mock.Mock()),
+    ):
+        ArgusAdaptiveTimeoutStore().store(
+            metrics={},
+            operation="SOFT_TIMEOUT",
+            duration=10,
+            timeout=20,
+            timeout_occurred=False,
+        )
+
+    mock_submit.assert_called_once()
+    table = mock_submit.call_args[0][1]
+    hard_timeout_cells = [cell for cell in table.results if cell.column == "hard_timeout"]
+    assert not hard_timeout_cells  # no cell reported when there's no hard timeout


### PR DESCRIPTION
When an operation has a hard timeout (tablets decommission, new_node, tablet_migration), it wasn't included in the Argus adaptive-timeout results table alongside the soft timeout.

Closes: SCT-877

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://argus.scylladb.com/tests/scylla-cluster-tests/19562838-e3d3-4a84-a964-904bd421767a

Operations that have a hard timeout mention it, while others are unaffected
<img width="775" height="968" alt="image" src="https://github.com/user-attachments/assets/983bf125-e99a-4db9-8b20-cbce16fe689a" />


### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
