### PR TITLE
chore(ruff): re-apply ruff-format to files that missed the 0.16.3 bump

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1326,7 +1326,7 @@ class BaseNode(AutoSshContainerMixin):
             ):
                 try:
                     extra_address = address_getter()
-                except (NetworkInterfaceNotFound, AttributeError):
+                except NetworkInterfaceNotFound, AttributeError:
                     continue
                 if not extra_address or extra_address == ScyllaNetworkConfiguration.LISTEN_ALL:
                     continue

--- a/sdcm/cluster_oci.py
+++ b/sdcm/cluster_oci.py
@@ -188,7 +188,7 @@ class OciNode(cluster.BaseNode):
                 if addrs:
                     ipv6_map[ifname] = addrs
             return ipv6_map
-        except (json.JSONDecodeError, KeyError):
+        except json.JSONDecodeError, KeyError:
             return {}
 
     def _build_network_interfaces(self) -> list:

--- a/sdcm/provision/oci/virtual_machine_provider.py
+++ b/sdcm/provision/oci/virtual_machine_provider.py
@@ -615,7 +615,7 @@ class VirtualMachineProvider:
             instance_id=instance_id,
         ).data
         active = [a for a in attachments if a.lifecycle_state == "ATTACHED"]
-        active.sort(key=lambda a: (a.nic_index or 0))
+        active.sort(key=lambda a: a.nic_index or 0)
         return active
 
     def get_vnic_details(self, vnic_id: str):


### PR DESCRIPTION
`pre-commit run --all-files` currently fails on **master**, which turns the
`jenkins/precommit` stage red on every open PR (e.g. #15833, whose own diff is
clean).

Root cause: c3c3afd46a upgraded ruff to 0.16.3 and reformatted the tree, but
two OCI / IPv6 branches were already in flight and merged afterwards carrying
code formatted by the older ruff.

This re-runs `ruff format` on the three drifted files:

- `sdcm/cluster.py`, `sdcm/cluster_oci.py` — PEP 758 unparenthesized `except`
  groups (matching the ~50 already in the tree)
- `sdcm/provision/oci/virtual_machine_provider.py` — redundant parens around a
  lambda body

No behaviour change.

### Testing

- `git ls-files '*.py' | grep -v '^argus/' | xargs ruff format --check` → 820 files already formatted
- `ruff check --preview .` → All checks passed