### PR TITLE
fix(nemesis): stop mgmt restore task before dropping the keyspace

### DIFF
--- a/sdcm/mgmt/cli.py
+++ b/sdcm/mgmt/cli.py
@@ -29,6 +29,7 @@ from sdcm.remote.libssh2_client.exceptions import Failure as Libssh2Failure
 from sdcm import wait
 from sdcm.mgmt.common import (
     TaskStatus,
+    TERMINAL_TASK_STATUSES,
     ScyllaManagerError,
     HostStatus,
     HostSsl,
@@ -420,13 +421,9 @@ class ManagerTask:
         if only_final:
             list_final_status = [TaskStatus.ERROR_FINAL, TaskStatus.DONE]
         else:
-            list_final_status = [
-                TaskStatus.ERROR,
-                TaskStatus.ERROR_FINAL,
-                TaskStatus.STOPPED,
-                TaskStatus.DONE,
-                TaskStatus.ABORTED,
-            ]
+            # ERROR is included here (unlike TERMINAL_TASK_STATUSES) because this helper only needs
+            # to stop waiting once any error surfaces, even a retryable "ERROR (#/4)".
+            list_final_status = [*TERMINAL_TASK_STATUSES, TaskStatus.ERROR]
         LOGGER.debug(f"Waiting for task: {self.id} getting to a final status ({list_final_status!s})..")
         res = self.wait_for_status(list_status=list_final_status, timeout=timeout, step=step)
         if not res:

--- a/sdcm/mgmt/common.py
+++ b/sdcm/mgmt/common.py
@@ -138,6 +138,19 @@ class TaskStatus:
         return set(getattr(cls, name) for name in dir(cls) if name.isupper())
 
 
+# Statuses a task can no longer leave. ERROR is deliberately excluded: the manager reports
+# "ERROR (#/4)" while retries are still pending and only "ERROR (4/4)" maps to ERROR_FINAL,
+# so a task in ERROR can still resume. Callers that must know whether a task is truly finished
+# (e.g. before dropping a restored keyspace) use this strict list; callers that only need to
+# stop waiting append TaskStatus.ERROR.
+TERMINAL_TASK_STATUSES = [
+    TaskStatus.DONE,
+    TaskStatus.ERROR_FINAL,
+    TaskStatus.STOPPED,
+    TaskStatus.ABORTED,
+]
+
+
 # ---------------------------------------------------------------------------
 # Data model classes (alphabetical)
 # ---------------------------------------------------------------------------

--- a/sdcm/nemesis/__init__.py
+++ b/sdcm/nemesis/__init__.py
@@ -70,7 +70,13 @@ from sdcm.cluster_k8s import (
 from sdcm.db_stats import PrometheusDBStats
 from sdcm.log import SDCMAdapter
 from sdcm.logcollector import save_kallsyms_map
-from sdcm.mgmt.common import TaskStatus, ScyllaManagerError, get_persistent_snapshots, ObjectStorageUploadMode
+from sdcm.mgmt.common import (
+    TaskStatus,
+    TERMINAL_TASK_STATUSES,
+    ScyllaManagerError,
+    get_persistent_snapshots,
+    ObjectStorageUploadMode,
+)
 from sdcm.mgmt.backup import run_manager_backup
 from sdcm.mgmt.argus_report import report_manager_backup_results_to_argus
 from sdcm.mgmt.helpers import get_dc_name_from_ks_statement, get_schema_create_statements_from_snapshot
@@ -182,6 +188,7 @@ from sdcm.exceptions import (
     BootstrapStreamErrorFailure,
     QuotaConfigurationFailure,
     NemesisStressFailure,
+    WaitForTimeoutError,
 )
 from test_lib.compaction import (
     CompactionStrategy,
@@ -3023,6 +3030,7 @@ class NemesisRunner:
             #
             # self.tester.set_ks_strategy_to_network_and_rf_according_to_cluster(
             #    keyspace=chosen_snapshot_info["keyspace_name"], repair_after_alter=False)
+        restore_task = None
         try:
             restore_task = mgr_cluster.create_restore_task(
                 restore_data=True, location_list=location_list, snapshot_tag=chosen_snapshot_tag
@@ -3045,12 +3053,47 @@ class NemesisRunner:
                     "Data verification stress command, triggered by the 'mgmt_restore' nemesis, has failed"
                 )
         finally:
-            self.log.info("Cleaning up restored keyspace '%s'", chosen_snapshot_info["keyspace_name"])
-            drop_ks_stmt = f'DROP KEYSPACE IF EXISTS "{chosen_snapshot_info["keyspace_name"]}";'
+            self._stop_unfinished_restore_task(restore_task)
+            keyspace_name = chosen_snapshot_info["keyspace_name"]
+            self.log.info("Cleaning up restored keyspace '%s'", keyspace_name)
+            drop_ks_stmt = f'DROP KEYSPACE IF EXISTS "{keyspace_name}";'
             try:
                 self.target_node.run_cqlsh(drop_ks_stmt)
             except Exception as drop_err:  # noqa: BLE001
                 self.log.warning("Failed to drop restored keyspace: %s", drop_err)
+
+    def _stop_unfinished_restore_task(self, restore_task) -> None:
+        """Stop a Manager restore task that hasn't reached a final status yet.
+
+        A WaitForTimeoutError from wait_and_get_final_status only means SCT gave up waiting; the
+        task may still be RUNNING. This method issues an sctool stop and waits for a terminal
+        status so the task is no longer touching the keyspace before the caller cleans it up.
+
+        Best effort only: every failure here is logged and swallowed rather than masking the
+        original error that brought us into the finally block.
+        """
+        if restore_task is None:
+            return
+        try:
+            status = restore_task.status
+            if status in TERMINAL_TASK_STATUSES:
+                return
+            self.log.warning(
+                "Restore task %s is still in %s state - stopping it",
+                restore_task.id,
+                status,
+            )
+            try:
+                restore_task.stop()
+            except WaitForTimeoutError:
+                pass
+            restore_task.wait_for_status(list_status=TERMINAL_TASK_STATUSES, timeout=600, step=30)
+        except Exception as stop_err:  # noqa: BLE001
+            self.log.warning(
+                "Failed to stop the restore task %s: %s",
+                restore_task.id,
+                stop_err,
+            )
 
     def _delete_existing_backups(self, mgr_cluster):
         deleted_tasks = []

--- a/unit_tests/unit/nemesis/monkey/test_mgmt_restore.py
+++ b/unit_tests/unit/nemesis/monkey/test_mgmt_restore.py
@@ -1,0 +1,139 @@
+"""Tests for the MgmtRestore cleanup guard in sdcm.nemesis.
+
+``NemesisRunner._stop_unfinished_restore_task`` stops a Manager restore task that
+is still in progress, so that the keyspace drop which follows does not race an
+in-flight load&stream (SCT-880).
+
+The drop itself is unconditional -- the next nemesis must start from the same
+cluster state as before this one ran -- so the guard is best effort: it must
+stop what it can and never raise, since it runs inside a ``finally`` block that
+must not mask the original failure.
+"""
+
+from unittest.mock import MagicMock, PropertyMock
+
+import pytest
+
+from sdcm.exceptions import WaitForTimeoutError
+from sdcm.mgmt.common import TaskStatus
+from sdcm.nemesis import NemesisRunner
+
+# Statuses the guard accepts as finished. 'ERROR' is absent on purpose: the Manager reports
+# 'ERROR (#/4)' while retries are still pending and only the last attempt maps to ERROR_FINAL.
+FINAL_STATUSES = [TaskStatus.DONE, TaskStatus.ERROR_FINAL, TaskStatus.STOPPED, TaskStatus.ABORTED]
+
+
+# ---------------------------------------------------------------------------
+# Helpers and fixtures
+# ---------------------------------------------------------------------------
+
+
+def stop_unfinished_restore_task(runner, restore_task):
+    """Call the method under test with the mock runner bound as ``self``.
+
+    Args:
+        runner: A ``TestRunner`` standing in for ``NemesisRunner``.
+        restore_task: The Manager restore task, or ``None``.
+    """
+    return NemesisRunner._stop_unfinished_restore_task(runner, restore_task)
+
+
+@pytest.fixture()
+def restore_task():
+    """A Manager restore task whose status each test sets explicitly."""
+    task = MagicMock()
+    task.id = "restore/01d56d06-0389-4418-af78-73637e66ab03"
+    return task
+
+
+# ---------------------------------------------------------------------------
+# Tasks that need no stopping
+# ---------------------------------------------------------------------------
+
+
+def test_absent_task_is_a_no_op(base_runner):
+    """create_restore_task itself failed, so there is no task to stop."""
+    stop_unfinished_restore_task(base_runner, None)
+
+
+@pytest.mark.parametrize(
+    "status",
+    [
+        pytest.param(TaskStatus.DONE, id="done"),
+        pytest.param(TaskStatus.ERROR_FINAL, id="error-final"),
+        pytest.param(TaskStatus.STOPPED, id="stopped"),
+        pytest.param(TaskStatus.ABORTED, id="aborted"),
+    ],
+)
+def test_finished_task_is_not_stopped(base_runner, restore_task, status):
+    """A task already in a final status is left alone."""
+    restore_task.status = status
+
+    stop_unfinished_restore_task(base_runner, restore_task)
+
+    restore_task.stop.assert_not_called()
+    restore_task.wait_for_status.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Tasks that must be stopped before the keyspace is dropped
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "status",
+    [
+        pytest.param(TaskStatus.RUNNING, id="running"),
+        pytest.param(TaskStatus.STARTING, id="starting"),
+        pytest.param(TaskStatus.NEW, id="new"),
+        # 'ERROR' means 'ERROR (#/4)' with retries still pending, so the Manager can come back
+        # and restore into the keyspace: it must be stopped like any other unfinished task.
+        pytest.param(TaskStatus.ERROR, id="error-retryable"),
+    ],
+)
+def test_unfinished_task_is_stopped(base_runner, restore_task, status):
+    """An unfinished task is stopped and its termination confirmed against the strict status list."""
+    restore_task.status = status
+
+    stop_unfinished_restore_task(base_runner, restore_task)
+
+    restore_task.stop.assert_called_once()
+    restore_task.wait_for_status.assert_called_once()
+    assert restore_task.wait_for_status.call_args.kwargs["list_status"] == FINAL_STATUSES
+
+
+def test_slow_stop_falls_through_to_longer_wait(base_runner, restore_task):
+    """stop() waits only 30s, so a slow load&stream abort is awaited instead of giving up."""
+    restore_task.status = TaskStatus.RUNNING
+    restore_task.stop.side_effect = WaitForTimeoutError("task did not stop within 30s")
+
+    stop_unfinished_restore_task(base_runner, restore_task)
+
+    restore_task.wait_for_status.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Failures must never escape into the finally block
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "failing_call",
+    [
+        pytest.param("status", id="status-lookup-fails"),
+        pytest.param("stop", id="stop-command-fails"),
+        pytest.param("wait_for_status", id="task-never-terminates"),
+    ],
+)
+def test_sctool_failure_is_swallowed(base_runner, restore_task, failing_call):
+    """A failure to stop must not propagate: it would mask the error that brought us to cleanup."""
+    error = RuntimeError("sctool is unreachable")
+    if failing_call == "status":
+        type(restore_task).status = PropertyMock(side_effect=error)
+    else:
+        restore_task.status = TaskStatus.RUNNING
+        getattr(restore_task, failing_call).side_effect = error
+
+    stop_unfinished_restore_task(base_runner, restore_task)
+
+    base_runner.log.warning.assert_called()


### PR DESCRIPTION
`disrupt_mgmt_restore`'s `finally` block ran `DROP KEYSPACE` on the restore target without checking the manager task first. A `WaitForTimeoutError` from `wait_and_get_final_status` only means SCT gave up waiting — the manager task may still be `RUNNING`. Dropping the keyspace then killed an in-flight rclone load&stream and buried the real failure under a cascade of secondary manager errors (`Failed to load new sstables: abort requested`, `Can't find a keyspace`, `table not found` on every retry).

Stop the task via sctool before the cleanup drop, mirroring the status check `_delete_existing_backups` already does. `ManagerTask.stop()` waits just 30s and its own final-status list accepts a retryable `ERROR`, so the stop is always followed by an explicit `wait_for_status` on the stricter list.

The stop is best effort and **the keyspace is always dropped afterwards**: the next nemesis has to start from the same cluster state as before this one ran, so a leftover keyspace is not an option. Failures to stop are logged and swallowed — they must not mask the original error that brought us into the `finally` block.

`ERROR` is deliberately not treated as final: the manager reports `ERROR (#/4)` while retries are still pending and only the last attempt maps to `ERROR_FINAL` (`sdcm/mgmt/cli.py:216-220`), so a task in `ERROR` can still come back and restore into the keyspace.

Also initialise `restore_task` before the `try`, so the `finally` block does not raise `UnboundLocalError` when `create_restore_task` itself fails.

The nemesis is still reported as failed — stopping the task does not convert a timeout into a pass. What changes is that the reported error is the real one, and the manager is not left retrying against a table that SCT deleted underneath it.

Verified on Argus run `8e190f15-6cff-4bfc-8883-b575f0d7b29c`, where the new path fired twice. For `restore/01d56d06` the wait expired at 12:17:59 with the task `RUNNING`, sctool stop was issued at 12:18:02.928, and the task reached `STOPPED` at 12:18:03.072 — ~4s, inside `stop()`'s own 30s window, with no retries and no `Can't find a keyspace` / `table not found` anywhere in `scylla_manager.log`.

Note that the underlying stall in that run is [SCYLLADB-3939](https://scylladb.atlassian.net/browse/SCYLLADB-3939): load&stream livelocks against the tablet load balancer because every shard of every node submits its own `quiesce_topology` group0 request (`await_topology_quiesced_and_get_erm`). `expected_timeout` is deliberately left untouched here — no timeout survives an unbounded wait, and raising it only makes the nemesis block the test for longer before giving up.

Adds `unit_tests/unit/nemesis/monkey/test_mgmt_restore.py` (13 tests) covering the cleanup guard: absent task, each final status, each unfinished status including retryable `ERROR`, a slow stop falling through to the longer wait, and every sctool failure that must be swallowed.

Fixes: https://scylladb.atlassian.net/browse/SCT-880
Refs: https://scylladb.atlassian.net/browse/SCYLLADB-3939

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [Job passed](https://argus.scylladb.com/tests/scylla-cluster-tests/0e7fa2d8-c0b1-42e7-8228-a4ae645b8c61)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)


[SCYLLADB-3939]: https://scylladb.atlassian.net/browse/SCYLLADB-3939?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ