### PR TITLE
fix(skill-review): stop executing PR code in privileged workflow

### DIFF
--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -13,10 +13,71 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      # Check out the base repository, never the PR head. `pull_request_target`
+      # runs with repository secrets and a write token, so every script this
+      # workflow executes has to come from the trusted base branch - checking
+      # out a fork's code here would hand both to anyone who opens a PR.
+      - name: Checkout base repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          allow-unsafe-pr-checkout: true
+          persist-credentials: false
+
+      # Overlay the PR's SKILL.md files as *data*: they get linted and sent to
+      # an LLM, never executed, and nothing outside skills/ comes from the PR.
+      - name: Sync SKILL.md files from PR head
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          names="$(mktemp)"
+          content="$(mktemp)"
+
+          # A 404 means the PR removed skills/ entirely, which is legitimate.
+          # Any other failure must not be mistaken for "no skills to review",
+          # or the next step would happily report that all 0 skills passed.
+          if ! gh api "repos/${REPO}/contents/skills?ref=${HEAD_SHA}" \
+                 --jq '.[] | select(.type == "dir") | .name' > "$names" 2>"$names.err"; then
+            if grep -q "Not Found" "$names.err"; then
+              echo "::notice::No skills/ directory at ${HEAD_SHA}"
+              : > "$names"
+            else
+              echo "::error::Failed to list skills/ at ${HEAD_SHA}"
+              cat "$names.err" >&2
+              exit 1
+            fi
+          fi
+
+          # Drop the base branch's skills so skills deleted or renamed by the
+          # PR are not reviewed as if they were still there.
+          rm -rf skills
+          mkdir -p skills
+
+          synced=0
+          while read -r name; do
+            [ -n "$name" ] || continue
+            # Reject anything that is not a plain directory name, so a crafted
+            # entry cannot make us write outside skills/.
+            case "$name" in
+              *[!A-Za-z0-9._-]* | . | ..)
+                echo "::warning::Skipping unexpected skill directory name: $name"
+                continue
+                ;;
+            esac
+            # </dev/null so gh can never consume the loop's input stream.
+            # A missing SKILL.md is fine - the directory just isn't a skill.
+            if gh api "repos/${REPO}/contents/skills/${name}/SKILL.md?ref=${HEAD_SHA}" \
+                 --header 'Accept: application/vnd.github.raw' \
+                 > "$content" 2>/dev/null </dev/null; then
+              mkdir -p "skills/${name}"
+              cp "$content" "skills/${name}/SKILL.md"
+              synced=$((synced + 1))
+            fi
+          done < "$names"
+
+          echo "Synced $synced SKILL.md file(s) from ${HEAD_SHA}"
 
       - name: SkillForge lint and security scan
         id: skillforge
@@ -81,9 +142,14 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
         run: |
-          DIRS=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}/files" \
-            --jq '[.[].filename | select(startswith("skills/")) | split("/")[0:2] | join("/")] | unique | .[]')
+          # Keep only well-formed skills/<name> paths. This value is expanded
+          # unquoted as command arguments below, so a directory name must not
+          # be able to smuggle in anything else.
+          DIRS=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/files" --paginate \
+            --jq '.[].filename | select(startswith("skills/")) | split("/")[0:2] | join("/")' \
+            | grep -E '^skills/[A-Za-z0-9._-]+$' | sort -u || true)
           # Use space-separated single line for GITHUB_OUTPUT (multiline breaks the format)
           DIRS_ONELINE=$(echo "$DIRS" | tr '\n' ' ' | xargs)
           echo "skill_dirs=$DIRS_ONELINE" >> "$GITHUB_OUTPUT"
@@ -101,8 +167,11 @@ jobs:
         if: steps.auth.outputs.available == 'true' && steps.changed.outputs.skill_dirs != ''
         continue-on-error: true
         id: judge
-        run: python .github/scripts/skill-quality-judge.py ${{ steps.changed.outputs.skill_dirs }}
+        # SKILL_DIRS is intentionally unquoted: it is a space-separated list
+        # of directories, already restricted to a safe character set above.
+        run: python .github/scripts/skill-quality-judge.py $SKILL_DIRS
         env:
+          SKILL_DIRS: ${{ steps.changed.outputs.skill_dirs }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           SKILL_QUALITY_THRESHOLD: "70"
           SKILL_REVIEW_REPORT: /tmp/skill-review-report.md
@@ -112,6 +181,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
           SKILLFORGE_OUTCOME: ${{ steps.skillforge.outcome }}
           JUDGE_OUTCOME: ${{ steps.judge.outcome }}
           AUTH_AVAILABLE: ${{ steps.auth.outputs.available }}
@@ -169,14 +239,14 @@ jobs:
           "
           fi
 
-          EXISTING=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+          EXISTING=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
             --jq ".[] | select(.body | startswith(\"$MARKER\")) | .id" | head -1)
 
           if [ -n "$EXISTING" ]; then
-            gh api "repos/${{ github.repository }}/issues/comments/${EXISTING}" \
+            gh api "repos/${REPO}/issues/comments/${EXISTING}" \
               -X PATCH -f body="$BODY"
           else
-            gh pr comment "$PR_NUMBER" --repo "${{ github.repository }}" --body "$BODY"
+            gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$BODY"
           fi
 
       - name: Fail if any review step failed


### PR DESCRIPTION
Fixes the `actions/untrusted-checkout/critical` alert that fails CodeQL on #15540.

### Why #15540 fails

#15540 is a Renovate bump of the `actions/checkout` SHA. It fails CodeQL not because of anything Renovate did, but because it touches line 16 of `skill-review.yml`, which re-surfaces [alert #115](https://github.com/scylladb/scylla-cluster-tests/security/code-scanning/115) — open on `master` since 2026-07-02. Any PR touching that line will fail the same way, so the fix belongs on `master`.

### The actual vulnerability

`skill-review.yml` triggers on `pull_request_target`, so it runs with repository secrets and a write `GITHUB_TOKEN`. It checked out the PR head:

```yaml
- uses: actions/checkout@... # v7.0.0
  with:
    ref: ${{ github.event.pull_request.head.sha }}
    allow-unsafe-pr-checkout: true
```

and then ran, from that same untrusted tree:

```yaml
run: python .github/scripts/skill-quality-judge.py ...
env:
  ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
```

Anyone opening a PR from a fork could replace `skill-quality-judge.py` and get `ANTHROPIC_API_KEY` plus a write token. The commit that added `allow-unsafe-pr-checkout` (fbde121e8d) reasoned "no code from the PR is executed" — that was true of the SkillForge step, but the judge step does execute a script from the checkout.

This is also why only this workflow is flagged: `build-docker-image.yaml` and `update-git-blame-ignore-revs.yaml` do the same unsafe checkout, but their `check_org_membership` job registers as a CodeQL `ControlCheck` and closed their alerts. `skill-review.yml` has no gate at all.

### The fix

Check out the **base** repository, then pull in only the PR's `SKILL.md` files through the contents API. Those files are linted and sent to an LLM — they are data, never executed — so no untrusted code runs in the privileged context. Nothing outside `skills/` comes from the PR.

Details worth noting:
- Skill directory names are filtered to `[A-Za-z0-9._-]`, so a crafted name can't escape `skills/`.
- `skills/` is cleared before the sync, so skills the PR deleted or renamed aren't reviewed as if they still existed.
- PR-controlled values moved out of `run:` interpolation into `env:` vars. `${{ steps.changed.outputs.skill_dirs }}` was being expanded directly into a shell command; the list is now also filtered with `grep -E '^skills/[A-Za-z0-9._-]+$'`.
- Added `--paginate` to the changed-files query, which was silently capped at 30 files.
- The sync step runs under `set -euo pipefail` and distinguishes a genuine 404 (the PR removed `skills/`, fine) from any other API failure. Without that, a transient error would leave `skills/` empty and SkillForge would cheerfully report "All 0 skills passed".

I picked this over adding a `check_org_membership` gate: a gate would satisfy CodeQL, but fork PRs are exactly the ones whose skills most need reviewing, and it would leave the workflow one config change away from executing untrusted code again. This removes the capability instead of gating it.

### Testing

Ran the new shell logic locally against real fork PRs:
- Sync step against a fork head SHA — pulled 15 `SKILL.md` files; a pre-seeded stale skill dir was correctly removed.
- Changed-skills detection — `[skills/test-run-comparison-reports]` on #15210 (touches skills), empty on PRs that don't.
- Name filter rejects `../../.github/scripts`, `a;rm -rf /`, `a$(id)`, `.`, `..`, and names with spaces; accepts `good-skill` and `ok_1.2`.
- Error handling: happy path syncs 15 skills; a pre-skills commit correctly reports "no skills/ directory" and exits 0; a bad ref (404) and a bad token (401) both fail loudly instead of silently reporting zero skills.
- `pre-commit` passes on the changed file.

Note that CI here runs the *base* copy of this workflow, since `pull_request_target` always uses the base version — the new logic only takes effect once merged, which is why I exercised it locally against real fork PRs.

Once this merges and Renovate rebases, #15540 should go green.
