### PR TITLE
fix(longevity-twcs-48h): reduce disk utilization

### DIFF
--- a/test-cases/longevity/longevity-twcs-48h.yaml
+++ b/test-cases/longevity/longevity-twcs-48h.yaml
@@ -14,8 +14,8 @@
 #   - Nemesis: SisyphusMonkey every 15 min, after reaching the space threshold
 #
 # Workload (scylla-bench timeseries, 48h each):
-#   - Write: 90K ops/s max rate, 150 concurrency, 200K partitions × 100K rows × 2000B
-#   - Read (×2): half-normal + uniform distribution, write-rate=600 per thread
+#   - Write: 36K ops/s max rate, 150 concurrency, 200K partitions × 100K rows × 2000B
+#   - Read (×2): half-normal + uniform distribution, write-rate=240 per thread
 #
 # Table Settings (applied via post_prepare_cql_cmds):
 #   - default_time_to_live: 10800 (3 hours)
@@ -26,14 +26,14 @@
 test_duration: 3000
 
 stress_cmd: [
-    "scylla-bench -workload=timeseries -mode=write -replication-factor=3 -partition-count=200000 -clustering-row-count=100000 -clustering-row-size=2000 -concurrency=150 -rows-per-request=1 -start-timestamp=SET_WRITE_TIMESTAMP -connection-count 100 -max-rate 90000 -timeout=120s -retry-number=30 -retry-interval=80ms,1s -duration=2880m"
+    "scylla-bench -workload=timeseries -mode=write -replication-factor=3 -partition-count=200000 -clustering-row-count=100000 -clustering-row-size=2000 -concurrency=150 -rows-per-request=1 -start-timestamp=SET_WRITE_TIMESTAMP -connection-count 100 -max-rate 18000 -timeout=120s -retry-number=30 -retry-interval=80ms,1s -duration=2880m"
 ]
 # write-rate with timeseries workload for read mode
 # calculated from timeseries workload for write mode by formula:
-# write-rate = -max-rate / -concurrency = 90000 / 150 = 600
+# write-rate = -max-rate / -concurrency = 18000 / 150 = 120
 stress_read_cmd: [
-    "scylla-bench -workload=timeseries -mode=read -partition-count=200000 -concurrency=150 -replication-factor=3 -clustering-row-count=100000 -clustering-row-size=2000  -rows-per-request=1 -start-timestamp=GET_WRITE_TIMESTAMP -write-rate 600 -distribution hnormal --connection-count 100 -duration=2880m -timeout=30s -retry-number=30 -retry-interval=80ms,1s",
-    "scylla-bench -workload=timeseries -mode=read -partition-count=200000 -concurrency=150 -replication-factor=3 -clustering-row-count=100000 -clustering-row-size=2000  -rows-per-request=1 -start-timestamp=GET_WRITE_TIMESTAMP -write-rate 600 -distribution uniform --connection-count 100 -duration=2880m -timeout=30s -retry-number=30 -retry-interval=80ms,1s"
+    "scylla-bench -workload=timeseries -mode=read -partition-count=200000 -concurrency=150 -replication-factor=3 -clustering-row-count=100000 -clustering-row-size=2000  -rows-per-request=1 -start-timestamp=GET_WRITE_TIMESTAMP -write-rate 120 -distribution hnormal --connection-count 100 -duration=2880m -timeout=30s -retry-number=30 -retry-interval=80ms,1s",
+    "scylla-bench -workload=timeseries -mode=read -partition-count=200000 -concurrency=150 -replication-factor=3 -clustering-row-count=100000 -clustering-row-size=2000  -rows-per-request=1 -start-timestamp=GET_WRITE_TIMESTAMP -write-rate 120 -distribution uniform --connection-count 100 -duration=2880m -timeout=30s -retry-number=30 -retry-interval=80ms,1s"
 ]
 
 n_db_nodes: 6
@@ -45,8 +45,8 @@ sizing_db:
   local_disk_gb: '>=900'
 
 nemesis_class_name: 'SisyphusMonkey'
-# exclude ModifyTableCompactionMonkey because it will change TWCS
-nemesis_selector: 'not ModifyTableCompactionMonkey'
+# exclude nemeses that change TWCS parameters
+nemesis_selector: 'not ModifyTableCompactionMonkey and not ModifyTableTwcsWindowSizeMonkey'
 nemesis_seed: '025'
 nemesis_interval: 15
 nemesis_during_prepare: false


### PR DESCRIPTION
This test currently always fails due to the cluster reaching critical disk utilization. (e.g. https://argus.scylladb.com/tests/scylla-cluster-tests/5300af7c-6920-44d6-a573-4b55d3a426fd)
<img width="552" height="265" alt="image" src="https://github.com/user-attachments/assets/1917e55b-701c-416f-a28e-9ea8fc2d6447" />
There are 2 reasons:
1.  If `ModifyTableTwcsWindowSizeMonkey` runs, it would change the 3h window to 49h, so space would never be reclaimed.
2. Due to scylla-bench changing what kind of data is written (https://github.com/scylladb/scylla-bench/pull/313), compression went from `98%` to `0%`.

Scylla bench version 1.3.1 or lower:
<img width="578" height="153" alt="image" src="https://github.com/user-attachments/assets/6316a34e-4a9c-433c-a369-2cceafbe32c7" />

Scylla bench version 1.3.2
<img width="578" height="153" alt="image" src="https://github.com/user-attachments/assets/54864667-3ce1-499d-9d78-248e24a03c55" />

This PR reduces the amount of data written to the cluster, so it reaches about 30% in the TWCS window and excludes `ModifyTableTwcsWindowSizeMonkey` from running.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://argus.scylladb.com/tests/scylla-cluster-tests/026eed84-8cbb-434a-86fe-c957f5809c3c

Load:
<img width="1042" height="506" alt="image" src="https://github.com/user-attachments/assets/8fba6f12-a6e1-4373-b952-da3ac849c259" />
Disk Utilization:
<img width="1053" height="251" alt="image" src="https://github.com/user-attachments/assets/f3e171a0-f0f3-4cd8-a088-401927e30f47" />


### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
