### PR TITLE
feature(performance): loader cpu diagnostics

### DIFF
--- a/data_dir/loader_cpu_sampler.sh
+++ b/data_dir/loader_cpu_sampler.sh
@@ -1,0 +1,188 @@
+#!/bin/bash
+#
+# Loader CPU/thread diagnostic sampler (SCT-601).
+#
+# Appends one timestamped block per sample to a log file on the loader host, so that a client-side
+# latency spike can be attributed to (or cleared of) loader CPU contention afterwards. The log is
+# streamed off the loader by LoaderCpuFileLogger and collected by LoaderLogCollector.
+#
+# One block per sample, every line tagged with its kind so the file stays greppable:
+#
+#   === <utc timestamp> sample=<n> uptime=<seconds>
+#   cpu       <mpstat -P ALL>: TIME CPU %usr %nice %sys %iowait %irq %soft %steal %guest %gnice %idle
+#   proc      <pidstat -u -h>: TIME UID PID %usr %system %guest %wait %CPU CPU Command
+#   thread    <pidstat -tu -h>: TIME UID TGID TID %usr %system %guest %wait %CPU CPU Command
+#   ctxt      PID <voluntary_ctxt_switches> <nonvoluntary_ctxt_switches> <threads>
+#   pressure  /proc/pressure/cpu (PSI): some|full avg10=.. avg60=.. avg300=.. total=..
+#   loadavg   /proc/loadavg: 1m 5m 15m running/total last_pid
+#
+# Without sysstat the same block is emitted from /proc only, tagged rawcpu/rawproc - cumulative
+# counters instead of percentages, so the reader has to diff consecutive samples.
+#
+# All tools of one block share a single measurement window, so the numbers inside a block line up.
+
+set -u
+
+# Pin the sysstat output format. Under a 12h locale mpstat/pidstat print "03:20:26 PM  all ..." -
+# one field more than "15:20:26     all ..." - which shifts every documented column by one and would
+# make the per-thread sort pick the wrong metric. S_TIME_FORMAT=ISO overrides the locale.
+export S_TIME_FORMAT=ISO
+export LC_ALL=C
+
+INTERVAL=1
+OUT=/var/tmp/loader-cpu.log
+# matched against the command name (`pidstat -C`, `pgrep` without -f), covers SCT's stress tools
+PATTERN='java|cassandra-stress|scylla-bench|latte|ycsb|cql-stress'
+THREAD_EVERY=0 # per-thread sampling every Nth sample; 0 disables it
+TOP_THREADS=20 # keep only the N hottest threads - a c-s run has ~1000 of them
+MAX_MB=2048    # stop sampling instead of filling up the loader disk
+MAX_PROCS=30   # bound the per-process lines of a block, however wide the pattern matches
+
+usage() {
+    echo "usage: $0 [-i interval] [-o out_file] [-p comm_pattern] [-t thread_every_n_samples]" >&2
+    echo "          [-T top_threads] [-m max_mb]" >&2
+    exit 2
+}
+
+while getopts "i:o:p:t:T:m:" opt; do
+    case "$opt" in
+    i) INTERVAL=$OPTARG ;;
+    o) OUT=$OPTARG ;;
+    p) PATTERN=$OPTARG ;;
+    t) THREAD_EVERY=$OPTARG ;;
+    T) TOP_THREADS=$OPTARG ;;
+    m) MAX_MB=$OPTARG ;;
+    *) usage ;;
+    esac
+done
+
+if command -v mpstat >/dev/null 2>&1 && command -v pidstat >/dev/null 2>&1; then
+    HAVE_SYSSTAT=1
+else
+    HAVE_SYSSTAT=0
+fi
+
+TMPDIR=$(mktemp -d)
+on_exit() {
+    echo "=== $(date -u +%Y-%m-%dT%H:%M:%SZ) sampler stopped" >>"$OUT"
+    rm -rf "$TMPDIR"
+}
+trap on_exit EXIT
+# a TERM/INT handler that does not exit would leave the loop running: bash resumes the script once
+# the handler returns, and `systemctl stop` would have to SIGKILL the sampler
+trap 'exit 0' TERM INT
+
+# processes to sample, matched by name the way `pidstat -C` does it. `pgrep -f` must not be used
+# here: the pattern is part of this script's own command line, so it would match the sampler itself
+sampled_pids() {
+    pgrep "$PATTERN" 2>/dev/null | head -n "$MAX_PROCS"
+}
+
+emit_header() {
+    cat <<EOF
+=== $(date -u +%Y-%m-%dT%H:%M:%SZ) sampler started pid=$$ interval=${INTERVAL}s \
+thread_every=${THREAD_EVERY} top_threads=${TOP_THREADS} pattern='${PATTERN}' sysstat=${HAVE_SYSSTAT}
+=== cpu: TIME CPU %usr %nice %sys %iowait %irq %soft %steal %guest %gnice %idle
+=== proc/thread: TIME UID [TGID] PID/TID %usr %system %guest %wait %CPU CPU Command
+=== ctxt: PID voluntary_ctxt_switches nonvoluntary_ctxt_switches threads
+EOF
+}
+
+# tagged sysstat output: the banner, the trailing Average block and the column headers are dropped,
+# so only data lines reach the log. Headers are recognized by '%usr', which every one of them carries
+# and no data line does - unlike a field position, that holds for any locale and sysstat version.
+tag_sysstat() {
+    local tag=$1 file=$2
+    awk -v tag="$tag" '
+        NF && $1 != "Average:" && $0 !~ /^Linux/ && $0 !~ /%usr/ {print tag, $0}
+    ' "$file"
+}
+
+# The %CPU field of `pidstat -tu -h` data lines, as the sort key of an already tagged line. Read from
+# the header instead of hardcoded: %wait only exists since sysstat 11.5, and a data line has one
+# field less than the header ('# Time' vs a single timestamp), which the prepended tag adds back.
+thread_cpu_sort_key() {
+    local file=$1 key
+    key=$(awk '/%CPU/ {for (i = 1; i <= NF; i++) if ($i == "%CPU") {print i; exit}}' "$file")
+    echo "${key:-10}"
+}
+
+sample_sysstat() {
+    local with_threads=$1
+    : >"$TMPDIR/mpstat"
+    : >"$TMPDIR/pidstat"
+    : >"$TMPDIR/pidstat_t"
+    # one shared measurement window for every tool of this block
+    mpstat -P ALL "$INTERVAL" 1 >"$TMPDIR/mpstat" 2>/dev/null &
+    pidstat -u -h -C "$PATTERN" "$INTERVAL" 1 >"$TMPDIR/pidstat" 2>/dev/null &
+    if [[ $with_threads -eq 1 ]]; then
+        pidstat -tu -h -C "$PATTERN" "$INTERVAL" 1 >"$TMPDIR/pidstat_t" 2>/dev/null &
+    fi
+    wait
+
+    tag_sysstat cpu "$TMPDIR/mpstat"
+    tag_sysstat proc "$TMPDIR/pidstat"
+    if [[ $with_threads -eq 1 ]]; then
+        tag_sysstat thread "$TMPDIR/pidstat_t" |
+            sort -k"$(thread_cpu_sort_key "$TMPDIR/pidstat_t")" -nr | head -n "$TOP_THREADS"
+    fi
+}
+
+sample_proc() {
+    sed 's/^/rawcpu /' /proc/stat | grep '^rawcpu cpu'
+    for pid in $(sampled_pids); do
+        # utime stime cutime cstime num_threads, all cumulative - diff two samples to get a rate
+        awk '{print "rawproc", $1, $2, $14, $15, $16, $17, $20}' "/proc/$pid/stat" 2>/dev/null
+    done
+    sleep "$INTERVAL"
+}
+
+# context switches and thread count, cheap enough to take on every sample
+sample_ctxt() {
+    for pid in $(sampled_pids); do
+        awk -v pid="$pid" '
+            /^voluntary_ctxt_switches/ {vol=$2}
+            /^nonvoluntary_ctxt_switches/ {nonvol=$2}
+            /^Threads/ {threads=$2}
+            END {if (vol != "") print "ctxt", pid, vol, nonvol, threads}
+        ' "/proc/$pid/status" 2>/dev/null
+    done
+}
+
+sample_pressure() {
+    if [[ -r /proc/pressure/cpu ]]; then
+        sed 's/^/pressure /' /proc/pressure/cpu
+    fi
+    echo "loadavg $(cat /proc/loadavg)"
+}
+
+emit_header >>"$OUT"
+
+sample=0
+while :; do
+    sample=$((sample + 1))
+    with_threads=0
+    if [[ $THREAD_EVERY -gt 0 ]] && ((sample % THREAD_EVERY == 0)); then
+        with_threads=1
+    fi
+
+    {
+        echo "=== $(date -u +%Y-%m-%dT%H:%M:%SZ) sample=$sample uptime=$(cut -d' ' -f1 /proc/uptime)"
+        if [[ $HAVE_SYSSTAT -eq 1 ]]; then
+            sample_sysstat "$with_threads"
+        else
+            sample_proc
+        fi
+        sample_ctxt
+        sample_pressure
+    } >>"$OUT" 2>/dev/null
+
+    # checked once a minute, the size call is not worth doing every second
+    if ((sample % 60 == 0)); then
+        size_mb=$(($(stat -c%s "$OUT" 2>/dev/null || echo 0) / 1024 / 1024))
+        if ((size_mb >= MAX_MB)); then
+            echo "=== $(date -u +%Y-%m-%dT%H:%M:%SZ) size cap reached (${size_mb}MB >= ${MAX_MB}MB), stopping" >>"$OUT"
+            exit 0
+        fi
+    fi
+done

--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -253,6 +253,9 @@ service_level_shares: [1000]
 
 use_hdrhistogram: false
 
+loader_cpu_diagnostics: false
+loader_cpu_diagnostics_per_thread: false
+
 stop_on_hw_perf_failure: false
 
 

--- a/docs/collected-logs.md
+++ b/docs/collected-logs.md
@@ -50,6 +50,7 @@ Each loader node directory contains:
 | `cloud-init.log` | Cloud-init execution log |
 | `cloud-init-output.log` | Cloud-init stdout/stderr |
 | `console_output.log` | Serial console output (when kernel panic checker is enabled) |
+| `loader-cpu.log` | Loader CPU/thread diagnostics samples (when `loader_cpu_diagnostics` is enabled) |
 
 ## Monitor Node Logs
 

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -3629,6 +3629,24 @@ Extra JVM options passed to cassandra-stress via JVM_OPTS environment variable. 
 **type:** str (appendable)
 
 
+## **loader_cpu_diagnostics** / SCT_LOADER_CPU_DIAGNOSTICS
+
+Run a 1 Hz CPU diagnostics sampler on the loaders (per-CPU utilization including %steal, PSI CPU pressure, per-process CPU and context switches of the stress tool). The log is streamed into the loader log directory and collected into the run log archive as 'loader-cpu.log'. Use it to tell loader-side CPU contention apart from a server-side stall behind a client-observed latency spike. Not supported on k8s backends.
+
+**default:** False
+
+**type:** bool
+
+
+## **loader_cpu_diagnostics_per_thread** / SCT_LOADER_CPU_DIAGNOSTICS_PER_THREAD
+
+Add per-thread CPU samples to the loader CPU diagnostics log, for the hottest threads of the stress tool only and every 10th sample only - a cassandra-stress run has hundreds of threads, sampling all of them every second would produce hundreds of MB per run. Requires 'loader_cpu_diagnostics'.
+
+**default:** False
+
+**type:** bool
+
+
 ## **stress_cmd_mv** / SCT_STRESS_CMD_MV
 
 cassandra-stress commands. You can specify everything but the -node parameter, which is going to be provided by the test suite infrastructure. Multiple commands can be passed as a list

--- a/docs/performance-tests.md
+++ b/docs/performance-tests.md
@@ -38,3 +38,114 @@ Main options:
 - --hdr-folder: Path to local folder with HDR files (optional).
 
 This utility is useful for performance engineers and developers investigating latency issues in distributed database clusters.
+
+## Loader CPU diagnostics
+
+A client-observed P99 spike with flat server-side metrics is not necessarily a ScyllaDB problem: the
+loaders themselves can be CPU starved, either by the stress tool or by a noisy neighbour on the
+hypervisor. Until now the only loader-side signal was `node_load1` from node_exporter, which says
+that a loader was busy but not why, so such a failure could only be correlated, never root-caused.
+
+`loader_cpu_diagnostics` starts a 1 Hz sampler on every loader for the whole run:
+
+```yaml
+loader_cpu_diagnostics: true
+loader_cpu_diagnostics_per_thread: false  # see "Per-thread samples" below
+```
+
+or `SCT_LOADER_CPU_DIAGNOSTICS=true`. It is off by default; enable it for the pipeline that is being
+diagnosed. The sampler is a systemd service (`loader-cpu-diag`) that costs one wakeup per second, so
+it is independent of how many stress threads come and go on a loader. It is not supported on k8s
+backends, and - like the node_exporter installation - it is skipped for `reuse_cluster` runs.
+
+### Where the log ends up
+
+The sampler writes `/var/tmp/loader-cpu.log` on the loader. The file is streamed off the loader while
+the run goes on (perf loaders get terminated, and the interesting samples are the last ones), lands
+in the loader log directory as `loader-cpu.log` and is collected into the run log archive next to
+`system.log` - one file per loader.
+
+### Reading it
+
+Every sample is one block, every line tagged with its kind:
+
+```
+=== 2026-08-27T09:13:33Z sample=3 uptime=1308728.49
+cpu 12:13:34     all    8.97    0.00    1.07    0.63    0.00    0.13    0.00    0.00    0.00   89.22
+cpu 12:13:34       7  100.00    0.00    0.00    0.00    0.00    0.00    0.00    0.00    0.00    0.00
+proc 12:13:34     1000   3017381   99.02    0.00    0.00    0.00   99.02     7  java
+ctxt 3017381 14 163 1
+pressure some avg10=0.11 avg60=0.92 avg300=0.78 total=3883844852
+pressure full avg10=0.00 avg60=0.00 avg300=0.00 total=0
+loadavg 2.45 2.57 2.14 3/3349 3017478
+```
+
+- `cpu` - `mpstat -P ALL`: `TIME CPU %usr %nice %sys %iowait %irq %soft %steal %guest %gnice %idle`,
+  the `all` line first, then one line per vCPU.
+- `proc` - `pidstat -u`: `TIME UID PID %usr %system %guest %wait %CPU CPU Command` for the stress
+  tool processes. `%wait` is the share of time the process was runnable but not running - the direct
+  measure of "the loader could not schedule the stress tool".
+- `ctxt` - `PID voluntary_ctxt_switches nonvoluntary_ctxt_switches threads`, cumulative: a jump in
+  the *nonvoluntary* counter means the scheduler preempted the process.
+- `pressure` - PSI from `/proc/pressure/cpu`: `some` is the share of time at least one task was
+  stalled waiting for CPU, `full` the share where every task was. `some avg10` is the single best
+  "was this loader CPU starved" number.
+- `loadavg` - `/proc/loadavg`, including the `running/total` task counts.
+
+To attribute a latency-step failure that happened at, say, `2026-08-27 09:13:33 UTC`:
+
+1. Find the failing interval in the c-s HDR histograms - `hydra hdr-investigate` (see above) reports
+   the intervals whose P99 crosses the threshold.
+2. Grep that wall clock second in the loader logs, all loaders at once:
+
+   ```bash
+   grep -A 30 '09:13:3' loader-*/loader-cpu.log | grep -E 'pressure some|^.*cpu .* all |proc '
+   ```
+
+3. Interpret what shows up:
+   - **High `%steal` on the `cpu all` line** - the hypervisor took the CPU away: a noisy neighbour or
+     a burstable/credit-limited instance. Not a Scylla problem and not a stress-tool problem.
+   - **High `pressure some avg10` with low `%steal`** - the loader oversubscribed itself: the stress
+     tool asks for more CPU than the instance has. Check `%wait` on the `proc` lines and the
+     nonvoluntary context switches.
+   - **Everything quiet on every loader** - the loaders are exonerated; move to the server side
+     (`scylla_reactor_stalls_*`, `scylla_database_queued_reads` per shard at that second) or to the
+     network.
+
+Because a client-side stall is usually visible on all loaders at once, compare the loaders against
+each other: a synchronized pause across independent loaders points away from the loaders and towards
+the cluster or the network.
+
+### Per-step figures in Argus
+
+Independently of the sampler, every latency step reports the loader load of its own time window next
+to its latencies, in the same Argus table:
+
+| Column | Query | Reads as |
+|--------|-------|----------|
+| `Loader CPU busy max` | `node_cpu_seconds_total{mode="idle"}` | how hot the hottest loader was, averaged over its vCPUs |
+| `Loader CPU steal max` | `node_cpu_seconds_total{mode="steal"}` | CPU the hypervisor took away |
+| `Loader CPU pressure max` | `node_pressure_cpu_waiting_seconds_total` | PSI: the loader was CPU starved |
+| `Loader load1 max` | `node_load1` | the coarse signal, kept for comparison with older runs |
+
+These need no configuration - they come from the loader `node_exporter` that every run already
+scrapes, over a 1 minute range vector, and are the peak across all loaders during the step. Busy is
+the peak of the *per-loader average* over its vCPUs, not of a single vCPU: the stress tools spread
+their load over all of them, and per-vCPU detail is in the sampler log anyway. They are
+there to compare two runs at a glance ("this step failed with the loaders at 90% busy, the passing
+one ran them at 56%"); use the sampler log for the second-by-second detail. A column is left out
+when its query returned nothing, so an empty cell means no data, not an idle loader.
+
+### Per-thread samples
+
+`loader_cpu_diagnostics_per_thread` adds `thread` lines (`pidstat -tu`, same columns as `proc` with a
+`TGID`/`TID` pair) for the 20 hottest threads, on every 10th sample only. Both bounds are deliberate:
+a cassandra-stress run has hundreds of threads, and sampling all of them every second would produce
+hundreds of MB per run for data that is only useful once the per-process lines already show the stress
+tool fighting for CPU. `pidstat` reports OS thread ids; mapping them to JVM thread names needs a
+thread dump (`jcmd <pid> Thread.print`), which must be taken **after** the stress command has
+finished - a thread dump is itself a safepoint and would perturb the tail latency being measured.
+
+The sampler stops appending at 2 GB (`=== ... size cap reached`), and falls back to raw `/proc`
+counters (`rawcpu`/`rawproc` lines, cumulative - diff two samples) when `sysstat` cannot be installed
+on the loader.

--- a/docs/plans/mini-plans/2026-08-27-sct601-loader-cpu-diagnostics.md
+++ b/docs/plans/mini-plans/2026-08-27-sct601-loader-cpu-diagnostics.md
@@ -1,0 +1,136 @@
+# Mini-Plan: Loader CPU/Thread Diagnostic Logging for Perf Tests
+
+**Date:** 2026-08-27
+**Estimated LOC:** ~280
+**Related PR:** TBD
+**Jira:** [SCT-601](https://scylladb.atlassian.net/browse/SCT-601)
+
+## Problem
+
+`test_latency_mixed_with_nemesis` run `936dcdb2` failed `_double_cluster_load` with a client-observed
+P99 read of 697 ms while a run of the *same* Scylla revision hours earlier reported 5.34 ms, and every
+server-side metric (`rlatencyp99` ~4 ms, `reactor_utilization` 50-60%, `sstable_overloads` 0) was flat.
+The only differentiating signal was loader `load1` (peak 89.6 vs 56.1) — too coarse to say whether the
+loaders were CPU-starved by a noisy neighbour, by the c-s JVM itself, or not at all. There is no
+loader-side per-process/per-thread CPU capture and no per-step loader load figure in Argus, so a
+client-side P99 spike can currently only be correlated, never root-caused.
+
+## Approach
+
+Follows the shape of the SCT-468 work (`cs_safepoint_logging`, commit `dd6dc98ef`, still unmerged on
+branch `sct-468-cs-safepoint-logging`): one opt-in flag, an artifact written on the loader host,
+carried into the loader logdir, collected by `LoaderLogCollector`, documented in
+`docs/performance-tests.md`. This branch is based on master and does not depend on it - the two only
+meet in the docs, when both have landed.
+
+**Commit 1 — loader host sampler + collection**
+
+- Add `loader_cpu_diagnostics` and `loader_cpu_diagnostics_per_thread` boolean flags (default
+  `false`), next to `cs_extra_jvm_opts`.
+- Add `data_dir/loader_cpu_sampler.sh`: a 1 Hz loop writing one timestamped block per sample —
+  per-CPU busy/steal/irq/soft (`mpstat -P ALL 1 1`, falling back to `/proc/stat` deltas when
+  `sysstat` is missing), `/proc/pressure/cpu` (PSI some/full avg10), `/proc/loadavg`, and per-process
+  CPU plus `voluntary_ctxt_switches`/`nonvoluntary_ctxt_switches` for the c-s JVM PIDs.
+- Emit per-**thread** samples (`pidstat -tu`) only every 10th sample, behind a separate
+  `loader_cpu_diagnostics_per_thread` flag, and cap the output file size in the script. A c-s perf run
+  uses hundreds to ~1000 threads, so `pidstat -t 1` alone would produce ~1000 lines/s (hundreds of MB
+  per run).
+- Install `sysstat` in `BaseLoaderSet.node_setup` with timeout + retries + non-interactive flags (per
+  the `package-installation` skill); degrade to the `/proc`-only path when the install fails.
+- Start the sampler as a systemd unit (`loader-cpu-diag.service`) in the same method, right after
+  `node_exporter_setup.install(node)`, so it is killable, survives a reboot, and covers the whole run.
+- Stream the file off the loader live with a new `LoaderCpuFileLogger(SSHGeneralFileLogger)` (only
+  `REMOTE_LOG_PATH` differs), started next to `start_journal_thread` and stopped in the existing
+  `stop_task_threads` path. Streaming rather than a teardown `receive_files` because perf loaders get
+  terminated and the interesting samples are exactly the ones near a failure.
+- Keep the sampler **per loader**, started at setup — not per stress thread like the safepoint log:
+  several stress threads share a loader and CPU contention is a host property.
+- Collect via one `FileLog(name="loader-cpu-*.log", search_locally=True)` entry in
+  `LoaderLogCollector.log_entities`.
+
+**Commit 2 — enable the `processes` node_exporter collector**
+
+- Add `--collector.processes` to the `ExecStart` in `NodeExporterSetup.install` (off by default in
+  node_exporter) for `node_procs_running` / `node_procs_blocked` on every loader and DB node.
+- The `pressure` collector is *already* enabled (the current flag list disables 15 collectors but not
+  `pressure`), so loader PSI is in the archived Prometheus snapshot of existing runs — no change needed
+  and worth checking against run `936dcdb2` before/while implementing.
+
+**Commit 3 — surface per-step loader load in Argus**
+
+- In `collect_latency`, add per-loader aggregates over the step window it already receives:
+  `max/avg` of `1 - rate(node_cpu_seconds_total{mode="idle"}[..])`, `max` of
+  `rate(node_cpu_seconds_total{mode="steal"}[..])`, `max` of
+  `rate(node_pressure_cpu_waiting_seconds_total[..])`, `max` of `node_load1`, and
+  `rate(node_context_switches_total[..])`.
+- Filter targets by `instance` against the loader nodes — loaders and DB nodes share the single
+  `node_exporter` scrape job.
+- The keys ride through `send_result_to_argus` into the per-cycle Argus row next to the P99, making the
+  run A vs run B comparison from the ticket a table lookup instead of a Prometheus dig.
+
+**Commit 4 — docs**
+
+- `docs/performance-tests.md`: a "Loader CPU diagnostics" section on reading the sampler output,
+  mirroring the safepoint one — read PSI/steal first, then per-process, then per-thread; pair it with
+  `cs-safepoint-*.log` (large `At safepoint` = JVM's fault, large `Reaching safepoint` + high
+  steal/PSI = host contention).
+- `docs/collected-logs.md`: one row for `loader-cpu-*.log`.
+- Regenerate `docs/configuration_options.md` for the new flags.
+
+## Files to Modify
+
+- `sdcm/sct_config.py` -- add `loader_cpu_diagnostics` and `loader_cpu_diagnostics_per_thread` fields
+  next to `cs_extra_jvm_opts` (~line 2003)
+- `defaults/test_default.yaml` -- defaults `false` for both flags
+- `data_dir/loader_cpu_sampler.sh` -- (new file) the 1 Hz sampler
+- `sdcm/cluster.py` -- `BaseLoaderSet.node_setup` (~line 6840): install `sysstat`, install + start the
+  sampler unit; start/stop the new logger alongside `_journal_thread` (~lines 1475, 1729, 1754)
+- `sdcm/utils/remote_logger.py` -- add `LoaderCpuFileLogger(SSHGeneralFileLogger)` (~line 341)
+- `sdcm/logcollector.py` -- add the `loader-cpu-*.log` `FileLog` to `LoaderLogCollector.log_entities`
+  (~line 1154)
+- `sdcm/node_exporter_setup.py` -- add `--collector.processes` to `ExecStart`
+- `sdcm/utils/latency.py` -- `collect_latency` (~line 24): add the per-loader step-window aggregates
+- `docs/performance-tests.md`, `docs/collected-logs.md`, `docs/configuration_options.md` -- docs
+- `unit_tests/unit/test_loader_cpu_diagnostics.py` -- (new file) sampler command/unit rendering and
+  flag handling
+- `unit_tests/integration/test_cassandra_stress_thread.py` -- integration test mirroring
+  `test_07_cassandra_stress_safepoint_logging`
+
+**Answered while implementing**
+
+- `sdcm/argus_results.py` does require the columns to be declared: the latency tables are
+  `StaticGenericResultTable`s with an explicit `Meta.Columns` list, and `send_result_to_argus` writes
+  only the columns it names, so extra keys in the result dict are silently dropped. The four
+  loader-load columns are declared once in `LOADER_LOAD_COLUMNS` and spliced into all four latency
+  tables; a unit test asserts they are present in every one of them.
+- Whether `sysstat` is present on the current loader AMIs — decides if the `/proc` fallback is the
+  common path or the exception.
+
+**Deliberately out of scope — follow-up PRs**
+
+- `process-exporter` on loaders at `:9256` plus a scrape job next to the loader `node_exporter` targets
+  in `configure_scylla_monitoring` (~`sdcm/cluster.py:7454-7481`), for per-process CPU as queryable
+  metrics rather than text. ~80 LOC, own PR.
+- JVM thread-name attribution: a single `jcmd <pid> Thread.print` taken **after** the stress command
+  finishes, to map `pidstat -t` OS tids to JVM thread names (`nid=0x...`). Never during the run — a
+  thread dump is itself a safepoint and would corrupt the tail latency being measured. Documented in
+  `docs/performance-tests.md` already, not automated.
+- The `de9cb6bc` anomaly (P99 read == P99 write == 91335.16 ms) — a stress-tool/results-parsing
+  artifact, separate ticket, as the Jira issue itself states.
+
+## Verification
+
+- [ ] Unit tests pass: `uv run python -m pytest unit_tests/unit/test_loader_cpu_diagnostics.py -v`
+- [ ] Integration test passes: the sampler file exists on the loader, is non-empty, and lands in the
+      loader logdir — `uv run python -m pytest unit_tests/integration/test_cassandra_stress_thread.py -k loader_cpu -v`
+- [ ] With `loader_cpu_diagnostics: false` (the default) no sampler unit is started on the loaders and
+      no `loader-cpu-*.log` appears — verified on a short AWS perf run
+- [ ] `loader-cpu-*.log` is present in the collected-logs archive under each loader directory and its
+      samples cover the whole run at ~1 s granularity, with per-thread blocks only every ~10 s
+- [ ] Per-thread output stays bounded: sampler log under ~200 MB for a 2-hour run with 1000 c-s threads
+- [ ] `node_procs_running` is queryable for a loader instance in the run's Prometheus
+- [ ] The Argus per-cycle row for a latency step shows the loader busy/steal/PSI/load1 fields
+- [ ] Overhead control: `latency-650gb-with-nemesis` run with the flag on vs off — steady-state P99 and
+      throughput within run-to-run noise (this is the precondition for enabling it by default in the
+      perf pipelines, which is a follow-up decision, not part of this PR)
+- [ ] `uv run sct.py pre-commit` passes

--- a/sdcm/argus_results.py
+++ b/sdcm/argus_results.py
@@ -44,6 +44,18 @@ LATENCY_ERROR_THRESHOLDS = {
     "default": {"percentile_90": 5, "percentile_99": 10},
 }
 
+# Loader-side CPU during the step (SCT-601). A client-observed P99 spike with flat server-side
+# metrics is not necessarily a ScyllaDB problem - reported next to the latencies so that two runs can
+# be compared at a glance instead of digging through Prometheus. No validation rules on purpose:
+# these are diagnostics, a hot loader is a hint about the latency figures, not a failure of its own.
+LOADER_LOAD_COLUMNS = [
+    ColumnMetadata(name="Loader CPU busy max", unit="%", type=ResultType.FLOAT, higher_is_better=False),
+    ColumnMetadata(name="Loader CPU steal max", unit="%", type=ResultType.FLOAT, higher_is_better=False),
+    ColumnMetadata(name="Loader CPU pressure max", unit="%", type=ResultType.FLOAT, higher_is_better=False),
+    ColumnMetadata(name="Loader load1 max", unit="", type=ResultType.FLOAT, higher_is_better=False),
+]
+LOADER_LOAD_COLUMN_NAMES = [column.name for column in LOADER_LOAD_COLUMNS]
+
 
 class LatencyCalculatorMixedResult(StaticGenericResultTable):
     class Meta:
@@ -61,6 +73,7 @@ class LatencyCalculatorMixedResult(StaticGenericResultTable):
             ColumnMetadata(name="start time", unit="", type=ResultType.TEXT),
             ColumnMetadata(name="Overview", unit="", type=ResultType.TEXT),
             ColumnMetadata(name="QA dashboard", unit="", type=ResultType.TEXT),
+            *LOADER_LOAD_COLUMNS,
         ]
 
 
@@ -77,6 +90,7 @@ class LatencyCalculatorWriteResult(StaticGenericResultTable):
             ColumnMetadata(name="start time", unit="", type=ResultType.TEXT),
             ColumnMetadata(name="Overview", unit="", type=ResultType.TEXT),
             ColumnMetadata(name="QA dashboard", unit="", type=ResultType.TEXT),
+            *LOADER_LOAD_COLUMNS,
         ]
 
 
@@ -93,6 +107,7 @@ class LatencyCalculatorReadResult(StaticGenericResultTable):
             ColumnMetadata(name="start time", unit="", type=ResultType.TEXT),
             ColumnMetadata(name="Overview", unit="", type=ResultType.TEXT),
             ColumnMetadata(name="QA dashboard", unit="", type=ResultType.TEXT),
+            *LOADER_LOAD_COLUMNS,
         ]
 
 
@@ -109,6 +124,7 @@ class LatencyCalculatorReadDiskOnlyResult(StaticGenericResultTable):
             ColumnMetadata(name="start time", unit="", type=ResultType.TEXT),
             ColumnMetadata(name="Overview", unit="", type=ResultType.TEXT),
             ColumnMetadata(name="QA dashboard", unit="", type=ResultType.TEXT),
+            *LOADER_LOAD_COLUMNS,
         ]
 
 
@@ -388,6 +404,10 @@ def send_result_to_argus(  # noqa: PLR0914
             continue
         result_table.add_result(column="duration", row=row_name, value=result["duration_in_sec"], status=Status.UNSET)
         result_table.add_result(column="start time", row=row_name, value=start_time, status=Status.UNSET)
+        for column in LOADER_LOAD_COLUMN_NAMES:
+            # a metric with no data is left out, not reported as 0 - see collect_loader_load()
+            if (loader_load := result.get(column)) is not None:
+                result_table.add_result(column=column, row=row_name, value=loader_load, status=Status.UNSET)
         if overview_screenshot:
             result_table.add_result(column="Overview", row=row_name, value=overview_screenshot[0], status=Status.UNSET)
         if qa_screenshot:
@@ -406,6 +426,11 @@ def send_result_to_argus(  # noqa: PLR0914
         result_table_summary.add_result(
             column="start time", row=summary_row_name, value=start_time, status=Status.UNSET
         )
+        for column in LOADER_LOAD_COLUMN_NAMES:
+            if (loader_load := result.get(column)) is not None:
+                result_table_summary.add_result(
+                    column=column, row=summary_row_name, value=loader_load, status=Status.UNSET
+                )
         if overview_screenshot:
             result_table_summary.add_result(
                 column="Overview", row=summary_row_name, value=overview_screenshot[0], status=Status.UNSET

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -61,6 +61,10 @@ from cassandra.policies import WhiteListRoundRobinPolicy, RackAwareRoundRobinPol
 from cassandra.query import SimpleStatement
 from argus.common.enums import ResourceState
 from argus.client.sct.types import LogLink
+from sdcm.loader_cpu_diagnostics_setup import (
+    LOCAL_LOG_NAME as LOADER_CPU_DIAGNOSTICS_LOCAL_LOG_NAME,
+    LoaderCpuDiagnosticsSetup,
+)
 from sdcm.node_exporter_setup import NodeExporterSetup
 from sdcm.db_log_reader import DbLogReader
 from sdcm.mgmt import AnyManagerCluster, ScyllaManagerError
@@ -193,7 +197,7 @@ from sdcm.utils.ldap import (
     LDAP_PORT,
     DEFAULT_PWD_SUFFIX,
 )
-from sdcm.utils.remote_logger import get_system_logging_thread
+from sdcm.utils.remote_logger import LoaderCpuFileLogger, get_system_logging_thread
 from sdcm.utils.scylla_args import ScyllaArgParser
 from sdcm.utils.file import File
 from sdcm.utils import cdc
@@ -442,6 +446,7 @@ class BaseNode(AutoSshContainerMixin):
 
         self._spot_monitoring_thread = None
         self._journal_thread = None
+        self._loader_cpu_diagnostics_thread = None
         self._docker_log_process = None
         self._public_ip_address_cached = None
         self._private_ip_address_cached = None
@@ -1493,6 +1498,22 @@ class BaseNode(AutoSshContainerMixin):
                 message="Got no logging daemon by unknown reason",
             ).publish_or_dump()
 
+    def start_loader_cpu_diagnostics_thread(self):
+        """Stream the loader CPU diagnostics sampler log into the loader log directory (SCT-601).
+
+        Started before the sampler itself is installed by the loader setup - the logger waits for the
+        remote file to show up, so the ordering does not matter.
+        """
+        if not self.parent_cluster.params.get("loader_cpu_diagnostics"):
+            return
+        if self.is_kubernetes():
+            self.log.warning("loader_cpu_diagnostics is not supported on k8s backends, skipping it")
+            return
+        self._loader_cpu_diagnostics_thread = LoaderCpuFileLogger(
+            self, os.path.join(self.logdir, LOADER_CPU_DIAGNOSTICS_LOCAL_LOG_NAME)
+        )
+        self._loader_cpu_diagnostics_thread.start()
+
     def start_coredump_thread(self):
         self._coredump_thread = CoredumpExportSystemdThread(self, self._maximum_number_of_cores_to_publish)
         self._coredump_thread.start()
@@ -1697,6 +1718,7 @@ class BaseNode(AutoSshContainerMixin):
             self.start_db_log_reader_thread()
         elif self.node_type == "loader":
             self.start_coredump_thread()
+            self.start_loader_cpu_diagnostics_thread()
         elif self.node_type == "monitor":
             # TODO: start alert manager thread here when start_task_threads will be run after node setup
             # self.start_alert_manager_thread()
@@ -1728,6 +1750,8 @@ class BaseNode(AutoSshContainerMixin):
             self._alert_manager.stop()
         if self._journal_thread:
             self._journal_thread.stop(timeout=5)
+        if self._loader_cpu_diagnostics_thread:
+            self._loader_cpu_diagnostics_thread.stop(timeout=5)
 
     @log_run_info
     def wait_till_tasks_threads_are_stopped(self, timeout: float = 120):
@@ -1753,6 +1777,8 @@ class BaseNode(AutoSshContainerMixin):
                 self.log.warning("Coredump thread still alive after 300s, abandoning")
         if self._journal_thread:
             self._journal_thread.stop(timeout // 10)
+        if self._loader_cpu_diagnostics_thread:
+            self._loader_cpu_diagnostics_thread.stop(timeout // 10)
         if self._scylla_manager_journal_thread:
             self.stop_scylla_manager_log_capture(timeout // 10)
         self._decoding_backtraces_thread = None
@@ -6861,6 +6887,9 @@ class BaseLoaderSet:
 
         node_exporter_setup = NodeExporterSetup()
         node_exporter_setup.install(node)
+
+        if self.params.get("loader_cpu_diagnostics") and not node.is_kubernetes():
+            LoaderCpuDiagnosticsSetup.install(node, per_thread=self.params.get("loader_cpu_diagnostics_per_thread"))
 
         if self.params.get("bare_loaders"):
             node.log.info("Don't install anything because bare loaders requested")

--- a/sdcm/loader_cpu_diagnostics_setup.py
+++ b/sdcm/loader_cpu_diagnostics_setup.py
@@ -1,0 +1,134 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2026 ScyllaDB
+
+"""Loader CPU/thread diagnostics sampler (SCT-601).
+
+A client-observed P99 spike with flat server-side metrics used to be impossible to attribute: the
+only loader-side signal was the coarse `node_load1` of node_exporter. This installs a 1 Hz sampler
+on the loader host that records per-CPU utilization (including `%steal`), PSI CPU pressure, per
+process and - optionally - per thread CPU of the stress tool, plus its context switches.
+
+The sampler is a systemd service so it covers the whole run regardless of how many stress threads
+come and go on the loader, and is `Restart=always` so a crashed sampler does not silently stop
+producing data. Its log is streamed off the loader live by
+:class:`~sdcm.utils.remote_logger.LoaderCpuFileLogger` (perf loaders get terminated, and the
+interesting samples are exactly the last ones) and collected by ``LoaderLogCollector``.
+"""
+
+import logging
+
+from sdcm.remote import shell_script_cmd
+
+LOGGER = logging.getLogger(__name__)
+
+SAMPLER_SCRIPT_NAME = "loader_cpu_sampler.sh"
+REMOTE_SCRIPT_PATH = f"/usr/local/bin/{SAMPLER_SCRIPT_NAME}"
+# /var/tmp and not /tmp: systemd-tmpfiles will not clean it up under a long run
+REMOTE_LOG_PATH = "/var/tmp/loader-cpu.log"
+# the local file name LoaderLogCollector picks up, per loader (node.logdir)
+LOCAL_LOG_NAME = "loader-cpu.log"
+SERVICE_NAME = "loader-cpu-diag"
+
+SAMPLE_INTERVAL = 1  # seconds
+# per-thread sampling every Nth sample only: a c-s run has ~1000 threads, one line each
+THREAD_EVERY_N_SAMPLES = 10
+TOP_THREADS = 20
+MAX_LOG_SIZE_MB = 2048
+
+
+class LoaderCpuDiagnosticsSetup:
+    """Install and start the loader CPU diagnostics sampler on a loader node."""
+
+    @staticmethod
+    def install(node: "BaseNode", per_thread: bool = False) -> None:  # noqa: F821
+        """Install sysstat, upload the sampler and start it as a systemd service.
+
+        `sysstat` gives the sampler mpstat/pidstat; it is best-effort on purpose - the sampler falls
+        back to reading /proc directly, and diagnostics must never fail a loader setup.
+        """
+        node.log.info("Setting up loader CPU diagnostics sampler")
+        try:
+            node.install_package("sysstat", ignore_status=True)
+        except Exception:  # noqa: BLE001
+            node.log.warning("Failed to install sysstat, the sampler will fall back to /proc", exc_info=True)
+        if not node.remoter.run("command -v pidstat", ignore_status=True).ok:
+            node.log.warning("pidstat is not available on %s, the sampler falls back to /proc counters", node.name)
+
+        # imported here and not at module level: sdcm.utils.common is heavy and this module is
+        # imported by sdcm.utils.remote_logger, which sits below it in the import order
+        from sdcm.utils.common import get_data_dir_path  # noqa: PLC0415
+
+        node.remoter.send_files(get_data_dir_path(SAMPLER_SCRIPT_NAME), f"/tmp/{SAMPLER_SCRIPT_NAME}")
+        thread_every = THREAD_EVERY_N_SAMPLES if per_thread else 0
+        # kept on one line: the script below is dedent()ed, a continuation line would break the heredoc
+        exec_start = (
+            f"{REMOTE_SCRIPT_PATH} -i {SAMPLE_INTERVAL} -o {REMOTE_LOG_PATH} "
+            f"-t {thread_every} -T {TOP_THREADS} -m {MAX_LOG_SIZE_MB}"
+        )
+        node.remoter.sudo(
+            shell_script_cmd(f"""
+            install -m 0755 /tmp/{SAMPLER_SCRIPT_NAME} {REMOTE_SCRIPT_PATH}
+
+            cat <<EOM > /etc/systemd/system/{SERVICE_NAME}.service
+            [Unit]
+            Description=SCT loader CPU diagnostics sampler
+            After=network.target
+
+            [Service]
+            Type=simple
+            # pin the sysstat output format, see the sampler script
+            Environment=S_TIME_FORMAT=ISO LC_ALL=C
+            ExecStart={exec_start}
+            Restart=always
+            RestartSec=5
+            # slightly favoured over the stress tool so that samples keep coming while the loader is
+            # saturated - which is exactly when they matter. One wakeup per second, no measurable cost.
+            Nice=-5
+
+            [Install]
+            WantedBy=multi-user.target
+            EOM
+
+            systemctl daemon-reload
+            systemctl enable {SERVICE_NAME}.service
+            systemctl restart {SERVICE_NAME}.service
+        """),
+            retry=3,
+        )
+        node.log.info("Loader CPU diagnostics sampler started, logging to %s", REMOTE_LOG_PATH)
+        LoaderCpuDiagnosticsSetup._verify_sampling(node)
+
+    @staticmethod
+    def _verify_sampling(node: "BaseNode") -> None:  # noqa: F821
+        """Warn if the service is not actually sampling.
+
+        `systemctl restart` of a Type=simple unit succeeds as soon as the process is forked, so a
+        sampler that dies immediately (missing interpreter, bad option, unwritable log) looks
+        installed and leaves the run without any diagnostics - the very failure this is here to
+        prevent. Only a warning: a missing sampler must not fail a test.
+        """
+        if not node.remoter.run(f"systemctl is-active {SERVICE_NAME}.service", ignore_status=True).ok:
+            node.log.warning(
+                "Loader CPU diagnostics service is not active on %s, no samples will be collected", node.name
+            )
+            return
+        # the first sample lands one interval after start, give it a couple of them
+        samples = node.remoter.run(
+            f"sleep {SAMPLE_INTERVAL * 3}; grep -c 'sample=' {REMOTE_LOG_PATH}", ignore_status=True
+        )
+        if not samples.ok or samples.stdout.strip() in ("", "0"):
+            node.log.warning(
+                "Loader CPU diagnostics service is running on %s but wrote no sample yet to %s",
+                node.name,
+                REMOTE_LOG_PATH,
+            )

--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -1164,6 +1164,7 @@ class LoaderLogCollector(LogCollector):
         FileLog(name="kcl-l*.log", search_locally=True),
         FileLog(name="*cassandra-harry*.log", search_locally=True),
         FileLog(name="hdrh-*.hdr", search_locally=True),
+        FileLog(name="loader-cpu.log", search_locally=True),
         FileLog(name="*latte*", search_locally=True),
         FileLog(
             name="test.crt",

--- a/sdcm/node_exporter_setup.py
+++ b/sdcm/node_exporter_setup.py
@@ -16,6 +16,12 @@ class NodeExporterSetup:
             f"https://github.com/prometheus/node_exporter/releases/download/v{NODE_EXPORTER_VERSION}/{tarball}"
         )
         download_cmd = curl_with_retry(download_url, retry=8, follow_redirects=True, fail_early=True, output=tarball)
+        # --collector.processes is off by default in node_exporter; it adds node_procs_running /
+        # node_procs_blocked, the run-queue view that tells a merely busy host from a CPU starved one
+        # (SCT-601). The pressure collector (PSI, node_pressure_cpu_waiting_seconds_total) is enabled
+        # by default and is deliberately not among the --no-collector flags below.
+        # This lands on the loaders and the monitors, and on DB nodes only when they have no
+        # scylla-node-exporter of their own - see BaseScyllaCluster node setup.
         remoter.sudo(
             shell_script_cmd(f"""
             if ! id node_exporter > /dev/null 2>&1; then
@@ -42,7 +48,7 @@ class NodeExporterSetup:
             User=node_exporter
             Group=node_exporter
             Type=simple
-            ExecStart=/usr/local/bin/node_exporter --no-collector.interrupts --no-collector.hwmon --no-collector.bcache --no-collector.btrfs --no-collector.fibrechannel --no-collector.infiniband --no-collector.ipvs --no-collector.nfs --no-collector.nfsd --no-collector.powersupplyclass --no-collector.rapl --no-collector.tapestats --no-collector.thermal_zone --no-collector.udp_queues --no-collector.zfs
+            ExecStart=/usr/local/bin/node_exporter --collector.processes --no-collector.interrupts --no-collector.hwmon --no-collector.bcache --no-collector.btrfs --no-collector.fibrechannel --no-collector.infiniband --no-collector.ipvs --no-collector.nfs --no-collector.nfsd --no-collector.powersupplyclass --no-collector.rapl --no-collector.tapestats --no-collector.thermal_zone --no-collector.udp_queues --no-collector.zfs
 
             [Install]
             WantedBy=multi-user.target

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -2004,6 +2004,19 @@ class SCTConfiguration(BaseModel):
         "Recommended for low-latency: '-XX:+UseZGC -XX:+ZGenerational -Xms8g -Xmx8g -XX:+AlwaysPreTouch' "
         "(requires Java 21+, which cassandra-stress 3.20.6+ ships with).",
     )
+    loader_cpu_diagnostics: Boolean = SctField(
+        description="Run a 1 Hz CPU diagnostics sampler on the loaders (per-CPU utilization including "
+        "%steal, PSI CPU pressure, per-process CPU and context switches of the stress tool). The log is "
+        "streamed into the loader log directory and collected into the run log archive as "
+        "'loader-cpu.log'. Use it to tell loader-side CPU contention apart from a server-side stall "
+        "behind a client-observed latency spike. Not supported on k8s backends.",
+    )
+    loader_cpu_diagnostics_per_thread: Boolean = SctField(
+        description="Add per-thread CPU samples to the loader CPU diagnostics log, for the hottest "
+        "threads of the stress tool only and every 10th sample only - a cassandra-stress run has "
+        "hundreds of threads, sampling all of them every second would produce hundreds of MB per run. "
+        "Requires 'loader_cpu_diagnostics'.",
+    )
     stress_cmd_mv: StringOrList = SctField(
         description="cassandra-stress commands. You can specify everything but the -node parameter, which is going to be provided by the test suite infrastructure. Multiple commands can be passed as a list",
     )
@@ -4109,6 +4122,7 @@ class SCTConfiguration(BaseModel):
 
         self._validate_placement_group_required_values()
         self._instance_type_validation()
+        self._verify_loader_cpu_diagnostics()
 
         if (teardown_validators := self.get("teardown_validators.rackaware")) and teardown_validators.get(
             "enabled", False
@@ -4474,6 +4488,18 @@ class SCTConfiguration(BaseModel):
             value = self.get(field_name)
             assert value is not None and not (isinstance(value, str) and not value.strip()), (
                 f"{field_name} missing from config for {backend}"
+            )
+
+    def _verify_loader_cpu_diagnostics(self):
+        """Warn when per-thread sampling was asked for without the sampler that would do it.
+
+        A warning and not an error: the pair is a diagnostic, and a run must not fail over how its
+        diagnostics were configured.
+        """
+        if self.get("loader_cpu_diagnostics_per_thread") and not self.get("loader_cpu_diagnostics"):
+            self.log.warning(
+                "loader_cpu_diagnostics_per_thread has no effect without loader_cpu_diagnostics, "
+                "no loader CPU samples will be collected at all"
             )
 
     def _instance_type_validation(self):

--- a/sdcm/utils/decorators.py
+++ b/sdcm/utils/decorators.py
@@ -294,6 +294,10 @@ def latency_calculator_decorator(  # noqa: PLR0915
                 result = (
                     latency.collect_latency(monitor, start, end, workload, cluster, all_nodes_list) if monitor else {}
                 )
+                # loader-side CPU over the same window: a client-observed spike with flat server-side
+                # metrics is only attributable if the loaders can be implicated or cleared (SCT-601)
+                if monitor and getattr(tester, "loaders", None):
+                    result.update(latency.collect_loader_load(monitor, start, end, tester.loaders.nodes))
                 result["screenshots"] = screenshots
                 result["duration"] = f"{datetime.timedelta(seconds=int(end - start))}"
                 result["duration_in_sec"] = int(end - start)

--- a/sdcm/utils/latency.py
+++ b/sdcm/utils/latency.py
@@ -10,11 +10,22 @@
 # See LICENSE for more details.
 #
 # Copyright (c) 2020 ScyllaDB
+import logging
+import re
 import statistics
 from typing import Any
 
 from sdcm.argus_results import LATENCY_ERROR_THRESHOLDS
 from sdcm.db_stats import PrometheusDBStats
+
+LOGGER = logging.getLogger(__name__)
+
+# node_exporter scrapes the loaders in the same job as the DB nodes, on this port
+NODE_EXPORTER_PORT = 9100
+# range vector for the loader rates: long enough to cover at least two scrapes of any interval SCT
+# uses. It smooths a sub-second stall away on purpose - these figures answer "were the loaders hot
+# during this step", the loader-cpu.log sampler answers "what happened in that second".
+LOADER_LOAD_RATE_WINDOW = "1m"
 
 
 def avg(values):
@@ -86,6 +97,86 @@ def collect_latency(monitor_node, start, end, load_type, cluster, nodes_list):  
                 if sequence:
                     res[metric] = float(format(avg(sequence) / 1000, ".2f"))
 
+    return res
+
+
+def _loader_instances_filter(loader_nodes) -> str:
+    """A Prometheus regex matching the node_exporter `instance` labels of the given loaders.
+
+    Every address a loader may have been registered under is included: the monitor builds the scrape
+    targets from one of them, and which one depends on the backend and on ip_ssh_connections.
+    """
+    instances = []
+    for node in loader_nodes:
+        for attr in ("ip_address", "private_ip_address", "public_ip_address"):
+            try:
+                address = getattr(node, attr, None)
+            except Exception:  # noqa: BLE001  # a cloud lookup of an already terminated node
+                continue
+            if not address:
+                continue
+            # IPv6 targets are registered in their bracketed form
+            targets = [f"{address}:{NODE_EXPORTER_PORT}"]
+            if ":" in address:
+                targets.append(f"[{address}]:{NODE_EXPORTER_PORT}")
+            for target in targets:
+                if target not in instances:
+                    instances.append(target)
+    return "|".join(re.escape(instance) for instance in instances)
+
+
+def collect_loader_load(monitor_node, start, end, loader_nodes) -> dict[str, float]:
+    """Peak loader-side CPU figures over a latency step window (SCT-601).
+
+    A client-observed P99 spike with flat server-side metrics is not necessarily a ScyllaDB problem -
+    the loaders themselves can be CPU starved. Reported per step next to the latencies so that two
+    runs can be compared directly instead of having to dig through Prometheus afterwards:
+
+    - **busy**: the hottest loader's CPU utilization.
+    - **steal**: CPU the hypervisor took away - a noisy neighbour or a credit-limited instance.
+    - **pressure**: PSI, the share of time at least one task was stalled waiting for a CPU. The
+      clearest "this loader was starved" signal, and it is high exactly when steal is not.
+    - **load1**: the coarse signal that used to be the only one available, kept for comparison
+      against past runs.
+
+    A metric whose query returned nothing is left out rather than reported as 0 - no data must not
+    read as an idle loader.
+    """
+    if not loader_nodes:
+        return {}
+    instances = _loader_instances_filter(loader_nodes)
+    if not instances:
+        LOGGER.warning("None of the loaders has an address to match node_exporter metrics with")
+        return {}
+
+    labels = f'instance=~"{instances}"'
+    queries = {
+        "Loader CPU busy max": f"100 - (avg by (instance) "
+        f'(rate(node_cpu_seconds_total{{mode="idle",{labels}}}[{LOADER_LOAD_RATE_WINDOW}])) * 100)',
+        "Loader CPU steal max": f"avg by (instance) "
+        f'(rate(node_cpu_seconds_total{{mode="steal",{labels}}}[{LOADER_LOAD_RATE_WINDOW}])) * 100',
+        "Loader CPU pressure max": f"rate(node_pressure_cpu_waiting_seconds_total{{{labels}}}"
+        f"[{LOADER_LOAD_RATE_WINDOW}]) * 100",
+        "Loader load1 max": f"node_load1{{{labels}}}",
+    }
+
+    prometheus = PrometheusDBStats(host=monitor_node.external_address)
+    res = {}
+    for metric, query in queries.items():
+        try:
+            query_res = prometheus.query(query, start, end)
+        except Exception:  # noqa: BLE001  # diagnostics must not fail the latency reporting
+            LOGGER.warning("Failed to query '%s' for %s", query, metric, exc_info=True)
+            continue
+        values = [
+            float(value[-1])
+            for entry in query_res
+            for value in entry.get("values") or []
+            if value[-1].lower() not in ("nan", "+inf", "-inf")
+        ]
+        if values:
+            res[metric] = float(format(max(values), ".2f"))
+    LOGGER.debug("Loader load during the step: %s", res)
     return res
 
 

--- a/sdcm/utils/remote_logger.py
+++ b/sdcm/utils/remote_logger.py
@@ -39,6 +39,7 @@ from sdcm.sct_events import Severity
 from sdcm.sct_events.decorators import raise_event_on_failure
 from sdcm.sct_events.loaders import HDRFileMissed
 from sdcm.sct_events.system import TestFrameworkEvent
+from sdcm.loader_cpu_diagnostics_setup import REMOTE_LOG_PATH as LOADER_CPU_DIAGNOSTICS_LOG_PATH
 from sdcm.utils.k8s import KubernetesOps
 from sdcm.utils.decorators import retrying
 
@@ -70,6 +71,8 @@ class SSHLoggerBase(LoggerBase):
     RETRIEVE_LOG_MESSAGE_TEMPLATE = "SSHLogger reading {log_file} from {since}"
     VERBOSE_RETRIEVE = True
     READINESS_CHECK_DELAY = 10  # seconds
+    # set it in a subclass that runs alongside another SSH logger on the same node, see _remote_file_id
+    LOGGER_FILE_ID = ""
 
     def __init__(self, node: BaseNode, target_log_file: str):
         super().__init__(target_log_file=target_log_file)
@@ -84,7 +87,9 @@ class SSHLoggerBase(LoggerBase):
 
     def stop(self, timeout: float | None = None) -> None:
         self._termination_event.set()
-        self._remoter.run(f"kill -9 -{self.remote_pid}", ignore_status=True)
+        # guarded: an empty pid would run `kill -9 -`, which only fails silently thanks to ignore_status
+        if remote_pid := self.remote_pid:
+            self._remoter.run(f"kill -9 -{remote_pid}", ignore_status=True)
         if self._thread.running():
             self._thread.cancel()
 
@@ -102,12 +107,23 @@ class SSHLoggerBase(LoggerBase):
         return self._remoter.is_up()
 
     @property
+    def _remote_file_id(self) -> str:
+        """Identifies the remote helper files (pid file, command script) of this logger.
+
+        Keyed on the SCT pid alone the files would be shared by every SSH logger attached to the
+        same node, so a second logger would overwrite the pid file of the first one and stopping
+        either would kill the other one's remote command. LOGGER_FILE_ID keeps them apart and is
+        empty for the system log logger, which keeps its historical file names.
+        """
+        return f"{os.getpid()}_{self.LOGGER_FILE_ID}" if self.LOGGER_FILE_ID else f"{os.getpid()}"
+
+    @property
     def remote_pid(self) -> str:
         """
         Returns the PID of the remote logger process.
         This is used to ensure that the logger is running and to manage its lifecycle.
         """
-        remote_pid_file = f"/tmp/logger_{os.getpid()}.pid"
+        remote_pid_file = f"/tmp/logger_{self._remote_file_id}.pid"
         if not self._remoter.run(f"test -f {remote_pid_file}", ignore_status=True).ok:
             return ""
         return self._remoter.run(f"cat {remote_pid_file}").stdout.strip()
@@ -118,11 +134,12 @@ class SSHLoggerBase(LoggerBase):
         )
         try:
             # Write the remote PID to a file before running the logger command
-            remote_pid_file = f"/tmp/logger_{os.getpid()}.pid"
+            remote_pid_file = f"/tmp/logger_{self._remote_file_id}.pid"
+            remote_cmd_file = f"/tmp/logger_cmd_{self._remote_file_id}.sh"
             cmd = self._logger_cmd_template.format(since=f'--since "{since}" ' if since else "")
             remote_cmd = (
-                f"cat <<'EOF' > /tmp/logger_cmd_{os.getpid()}.sh\n{cmd}\nEOF\n"
-                f"setsid bash /tmp/logger_cmd_{os.getpid()}.sh & echo $! > {remote_pid_file}; wait"
+                f"cat <<'EOF' > {remote_cmd_file}\n{cmd}\nEOF\n"
+                f"setsid bash {remote_cmd_file} & echo $! > {remote_pid_file}; wait"
             )
             self._remoter.run(
                 cmd=remote_cmd,
@@ -360,6 +377,78 @@ class SSHScyllaFileLogger(SSHGeneralFileLogger):
     @cached_property
     def _logger_cmd_template(self) -> str:
         return f"{super()._logger_cmd_template} | grep scylla"
+
+
+class LoaderCpuFileLogger(SSHGeneralFileLogger):
+    """Stream the loader CPU diagnostics sampler log (SCT-601) off a loader host.
+
+    Streamed rather than pulled at teardown: perf loaders get terminated (and spot loaders can go
+    away mid-run), while the interesting samples are exactly the last ones before a failure.
+    Inherits the readiness check of the parent, so it simply waits until the sampler service has
+    created the file instead of failing when it is started before the loader setup.
+    """
+
+    REMOTE_LOG_PATH = LOADER_CPU_DIAGNOSTICS_LOG_PATH
+    LOGGER_FILE_ID = "loader_cpu"
+    VERBOSE_RETRIEVE = False
+    # the teardown command must never outlive a wedged connection, see stop()
+    STOP_TIMEOUT = 30  # seconds
+
+    def __init__(self, node: BaseNode, target_log_file: str):
+        super().__init__(node=node, target_log_file=target_log_file)
+        self._stop_lock = Lock()
+        self._stopped = False
+
+    def stop(self, timeout: float | None = None) -> None:
+        """Stop the remote tail by its command line, not by killing its process group.
+
+        The parent runs `kill -9 -<pid>` on the pid it wrote for this logger. That pid's process
+        group can include the shell serving the SSH channel, so the kill takes down the connection
+        it is issued over: the remoter to that loader is wedged, this logger's worker stays blocked
+        in the dead SSH read, and because `concurrent.futures` joins its worker threads at
+        interpreter exit, the whole run then cannot exit. Run 8597ebfd hung for 6.5 hours that way,
+        after the test itself had finished.
+
+        `pkill -f` on the tail's own command line ends only the tail - the same approach
+        :class:`HDRHistogramFileLogger` uses, and the reason it never leaked a worker. `sudo` is
+        needed because the tail runs as root.
+
+        Idempotent and bounded: the flag makes a second call (the teardown calls this from both
+        `stop_task_threads` and `wait_till_tasks_threads_are_stopped`) a pure no-op that issues no
+        remote command at all, and the timeout keeps a wedged remoter from blocking teardown.
+        """
+        with self._stop_lock:
+            if self._stopped:
+                return
+            self._stopped = True
+        self._termination_event.set()
+        try:
+            self._remoter.run(
+                f"sudo pkill -f 'tail -f {self.REMOTE_LOG_PATH}'",
+                ignore_status=True,
+                verbose=False,
+                timeout=self.STOP_TIMEOUT,
+            )
+        except Exception:  # noqa: BLE001  # teardown must not fail over a diagnostics logger
+            self._log.warning("Failed to stop the loader CPU diagnostics tail, its worker may leak", exc_info=True)
+        if self._thread is not None and self._thread.running():
+            self._thread.cancel()
+
+    @property
+    def _logger_cmd_template(self) -> str:
+        """Tail the sampler log, resuming where the local copy left off.
+
+        A plain property, not the cached_property of the parent: the offset has to be recomputed on
+        every reconnect. The parent tails from `-c +0` unconditionally, which re-reads the whole
+        remote file after every SSH reconnect - for a 1 Hz log over a multi-hour run that means
+        megabytes of duplicated samples. The sampler only ever appends, so a byte offset is a safe
+        resume point.
+        """
+        try:
+            offset = os.path.getsize(self._target_log_file)
+        except OSError:  # not created yet, or gone
+            offset = 0
+        return f"sudo tail -f {self.REMOTE_LOG_PATH} -c +{offset + 1}"
 
 
 class CommandLoggerBase(LoggerBase):

--- a/unit_tests/unit/test_loader_cpu_diagnostics.py
+++ b/unit_tests/unit/test_loader_cpu_diagnostics.py
@@ -1,0 +1,234 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2026 ScyllaDB
+
+"""Unit tests for the loader CPU diagnostics sampler and its log streaming (SCT-601)."""
+
+import os
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from sdcm.loader_cpu_diagnostics_setup import (
+    MAX_LOG_SIZE_MB,
+    REMOTE_LOG_PATH,
+    REMOTE_SCRIPT_PATH,
+    SAMPLER_SCRIPT_NAME,
+    SERVICE_NAME,
+    THREAD_EVERY_N_SAMPLES,
+    TOP_THREADS,
+    LoaderCpuDiagnosticsSetup,
+)
+from sdcm.utils.remote_logger import LoaderCpuFileLogger, SSHGeneralSystemdLogger
+
+SAMPLER_SCRIPT_PATH = Path(__file__).parent.parent.parent / "data_dir" / SAMPLER_SCRIPT_NAME
+
+
+@pytest.fixture(name="node")
+def fixture_node():
+    """A loader node whose remoter records the commands the setup runs on it."""
+    node = MagicMock()
+    node.name = "loader-node-1"
+    return node
+
+
+def _sampler_setup_script(node) -> str:
+    """The shell script the setup passed to remoter.sudo()."""
+    assert node.remoter.sudo.call_args, "the setup ran no sudo command"
+    return node.remoter.sudo.call_args.args[0]
+
+
+# --- sampler service installation ---
+
+
+def test_install_uploads_the_sampler_and_starts_the_service(node):
+    LoaderCpuDiagnosticsSetup.install(node)
+
+    node.install_package.assert_called_once_with("sysstat", ignore_status=True)
+    src, dst = node.remoter.send_files.call_args.args
+    assert Path(src).name == SAMPLER_SCRIPT_NAME
+    assert Path(src).is_file(), f"the sampler is not shipped in data_dir: {src}"
+    assert dst == f"/tmp/{SAMPLER_SCRIPT_NAME}"
+
+    script = _sampler_setup_script(node)
+    assert f"install -m 0755 /tmp/{SAMPLER_SCRIPT_NAME} {REMOTE_SCRIPT_PATH}" in script
+    assert f"ExecStart={REMOTE_SCRIPT_PATH} " in script
+    assert f"-o {REMOTE_LOG_PATH}" in script
+    assert f"-T {TOP_THREADS} -m {MAX_LOG_SIZE_MB}" in script
+    # restart and not start: a reused loader may already run an older sampler
+    assert f"systemctl restart {SERVICE_NAME}.service" in script
+    assert f"systemctl enable {SERVICE_NAME}.service" in script
+
+
+def test_install_without_per_thread_disables_thread_sampling(node):
+    LoaderCpuDiagnosticsSetup.install(node, per_thread=False)
+
+    assert "-t 0 " in _sampler_setup_script(node)
+
+
+def test_install_with_per_thread_samples_threads_every_nth_sample(node):
+    LoaderCpuDiagnosticsSetup.install(node, per_thread=True)
+
+    assert f"-t {THREAD_EVERY_N_SAMPLES} " in _sampler_setup_script(node)
+
+
+def test_install_exec_start_is_a_single_line(node):
+    """The unit file is written through a dedent()ed heredoc: a wrapped ExecStart would break it."""
+    LoaderCpuDiagnosticsSetup.install(node, per_thread=True)
+
+    exec_start = [line for line in _sampler_setup_script(node).splitlines() if "ExecStart=" in line]
+    assert len(exec_start) == 1
+    assert exec_start[0].rstrip().endswith(str(MAX_LOG_SIZE_MB))
+
+
+def test_install_pins_the_sysstat_output_format(node):
+    """A 12h locale shifts every mpstat/pidstat column by one field."""
+    LoaderCpuDiagnosticsSetup.install(node)
+
+    assert "Environment=S_TIME_FORMAT=ISO LC_ALL=C" in _sampler_setup_script(node)
+
+
+def test_install_warns_when_the_service_is_not_sampling(node):
+    """`systemctl restart` succeeds as soon as the process is forked, even if it dies right after."""
+    node.remoter.run.return_value.ok = False
+
+    LoaderCpuDiagnosticsSetup.install(node)
+
+    assert any("is not active" in str(call) for call in node.log.warning.call_args_list)
+    assert any("systemctl is-active" in str(call) for call in node.remoter.run.call_args_list)
+
+
+def test_install_keeps_going_when_sysstat_is_unavailable(node):
+    """sysstat is best effort - the sampler falls back to /proc, diagnostics must not fail a setup."""
+    node.install_package.side_effect = Exception("no such package")
+    node.remoter.run.return_value.ok = False
+
+    LoaderCpuDiagnosticsSetup.install(node)
+
+    assert f"systemctl restart {SERVICE_NAME}.service" in _sampler_setup_script(node)
+
+
+# --- log streaming ---
+
+
+def test_loader_cpu_logger_reads_the_path_the_sampler_writes():
+    assert LoaderCpuFileLogger.REMOTE_LOG_PATH == REMOTE_LOG_PATH
+
+
+def test_loader_cpu_logger_remote_files_do_not_collide_with_the_journal_logger():
+    """Two SSH loggers on one node must not share the remote pid file.
+
+    Keyed on the SCT pid alone, the second logger overwrote the pid file of the first one and
+    stopping either killed the other one's remote command.
+    """
+    node = MagicMock()
+    journal_logger = SSHGeneralSystemdLogger(node, "/tmp/system.log")
+    cpu_logger = LoaderCpuFileLogger(node, "/tmp/loader-cpu.log")
+
+    assert journal_logger._remote_file_id != cpu_logger._remote_file_id
+    # the system log logger keeps its historical file names
+    assert journal_logger._remote_file_id == str(os.getpid())
+    assert cpu_logger._remote_file_id == f"{os.getpid()}_loader_cpu"
+
+
+def test_loader_cpu_logger_resumes_at_the_local_offset(tmp_path):
+    """The parent tails from byte 0, so every reconnect would duplicate the whole log."""
+    target = tmp_path / "loader-cpu.log"
+    target.write_bytes(b"x" * 4096)
+
+    logger = LoaderCpuFileLogger(MagicMock(), str(target))
+
+    assert logger._logger_cmd_template.endswith(f"-c +{4096 + 1}")
+    # recomputed per call, the parent caches it
+    target.write_bytes(b"x" * 8192)
+    assert logger._logger_cmd_template.endswith(f"-c +{8192 + 1}")
+
+
+def test_loader_cpu_logger_starts_from_the_beginning_without_a_local_file(tmp_path):
+    logger = LoaderCpuFileLogger(MagicMock(), str(tmp_path / "missing.log"))
+
+    assert logger._logger_cmd_template.endswith("-c +1")
+
+
+def test_loader_cpu_logger_stop_kills_the_tail_by_command_line(tmp_path):
+    """A process-group kill takes down the SSH channel it is issued over and wedges the remoter.
+
+    That is what left four workers blocked after run 8597ebfd finished, and `concurrent.futures`
+    joins its workers at interpreter exit, so the run hung for 6.5 hours.
+    """
+    node = MagicMock()
+    logger = LoaderCpuFileLogger(node, str(tmp_path / "loader-cpu.log"))
+
+    logger.stop()
+
+    command = node.remoter.run.call_args.args[0]
+    assert command == f"sudo pkill -f 'tail -f {REMOTE_LOG_PATH}'"
+    assert "kill -9 -" not in command
+    assert node.remoter.run.call_args.kwargs["timeout"] == LoaderCpuFileLogger.STOP_TIMEOUT
+
+
+def test_loader_cpu_logger_stop_is_idempotent(tmp_path):
+    """Teardown stops it twice; the second call must not touch a possibly wedged connection."""
+    node = MagicMock()
+    logger = LoaderCpuFileLogger(node, str(tmp_path / "loader-cpu.log"))
+
+    logger.stop()
+    logger.stop()
+
+    assert node.remoter.run.call_count == 1
+
+
+def test_loader_cpu_logger_stop_survives_an_unreachable_loader(tmp_path):
+    """Teardown must not fail over a diagnostics logger."""
+    node = MagicMock()
+    node.remoter.run.side_effect = Exception("connection lost")
+    logger = LoaderCpuFileLogger(node, str(tmp_path / "loader-cpu.log"))
+
+    logger.stop()  # must not raise
+
+    assert logger._termination_event.is_set()
+
+
+# --- the sampler script itself ---
+
+
+def test_sampler_script_has_valid_bash_syntax():
+    assert subprocess.run(["bash", "-n", str(SAMPLER_SCRIPT_PATH)], capture_output=True, check=False).returncode == 0
+
+
+def test_sampler_script_matches_processes_by_name_only():
+    """`pgrep -f` would match the sampler itself: its own pattern is part of its command line."""
+    code_lines = [line for line in SAMPLER_SCRIPT_PATH.read_text().splitlines() if not line.lstrip().startswith("#")]
+    assert not [line for line in code_lines if "pgrep -f" in line]
+
+
+def test_sampler_script_exits_on_termination_signals():
+    """A TERM handler that does not exit leaves the loop running until systemd SIGKILLs it."""
+    assert "trap 'exit 0' TERM INT" in SAMPLER_SCRIPT_PATH.read_text()
+
+
+def test_sampler_script_pins_the_sysstat_time_format():
+    """Belt and braces with the systemd unit: a 12h locale shifts every column by one field."""
+    script = SAMPLER_SCRIPT_PATH.read_text()
+
+    assert "export S_TIME_FORMAT=ISO" in script
+    assert "export LC_ALL=C" in script
+
+
+def test_sampler_script_does_not_hardcode_the_thread_sort_column():
+    """%wait only exists since sysstat 11.5, so a fixed field index sorts by the wrong metric."""
+    script = SAMPLER_SCRIPT_PATH.read_text()
+
+    assert "thread_cpu_sort_key" in script
+    assert "sort -k10" not in script

--- a/unit_tests/unit/test_loader_load_metrics.py
+++ b/unit_tests/unit/test_loader_load_metrics.py
@@ -1,0 +1,134 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2026 ScyllaDB
+
+"""Unit tests for the per-step loader load reported next to the latencies (SCT-601)."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from sdcm.argus_results import LOADER_LOAD_COLUMN_NAMES, workload_to_table
+from sdcm.utils.latency import collect_loader_load
+
+
+class FakePrometheus:
+    """Answers the loader load queries with canned series, recording what was asked."""
+
+    def __init__(self, values_by_metric=None, raises=False):
+        self.values_by_metric = values_by_metric or {}
+        self.raises = raises
+        self.queries = []
+
+    def query(self, query, start, end):  # noqa: ARG002
+        self.queries.append(query)
+        if self.raises:
+            raise RuntimeError("prometheus is down")
+        for metric, series in self.values_by_metric.items():
+            if metric in query:
+                return series
+        return []
+
+
+def _loader(ip_address, private_ip_address=None):
+    node = MagicMock()
+    node.ip_address = ip_address
+    node.private_ip_address = private_ip_address or ip_address
+    node.public_ip_address = None
+    return node
+
+
+def _series(*values):
+    return [{"metric": {"instance": "10.0.0.1:9100"}, "values": [[0, str(value)] for value in values]}]
+
+
+def _collect(prometheus, loaders):
+    with patch("sdcm.utils.latency.PrometheusDBStats", return_value=prometheus):
+        return collect_loader_load(MagicMock(), start=1, end=2, loader_nodes=loaders)
+
+
+def test_collect_loader_load_reports_the_peak_of_the_window():
+    prometheus = FakePrometheus(
+        {
+            'mode="idle"': _series(41.5, 89.64, 55.0),
+            'mode="steal"': _series(0.0, 3.25),
+            "node_pressure_cpu_waiting_seconds_total": _series(1.0, 17.9),
+            "node_load1": _series(56.08, 42.0),
+        }
+    )
+
+    result = _collect(prometheus, [_loader("10.0.0.1")])
+
+    assert result == {
+        "Loader CPU busy max": 89.64,
+        "Loader CPU steal max": 3.25,
+        "Loader CPU pressure max": 17.9,
+        "Loader load1 max": 56.08,
+    }
+
+
+def test_collect_loader_load_omits_metrics_without_data():
+    """A metric with no data must not be reported as 0 - that would read as an idle loader."""
+    prometheus = FakePrometheus({"node_load1": _series(12.0)})
+
+    result = _collect(prometheus, [_loader("10.0.0.1")])
+
+    assert result == {"Loader load1 max": 12.0}
+
+
+def test_collect_loader_load_ignores_nan_samples():
+    prometheus = FakePrometheus({"node_load1": [{"metric": {}, "values": [[0, "NaN"], [1, "7.5"]]}]})
+
+    assert _collect(prometheus, [_loader("10.0.0.1")]) == {"Loader load1 max": 7.5}
+
+
+def test_collect_loader_load_queries_only_the_loader_instances():
+    prometheus = FakePrometheus()
+
+    _collect(prometheus, [_loader("10.0.0.1", "10.0.0.2")])
+
+    assert prometheus.queries, "no query was sent"
+    for query in prometheus.queries:
+        assert "10\\.0\\.0\\.1:9100" in query or "10.0.0.1:9100" in query
+        assert "10.0.0.2:9100" in query.replace("\\", "")
+        # the node_exporter job holds the DB nodes as well, they must not be mixed in
+        assert "10.0.0.9" not in query
+
+
+def test_collect_loader_load_does_not_repeat_an_address_a_loader_has_twice():
+    """A loader whose private and public address are the same must appear once in the filter."""
+    prometheus = FakePrometheus()
+
+    _collect(prometheus, [_loader("10.0.0.1", "10.0.0.1")])
+
+    # the instances are regex escaped in the query
+    assert prometheus.queries[0].replace("\\", "").count("10.0.0.1:9100") == 1
+
+
+def test_collect_loader_load_without_loaders_does_not_query():
+    prometheus = FakePrometheus()
+
+    assert _collect(prometheus, []) == {}
+    assert not prometheus.queries
+
+
+def test_collect_loader_load_survives_a_prometheus_failure():
+    """Diagnostics must never break the latency reporting of a step."""
+    assert _collect(FakePrometheus(raises=True), [_loader("10.0.0.1")]) == {}
+
+
+@pytest.mark.parametrize("workload", sorted(workload_to_table))
+def test_loader_load_columns_are_declared_in_every_latency_table(workload):
+    """An undeclared column is silently dropped, so the figures would never reach Argus."""
+    declared = [column.name for column in workload_to_table[workload].Meta.Columns]
+
+    assert set(LOADER_LOAD_COLUMN_NAMES) <= set(declared)


### PR DESCRIPTION
The goal - to make a client-side P99 spike attributable. So when a perf step fails with flat server-side 
metrics, the loaders can be proven guilty or innocent from a single run's data.

Three commits:

1. **`loader_cpu_diagnostics`** - a 1 Hz systemd sampler on every loader: per-vCPU `%steal`, PSI CPU
   pressure, stress-tool CPU and `%wait`, context switches, loadavg. `%steal` separates a noisy
   neighbour from self-inflicted saturation, PSI a starved loader from a busy one. Per loader, not per
   stress thread; streamed off live, since perf loaders get terminated. Optional per-thread lines are
   capped at the 20 hottest threads every 10th sample. Also fixes a latent bug: two SSH loggers on one
   node shared their remote pid file, so stopping one killed the other's remote command.
2. **`--collector.processes`** for node_exporter - off by default, so `node_procs_running`/`_blocked`
   were missing from every run.
3. **Per-step loader load in Argus** - peak loader busy/`%steal`/PSI/`load1` per latency step, next to
   its P99s, so the run-A-vs-run-B comparison from the ticket is a table lookup. From the loader
   node_exporter already scraped; no data is omitted rather than reported as 0.

Both flags default to `false`. Docs in `docs/performance-tests.md` explain how to read the log.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
- [ ] [perf run with `loader_cpu_diagnostics: true` - `loader-cpu.log` collected per loader](https://argus.scylladb.com/tests/scylla-cluster-tests/e560dc8e-1716-4ff9-8f79-00724b5e1752)


### PR pre-checks (self review)

- [ ] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code


Fixes [SCT-601](https://scylladb.atlassian.net/browse/SCT-601).


[SCT-601]: https://scylladb.atlassian.net/browse/SCT-601?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ