### PR TITLE
fix(cloud_catalog): correct z3 local SSD capacity in the GCE catalog

### DIFF
--- a/data/instance_catalog/gce.yaml
+++ b/data/instance_catalog/gce.yaml
@@ -3682,8 +3682,8 @@ instances:
   family: z3-highmem-highlssd
   vcpus: 16
   memory_gb: 128.0
-  local_disk_gb: 12000.0
-  local_disk_count: 4
+  local_disk_gb: 6000.0
+  local_disk_count: 2
   arch: x86_64
   price_per_hour:
     europe-west6: 3.011599225
@@ -3731,8 +3731,8 @@ instances:
   family: z3-highmem-highlssd
   vcpus: 192
   memory_gb: 1536.0
-  local_disk_gb: 144000.0
-  local_disk_count: 24
+  local_disk_gb: 72000.0
+  local_disk_count: 12
   arch: x86_64
   price_per_hour:
     europe-west6: 36.139190695
@@ -3780,8 +3780,8 @@ instances:
   family: z3-highmem-highlssd
   vcpus: 22
   memory_gb: 176.0
-  local_disk_gb: 18000.0
-  local_disk_count: 6
+  local_disk_gb: 9000.0
+  local_disk_count: 3
   arch: x86_64
   price_per_hour:
     europe-west6: 4.247798249
@@ -3829,8 +3829,8 @@ instances:
   family: z3-highmem-highlssd
   vcpus: 32
   memory_gb: 256.0
-  local_disk_gb: 24000.0
-  local_disk_count: 8
+  local_disk_gb: 12000.0
+  local_disk_count: 4
   arch: x86_64
   price_per_hour:
     europe-west6: 6.023198449
@@ -3878,8 +3878,8 @@ instances:
   family: z3-highmem-highlssd
   vcpus: 44
   memory_gb: 352.0
-  local_disk_gb: 36000.0
-  local_disk_count: 12
+  local_disk_gb: 18000.0
+  local_disk_count: 6
   arch: x86_64
   price_per_hour:
     europe-west6: 8.495596498
@@ -3927,8 +3927,8 @@ instances:
   family: z3-highmem-highlssd
   vcpus: 8
   memory_gb: 64.0
-  local_disk_gb: 6000.0
-  local_disk_count: 2
+  local_disk_gb: 3000.0
+  local_disk_count: 1
   arch: x86_64
   price_per_hour:
     europe-west6: 1.505799612
@@ -3976,8 +3976,8 @@ instances:
   family: z3-highmem-highlssd
   vcpus: 88
   memory_gb: 704.0
-  local_disk_gb: 72000.0
-  local_disk_count: 24
+  local_disk_gb: 36000.0
+  local_disk_count: 12
   arch: x86_64
   price_per_hour:
     europe-west6: 16.991192995
@@ -4025,8 +4025,8 @@ instances:
   family: z3-highmem-standardlssd
   vcpus: 14
   memory_gb: 112.0
-  local_disk_gb: 6000.0
-  local_disk_count: 2
+  local_disk_gb: 3000.0
+  local_disk_count: 1
   arch: x86_64
   price_per_hour:
     europe-west9: 2.052392839
@@ -4074,8 +4074,8 @@ instances:
   family: z3-highmem-standardlssd
   vcpus: 176
   memory_gb: 1408.0
-  local_disk_gb: 48000.0
-  local_disk_count: 16
+  local_disk_gb: 36000.0
+  local_disk_count: 12
   arch: x86_64
   price_per_hour:
     europe-west9: 25.58358434
@@ -4123,8 +4123,8 @@ instances:
   family: z3-highmem-standardlssd
   vcpus: 22
   memory_gb: 176.0
-  local_disk_gb: 12000.0
-  local_disk_count: 4
+  local_disk_gb: 6000.0
+  local_disk_count: 2
   arch: x86_64
   price_per_hour:
     europe-west9: 3.388632974
@@ -4172,8 +4172,8 @@ instances:
   family: z3-highmem-standardlssd
   vcpus: 44
   memory_gb: 352.0
-  local_disk_gb: 24000.0
-  local_disk_count: 8
+  local_disk_gb: 9000.0
+  local_disk_count: 3
   arch: x86_64
   price_per_hour:
     europe-west9: 6.395896085
@@ -4221,8 +4221,8 @@ instances:
   family: z3-highmem-standardlssd
   vcpus: 88
   memory_gb: 704.0
-  local_disk_gb: 48000.0
-  local_disk_count: 16
+  local_disk_gb: 18000.0
+  local_disk_count: 6
   arch: x86_64
   price_per_hour:
     europe-west9: 12.79179217

--- a/sdcm/utils/cloud_catalog/catalog_generator.py
+++ b/sdcm/utils/cloud_catalog/catalog_generator.py
@@ -223,18 +223,18 @@ _Z3_METAL_DISK_SIZE_GIB = 6000.0
 # z3 local SSD partition counts per instance (from GCE docs).
 # Used as fallback when the API doesn't return bundled_local_ssds.
 _Z3_PARTITION_COUNTS: dict[str, int] = {
-    "z3-highmem-8-highlssd": 2,
-    "z3-highmem-16-highlssd": 4,
-    "z3-highmem-22-highlssd": 6,
-    "z3-highmem-32-highlssd": 8,
-    "z3-highmem-44-highlssd": 12,
-    "z3-highmem-88-highlssd": 24,
-    "z3-highmem-192-highlssd-metal": 24,
-    "z3-highmem-14-standardlssd": 2,
-    "z3-highmem-22-standardlssd": 4,
-    "z3-highmem-44-standardlssd": 8,
-    "z3-highmem-88-standardlssd": 16,
-    "z3-highmem-176-standardlssd": 16,
+    "z3-highmem-8-highlssd": 1,
+    "z3-highmem-16-highlssd": 2,
+    "z3-highmem-22-highlssd": 3,
+    "z3-highmem-32-highlssd": 4,
+    "z3-highmem-44-highlssd": 6,
+    "z3-highmem-88-highlssd": 12,
+    "z3-highmem-192-highlssd-metal": 12,
+    "z3-highmem-14-standardlssd": 1,
+    "z3-highmem-22-standardlssd": 2,
+    "z3-highmem-44-standardlssd": 3,
+    "z3-highmem-88-standardlssd": 6,
+    "z3-highmem-176-standardlssd": 12,
 }
 
 # GCE resource-based pricing: per-vCPU/hr and per-GB-RAM/hr rates (USD, us-east1).


### PR DESCRIPTION
Every z3-*lssd machine type reported up to 2.7x its real local SSD capacity, because _Z3_PARTITION_COUNTS held doubled partition counts and the generator derives local_disk_gb from count * partition size.

z3-highmem-8-highlssd was recorded as 6000 GiB over 2 partitions; GCE documents 1 partition of 3000 GiB, and a longevity run on that machine confirms it - Grafana shows 1.48 TB used at 46%, i.e. 3.22 TB = 3000 GiB total.

Sizing constraints and `sct.py sizing` cost/capacity output were wrong as a result: a config asking for local_disk_gb >= 5000 was given a machine that cannot physically hold it.

- Replace _Z3_PARTITION_COUNTS with the documented counts for all 12 z3 shapes (highlssd was uniformly 2x off, standardlssd by 1.33x-2.67x)
- Treat the documented table as the source of truth and consult the API's bundled_local_ssds only for unknown machine types, warning on disagreement. The previous check also read partition_count off a present-but-unset proto message, which would have yielded a 0 GiB disk.
- Correct the 12 z3 entries in data/instance_catalog/gce.yaml
- Pin the documented capacities in unit tests, plus the local_disk_gb == local_disk_count * partition_size invariant

No instance selection changes: verified across all 308 (config, role, cloud) combinations in test-cases/ and configurations/.

Fixes: SCT-879

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- The provisioning passed ok in https://argus.scylladb.com/tests/scylla-cluster-tests/7f2d4f0d-4ab6-4541-b42f-882dae453b9f. It configured a value of local_disk_gb "3000-4000". 
- A comparison test of local_disk_gb "3000-4000" without this fix, the provisioning failed to find an instance - https://argus.scylladb.com/tests/scylla-cluster-tests/0d4ba90b-c020-4115-9cf9-044aafc5ccbc

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
