### PR TITLE
fix(oci): properly set SCT runner root disk size

### DIFF
--- a/sdcm/provision/oci/virtual_machine_provider.py
+++ b/sdcm/provision/oci/virtual_machine_provider.py
@@ -41,7 +41,7 @@ from sdcm.provision.provisioner import (
 )
 from sdcm.provision.user_data import UserDataBuilder
 from sdcm.utils.oci_region import OciRegion
-from sdcm.utils.oci_utils import OciService, build_hostname_label
+from sdcm.utils.oci_utils import OciService, build_hostname_label, build_image_source_details
 from sdcm.utils.parallel_object import ParallelObject
 
 LOGGER = logging.getLogger(__name__)
@@ -297,7 +297,9 @@ class VirtualMachineProvider:
             "compartment_id": self._compartment_id,
             "availability_domain": self._get_availability_domain(definition),
             "display_name": definition.name,
-            "image_id": definition.image_id,
+            "source_details": build_image_source_details(
+                image_id=definition.image_id, root_disk_size_gb=definition.root_disk_size, name=definition.name
+            ),
             "shape": shape_type,
             "shape_config": shape_config_obj,
             "create_vnic_details": self._build_primary_vnic_details(

--- a/sdcm/runner_configs/oci-sct-runner-cloud-config.yaml
+++ b/sdcm/runner_configs/oci-sct-runner-cloud-config.yaml
@@ -1,5 +1,15 @@
 #cloud-config
 
+# The boot volume is launched larger than the image it comes from (see OciSctRunner._create_instance).
+# Growing the volume does not grow the filesystem: without this the extra space stays outside the root
+# partition and `df' keeps reporting the image's original size.
+growpart:
+  mode: auto
+  devices: ['/']
+  ignore_growroot_disabled: false
+
+resize_rootfs: true
+
 # Remove opc user early
 bootcmd:
   - userdel -f -r opc 2>/dev/null || true

--- a/sdcm/sct_runner.py
+++ b/sdcm/sct_runner.py
@@ -100,6 +100,7 @@ from sdcm.utils.oci_utils import (
     OciService,
     build_hostname_label,
     list_instances_oci,
+    build_image_source_details,
     oci_public_addresses,
     wait_for_instance_state,
     wait_for_image_state,
@@ -1710,11 +1711,20 @@ class OciSctRunner(SctRunner):
             "user_data": base64.b64encode(cloud_init_script.encode()).decode(),
         }
 
+        # Without explicit source details OCI sizes the boot volume from the image (50G), regardless of
+        # `root_disk_size_runner' / `--root-disk-size-gb', which left OCI runners with roughly a third of
+        # the space their AWS/GCE/Azure counterparts get and ran them out of disk during log collection.
+        source_details = build_image_source_details(
+            image_id=base_image,
+            root_disk_size_gb=root_disk_size_gb or self.instance_root_disk_size(test_duration),
+            name=instance_name,
+        )
+
         instance_details = LaunchInstanceDetails(
             availability_domain=full_ad,
             compartment_id=oci_region.compartment_id,
             display_name=instance_name,
-            image_id=base_image,
+            source_details=source_details,
             shape=shape_type,
             shape_config=shape_config,
             create_vnic_details=vnic_details,

--- a/sdcm/utils/oci_utils.py
+++ b/sdcm/utils/oci_utils.py
@@ -26,7 +26,7 @@ import time
 
 import oci
 from oci.core import BlockstorageClient, ComputeClient, VirtualNetworkClient
-from oci.core.models import Image, Instance
+from oci.core.models import Image, Instance, InstanceSourceViaImageDetails
 from oci.exceptions import ServiceError
 from oci.identity import IdentityClient
 from oci.object_storage import ObjectStorageClient
@@ -37,6 +37,9 @@ from sdcm.provision.provisioner import VmArch
 from sdcm.utils.metaclasses import Singleton
 
 LOGGER = logging.getLogger(__name__)
+
+# OCI refuses to create a boot volume smaller than this.
+MIN_BOOT_VOLUME_SIZE_IN_GBS = 50
 
 OCI_RETRY_STRATEGY = oci.retry.RetryStrategyBuilder(
     max_attempts_check=True,
@@ -933,6 +936,28 @@ def build_hostname_label(name: str, default_hostname: str = "node") -> str:
     max_base_len = 63 - len(suffix)
     hostname = hostname[:max_base_len].strip("-") or default_hostname
     return f"{hostname}{suffix}"
+
+
+def build_image_source_details(
+    image_id: str, root_disk_size_gb: int | None, name: str = ""
+) -> InstanceSourceViaImageDetails:
+    """Pair an image with an explicit boot volume size.
+
+    `LaunchInstanceDetails' has no root disk field, so a bare `image_id' makes OCI size the boot volume
+    from the image itself and silently drop whatever root disk size was configured. OCI also refuses
+    anything under `MIN_BOOT_VOLUME_SIZE_IN_GBS', so a smaller request is raised to that floor rather
+    than failing the launch.
+    """
+    requested_gb = root_disk_size_gb or MIN_BOOT_VOLUME_SIZE_IN_GBS
+    boot_volume_size_in_gbs = max(requested_gb, MIN_BOOT_VOLUME_SIZE_IN_GBS)
+    if boot_volume_size_in_gbs != requested_gb:
+        LOGGER.info(
+            "Requested %sG root disk%s is under the OCI %sG boot volume minimum, using the minimum",
+            requested_gb,
+            f" for '{name}'" if name else "",
+            MIN_BOOT_VOLUME_SIZE_IN_GBS,
+        )
+    return InstanceSourceViaImageDetails(image_id=image_id, boot_volume_size_in_gbs=boot_volume_size_in_gbs)
 
 
 def _get_images(region: str | None = None):

--- a/unit_tests/unit/test_oci_virtual_machine_provider.py
+++ b/unit_tests/unit/test_oci_virtual_machine_provider.py
@@ -1,9 +1,12 @@
-"""Unit tests for OCI virtual machine provider DNS behavior."""
+"""Unit tests for OCI virtual machine provider DNS and boot volume behavior."""
 
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from sdcm.provision.oci.virtual_machine_provider import VirtualMachineProvider
+from sdcm.utils.oci_utils import MIN_BOOT_VOLUME_SIZE_IN_GBS, build_image_source_details
 
 
 @patch("sdcm.utils.oci_utils.OciService.get_block_storage_client", return_value=MagicMock())
@@ -81,3 +84,91 @@ def test_get_private_dns_name_builds_fqdn_from_vnic_subnet_vcn_labels(
     fqdn = provider.get_private_dns_name("db-node")
 
     assert fqdn == "db-host.sctprvtest.sct2vcn.oraclevcn.com"
+
+
+# --- boot volume sizing ---
+#
+# LaunchInstanceDetails has no root disk field: a bare `image_id' makes OCI size the boot volume from
+# the image and silently drop `root_disk_size_db' / `_loader' / `_monitor'. The size has to be carried
+# in `source_details', and OCI refuses anything under 50G - which two of the oci_config defaults are.
+# `build_image_source_details' is shared with the SCT runner, so these cover both call sites' sizing.
+
+
+@pytest.mark.parametrize(
+    "root_disk_size,expected_gb",
+    [
+        pytest.param(100, 100, id="honours-requested-size"),
+        pytest.param(30, MIN_BOOT_VOLUME_SIZE_IN_GBS, id="db-default-30g-raised-to-oci-minimum"),
+        pytest.param(20, MIN_BOOT_VOLUME_SIZE_IN_GBS, id="loader-default-20g-raised-to-oci-minimum"),
+        pytest.param(50, 50, id="monitor-default-50g-is-already-the-minimum"),
+        pytest.param(None, MIN_BOOT_VOLUME_SIZE_IN_GBS, id="unset-falls-back-to-oci-minimum"),
+    ],
+)
+def test_build_image_source_details_sizes_boot_volume_within_oci_limits(root_disk_size, expected_gb):
+    """Test that the requested root disk size becomes an explicit boot volume size, floored at the OCI minimum."""
+    source_details = build_image_source_details(
+        image_id="ocid1.image.oc1..example", root_disk_size_gb=root_disk_size, name="test-oci-node-a"
+    )
+
+    assert source_details.boot_volume_size_in_gbs == expected_gb
+
+
+def test_build_image_source_details_carries_the_image() -> None:
+    """Test that the image is carried by source_details rather than the deprecated image_id field."""
+    source_details = build_image_source_details(
+        image_id="ocid1.image.oc1..example", root_disk_size_gb=100, name="test-oci-node-a"
+    )
+
+    assert source_details.image_id == "ocid1.image.oc1..example"
+    assert source_details.source_type == "image"
+
+
+@patch("oci.pagination.list_call_get_all_results", return_value=SimpleNamespace(data=[]))
+@patch("sdcm.utils.oci_utils.OciService.get_block_storage_client", return_value=MagicMock())
+@patch("sdcm.utils.oci_utils.OciService.get_network_client", return_value=MagicMock())
+@patch(
+    "sdcm.utils.oci_utils.OciService.get_identity_client",
+    return_value=MagicMock(
+        list_availability_domains=MagicMock(
+            return_value=SimpleNamespace(data=[SimpleNamespace(name="us-ashburn-1-AD-1")])
+        )
+    ),
+)
+@patch("sdcm.utils.oci_utils.OciService.get_compute_client", return_value=MagicMock())
+def test_provision_instance_sends_boot_volume_size_to_oci(
+    mock_compute,
+    mock_identity,
+    mock_network,
+    mock_bs,
+    mock_pagination,
+) -> None:
+    """Test that the sized source_details reaches launch_instance, leaving image_id unset.
+
+    Guards the original defect, where root_disk_size was resolved into the InstanceDefinition and then
+    never referenced when launch_details was assembled.
+    """
+    provider = VirtualMachineProvider(
+        _compartment_id="ocid1.compartment.oc1..example",
+        _region="us-ashburn-1",
+        _az="us-ashburn-1-AD-1",
+    )
+    definition = SimpleNamespace(
+        name="test-oci-node-a",
+        image_id="ocid1.image.oc1..example",
+        root_disk_size=100,
+        type="VM.Standard.E4.Flex:2:8",
+        tags={"NodeIndex": "1", "NodeType": "scylla-db"},
+        rack_index=None,
+        ssh_key=SimpleNamespace(name="test-key", public_key=b"ssh-ed25519 AAAATEST"),
+        user_name="scyllaadm",
+        user_data=None,
+        use_public_ip=False,
+    )
+
+    with patch.object(VirtualMachineProvider, "_wait_for_state", return_value=MagicMock()):
+        provider._provision_instance(oci_region=MagicMock(), definition=definition, pricing_model=MagicMock())
+
+    launch_details = provider._compute_client.launch_instance.call_args.args[0]
+    assert launch_details.source_details.boot_volume_size_in_gbs == 100
+    assert launch_details.source_details.image_id == "ocid1.image.oc1..example"
+    assert launch_details.image_id is None

--- a/unit_tests/unit/test_sct_runner.py
+++ b/unit_tests/unit/test_sct_runner.py
@@ -11,11 +11,14 @@
 #
 # Copyright (c) 2025 ScyllaDB
 
+import base64
 from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
 import pytest
+import yaml
 
+from sdcm.keystore import SSHKey
 from sdcm.sct_runner import (
     list_sct_runners,
     clean_sct_runners,
@@ -26,6 +29,8 @@ from sdcm.sct_runner import (
     AzureSctRunner,
     OciSctRunner,
 )
+
+BASE_IMAGE_OCID = "ocid1.image.oc1.iad.aaaaaaaatestimage"
 
 
 class TestListSctRunners:
@@ -404,3 +409,93 @@ class TestFindRunnerInstance:
     def test_keep_tag_calculation_from_duration(self, elapsed_hours, duration_minutes, expected):
         """Test the keep tag value: elapsed_hours + duration_minutes / 60 + 6 hours buffer."""
         assert str(elapsed_hours + int(duration_minutes / 60) + 6) == expected
+
+
+# --- OCI runner boot volume sizing ---
+#
+# LaunchInstanceDetails has no root disk field: a bare `image_id' makes OCI inherit the image's own
+# size (50G) and silently ignore both `root_disk_size_runner' and `--root-disk-size-gb'. The size has
+# to travel in `source_details' instead, and the guest has to grow its filesystem onto it.
+
+
+@pytest.fixture
+def oci_runner():
+    """Build a real OciSctRunner with only its cloud boundaries mocked.
+
+    OciService and OciRegion are the network boundary; key_pair reaches the remote keystore.
+    Everything else, including the availability-domain mapping, runs for real.
+    """
+    oci_region = MagicMock(compartment_id="ocid1.compartment.oc1..test")
+    oci_region.availability_domains = ["us-ashburn-1-AD-1", "us-ashburn-1-AD-2", "us-ashburn-1-AD-3"]
+    ssh_key = SSHKey(name="scylla_test_id_ed25519", public_key=b"ssh-ed25519 AAAATEST", private_key=b"dummy\n")
+
+    with (
+        patch("sdcm.sct_runner.OciService"),
+        patch("sdcm.sct_runner.OciRegion", return_value=oci_region),
+        patch.object(OciSctRunner, "key_pair", ssh_key),
+    ):
+        yield OciSctRunner(region_name="us-ashburn-1", availability_zone="a", params=None)
+
+
+@pytest.fixture
+def launch_oci_runner(oci_runner):
+    """Return a factory that runs _create_instance and gives back the details OCI was asked to launch."""
+
+    def _launch(**kwargs):
+        with (
+            patch("sdcm.sct_runner.wait_for_instance_state", return_value=MagicMock()),
+            patch("sdcm.sct_runner.oci_public_addresses", return_value=["1.2.3.4"]),
+        ):
+            oci_runner._create_instance(
+                instance_type="VM.Standard.E4.Flex-2-8",
+                base_image=BASE_IMAGE_OCID,
+                tags={"TestId": "test-id"},
+                instance_name="sct-runner-test",
+                **kwargs,
+            )
+        return oci_runner.compute_client.launch_instance.call_args.args[0]
+
+    return _launch
+
+
+@pytest.mark.parametrize(
+    "test_duration,root_disk_size_gb,expected_gb",
+    [
+        pytest.param(600, 0, 80, id="regular-test-gets-default-80g"),
+        pytest.param(3 * 24 * 60, 0, 120, id="test-over-1.5-days-gets-extra-40g"),
+        pytest.param(600, 250, 250, id="explicit-size-overrides-default"),
+    ],
+)
+def test_create_instance_sizes_boot_volume_from_duration_and_override(
+    test_duration, root_disk_size_gb, expected_gb, launch_oci_runner
+):
+    """Test that the requested root disk size reaches OCI as an explicit boot volume size."""
+    details = launch_oci_runner(test_duration=test_duration, root_disk_size_gb=root_disk_size_gb)
+
+    assert details.source_details.boot_volume_size_in_gbs == expected_gb
+
+
+def test_create_instance_passes_image_through_source_details_only(launch_oci_runner):
+    """Test that the image is carried by source_details, leaving the deprecated image_id unset.
+
+    The two are mutually exclusive on LaunchInstanceDetails, so keeping image_id would either be
+    rejected by OCI or drop the boot volume size.
+    """
+    details = launch_oci_runner(test_duration=600)
+
+    assert details.image_id is None
+    assert details.source_details.image_id == BASE_IMAGE_OCID
+    assert details.source_details.source_type == "image"
+
+
+def test_create_instance_user_data_grows_root_filesystem(launch_oci_runner):
+    """Test that cloud-init is told to grow the root filesystem onto the enlarged boot volume.
+
+    A bigger volume is inert on its own: without growpart the partition keeps the image's size.
+    """
+    details = launch_oci_runner(test_duration=600)
+    cloud_config = yaml.safe_load(base64.b64decode(details.metadata["user_data"]).decode())
+
+    assert cloud_config["growpart"]["mode"] == "auto"
+    assert "/" in cloud_config["growpart"]["devices"]
+    assert cloud_config["resize_rootfs"] is True


### PR DESCRIPTION
`LaunchInstanceDetails` has no root disk field, so passing a bare `image_id` let OCI size the boot volume from the image (50G) and silently ignore both `root_disk_size_runner` and `--root-disk-size-gb`.

Carry the image in `source_details` instead so it can hold `boot_volume_size_in_gbs`, and add `growpart`/`resize_rootfs` to the runner cloud-config, since a bigger volume alone leaves the root partition at the image's size.

Closes: #SCT-862
Closes: #SCT-816

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
