### PR TITLE
fix(gce provision): retry transient GCE API errors while polling operations

### DIFF
--- a/sdcm/utils/gce_utils.py
+++ b/sdcm/utils/gce_utils.py
@@ -22,6 +22,7 @@ from functools import cached_property
 from typing import Any, Callable, List, Literal, TYPE_CHECKING
 
 import google.api_core.exceptions
+from google.api_core import retry as api_core_retry
 from google.api_core.client_options import ClientOptions
 from google.oauth2 import service_account
 from google.cloud import compute_v1
@@ -756,6 +757,51 @@ class GceLoggingClient:
         return entries
 
 
+# Transient GCE API failures: the long-running operation itself is unaffected, only the HTTP call used to
+# poll it failed, so the call is safe to repeat. Seen in the wild as
+# "503 GET .../zones/<zone>/operations/<id>: Authentication backend unavailable" during node provisioning.
+GCE_TRANSIENT_API_ERRORS = (
+    google.api_core.exceptions.TooManyRequests,  # 429
+    google.api_core.exceptions.InternalServerError,  # 500
+    google.api_core.exceptions.BadGateway,  # 502
+    google.api_core.exceptions.ServiceUnavailable,  # 503
+    google.api_core.exceptions.GatewayTimeout,  # 504
+)
+GCE_OPERATION_RETRY_INITIAL_BACKOFF = 2.0
+GCE_OPERATION_RETRY_MAX_BACKOFF = 30.0
+GCE_OPERATION_RETRY_TIMEOUT = 180.0
+# How many times a whole set_labels call (issue + poll) is replayed when it fails transiently.
+GCE_SET_LABELS_RETRIES = 3
+# A stale label fingerprint comes back as 412, which is worth replaying here too: the retry re-reads it.
+GCE_SET_LABELS_ERRORS = GCE_TRANSIENT_API_ERRORS + (google.api_core.exceptions.PreconditionFailed,)
+
+
+def gce_operation_poll_retry(
+    timeout: float | None = None, on_error: Callable[[Exception], None] | None = None
+) -> api_core_retry.Retry:
+    """Build the retry policy for the HTTP calls that poll a GCE long-running operation.
+
+    `ExtendedOperation.result()` gives up as soon as one `GET .../operations/<id>` poll returns a
+    transient error, even though the operation itself is still progressing - which aborts a whole test
+    when GCE has a short-lived hiccup. Polling is an idempotent GET, so those errors are retried with
+    exponential backoff instead.
+
+    Args:
+        timeout: the caller's operation timeout; the retry deadline is capped by it so that retrying
+            a poll cannot outlive the operation it is polling. `None` means the default deadline.
+        on_error: (optional) called with every transient error that is retried.
+    """
+    retry_timeout = GCE_OPERATION_RETRY_TIMEOUT if timeout is None else min(GCE_OPERATION_RETRY_TIMEOUT, timeout)
+    return api_core_retry.Retry(
+        predicate=api_core_retry.if_exception_type(*GCE_TRANSIENT_API_ERRORS),
+        initial=GCE_OPERATION_RETRY_INITIAL_BACKOFF,
+        maximum=GCE_OPERATION_RETRY_MAX_BACKOFF,
+        multiplier=2.0,
+        timeout=retry_timeout,
+        on_error=on_error,
+    )
+
+
 def wait_for_extended_operation(
     operation: ExtendedOperation, verbose_name: str = "operation", timeout: int = 300
 ) -> Any:
@@ -784,8 +830,36 @@ def wait_for_extended_operation(
 
         In case of an operation taking longer than `timeout` seconds to complete,
         a `concurrent.futures.TimeoutError` will be raised.
+
+        Transient GCE API errors hit while polling the operation (429, 5xx) are retried with
+        exponential backoff and do not fail the call, see `gce_operation_poll_retry()`.
     """
-    result = operation.result(timeout=timeout)
+    transient_errors: List[Exception] = []
+
+    def _on_transient_error(exc: Exception) -> None:
+        transient_errors.append(exc)
+        LOGGER.warning(
+            "Transient GCE API error while polling %s (occurrence #%s), retrying: %s",
+            verbose_name,
+            len(transient_errors),
+            exc,
+        )
+
+    try:
+        result = operation.result(timeout=timeout, retry=gce_operation_poll_retry(timeout, _on_transient_error))
+    except TimeoutError as exc:
+        # An exhausted poll retry surfaces as a plain timeout, which hides the actual GCE error - restate it.
+        if transient_errors:
+            raise TimeoutError(
+                f"{verbose_name} did not complete within {timeout} seconds: polling it hit "
+                f"{len(transient_errors)} transient GCE API error(s), the last one was: {transient_errors[-1]}"
+            ) from exc
+        raise
+
+    if transient_errors:
+        LOGGER.info(
+            "%s completed after %s transient GCE API error(s) while polling", verbose_name, len(transient_errors)
+        )
 
     if operation.error_code:
         LOGGER.debug("Error during %s: [Code: %s]: %s", verbose_name, operation.error_code, operation.error_message)
@@ -1039,18 +1113,45 @@ def gce_set_labels(
 
     Returns:
         Whatever the operation.result() returns.
+
+    Raises:
+        The last transient GCE API error if `GCE_SET_LABELS_RETRIES` attempts all failed, or whatever
+        `wait_for_extended_operation()` raises for a non-transient failure.
     """
+    last_error = None
+    for attempt in range(1, GCE_SET_LABELS_RETRIES + 1):
+        if attempt > 1:
+            # The label fingerprint is invalidated by any concurrent label change and by a request that
+            # reached GCE before the error did, so re-read the instance instead of replaying the old one.
+            instance = instances_client.get(project=project, zone=zone, instance=instance.name)
 
-    request = compute_v1.InstancesSetLabelsRequest()
-    request.labels = instance.labels
-    request.label_fingerprint = instance.label_fingerprint
-    request.labels.update(new_labels)
+        request = compute_v1.InstancesSetLabelsRequest()
+        request.labels = instance.labels
+        request.label_fingerprint = instance.label_fingerprint
+        request.labels.update(new_labels)
 
-    operation = instances_client.set_labels(
-        project=project, zone=zone, instance=instance.name, instances_set_labels_request_resource=request
-    )
+        try:
+            operation = instances_client.set_labels(
+                project=project, zone=zone, instance=instance.name, instances_set_labels_request_resource=request
+            )
+            return wait_for_extended_operation(operation, f"setting labels on {instance.name}")
+        except GCE_SET_LABELS_ERRORS as exc:
+            last_error = exc
+            if attempt == GCE_SET_LABELS_RETRIES:
+                break
+            backoff = min(GCE_OPERATION_RETRY_INITIAL_BACKOFF * 2 ** (attempt - 1), GCE_OPERATION_RETRY_MAX_BACKOFF)
+            LOGGER.warning(
+                "Failed to set labels on %s (attempt %s/%s), retrying in %ss: %s",
+                instance.name,
+                attempt,
+                GCE_SET_LABELS_RETRIES,
+                backoff,
+                exc,
+            )
+            time.sleep(backoff)
 
-    return wait_for_extended_operation(operation, f"setting labels on {instance.name}")
+    LOGGER.error("Failed to set labels on %s after %s attempts", instance.name, GCE_SET_LABELS_RETRIES)
+    raise last_error
 
 
 def gce_set_tags(

--- a/unit_tests/unit/test_gce_transient_api_error_retry.py
+++ b/unit_tests/unit/test_gce_transient_api_error_retry.py
@@ -1,0 +1,237 @@
+"""SCT-417: a transient GCE API error while polling a long-running operation must not fail the test.
+
+GCE returned `503 Authentication backend unavailable` on the `GET .../operations/<id>` poll that
+`set_keep_alive()` issues right after a node was created, which aborted the whole rolling-upgrade run.
+Covers the retry added to `wait_for_extended_operation()` and to the `gce_set_labels()` call around it.
+"""
+
+from dataclasses import dataclass, field
+from unittest.mock import MagicMock, patch
+
+import pytest
+from google.api_core import exceptions, extended_operation
+from google.api_core.future import polling
+from google.cloud import compute_v1
+
+from sdcm.utils import gce_utils
+from sdcm.utils.gce_utils import (
+    GCE_OPERATION_RETRY_TIMEOUT,
+    GCE_SET_LABELS_RETRIES,
+    gce_operation_poll_retry,
+    gce_set_labels,
+    wait_for_extended_operation,
+)
+
+TRANSIENT_ERRORS = [
+    exceptions.TooManyRequests("429 Rate limit exceeded."),
+    exceptions.InternalServerError("500 Internal error."),
+    exceptions.BadGateway("502 Bad gateway."),
+    exceptions.ServiceUnavailable("503 Authentication backend unavailable."),
+    exceptions.GatewayTimeout("504 Gateway timeout."),
+]
+
+
+@dataclass
+class FakeOperation:
+    """The minimal shape `ExtendedOperation` expects from the wrapped operation message."""
+
+    name: str = "operation-1779953504333-652dbb857aefa"
+    status: str = "RUNNING"
+    error_code: int = 0
+    error_message: str = ""
+    done: bool = False
+    warnings: list = field(default_factory=list)
+
+
+@pytest.fixture(autouse=True)
+def no_backoff_sleeps(monkeypatch):
+    """Keep the retries instant - the backoff values themselves are asserted separately."""
+    monkeypatch.setattr(gce_utils, "GCE_OPERATION_RETRY_INITIAL_BACKOFF", 0.0)
+    monkeypatch.setattr(gce_utils, "GCE_OPERATION_RETRY_MAX_BACKOFF", 0.0)
+
+
+def make_operation(refresh_results: list) -> tuple[extended_operation.ExtendedOperation, MagicMock]:
+    """Build a real ExtendedOperation whose poll raises/returns `refresh_results` in order.
+
+    Using the real future (rather than a mock) is what makes these tests meaningful: the retry is
+    handed to `operation.result()` and applied by api_core deep inside the polling loop.
+    """
+    refresh = MagicMock(side_effect=refresh_results)
+
+    def poll(retry=None):
+        # mirrors the generated GCE client: the retry policy handed down by `result()` wraps the
+        # polling RPC itself, it is not applied by ExtendedOperation
+        return retry(refresh)() if retry else refresh()
+
+    # the real polling policy (so "operation not complete yet" keeps its own semantics), only without waits
+    instant_polling = polling.DEFAULT_POLLING.with_delay(initial=0.0, maximum=0.0, multiplier=1.0).with_timeout(30.0)
+    operation = extended_operation.ExtendedOperation.make(poll, lambda: None, FakeOperation(), polling=instant_polling)
+    return operation, refresh
+
+
+def done_operation(error_code: int = 0, error_message: str = "") -> FakeOperation:
+    return FakeOperation(status="DONE", error_code=error_code, error_message=error_message, done=True)
+
+
+@pytest.mark.parametrize("transient_error", TRANSIENT_ERRORS, ids=lambda err: type(err).__name__)
+def test_transient_poll_error_is_retried_until_the_operation_completes(transient_error) -> None:
+    operation, refresh = make_operation([transient_error, transient_error, done_operation()])
+
+    assert wait_for_extended_operation(operation, "instance creation", timeout=30) is None
+    assert refresh.call_count == 3
+
+
+def test_non_transient_poll_error_fails_immediately() -> None:
+    operation, refresh = make_operation([exceptions.Forbidden("403 Permission denied."), done_operation()])
+
+    with pytest.raises(exceptions.Forbidden):
+        wait_for_extended_operation(operation, "instance creation", timeout=30)
+    assert refresh.call_count == 1
+
+
+def test_exhausted_transient_retry_reports_the_underlying_gce_error() -> None:
+    error = exceptions.ServiceUnavailable("503 Authentication backend unavailable.")
+    operation, _ = make_operation([error] * 50)
+
+    with pytest.raises(TimeoutError) as exc_info:
+        # a 0s retry deadline lets the first poll run and then refuses to retry it
+        with patch.object(gce_utils, "GCE_OPERATION_RETRY_TIMEOUT", 0.0):
+            wait_for_extended_operation(operation, "setting labels on db-node-1", timeout=30)
+
+    message = str(exc_info.value)
+    assert "setting labels on db-node-1" in message
+    assert "transient GCE API error" in message
+    assert "Authentication backend unavailable" in message
+
+
+def test_operation_failing_with_an_error_code_still_raises() -> None:
+    operation, _ = make_operation([done_operation(error_code=400, error_message="Invalid machine type.")])
+
+    with pytest.raises(exceptions.BadRequest, match="Invalid machine type."):
+        wait_for_extended_operation(operation, "instance creation", timeout=30)
+
+
+def test_successful_operation_is_not_retried() -> None:
+    operation, refresh = make_operation([done_operation()])
+
+    assert wait_for_extended_operation(operation, "instance creation", timeout=30) is None
+    assert refresh.call_count == 1
+
+
+@pytest.mark.parametrize(
+    ("operation_timeout", "expected"),
+    [
+        (None, GCE_OPERATION_RETRY_TIMEOUT),
+        (30, 30),
+        (600, GCE_OPERATION_RETRY_TIMEOUT),
+    ],
+)
+def test_retry_deadline_never_outlives_the_operation_timeout(operation_timeout, expected) -> None:
+    assert gce_operation_poll_retry(operation_timeout).timeout == expected
+
+
+@pytest.mark.parametrize("transient_error", TRANSIENT_ERRORS, ids=lambda err: type(err).__name__)
+def test_retry_predicate_matches_only_transient_errors(transient_error) -> None:
+    predicate = gce_operation_poll_retry()._predicate
+
+    assert predicate(transient_error)
+    assert not predicate(exceptions.Forbidden("403 Permission denied."))
+    assert not predicate(exceptions.NotFound("404 Instance not found."))
+
+
+def make_instance(fingerprint: str) -> compute_v1.Instance:
+    return compute_v1.Instance(name="db-node-0-1", labels={"keep-action": "terminate"}, label_fingerprint=fingerprint)
+
+
+@patch("sdcm.utils.gce_utils.wait_for_extended_operation", return_value=None)
+def test_set_labels_retries_transient_error_with_a_fresh_fingerprint(mock_wait) -> None:
+    """The SCT-417 scenario: the node exists, only its keep-alive labelling failed transiently."""
+    instances_client = MagicMock()
+    instances_client.set_labels.side_effect = [
+        exceptions.ServiceUnavailable("503 Authentication backend unavailable."),
+        MagicMock(),
+    ]
+    instances_client.get.return_value = make_instance("fingerprint-2")
+
+    gce_set_labels(
+        instances_client=instances_client,
+        instance=make_instance("fingerprint-1"),
+        new_labels={"keep": "12"},
+        project="sct-project-1",
+        zone="us-central1-c",
+    )
+
+    assert instances_client.set_labels.call_count == 2
+    instances_client.get.assert_called_once_with(project="sct-project-1", zone="us-central1-c", instance="db-node-0-1")
+    # the replay must not reuse the fingerprint the failed request was built with
+    fingerprints = [
+        call.kwargs["instances_set_labels_request_resource"].label_fingerprint
+        for call in instances_client.set_labels.call_args_list
+    ]
+    assert fingerprints == ["fingerprint-1", "fingerprint-2"]
+    # existing labels are preserved across the retry
+    assert dict(instances_client.set_labels.call_args.kwargs["instances_set_labels_request_resource"].labels) == {
+        "keep-action": "terminate",
+        "keep": "12",
+    }
+    mock_wait.assert_called_once()
+
+
+@patch("sdcm.utils.gce_utils.wait_for_extended_operation", return_value=None)
+def test_set_labels_replays_a_stale_fingerprint_rejection(mock_wait) -> None:
+    """A 503 whose request did reach GCE comes back as 412 on the replay - re-read and try again."""
+    instances_client = MagicMock()
+    instances_client.set_labels.side_effect = [
+        exceptions.PreconditionFailed("412 Labels fingerprint does not match."),
+        MagicMock(),
+    ]
+    instances_client.get.return_value = make_instance("fingerprint-2")
+
+    gce_set_labels(
+        instances_client=instances_client,
+        instance=make_instance("fingerprint-1"),
+        new_labels={"keep": "12"},
+        project="sct-project-1",
+        zone="us-central1-c",
+    )
+
+    assert instances_client.set_labels.call_count == 2
+    mock_wait.assert_called_once()
+
+
+@patch("sdcm.utils.gce_utils.wait_for_extended_operation", return_value=None)
+def test_set_labels_gives_up_after_the_configured_attempts(mock_wait) -> None:
+    instances_client = MagicMock()
+    instances_client.set_labels.side_effect = exceptions.ServiceUnavailable("503 Authentication backend unavailable.")
+    instances_client.get.return_value = make_instance("fingerprint-2")
+
+    with pytest.raises(exceptions.ServiceUnavailable):
+        gce_set_labels(
+            instances_client=instances_client,
+            instance=make_instance("fingerprint-1"),
+            new_labels={"keep": "12"},
+            project="sct-project-1",
+            zone="us-central1-c",
+        )
+
+    assert instances_client.set_labels.call_count == GCE_SET_LABELS_RETRIES
+    mock_wait.assert_not_called()
+
+
+@patch("sdcm.utils.gce_utils.wait_for_extended_operation", return_value=None)
+def test_set_labels_does_not_retry_a_non_transient_error(mock_wait) -> None:
+    instances_client = MagicMock()
+    instances_client.set_labels.side_effect = exceptions.Forbidden("403 Permission denied.")
+
+    with pytest.raises(exceptions.Forbidden):
+        gce_set_labels(
+            instances_client=instances_client,
+            instance=make_instance("fingerprint-1"),
+            new_labels={"keep": "12"},
+            project="sct-project-1",
+            zone="us-central1-c",
+        )
+
+    assert instances_client.set_labels.call_count == 1
+    instances_client.get.assert_not_called()
+    mock_wait.assert_not_called()


### PR DESCRIPTION
A GCE node was created successfully, but the `set_keep_alive()` label operation that follows failed with `503 Authentication backend unavailable` on the `GET .../zones/us-central1-c/operations/<id>` poll, which raised `CreateGCENodeError` and aborted the whole rolling-upgrade run.

`ExtendedOperation.result()` gives up on the first failed poll: its `polling` policy only retries "operation not complete yet", so any HTTP error from the polling GET propagates even though the operation itself is still progressing. Its `retry` argument is the knob for that, and it was never passed.

`wait_for_extended_operation()` now hands `result()` a retry policy that retries 429/500/502/503/504 with exponential backoff, capped by the caller's operation timeout so a retried poll cannot outlive the operation it polls. When the retry is exhausted api_core reports a bare timeout, so the underlying GCE error is restated in the raised message instead of being lost.

`gce_set_labels()` additionally replays the whole call on a transient error, re-reading the instance first: the label fingerprint of the failed attempt is stale if the request reached GCE before the error did, and replaying it would come back as 412.

Refs: SCT-417

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [rolling-upgrade-gce-image-test](https://argus.scylladb.com/tests/scylla-cluster-tests/eb6580e9-3946-43a5-9514-76b4fcff06d0)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
