### PR TITLE
fix(nemesis): don't re-decommission already terminated new-DC nodes

### DIFF
--- a/sdcm/nemesis/monkey/add_remove_dc.py
+++ b/sdcm/nemesis/monkey/add_remove_dc.py
@@ -254,10 +254,19 @@ class AddRemoveDcNemesis(NemesisBaseClass):
             )
 
     def decommission_new_nodes(self) -> None:
-        """Decommission temporary datacenter nodes and clear local node tracking."""
-        with self.runner.action_log_scope(f"Decommission nodes in the new datacenter {self.new_dc_name}"):
-            self.runner.decommission_nodes(self.new_nodes)
-        self.new_nodes = []
+        """Decommission temporary datacenter nodes and untrack the ones that left the cluster.
+
+        Tracking is pruned in a ``finally`` block, based on cluster membership: a decommissioned
+        node is removed from ``cluster.nodes`` by ``terminate_node()``, so a failure raised after
+        that point (e.g. the monitoring reconfiguration that follows termination) cannot leave an
+        already-terminated node queued for a second, doomed decommission in ``finalizer()``.
+        A node whose decommission really failed is still in the cluster and stays tracked.
+        """
+        try:
+            with self.runner.action_log_scope(f"Decommission nodes in the new datacenter {self.new_dc_name}"):
+                self.runner.decommission_nodes(self.new_nodes)
+        finally:
+            self.new_nodes = [node for node in self.new_nodes if node in self.runner.cluster.nodes]
 
     def finalizer(self, exc_type, *_):
         """Clean up the validation keyspace and temporary nodes on regular exits.

--- a/unit_tests/unit/nemesis/monkey/test_add_remove_dc.py
+++ b/unit_tests/unit/nemesis/monkey/test_add_remove_dc.py
@@ -340,6 +340,68 @@ def test_finalizer_skips_decommission_when_no_new_nodes(runner):
     monkey.decommission_new_nodes.assert_not_called()
 
 
+def test_decommission_new_nodes_clears_tracking_on_success(runner):
+    """decommission_new_nodes() should stop tracking nodes that left the cluster."""
+    new_node = MagicMock(name="node-new")
+    runner.cluster.nodes = list(runner.cluster.data_nodes)
+
+    monkey = AddRemoveDcNemesis(runner)
+    monkey.new_nodes = [new_node]
+
+    monkey.decommission_new_nodes()
+
+    runner.decommission_nodes.assert_called_once_with([new_node])
+    assert monkey.new_nodes == []
+
+
+def test_decommission_new_nodes_untracks_terminated_nodes_on_failure(runner):
+    """A failure raised after termination (e.g. monitoring reconfiguration) must not keep tracking."""
+    new_node = MagicMock(name="node-new")
+    # verify_decommission() terminated the node, so it is no longer a cluster member
+    runner.cluster.nodes = list(runner.cluster.data_nodes)
+    runner.decommission_nodes.side_effect = RuntimeError("ConnectTimeout to monitor node")
+
+    monkey = AddRemoveDcNemesis(runner)
+    monkey.new_nodes = [new_node]
+
+    with pytest.raises(RuntimeError, match="ConnectTimeout to monitor node"):
+        monkey.decommission_new_nodes()
+
+    assert monkey.new_nodes == []
+
+
+def test_decommission_new_nodes_keeps_tracking_nodes_still_in_cluster(runner):
+    """A node whose decommission really failed is still a cluster member and stays tracked."""
+    new_node = MagicMock(name="node-new")
+    runner.cluster.nodes = [*runner.cluster.data_nodes, new_node]
+    runner.decommission_nodes.side_effect = RuntimeError("decommission failed")
+
+    monkey = AddRemoveDcNemesis(runner)
+    monkey.new_nodes = [new_node]
+
+    with pytest.raises(RuntimeError, match="decommission failed"):
+        monkey.decommission_new_nodes()
+
+    assert monkey.new_nodes == [new_node]
+
+
+def test_finalizer_does_not_redecommission_terminated_nodes(runner):
+    """finalizer() must not re-decommission nodes that a failed decommission already terminated."""
+    new_node = MagicMock(name="node-new")
+    runner.cluster.nodes = list(runner.cluster.data_nodes)
+    runner.decommission_nodes.side_effect = RuntimeError("ConnectTimeout to monitor node")
+
+    monkey = AddRemoveDcNemesis(runner)
+    monkey.new_nodes = [new_node]
+
+    with pytest.raises(RuntimeError, match="ConnectTimeout to monitor node"):
+        monkey.decommission_new_nodes()
+    monkey.finalizer(RuntimeError, None, None)
+
+    runner.decommission_nodes.assert_called_once_with([new_node])
+    assert runner.executed[-1] == f"DROP KEYSPACE IF EXISTS {monkey.new_ks_name}"
+
+
 @pytest.mark.parametrize(
     "feature_enabled,expected_count",
     [


### PR DESCRIPTION
verify_decommission() refreshes monitoring targets *after* it terminates the node, so an unreachable monitor node made decommission_new_nodes() raise once the new-DC nodes were already gone. self.new_nodes was never cleared, and finalizer() re-decommissioned destroyed instances, failing with "No route to host" and marking a successful topology change failed.

Prune self.new_nodes in a finally block, by cluster membership: terminate_node() removes a node from cluster.nodes, so a decommissioned node is untracked no matter what fails afterwards, while a node whose decommission really failed stays tracked and is still retried. The original exception still propagates.

Tests: unit_tests/unit/nemesis/monkey/test_add_remove_dc.py -- 20 passed

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ Job passed ](https://argus.scylladb.com/tests/scylla-cluster-tests/7bea04d0-439d-4f5b-a780-a97a953fd980)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
