### PR TITLE
refactor(nemesis): extract grow/shrink nemesis into monkey/topology/grow_shrink.py

### DIFF
--- a/sdcm/nemesis/__init__.py
+++ b/sdcm/nemesis/__init__.py
@@ -140,6 +140,7 @@ from sdcm.nemesis.utils.indexes import (
     is_cf_a_view,
 )
 from sdcm.nemesis.utils.node_allocator import NemesisNodeAllocator
+from sdcm.nemesis.utils.topology_ops import grow_cluster, shrink_cluster
 from sdcm.utils.node import build_node_api_command
 from sdcm.utils.sstable.load_utils import SstableLoadUtils
 from sdcm.utils.sstable.sstable_utils import SstableUtils
@@ -3508,31 +3509,6 @@ class NemesisRunner:
             result = self.target_node.run_nodetool(sub_cmd="toppartitions", args=top_partition_api.get_cmd_args())
             top_partition_api.verify_output(result.stdout)
 
-    def disrupt_remove_node_then_add_node(self):
-        """
-        https://docs.scylladb.com/operating-scylla/procedures/cluster-management/remove_node/
-
-        1. Terminate node
-        2. Run full repair
-        3. Nodetool removenode, if removenode rejected, because removing node is UN in gossiper,
-           repeat operation in 5 second
-        4. Add new node
-        5. Run nodetool cleanup (on each node) for each keyspace
-        """
-        if self.cluster.params.get("db_type") == "cloud_scylla":
-            raise UnsupportedNemesis(
-                "Skipping this nemesis due the replace node option that supported by Cloud "
-                "is tested by CloudReplaceNonResponsiveNode nemesis"
-            )
-
-        node_to_remove = self.target_node
-        up_normal_nodes = self.cluster.get_nodes_up_and_normal(verification_node=node_to_remove)
-
-        with self.node_allocator.run_nemesis(
-            nemesis_label="RemoveNodeAddNode", node_list=up_normal_nodes
-        ) as verification_node:
-            self._remove_node_add_node(verification_node=verification_node, node_to_remove=node_to_remove)
-
     def _remove_node_add_node(self, verification_node, node_to_remove, remove_node_host_id=None):
         # node_to_remove must be different than node
         # node_to_remove is single/last seed in cluster, before
@@ -3936,150 +3912,6 @@ class NemesisRunner:
         self.monitoring_set.reconfigure_scylla_monitoring()
         InfoEvent(f"FinishEvent - ShrinkCluster has done decommissioning {len(nodes)} nodes").publish()
 
-    def _decommission_nodes(
-        self,
-        nodes_number,
-        rack,
-        is_seed: Optional[Union[bool, DefaultValue]] = DefaultValue,
-        dc_idx: Optional[int] = None,
-        exact_nodes: list[BaseNode] | None = None,
-    ):
-        nodes_to_decommission = []
-        if exact_nodes:
-            nodes_to_decommission = exact_nodes
-            for node in exact_nodes:
-                self.node_allocator.set_running_nemesis(node, self.current_disruption)
-        else:
-            for idx in range(nodes_number):
-                if self._is_it_on_kubernetes():
-                    if rack is None and self._is_it_on_kubernetes():
-                        rack = 0
-                    self.set_target_node_pool_type(NEMESIS_TARGET_POOLS.data_nodes)
-                    self.set_target_node(rack=rack, is_seed=is_seed, allow_only_last_node_in_rack=True)
-                else:
-                    rack_idx = rack if rack is not None else idx % self.cluster.racks_count
-                    # if rack is not specified, round-robin racks
-                    self.set_target_node(is_seed=is_seed, dc_idx=dc_idx, rack=rack_idx)
-                nodes_to_decommission.append(self.target_node)
-                self.target_node = (
-                    None  # otherwise node.running_nemesis will be taken off the node by self.set_target_node
-                )
-        try:
-            if self.cluster.parallel_node_operations:
-                self.decommission_nodes(nodes_to_decommission)
-            else:
-                for node in nodes_to_decommission:
-                    self.decommission_nodes([node])
-        except Exception as exc:  # noqa: BLE001
-            InfoEvent(
-                f"FinishEvent - ShrinkCluster failed decommissioning a node {self.target_node} with error {exc!s}"
-            ).publish()
-
-    @latency_calculator_decorator(legend="Doubling cluster load")
-    def _double_cluster_load(self, duration: int) -> None:
-        duration = 30
-        stress_cmd = self.tester.stress_cmd
-        if isinstance(stress_cmd, list):
-            stress_cmd = stress_cmd[0]
-        self.log.info("Doubling the load on the cluster for %s minutes", duration)
-        stress_queue = self.tester.run_stress_thread(
-            stress_cmd=stress_cmd, stress_num=1, stats_aggregate_cmds=False, duration=duration
-        )
-        results = self.tester.verify_stress_thread(
-            thread_pool=stress_queue, error_handler=self._nemesis_stress_failure_handler
-        )
-        self.log.info(f"Double load results: {results}")
-
-    def disrupt_grow_shrink_cluster(self):
-        sleep_time_between_ops = self.cluster.params.get("nemesis_sequence_sleep_between_ops")
-        if not self.has_steady_run and sleep_time_between_ops:
-            self.steady_state_latency()
-            self.has_steady_run = True
-        new_nodes = self._grow_cluster(rack=None)
-
-        # pass on the exact nodes only if we have specific types for them
-        new_nodes = new_nodes if self.tester.params.get("nemesis_grow_shrink_instance_type") else None
-        if duration := self.tester.params.get("nemesis_double_load_during_grow_shrink_duration"):
-            with self.action_log_scope("Double load after grow cluster"):
-                self._double_cluster_load(duration)
-        self._shrink_cluster(rack=None, new_nodes=new_nodes)
-
-    # NOTE: version limitation is caused by the following:
-    #       - https://github.com/scylladb/scylla-enterprise/issues/3211
-    #       - https://github.com/scylladb/scylladb/issues/14184
-    @scylla_versions(("5.2.7", None), ("2023.1.1", None))
-    def disrupt_grow_shrink_new_rack(self):
-        if not self._is_it_on_kubernetes():
-            raise UnsupportedNemesis("Adding new rack is not supported for non-k8s Scylla clusters")
-        rack = max(self.cluster.racks) + 1
-        self._grow_cluster(rack)
-        self._shrink_cluster(rack)
-
-    def _grow_cluster(self, rack=None):
-        if rack is None and self._is_it_on_kubernetes():
-            rack = 0
-        add_nodes_number = self.tester.params.get("nemesis_add_node_cnt")
-        new_nodes = []
-        with self.action_log_scope(f"Grow cluster by {add_nodes_number} nodes"):
-            if self.cluster.parallel_node_operations:
-                new_nodes = self.add_new_nodes(
-                    count=add_nodes_number,
-                    rack=rack,
-                    instance_type=self.tester.params.get("nemesis_grow_shrink_instance_type"),
-                )
-            else:
-                for idx in range(add_nodes_number):
-                    # if rack is not specified, round-robin racks to spread nodes evenly
-                    rack_idx = rack if rack is not None else idx % self.cluster.racks_count
-                    new_nodes += self.add_new_nodes(
-                        count=1,
-                        rack=rack_idx,
-                        instance_type=self.tester.params.get("nemesis_grow_shrink_instance_type"),
-                    )
-        time.sleep(self.interval)
-        for node in new_nodes:
-            self.node_allocator.unset_running_nemesis(node, self.current_disruption)
-        return new_nodes
-
-    def _shrink_cluster(self, rack=None, new_nodes: list[BaseNode] | None = None):
-        add_nodes_number = self.tester.params.get("nemesis_add_node_cnt")
-        InfoEvent(message=f"Start shrink cluster by {add_nodes_number} nodes").publish()
-        # Check that number of nodes is enough for decommission:
-        self.log.debug(
-            "Current target_node %s, is zero_node: %s, dc_idx: %s",
-            self.target_node.name,
-            self.target_node._is_zero_token_node,
-            self.target_node.dc_idx,
-        )
-        cur_num_nodes_in_dc = len([n for n in self.cluster.data_nodes if n.dc_idx == self.target_node.dc_idx])
-        initial_db_size = self.tester.params.get("n_db_nodes")
-        if self._is_it_on_kubernetes():
-            k8s_size = self.tester.params.get("k8s_n_scylla_pods_per_cluster")
-            initial_db_size = [k8s_size] * len(initial_db_size) if k8s_size else initial_db_size
-
-        initial_db_size_in_dc = initial_db_size[self.target_node.dc_idx]
-        decommission_nodes_number = min(cur_num_nodes_in_dc - initial_db_size_in_dc, add_nodes_number)
-
-        if decommission_nodes_number < 1:
-            error = "Not enough nodes for decommission"
-            self.log.warning("Shrink cluster skipped. Error: %s", error)
-            raise Exception(error)
-
-        self.log.info("Start shrink cluster by %s nodes", decommission_nodes_number)
-        # Currently on kubernetes first two nodes of each rack are getting seed status
-        # Because of such behavior only way to get them decommission is to enable decommissioning
-        # TBD: After https://github.com/scylladb/scylla-operator/issues/292 is fixed remove is_seed parameter
-        self._decommission_nodes(
-            decommission_nodes_number,
-            rack,
-            is_seed=None if self._is_it_on_kubernetes() else DefaultValue,
-            dc_idx=self.target_node.dc_idx,
-            exact_nodes=new_nodes,
-        )
-        num_of_nodes = len(self.cluster.data_nodes)
-        self.log.info("Cluster shrink finished. Current number of data nodes %s", num_of_nodes)
-        InfoEvent(message=f"Cluster shrink finished. Current number of data nodes {num_of_nodes}").publish()
-
     def disrupt_hot_reloading_internode_certificate(self):
         """
         https://github.com/scylladb/scylla/issues/6067
@@ -4156,7 +3988,7 @@ class NemesisRunner:
             InfoEvent(message="FinishEvent - Manager repair was Skipped").publish()
         time.sleep(sleep_time_between_ops)
         InfoEvent(message="Starting grow disruption").publish()
-        self._grow_cluster(rack=None)
+        grow_cluster(self, rack=None)
         InfoEvent(message="Finished grow disruption").publish()
         time.sleep(sleep_time_between_ops)
         InfoEvent(message="Starting terminate_and_replace disruption").publish()
@@ -4164,7 +3996,7 @@ class NemesisRunner:
         InfoEvent(message="Finished terminate_and_replace disruption").publish()
         time.sleep(sleep_time_between_ops)
         InfoEvent(message="Starting shrink disruption").publish()
-        self._shrink_cluster(rack=None)
+        shrink_cluster(self, rack=None)
         InfoEvent(message="Finished shrink disruption").publish()
 
     def _k8s_disrupt_memory_stress(self):
@@ -4594,18 +4426,6 @@ class NemesisRunner:
             self.actions_log.info(f"Restarting {self.target_node.name} node")
             self.target_node.restart_scylla_server()
             raise
-
-    def disrupt_grow_shrink_zero_nodes(self):
-        """ "Add/remove znodes to same dc where target node. The target node could be any node"""
-        if not self.cluster.params.get("use_zero_nodes"):
-            raise UnsupportedNemesis("The zero tokens support is not enabled")
-
-        duration_with_znode = 300
-        new_znode = self._add_and_init_new_cluster_nodes(count=1, is_zero_node=True)[0]
-        self.log.debug("Run with zero-token node %s for %ds", new_znode.name, duration_with_znode)
-        time.sleep(duration_with_znode)
-        znode = self.random.choice([node for node in self.cluster.zero_nodes if node.dc_idx == self.target_node.dc_idx])
-        self.decommission_nodes(nodes=[znode])
 
     def disrupt_serial_restart_elected_topology_coordinator(self):
         """Serial restart of elected topology coordinator node,

--- a/sdcm/nemesis/monkey/__init__.py
+++ b/sdcm/nemesis/monkey/__init__.py
@@ -37,25 +37,6 @@ class ToggleLdapConfiguration(NemesisBaseClass):
         self.runner.disrupt_disable_enable_ldap_authorization()
 
 
-@target_data_nodes
-class GrowShrinkClusterNemesis(NemesisBaseClass):
-    disruptive = True
-    kubernetes = True
-    topology_changes = True
-
-    def disrupt(self):
-        self.runner.disrupt_grow_shrink_cluster()
-
-
-class AddRemoveRackNemesis(NemesisBaseClass):
-    disruptive = True
-    kubernetes = True
-    config_changes = True
-
-    def disrupt(self):
-        self.runner.disrupt_grow_shrink_new_rack()
-
-
 @target_all_nodes
 class StopWaitStartMonkey(NemesisBaseClass):
     disruptive = True
@@ -576,21 +557,6 @@ class NemesisSequence(NemesisBaseClass):
         self.runner.disrupt_run_unique_sequence()
 
 
-@target_all_nodes
-class TerminateAndRemoveNodeMonkey(NemesisBaseClass):
-    """Remove a Node from a Scylla Cluster (Down Scale)"""
-
-    disruptive = True
-    # It should not be run on kubernetes, since it is a manual procedure
-    # While on kubernetes we put it all on scylla-operator
-    kubernetes = False
-    topology_changes = True
-    supports_high_disk_utilization = False  # Removing a node consumes disk space
-
-    def disrupt(self):
-        self.runner.disrupt_remove_node_then_add_node()
-
-
 class ToggleCDCMonkey(NemesisBaseClass):
     disruptive = False
     schema_changes = True
@@ -724,15 +690,6 @@ class EndOfQuotaNemesis(NemesisBaseClass):
 
     def disrupt(self):
         self.runner.disrupt_end_of_quota_nemesis()
-
-
-@target_all_nodes
-class GrowShrinkZeroTokenNode(NemesisBaseClass):
-    disruptive = True
-    zero_node_changes = True
-
-    def disrupt(self):
-        self.runner.disrupt_grow_shrink_zero_nodes()
 
 
 @target_all_nodes

--- a/sdcm/nemesis/monkey/grow_shrink.py
+++ b/sdcm/nemesis/monkey/grow_shrink.py
@@ -1,0 +1,142 @@
+"""
+Module containing the cluster grow/shrink nemesis classes.
+
+Covers scaling the cluster up and down (adding then decommissioning data
+nodes), doing the same within a brand new rack, adding and removing a
+zero-token node, and removing a node from the cluster and adding a
+replacement for it.
+
+The grow/shrink primitives live in ``sdcm.nemesis.utils.topology_ops`` so
+other nemesis that orchestrate topology operations (e.g.
+``NemesisSequence``) can reuse them as well.
+"""
+
+import time
+
+from sdcm.exceptions import UnsupportedNemesis
+from sdcm.nemesis import NemesisBaseClass, target_all_nodes, target_data_nodes
+from sdcm.nemesis.utils.topology_ops import grow_cluster, shrink_cluster
+from sdcm.utils.decorators import latency_calculator_decorator
+from sdcm.utils.version_utils import scylla_versions
+
+
+@latency_calculator_decorator(legend="Doubling cluster load")
+def _double_cluster_load(runner, duration: int) -> None:
+    duration = 30
+    stress_cmd = runner.tester.stress_cmd
+    if isinstance(stress_cmd, list):
+        stress_cmd = stress_cmd[0]
+    runner.log.info("Doubling the load on the cluster for %s minutes", duration)
+    stress_queue = runner.tester.run_stress_thread(
+        stress_cmd=stress_cmd, stress_num=1, stats_aggregate_cmds=False, duration=duration
+    )
+    results = runner.tester.verify_stress_thread(
+        thread_pool=stress_queue, error_handler=runner._nemesis_stress_failure_handler
+    )
+    runner.log.info(f"Double load results: {results}")
+
+
+@target_data_nodes
+class GrowShrinkClusterNemesis(NemesisBaseClass):
+    """Add nodes to the cluster, optionally double the load, then decommission them back."""
+
+    disruptive = True
+    kubernetes = True
+    topology_changes = True
+
+    def disrupt(self):
+        sleep_time_between_ops = self.runner.cluster.params.get("nemesis_sequence_sleep_between_ops")
+        if not self.runner.has_steady_run and sleep_time_between_ops:
+            self.runner.steady_state_latency()
+            self.runner.has_steady_run = True
+        new_nodes = grow_cluster(self.runner, rack=None)
+
+        # pass on the exact nodes only if we have specific types for them
+        new_nodes = new_nodes if self.runner.tester.params.get("nemesis_grow_shrink_instance_type") else None
+        if duration := self.runner.tester.params.get("nemesis_double_load_during_grow_shrink_duration"):
+            with self.runner.action_log_scope("Double load after grow cluster"):
+                _double_cluster_load(self.runner, duration)
+        shrink_cluster(self.runner, rack=None, new_nodes=new_nodes)
+
+
+class AddRemoveRackNemesis(NemesisBaseClass):
+    """Add a new rack to a Kubernetes cluster and decommission it back."""
+
+    disruptive = True
+    kubernetes = True
+    config_changes = True
+
+    @property
+    def cluster(self):
+        """Cluster under test, required by the ``scylla_versions`` decorator."""
+        return self.runner.cluster
+
+    # NOTE: version limitation is caused by the following:
+    #       - https://github.com/scylladb/scylla-enterprise/issues/3211
+    #       - https://github.com/scylladb/scylladb/issues/14184
+    @scylla_versions(("5.2.7", None), ("2023.1.1", None))
+    def disrupt(self):
+        if not self.runner._is_it_on_kubernetes():
+            raise UnsupportedNemesis("Adding new rack is not supported for non-k8s Scylla clusters")
+        rack = max(self.runner.cluster.racks) + 1
+        grow_cluster(self.runner, rack)
+        shrink_cluster(self.runner, rack)
+
+
+@target_all_nodes
+class GrowShrinkZeroTokenNode(NemesisBaseClass):
+    """Add a zero-token node to the target node datacenter and decommission one back."""
+
+    disruptive = True
+    zero_node_changes = True
+
+    def disrupt(self):
+        """Add/remove znodes to same dc where target node. The target node could be any node"""
+        if not self.runner.cluster.params.get("use_zero_nodes"):
+            raise UnsupportedNemesis("The zero tokens support is not enabled")
+
+        duration_with_znode = 300
+        new_znode = self.runner._add_and_init_new_cluster_nodes(count=1, is_zero_node=True)[0]
+        self.runner.log.debug("Run with zero-token node %s for %ds", new_znode.name, duration_with_znode)
+        time.sleep(duration_with_znode)
+        znode = self.runner.random.choice(
+            [node for node in self.runner.cluster.zero_nodes if node.dc_idx == self.runner.target_node.dc_idx]
+        )
+        self.runner.decommission_nodes(nodes=[znode])
+
+
+@target_all_nodes
+class TerminateAndRemoveNodeMonkey(NemesisBaseClass):
+    """Remove a Node from a Scylla Cluster (Down Scale)"""
+
+    disruptive = True
+    # It should not be run on kubernetes, since it is a manual procedure
+    # While on kubernetes we put it all on scylla-operator
+    kubernetes = False
+    topology_changes = True
+    supports_high_disk_utilization = False  # Removing a node consumes disk space
+
+    def disrupt(self):
+        """
+        https://docs.scylladb.com/operating-scylla/procedures/cluster-management/remove_node/
+
+        1. Terminate node
+        2. Run full repair
+        3. Nodetool removenode, if removenode rejected, because removing node is UN in gossiper,
+           repeat operation in 5 second
+        4. Add new node
+        5. Run nodetool cleanup (on each node) for each keyspace
+        """
+        if self.runner.cluster.params.get("db_type") == "cloud_scylla":
+            raise UnsupportedNemesis(
+                "Skipping this nemesis due the replace node option that supported by Cloud "
+                "is tested by CloudReplaceNonResponsiveNode nemesis"
+            )
+
+        node_to_remove = self.runner.target_node
+        up_normal_nodes = self.runner.cluster.get_nodes_up_and_normal(verification_node=node_to_remove)
+
+        with self.runner.node_allocator.run_nemesis(
+            nemesis_label="RemoveNodeAddNode", node_list=up_normal_nodes
+        ) as verification_node:
+            self.runner._remove_node_add_node(verification_node=verification_node, node_to_remove=node_to_remove)

--- a/sdcm/nemesis/utils/topology_ops.py
+++ b/sdcm/nemesis/utils/topology_ops.py
@@ -1,0 +1,152 @@
+"""Shared node-topology operations reused by topology-changing nemesis.
+
+These primitives take the ``NemesisRunner`` as their first argument so any
+monkey module (and ``NemesisRunner`` itself, e.g. ``NemesisSequence``) can
+reuse them without inheriting from a common base class. Keeping them in
+``sdcm.nemesis.utils`` (which does not import from ``sdcm.nemesis``) lets
+both sides import them at the top level without circular imports.
+"""
+
+import time
+from typing import Optional, Union
+
+from sdcm.cluster import BaseNode
+from sdcm.nemesis.utils import NEMESIS_TARGET_POOLS, DefaultValue
+from sdcm.sct_events.system import InfoEvent
+
+
+def decommission_nodes_by_criteria(
+    runner,
+    nodes_number: int,
+    rack: Optional[int],
+    is_seed: Optional[Union[bool, DefaultValue]] = DefaultValue,
+    dc_idx: Optional[int] = None,
+    exact_nodes: list[BaseNode] | None = None,
+) -> None:
+    """Decommission either the given nodes or ``nodes_number`` nodes matching the criteria.
+
+    Args:
+        runner: The ``NemesisRunner`` owning the cluster and the node allocator.
+        nodes_number: How many nodes to pick when ``exact_nodes`` is not given.
+        rack: Rack to pick the nodes from, ``None`` to round-robin over all racks.
+        is_seed: Seed filter passed to the target node selection.
+        dc_idx: Datacenter index to pick the nodes from.
+        exact_nodes: Nodes to decommission, bypassing the selection logic.
+    """
+    nodes_to_decommission = []
+    if exact_nodes:
+        nodes_to_decommission = exact_nodes
+        for node in exact_nodes:
+            runner.node_allocator.set_running_nemesis(node, runner.current_disruption)
+    else:
+        for idx in range(nodes_number):
+            if runner._is_it_on_kubernetes():
+                if rack is None:
+                    rack = 0
+                runner.set_target_node_pool_type(NEMESIS_TARGET_POOLS.data_nodes)
+                runner.set_target_node(rack=rack, is_seed=is_seed, allow_only_last_node_in_rack=True)
+            else:
+                rack_idx = rack if rack is not None else idx % runner.cluster.racks_count
+                # if rack is not specified, round-robin racks
+                runner.set_target_node(is_seed=is_seed, dc_idx=dc_idx, rack=rack_idx)
+            nodes_to_decommission.append(runner.target_node)
+            runner.target_node = (
+                None  # otherwise node.running_nemesis will be taken off the node by runner.set_target_node
+            )
+    try:
+        if runner.cluster.parallel_node_operations:
+            runner.decommission_nodes(nodes_to_decommission)
+        else:
+            for node in nodes_to_decommission:
+                runner.decommission_nodes([node])
+    except Exception as exc:  # noqa: BLE001
+        InfoEvent(
+            f"FinishEvent - ShrinkCluster failed decommissioning a node {runner.target_node} with error {exc!s}"
+        ).publish()
+
+
+def grow_cluster(runner, rack: Optional[int] = None) -> list[BaseNode]:
+    """Add ``nemesis_add_node_cnt`` nodes to the cluster and release them from the nemesis.
+
+    Args:
+        runner: The ``NemesisRunner`` owning the cluster and the node allocator.
+        rack: Rack to add the new nodes to, ``None`` to round-robin over all racks.
+
+    Returns:
+        The nodes that were added to the cluster.
+    """
+    if rack is None and runner._is_it_on_kubernetes():
+        rack = 0
+    add_nodes_number = runner.tester.params.get("nemesis_add_node_cnt")
+    new_nodes = []
+    with runner.action_log_scope(f"Grow cluster by {add_nodes_number} nodes"):
+        if runner.cluster.parallel_node_operations:
+            new_nodes = runner.add_new_nodes(
+                count=add_nodes_number,
+                rack=rack,
+                instance_type=runner.tester.params.get("nemesis_grow_shrink_instance_type"),
+            )
+        else:
+            for idx in range(add_nodes_number):
+                # if rack is not specified, round-robin racks to spread nodes evenly
+                rack_idx = rack if rack is not None else idx % runner.cluster.racks_count
+                new_nodes += runner.add_new_nodes(
+                    count=1,
+                    rack=rack_idx,
+                    instance_type=runner.tester.params.get("nemesis_grow_shrink_instance_type"),
+                )
+    time.sleep(runner.interval)
+    for node in new_nodes:
+        runner.node_allocator.unset_running_nemesis(node, runner.current_disruption)
+    return new_nodes
+
+
+def shrink_cluster(runner, rack: Optional[int] = None, new_nodes: list[BaseNode] | None = None) -> None:
+    """Decommission nodes from the target node datacenter back towards the initial cluster size.
+
+    Args:
+        runner: The ``NemesisRunner`` owning the cluster and the node allocator.
+        rack: Rack to decommission the nodes from, ``None`` to round-robin over all racks.
+        new_nodes: Exact nodes to decommission, ``None`` to select them by criteria.
+
+    Raises:
+        Exception: If the cluster does not have enough nodes above its initial size.
+    """
+    add_nodes_number = runner.tester.params.get("nemesis_add_node_cnt")
+    InfoEvent(message=f"Start shrink cluster by {add_nodes_number} nodes").publish()
+    # Check that number of nodes is enough for decommission:
+    runner.log.debug(
+        "Current target_node %s, is zero_node: %s, dc_idx: %s",
+        runner.target_node.name,
+        runner.target_node._is_zero_token_node,
+        runner.target_node.dc_idx,
+    )
+    cur_num_nodes_in_dc = len([n for n in runner.cluster.data_nodes if n.dc_idx == runner.target_node.dc_idx])
+    initial_db_size = runner.tester.params.get("n_db_nodes")
+    if runner._is_it_on_kubernetes():
+        k8s_size = runner.tester.params.get("k8s_n_scylla_pods_per_cluster")
+        initial_db_size = [k8s_size] * len(initial_db_size) if k8s_size else initial_db_size
+
+    initial_db_size_in_dc = initial_db_size[runner.target_node.dc_idx]
+    decommission_nodes_number = min(cur_num_nodes_in_dc - initial_db_size_in_dc, add_nodes_number)
+
+    if decommission_nodes_number < 1:
+        error = "Not enough nodes for decommission"
+        runner.log.warning("Shrink cluster skipped. Error: %s", error)
+        raise Exception(error)
+
+    runner.log.info("Start shrink cluster by %s nodes", decommission_nodes_number)
+    # Currently on kubernetes first two nodes of each rack are getting seed status
+    # Because of such behavior only way to get them decommission is to enable decommissioning
+    # TBD: After https://github.com/scylladb/scylla-operator/issues/292 is fixed remove is_seed parameter
+    decommission_nodes_by_criteria(
+        runner,
+        decommission_nodes_number,
+        rack,
+        is_seed=None if runner._is_it_on_kubernetes() else DefaultValue,
+        dc_idx=runner.target_node.dc_idx,
+        exact_nodes=new_nodes,
+    )
+    num_of_nodes = len(runner.cluster.data_nodes)
+    runner.log.info("Cluster shrink finished. Current number of data nodes %s", num_of_nodes)
+    InfoEvent(message=f"Cluster shrink finished. Current number of data nodes {num_of_nodes}").publish()

--- a/unit_tests/unit/nemesis/monkey/test_grow_shrink.py
+++ b/unit_tests/unit/nemesis/monkey/test_grow_shrink.py
@@ -1,0 +1,401 @@
+"""Tests for sdcm.nemesis.monkey.topology.grow_shrink module."""
+
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from sdcm.exceptions import UnsupportedNemesis
+from sdcm.nemesis import NemesisBaseClass, NemesisFlags
+from sdcm.nemesis.monkey.grow_shrink import (
+    AddRemoveRackNemesis,
+    GrowShrinkClusterNemesis,
+    GrowShrinkZeroTokenNode,
+    TerminateAndRemoveNodeMonkey,
+)
+from sdcm.nemesis.registry import NemesisRegistry
+from sdcm.nemesis.utils import DefaultValue
+from sdcm.nemesis.utils.topology_ops import (
+    decommission_nodes_by_criteria,
+    grow_cluster,
+    shrink_cluster,
+)
+from sdcm.utils.version_utils import MethodVersionNotFound
+
+_MODULE = "sdcm.nemesis.monkey.grow_shrink"
+_OPS_MODULE = "sdcm.nemesis.utils.topology_ops"
+
+pytestmark = pytest.mark.usefixtures("events")
+
+
+def _make_data_node(name, dc_idx=0):
+    """Return a mock data node placed in the given datacenter."""
+    node = MagicMock()
+    node.name = name
+    node.dc_idx = dc_idx
+    node._is_zero_token_node = False
+    return node
+
+
+@pytest.fixture()
+def runner(base_runner):
+    """``base_runner`` extended with the attributes grow/shrink helpers rely on."""
+    base_runner.interval = 0
+    base_runner.current_disruption = "GrowShrinkCluster-deadbeef"
+    base_runner.node_allocator = MagicMock()
+    base_runner.monitoring_set = MagicMock()
+    base_runner._is_it_on_kubernetes = MagicMock(return_value=False)
+    base_runner.decommission_nodes = MagicMock()
+    base_runner.add_new_nodes = MagicMock(return_value=[])
+    base_runner.set_target_node = MagicMock()
+    base_runner.set_target_node_pool_type = MagicMock()
+    base_runner.cluster.parallel_node_operations = True
+    base_runner.cluster.racks_count = 2
+    base_runner.target_node.dc_idx = 0
+    base_runner.target_node._is_zero_token_node = False
+    base_runner.tester.params = {}
+    base_runner.cluster.params = {}
+    return base_runner
+
+
+# ---------------------------------------------------------------------------
+# grow_cluster
+# ---------------------------------------------------------------------------
+
+
+def test_grow_cluster_adds_all_nodes_at_once_when_parallel_operations_enabled(runner):
+    """With parallel node operations a single add_new_nodes call adds every node."""
+    new_nodes = [_make_data_node("new1"), _make_data_node("new2")]
+    runner.add_new_nodes.return_value = new_nodes
+    runner.tester.params = {"nemesis_add_node_cnt": 2, "nemesis_grow_shrink_instance_type": None}
+
+    with patch(f"{_OPS_MODULE}.time.sleep"):
+        result = grow_cluster(runner, rack=None)
+
+    assert result == new_nodes
+    runner.add_new_nodes.assert_called_once_with(count=2, rack=None, instance_type=None)
+    assert runner.node_allocator.unset_running_nemesis.call_args_list == [
+        call(node, runner.current_disruption) for node in new_nodes
+    ]
+
+
+def test_grow_cluster_round_robins_racks_when_operations_are_serial(runner):
+    """Without parallel node operations nodes are added one by one, spread over racks."""
+    runner.cluster.parallel_node_operations = False
+    runner.cluster.racks_count = 2
+    runner.tester.params = {"nemesis_add_node_cnt": 3, "nemesis_grow_shrink_instance_type": "i4i.large"}
+    runner.add_new_nodes.side_effect = lambda **kwargs: [_make_data_node(f"new{kwargs['rack']}")]
+
+    with patch(f"{_OPS_MODULE}.time.sleep"):
+        result = grow_cluster(runner, rack=None)
+
+    assert [c.kwargs["rack"] for c in runner.add_new_nodes.call_args_list] == [0, 1, 0]
+    assert all(c.kwargs["instance_type"] == "i4i.large" for c in runner.add_new_nodes.call_args_list)
+    assert len(result) == 3
+
+
+def test_grow_cluster_defaults_rack_to_zero_on_kubernetes(runner):
+    """On k8s an unspecified rack is pinned to rack 0 instead of round-robin."""
+    runner._is_it_on_kubernetes.return_value = True
+    runner.tester.params = {"nemesis_add_node_cnt": 1, "nemesis_grow_shrink_instance_type": None}
+
+    with patch(f"{_OPS_MODULE}.time.sleep"):
+        grow_cluster(runner, rack=None)
+
+    runner.add_new_nodes.assert_called_once_with(count=1, rack=0, instance_type=None)
+
+
+# ---------------------------------------------------------------------------
+# shrink_cluster
+# ---------------------------------------------------------------------------
+
+
+def test_shrink_cluster_decommissions_down_to_initial_size(runner):
+    """Only the nodes added on top of the initial cluster size are decommissioned."""
+    runner.cluster.data_nodes = [_make_data_node(f"node{i}") for i in range(5)]
+    runner.tester.params = {"nemesis_add_node_cnt": 3, "n_db_nodes": [3]}
+
+    with patch(f"{_OPS_MODULE}.decommission_nodes_by_criteria") as decommission:
+        shrink_cluster(runner, rack=None)
+
+    decommission.assert_called_once_with(runner, 2, None, is_seed=DefaultValue, dc_idx=0, exact_nodes=None)
+
+
+def test_shrink_cluster_passes_exact_nodes_through(runner):
+    """When exact nodes are given they are decommissioned instead of freshly picked ones."""
+    exact_nodes = [_make_data_node("new1")]
+    runner.cluster.data_nodes = [_make_data_node(f"node{i}") for i in range(4)]
+    runner.tester.params = {"nemesis_add_node_cnt": 1, "n_db_nodes": [3]}
+
+    with patch(f"{_OPS_MODULE}.decommission_nodes_by_criteria") as decommission:
+        shrink_cluster(runner, rack=None, new_nodes=exact_nodes)
+
+    assert decommission.call_args.kwargs["exact_nodes"] == exact_nodes
+
+
+def test_shrink_cluster_uses_k8s_pods_per_cluster_as_initial_size(runner):
+    """On k8s the initial size comes from k8s_n_scylla_pods_per_cluster and seeds are not filtered."""
+    runner._is_it_on_kubernetes.return_value = True
+    runner.cluster.data_nodes = [_make_data_node(f"node{i}") for i in range(5)]
+    runner.tester.params = {
+        "nemesis_add_node_cnt": 3,
+        "n_db_nodes": [3],
+        "k8s_n_scylla_pods_per_cluster": 4,
+    }
+
+    with patch(f"{_OPS_MODULE}.decommission_nodes_by_criteria") as decommission:
+        shrink_cluster(runner, rack=1)
+
+    decommission.assert_called_once_with(runner, 1, 1, is_seed=None, dc_idx=0, exact_nodes=None)
+
+
+def test_shrink_cluster_raises_when_cluster_is_already_at_initial_size(runner):
+    """Shrinking below the configured cluster size is refused."""
+    runner.cluster.data_nodes = [_make_data_node(f"node{i}") for i in range(3)]
+    runner.tester.params = {"nemesis_add_node_cnt": 2, "n_db_nodes": [3]}
+
+    with (
+        patch(f"{_OPS_MODULE}.decommission_nodes_by_criteria") as decommission,
+        pytest.raises(Exception, match="Not enough nodes for decommission"),
+    ):
+        shrink_cluster(runner, rack=None)
+
+    decommission.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# decommission_nodes_by_criteria
+# ---------------------------------------------------------------------------
+
+
+def test_decommission_nodes_by_criteria_marks_and_decommissions_exact_nodes(runner):
+    """Exact nodes are claimed by the nemesis and decommissioned in one batch."""
+    exact_nodes = [_make_data_node("new1"), _make_data_node("new2")]
+
+    decommission_nodes_by_criteria(runner, 2, None, exact_nodes=exact_nodes)
+
+    assert runner.node_allocator.set_running_nemesis.call_args_list == [
+        call(node, runner.current_disruption) for node in exact_nodes
+    ]
+    runner.decommission_nodes.assert_called_once_with(exact_nodes)
+
+
+def test_decommission_nodes_by_criteria_decommissions_one_by_one_when_serial(runner):
+    """Without parallel node operations every node is decommissioned on its own."""
+    runner.cluster.parallel_node_operations = False
+    exact_nodes = [_make_data_node("new1"), _make_data_node("new2")]
+
+    decommission_nodes_by_criteria(runner, 2, None, exact_nodes=exact_nodes)
+
+    assert runner.decommission_nodes.call_args_list == [call([node]) for node in exact_nodes]
+
+
+def test_decommission_nodes_by_criteria_selects_nodes_round_robin_over_racks(runner):
+    """Without exact nodes, targets are selected rack by rack and released from the runner."""
+    picked = [_make_data_node("picked1"), _make_data_node("picked2")]
+    runner.set_target_node.side_effect = lambda **_: setattr(runner, "target_node", picked.pop(0))
+
+    decommission_nodes_by_criteria(runner, 2, None, dc_idx=1)
+
+    assert runner.set_target_node.call_args_list == [
+        call(is_seed=DefaultValue, dc_idx=1, rack=0),
+        call(is_seed=DefaultValue, dc_idx=1, rack=1),
+    ]
+    assert runner.target_node is None
+    assert runner.decommission_nodes.call_count == 1
+
+
+def test_decommission_nodes_by_criteria_swallows_decommission_failures(runner):
+    """A failed decommission is reported as an event but does not propagate."""
+    runner.decommission_nodes.side_effect = RuntimeError("boom")
+
+    decommission_nodes_by_criteria(runner, 1, None, exact_nodes=[_make_data_node("new1")])
+
+
+# ---------------------------------------------------------------------------
+# GrowShrinkClusterNemesis
+# ---------------------------------------------------------------------------
+
+
+def test_grow_shrink_cluster_runs_steady_state_once_then_grows_and_shrinks(runner):
+    """The first run captures steady-state latency, then grows and shrinks the cluster."""
+    runner.cluster.params = {"nemesis_sequence_sleep_between_ops": 5}
+    runner.tester.params = {
+        "nemesis_grow_shrink_instance_type": None,
+        "nemesis_double_load_during_grow_shrink_duration": 0,
+    }
+    runner.has_steady_run = False
+    runner.steady_state_latency = MagicMock()
+
+    with (
+        patch(f"{_MODULE}.grow_cluster", return_value=[_make_data_node("new1")]) as grow,
+        patch(f"{_MODULE}.shrink_cluster") as shrink,
+        patch(f"{_MODULE}._double_cluster_load") as double_load,
+    ):
+        GrowShrinkClusterNemesis(runner).disrupt()
+
+    runner.steady_state_latency.assert_called_once_with()
+    assert runner.has_steady_run is True
+    grow.assert_called_once_with(runner, rack=None)
+    # instance type is not configured, so the exact nodes are not pinned for the shrink
+    shrink.assert_called_once_with(runner, rack=None, new_nodes=None)
+    double_load.assert_not_called()
+
+
+def test_grow_shrink_cluster_shrinks_exact_nodes_when_instance_type_configured(runner):
+    """A dedicated grow/shrink instance type pins the shrink to the freshly added nodes."""
+    new_nodes = [_make_data_node("new1")]
+    runner.cluster.params = {"nemesis_sequence_sleep_between_ops": 0}
+    runner.tester.params = {
+        "nemesis_grow_shrink_instance_type": "i4i.large",
+        "nemesis_double_load_during_grow_shrink_duration": 0,
+    }
+    runner.has_steady_run = False
+    runner.steady_state_latency = MagicMock()
+
+    with (
+        patch(f"{_MODULE}.grow_cluster", return_value=new_nodes),
+        patch(f"{_MODULE}.shrink_cluster") as shrink,
+    ):
+        GrowShrinkClusterNemesis(runner).disrupt()
+
+    runner.steady_state_latency.assert_not_called()
+    shrink.assert_called_once_with(runner, rack=None, new_nodes=new_nodes)
+
+
+def test_grow_shrink_cluster_doubles_load_between_grow_and_shrink(runner):
+    """A configured double-load duration triggers the extra load run after the grow."""
+    runner.cluster.params = {"nemesis_sequence_sleep_between_ops": 0}
+    runner.tester.params = {
+        "nemesis_grow_shrink_instance_type": None,
+        "nemesis_double_load_during_grow_shrink_duration": 15,
+    }
+    runner.has_steady_run = True
+
+    with (
+        patch(f"{_MODULE}.grow_cluster", return_value=[]),
+        patch(f"{_MODULE}.shrink_cluster"),
+        patch(f"{_MODULE}._double_cluster_load") as double_load,
+    ):
+        GrowShrinkClusterNemesis(runner).disrupt()
+
+    double_load.assert_called_once_with(runner, 15)
+
+
+# ---------------------------------------------------------------------------
+# AddRemoveRackNemesis
+# ---------------------------------------------------------------------------
+
+
+def test_add_remove_rack_grows_and_shrinks_a_brand_new_rack(runner):
+    """On k8s the nemesis operates on a rack index one above the highest existing rack."""
+    runner._is_it_on_kubernetes.return_value = True
+    runner.cluster.params = {"scylla_version": "6.0.0"}
+    runner.cluster.racks = [0, 1]
+
+    with patch(f"{_MODULE}.grow_cluster") as grow, patch(f"{_MODULE}.shrink_cluster") as shrink:
+        AddRemoveRackNemesis(runner).disrupt()
+
+    grow.assert_called_once_with(runner, 2)
+    shrink.assert_called_once_with(runner, 2)
+
+
+def test_add_remove_rack_is_unsupported_outside_kubernetes(runner):
+    """Adding a rack is a scylla-operator feature, so non-k8s backends are skipped."""
+    runner.cluster.params = {"scylla_version": "6.0.0"}
+
+    with pytest.raises(UnsupportedNemesis, match="not supported for non-k8s"):
+        AddRemoveRackNemesis(runner).disrupt()
+
+
+def test_add_remove_rack_is_skipped_on_unsupported_scylla_version(runner):
+    """Versions below the documented limitation are rejected by the scylla_versions guard."""
+    runner.cluster.params = {"scylla_version": "5.2.0"}
+
+    with pytest.raises(MethodVersionNotFound):
+        AddRemoveRackNemesis(runner).disrupt()
+
+
+# ---------------------------------------------------------------------------
+# GrowShrinkZeroTokenNode
+# ---------------------------------------------------------------------------
+
+
+def test_grow_shrink_zero_token_node_adds_then_decommissions_a_zero_node(runner):
+    """A zero-token node is added, kept for a while, then one is decommissioned from the same DC."""
+    new_znode = _make_data_node("znode-new")
+    same_dc_znode = _make_data_node("znode-old", dc_idx=0)
+    other_dc_znode = _make_data_node("znode-other", dc_idx=1)
+    runner.cluster.params = {"use_zero_nodes": True}
+    runner.cluster.zero_nodes = [other_dc_znode, same_dc_znode]
+    runner._add_and_init_new_cluster_nodes = MagicMock(return_value=[new_znode])
+
+    with patch(f"{_MODULE}.time.sleep") as sleep:
+        GrowShrinkZeroTokenNode(runner).disrupt()
+
+    runner._add_and_init_new_cluster_nodes.assert_called_once_with(count=1, is_zero_node=True)
+    sleep.assert_called_once_with(300)
+    # base_runner's random.choice picks the first element of the DC-filtered list
+    runner.decommission_nodes.assert_called_once_with(nodes=[same_dc_znode])
+
+
+def test_grow_shrink_zero_token_node_is_unsupported_without_zero_nodes(runner):
+    """The nemesis is skipped when the test does not run with zero-token nodes."""
+    runner.cluster.params = {"use_zero_nodes": False}
+
+    with pytest.raises(UnsupportedNemesis, match="zero tokens support is not enabled"):
+        GrowShrinkZeroTokenNode(runner).disrupt()
+
+
+# ---------------------------------------------------------------------------
+# TerminateAndRemoveNodeMonkey
+# ---------------------------------------------------------------------------
+
+
+def test_terminate_and_remove_node_removes_target_and_adds_replacement(runner):
+    """The target node is removed using a live node as the verification node."""
+    verification_node = _make_data_node("node2")
+    up_normal_nodes = [verification_node]
+    runner.cluster.params = {"db_type": "scylla"}
+    runner.cluster.get_nodes_up_and_normal.return_value = up_normal_nodes
+    runner.node_allocator.run_nemesis.return_value.__enter__.return_value = verification_node
+    runner._remove_node_add_node = MagicMock()
+
+    target_node = runner.target_node
+    TerminateAndRemoveNodeMonkey(runner).disrupt()
+
+    runner.cluster.get_nodes_up_and_normal.assert_called_once_with(verification_node=target_node)
+    runner.node_allocator.run_nemesis.assert_called_once_with(
+        nemesis_label="RemoveNodeAddNode", node_list=up_normal_nodes
+    )
+    runner._remove_node_add_node.assert_called_once_with(
+        verification_node=verification_node, node_to_remove=target_node
+    )
+
+
+def test_terminate_and_remove_node_is_unsupported_on_cloud_scylla(runner):
+    """Cloud deployments cover this scenario with a dedicated nemesis."""
+    runner.cluster.params = {"db_type": "cloud_scylla"}
+    runner._remove_node_add_node = MagicMock()
+
+    with pytest.raises(UnsupportedNemesis, match="CloudReplaceNonResponsiveNode"):
+        TerminateAndRemoveNodeMonkey(runner).disrupt()
+
+    runner._remove_node_add_node.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Migration guards
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "nemesis_class",
+    [GrowShrinkClusterNemesis, AddRemoveRackNemesis, GrowShrinkZeroTokenNode, TerminateAndRemoveNodeMonkey],
+)
+def test_moved_nemesis_are_still_discovered_by_the_registry(nemesis_class):
+    """The extracted classes keep their names and stay visible to the nemesis registry."""
+    registry = NemesisRegistry(base_class=NemesisBaseClass, flag_class=NemesisFlags)
+    discovered = [cls for cls in registry.get_subclasses() if cls.__name__ == nemesis_class.__name__]
+
+    assert discovered == [nemesis_class]
+    assert nemesis_class.__module__ == _MODULE


### PR DESCRIPTION
Move the grow/shrink disrupt_* methods and their monkey classes out of the NemesisRunner god-class into a new monkey/topology sub-package, per the nemesis-extraction plan Phase 8b:

- GrowShrinkClusterNemesis (disrupt_grow_shrink_cluster)
- AddRemoveRackNemesis (disrupt_grow_shrink_new_rack)
- GrowShrinkZeroTokenNode (disrupt_grow_shrink_zero_nodes)
- TerminateAndRemoveNodeMonkey (disrupt_remove_node_then_add_node)

The grow/shrink primitives (grow_cluster, shrink_cluster, decommission_nodes_by_criteria) become module-level functions taking the runner as their first argument so NemesisSequence can keep reusing them. The _remove_node_add_node helper stays on NemesisRunner because it is shared with the node_isolation monkeys.

Class names, flags, and behavior are unchanged; the generated data_dir/nemesis*.yml files show no drift.

Fixes https://scylladb.atlassian.net/browse/SCT-215

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://argus.scylladb.com/tests/scylla-cluster-tests/72a9a193-2f50-4c7c-9d6e-8a05bc0a41b8

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
