### PR TITLE
fix(health_checker): don't fail on peers schema lag if gossip agrees

### DIFF
--- a/sdcm/utils/health_checker.py
+++ b/sdcm/utils/health_checker.py
@@ -154,6 +154,17 @@ def check_schema_version(gossip_info, peers_details, nodes_status, current_node)
         return
 
     debug_message = f"Gossip info: {gossip_info}\nSYSTEM.PEERS info: {peers_details}"
+
+    active_schema_versions = {
+        node_values["schema"]
+        for node_values in gossip_info.values()
+        if node_values["status"] not in current_node.GOSSIP_STATUSES_FILTER_OUT
+    }
+    # gossip is the source of truth for schema agreement: SYSTEM.PEERS.schema_version can lag
+    # behind it until the next schema change (SCYLLADB-4037), so a peers-vs-gossip
+    # mismatch is only a WARNING while gossip agrees on all nodes
+    gossip_schema_agreed = len(active_schema_versions) <= 1
+
     # Validate schema version
     for node, node_info in gossip_info.items():
         # SYSTEM.PEERS table includes peers of the current node, so the node itcurrent_node doesn't exist in the list
@@ -177,14 +188,23 @@ def check_schema_version(gossip_info, peers_details, nodes_status, current_node)
 
         if node_info["schema"] != str(peers_details[node]["schema_version"]):
             LOGGER.debug(debug_message)
-            yield ClusterHealthValidatorEvent.NodeSchemaVersion(
-                severity=Severity.ERROR,
-                node=current_node.name,
-                error=f"Current node {current_node}. Wrong Schema version. "
-                f"Node {node}{is_target} schema version in SYSTEM.PEERS is "
-                f"{peers_details[node]['schema_version']}, "
-                f"but schema version in gossip {node_info['schema']}",
+            mismatch_details = (
+                f"Node {node}{is_target} schema version in SYSTEM.PEERS is {peers_details[node]['schema_version']}, "
+                f"but schema version in gossip {node_info['schema']}"
             )
+            if gossip_schema_agreed:
+                event_kwargs = {
+                    "severity": Severity.WARNING,
+                    "message": f"Current node {current_node}. {mismatch_details}. Gossip schema versions agree on "
+                    "all nodes, so this is the known transient SYSTEM.PEERS lag that self-heals on the "
+                    "next schema change (https://scylladb.atlassian.net/browse/SCYLLADB-4037)",
+                }
+            else:
+                event_kwargs = {
+                    "severity": Severity.ERROR,
+                    "error": f"Current node {current_node}. Wrong Schema version. {mismatch_details}",
+                }
+            yield ClusterHealthValidatorEvent.NodeSchemaVersion(node=current_node.name, **event_kwargs)
 
     # Validate that all nodes in SYSTEM.PEERS exist in gossip
     not_in_gossip = list(set(peers_details.keys()) - set(gossip_info.keys()))
@@ -198,13 +218,7 @@ def check_schema_version(gossip_info, peers_details, nodes_status, current_node)
         )
 
     # Validate that same schema on all nodes in the gossip
-    schema_version_on_all_nodes = [
-        values["schema"]
-        for values in gossip_info.values()
-        if values["status"] not in current_node.GOSSIP_STATUSES_FILTER_OUT
-    ]
-
-    if len(set(schema_version_on_all_nodes)) > 1:
+    if not gossip_schema_agreed:
         LOGGER.debug(debug_message)
         gossip_info_str = "\n".join(
             f"{node}: {schema_version['schema']}" for node, schema_version in gossip_info.items()
@@ -267,10 +281,14 @@ def check_schema_agreement_in_gossip_and_peers(node, retries: int = CHECK_NODE_H
             if not (data["status"] == "NORMAL" and current_node in peers_info):
                 continue
             if data["schema"] != str(peers_info[current_node]["schema_version"]):
-                current_err = f"{message_pref} Schema version is not same in the gossip and peers for {current_node}"
-                LOGGER.warning(current_err)
-                err += f"{current_err}\n"
-                continue
+                # gossip already agrees here, so a lagging SYSTEM.PEERS row is the known transient
+                # raft-topology artifact that self-heals on the next schema change
+                # (SCYLLADB-4037) - not a failure
+                LOGGER.warning(
+                    "%s Schema version in SYSTEM.PEERS lags behind the agreed gossip version for %s",
+                    message_pref,
+                    current_node,
+                )
         break  # Everything is OK, break the cycle.
     if not err:
         LOGGER.debug("Schema agreement has been completed on all nodes")

--- a/unit_tests/unit/test_utils_health_checker.py
+++ b/unit_tests/unit/test_utils_health_checker.py
@@ -281,3 +281,73 @@ class TestHealthChecker:
         error_event = events[0]
         assert error_event.severity == Severity.ERROR
         assert "Test exception" in error_event.error
+
+
+# the initial (empty) schema version a bootstrapping node advertises before it catches up with group0 schema;
+# SYSTEM.PEERS may keep it until the next schema change (SCYLLADB-4037)
+EMPTY_SCHEMA_VERSION = "59adb24e-f3cd-3e02-97f0-5b395827453f"
+AGREED_SCHEMA_VERSION = "cbe15453-33f3-3387-aaf1-4120548f41e8"
+OTHER_SCHEMA_VERSION = "657aac4c-63fd-11f1-aca2-12efe961f2b9"
+
+
+def _peers_entry(schema_version: str) -> dict:
+    return {
+        "data_center": "datacenter1",
+        "host_id": UUID("b231fe54-8093-4d5c-9a35-b5e34dc81500"),
+        "rack": "rack1",
+        "release_version": "3.0.8",
+        "rpc_address": "127.0.0.2",
+        "schema_version": UUID(schema_version),
+    }
+
+
+def _normal_gossip(*schema_versions: str) -> dict:
+    """Gossip info for node1/node2/node3, all in NORMAL status."""
+    return {
+        node: {"schema": schema_version, "status": "NORMAL", "dc": "datacenter1"}
+        for node, schema_version in zip((node1, node2, node3), schema_versions)
+    }
+
+
+def test_check_schema_version_peers_lag_demoted_to_warning_when_gossip_agrees():
+    gossip_info = _normal_gossip(AGREED_SCHEMA_VERSION, AGREED_SCHEMA_VERSION, AGREED_SCHEMA_VERSION)
+    peers_info = {
+        node2: _peers_entry(AGREED_SCHEMA_VERSION),
+        node3: _peers_entry(EMPTY_SCHEMA_VERSION),
+    }
+
+    events = list(check_schema_version(gossip_info, peers_info, NODES_STATUS, node1))
+    assert events, "expected events for the lagging SYSTEM.PEERS row"
+    assert all(event.severity == Severity.WARNING for event in events), (
+        f"peers-vs-gossip lag must not raise ERROR when gossip agrees: {[str(event) for event in events]}"
+    )
+    assert any(EMPTY_SCHEMA_VERSION in event.message for event in events)
+
+
+def test_check_schema_version_peers_mismatch_stays_error_when_gossip_disagrees():
+    gossip_info = _normal_gossip(AGREED_SCHEMA_VERSION, OTHER_SCHEMA_VERSION, AGREED_SCHEMA_VERSION)
+    peers_info = {
+        node2: _peers_entry(AGREED_SCHEMA_VERSION),
+        node3: _peers_entry(AGREED_SCHEMA_VERSION),
+    }
+
+    events = list(check_schema_version(gossip_info, peers_info, NODES_STATUS, node1))
+    assert any(event.severity == Severity.ERROR and "Wrong Schema version" in event.error for event in events), (
+        "peers-vs-gossip mismatch must stay ERROR when gossip itself disagrees"
+    )
+
+
+def test_check_schema_agreement_in_gossip_and_peers_tolerates_peers_lag():
+    class PeersLagNode(Node):
+        @staticmethod
+        def get_peers_info():
+            return {
+                node2: _peers_entry(AGREED_SCHEMA_VERSION),
+                node3: _peers_entry(EMPTY_SCHEMA_VERSION),
+            }
+
+    with unittest.mock.patch("time.sleep") as mocked_sleep:
+        err = check_schema_agreement_in_gossip_and_peers(PeersLagNode("127.0.0.1", "node-0"), 3)
+
+    assert mocked_sleep.call_count == 0, "peers lag under gossip agreement must not consume retries"
+    assert err == "", "peers lag under gossip agreement must not be reported as an error"


### PR DESCRIPTION
After a node joins a raft-topology cluster, its schema_version in the other nodes' system.peers can stay stale until the next schema change (scylladb/scylladb#15078). The health check reports this as ERROR and fails a test run, even though gossip already agreed on the schema version on all nodes.

The change fixes this by reporting the mismatch as WARNING when gossip agrees, but keeping ERROR when gossip itself disagrees.
Same tolerance in the schema agreement wait.

Fixes: SCT-465

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->https://github.com/dimakr/scylla-cluster-tests/tree/fix_nodeschemaversion
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :green_circle: [pr-provision-test, regression check](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/pr-provision-test/327/)
- [x] :green_circle: [rolling-upgrade-with-sla-no-shares test](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/upgrades/job/rolling-upgrade-with-sla-no-shares-test/7/)
Few builds were executed in a row and the referenced one exactly reproduced the race problem from original issue and now it don't cause test error, but published as a new warning `... Gossip schema versions agree on all nodes, so this is the known transient SYSTEM.PEERS lag that self-heals on the next schema change ...`