### PR TITLE
feature(pgo-trigger): add cql_raw microbenchmark jobs to PGO offline installer trigger

### DIFF
--- a/configurations/triggers/pgo-offline-installer.yaml
+++ b/configurations/triggers/pgo-offline-installer.yaml
@@ -21,7 +21,7 @@ defaults:
   post_behavior_monitor_nodes: "destroy"
 
 jobs:
-  # --- x86_64 microbenchmarks ---
+  # --- x86_64 microbenchmarks simple-query ---
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-simple-query-weekly-microbenchmark_x86_64"
     backend: "aws"
     wait: false
@@ -44,7 +44,7 @@ jobs:
       unified_package: "{unified_package}"
       nonroot_offline_install: "false"
 
-  # --- ARM64 microbenchmarks ---
+  # --- ARM64 microbenchmarks simple-query ---
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-simple-query-weekly-microbenchmark_arm64"
     backend: "aws"
     wait: false
@@ -57,6 +57,52 @@ jobs:
       nonroot_offline_install: "false"
 
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-simple-query-weekly-microbenchmark_arm64-write"
+    backend: "aws"
+    wait: false
+    labels:
+      - "pgo-arm"
+    exclude_versions: []
+    params:
+      region: "us-east-1"
+      unified_package: "{unified_package}"
+      nonroot_offline_install: "false"
+
+  # --- x86_64 microbenchmarks cql_raw ---
+  - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-cql-raw-weekly-microbenchmark_x86_64"
+    backend: "aws"
+    wait: false
+    labels:
+      - "pgo-x86"
+    exclude_versions: []
+    params:
+      region: "us-east-1"
+      unified_package: "{unified_package}"
+      nonroot_offline_install: "false"
+
+  - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-cql-raw-weekly-microbenchmark_x86_64-write"
+    backend: "aws"
+    wait: false
+    labels:
+      - "pgo-x86"
+    exclude_versions: []
+    params:
+      region: "us-east-1"
+      unified_package: "{unified_package}"
+      nonroot_offline_install: "false"
+
+  # --- ARM64 microbenchmarks cql_raw ---
+  - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-cql-raw-weekly-microbenchmark_arm64"
+    backend: "aws"
+    wait: false
+    labels:
+      - "pgo-arm"
+    exclude_versions: []
+    params:
+      region: "us-east-1"
+      unified_package: "{unified_package}"
+      nonroot_offline_install: "false"
+
+  - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-cql-raw-weekly-microbenchmark_arm64-write"
     backend: "aws"
     wait: false
     labels:


### PR DESCRIPTION
Add four cql-raw weekly microbenchmark jobs — read and write variants for both x86_64 and ARM64 — reusing the existing pgo-x86 / pgo-arm label selectors so they are picked up by the current trigger jenkinsfiles with no pipeline changes. Job parameters mirror the simple-query entries (us-east-1, unified_package passthrough, non-root offline install off).

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
