### PR TITLE
fix(nvme): define the diagnostics parsing contract and stop self-inflicted errors

### DIFF
--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -4240,7 +4240,7 @@ Collect NVMe SMART logs, error logs, and self-test results from DB nodes during 
 
 ## **nvme_self_test_type** / SCT_NVME_SELF_TEST_TYPE
 
-NVMe device self-test type to run: 1 (short, ~2 min) or 2 (extended, may take hours). Only used when collect_nvme_diagnostics is enabled.
+NVMe device self-test type to run: 1 (short, ~2 min) or 2 (extended, may take hours). Only used when collect_nvme_diagnostics is enabled. Honored only on controllers that advertise Device Self-test support (Identify Controller OACS bit 4); unsupported controllers are skipped without issuing the command. This has no effect on AWS: neither instance-store (Nitro SSD) nor EBS implements Device Self-test, so on AWS the diagnostics rely on SMART counters and the error log instead.
 
 **default:** 1
 

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -169,7 +169,7 @@ from sdcm.utils.version_utils import (
 )
 from sdcm.utils.net import get_my_ip, to_inet_ntop_format
 from sdcm.utils.node import build_node_api_command
-from sdcm.utils.nvme_diagnostics import install_nvme_cli, collect_all_smart_logs
+from sdcm.utils.nvme_diagnostics import install_nvme_cli, collect_all_smart_logs, store_baseline_smart_logs
 from sdcm.wait import wait_for_log_lines
 from sdcm.sct_events import Severity
 from sdcm.sct_events.base import LogEvent, add_severity_limit_rules, max_severity
@@ -6415,6 +6415,10 @@ class BaseScyllaCluster:
         if not baseline_logs:
             node.log.info("NVMe diagnostics: no NVMe data disks found, skipping")
             return
+
+        # Error and media counters are lifetime totals, so the teardown health
+        # check compares against this baseline instead of against zero.
+        store_baseline_smart_logs(node, baseline_logs)
 
         for smart_log in baseline_logs:
             node.log.info(

--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -989,6 +989,10 @@ class ScyllaLogCollector(LogCollector):
         ),
         CommandLog(
             name="nvme_self_test_log.log",
+            # Reading log page 06h from a controller that does not implement
+            # Device Self-test is rejected, and the rejected command is recorded
+            # in the device Error Information Log. Gate the read on OACS bit 4
+            # so collection does not leave errors behind on AWS Nitro SSDs.
             command=(
                 "( command -v nvme > /dev/null 2>&1 && "
                 "for dev in $(sudo nvme list -o json 2>/dev/null "
@@ -998,7 +1002,12 @@ class ScyllaLogCollector(LogCollector):
                 "[print(ns.get('DevicePath',ns.get('device',ns.get('NameSpace','')))) "
                 "for item in devs "
                 "for ns in (item.get('Namespaces',[item]) if isinstance(item,dict) and 'Namespaces' in item else [item])]"
-                '" 2>/dev/null); do echo "=== $dev ==="; sudo nvme self-test-log $dev 2>&1; done '
+                '" 2>/dev/null); do echo "=== $dev ==="; '
+                "if sudo nvme id-ctrl $dev -o json 2>/dev/null "
+                '| python3 -c "import sys,json; '
+                "sys.exit(0 if json.load(sys.stdin).get('oacs',0) & 16 else 1)"
+                '" 2>/dev/null; then sudo nvme self-test-log $dev 2>&1; '
+                'else echo "device self-test not supported by controller (OACS bit 4 clear)"; fi; done '
                 "|| true )"
             ),
         ),

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -2469,7 +2469,11 @@ class SCTConfiguration(BaseModel):
     )
     nvme_self_test_type: int = SctField(
         description="NVMe device self-test type to run: 1 (short, ~2 min) or 2 (extended, may take hours). "
-        "Only used when collect_nvme_diagnostics is enabled.",
+        "Only used when collect_nvme_diagnostics is enabled. "
+        "Honored only on controllers that advertise Device Self-test support (Identify Controller "
+        "OACS bit 4); unsupported controllers are skipped without issuing the command. "
+        "This has no effect on AWS: neither instance-store (Nitro SSD) nor EBS implements "
+        "Device Self-test, so on AWS the diagnostics rely on SMART counters and the error log instead.",
     )
     use_scylla_doctor_on_failure: Boolean = SctField(
         description="Run scylla-doctor on test failure to collect additional diagnostics",

--- a/sdcm/teardown_validators/nvme.py
+++ b/sdcm/teardown_validators/nvme.py
@@ -30,6 +30,11 @@ class NvmeValidator(TeardownValidator):
     """Run NVMe self-tests and health checks on all DB nodes during teardown.
 
     Controlled by ``teardown_validators.nvme.enabled`` (standard validator config).
+
+    Self-tests only run where the controller advertises Device Self-test support.
+    AWS implements it on neither instance-store nor EBS, so on that backend this
+    validator does the health collection only - see sdcm.utils.nvme_diagnostics
+    for the measurements and the reason.
     """
 
     validator_name = "nvme"

--- a/sdcm/utils/nvme_diagnostics.py
+++ b/sdcm/utils/nvme_diagnostics.py
@@ -24,13 +24,38 @@ This module provides functions to:
 All functions accept a ``node`` argument that exposes ``.remoter`` (with ``.run()`` / ``.sudo()``)
 and ``.log`` for logging. Device discovery returns an empty list (never raises) when no NVMe
 devices are present, making it safe for docker and EBS-only backends.
+
+Output format
+-------------
+Log pages are read as raw bytes (``nvme get-log ... -b``) and decoded at the fixed offsets the
+NVMe Base Specification defines. The layouts are stable across spec revisions; only the way
+nvme-cli renders them changes, and it has changed repeatedly - inline value descriptions
+("status_field : 0x2001 (Invalid Command Opcode: ...)"), the temperature unit order flipping
+between 1.x and 2.x, and a field rename due in 3.0. Reading the page directly removes that whole
+dependency. The contract is a length check: either the page was read in full or it was not.
+Device discovery still uses ``nvme list -o json``, which is not a log page.
+
+Self-test availability
+----------------------
+Device Self-test is optional in the NVMe spec and is advertised by Identify Controller OACS
+bit 4. It is *not* available on AWS - neither on instance-store (Nitro SSD) nor on EBS - so
+``nvme_self_test_type`` has no effect there and the self-test code paths never run. See
+NvmeControllerInfo.supports_self_test for the measurements and the reason. Support elsewhere is
+probed at runtime, so the feature activates by itself on hardware that does implement it.
+
+What remains usable everywhere is the passive evidence: the SMART counters that AWS does
+populate (``media_errors``, ``critical_warning``, ``available_spare``, ``percentage_used``,
+data/command counters) and the Error Information Log. Note that AWS leaves ``temperature``,
+``power_on_hours``, ``power_cycles``, ``unsafe_shutdowns`` and ``controller_busy_time`` at
+placeholder zeros, so those must not be used as health signals on that backend.
 """
 
 from __future__ import annotations
 
+import base64
+import binascii
 import json
 import logging
-import re
 import time
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -80,6 +105,40 @@ class NvmeDevice:
 
 
 @dataclass
+class NvmeControllerInfo:
+    """The Identify Controller fields this module acts on."""
+
+    oacs: int  # Optional Admin Command Support bitmap
+    error_log_entries: int  # Error Information Log entries the controller supports
+
+    @property
+    def supports_self_test(self) -> bool:
+        """Whether the controller implements the Device Self-test command.
+
+        Issuing ``nvme device-self-test`` against a controller that does not
+        support it is not free: the rejected admin command is recorded in the
+        device's Error Information Log and increments ``num_err_log_entries``,
+        so the diagnostic would manufacture the very anomaly it reports. The
+        same OACS bit gates log page 06h, so this also decides whether the
+        self-test log can be read at all.
+
+        On AWS neither NVMe disk type supports it. Measured on i4i.4xlarge:
+
+            /dev/nvme0n1  "Amazon Elastic Block Store"          OACS bit 4 clear
+            /dev/nvme1n1  "Amazon EC2 NVMe Instance Storage"    oacs=0x8
+
+        Both are presented by the Nitro card rather than by the physical SSD's
+        own controller, so the media operation a self-test performs has nothing
+        to act on - EBS is network-attached and has no local medium at all. AWS
+        monitors and retires the physical drives itself; the guest was never
+        meant to run media diagnostics. Other instance families and other cloud
+        backends are unverified, hence the runtime probe rather than a hardcoded
+        backend check.
+        """
+        return bool(self.oacs & OACS_DEVICE_SELF_TEST)
+
+
+@dataclass
 class NvmeSmartLog:
     """Parsed NVMe SMART / Health Information Log (Log Page 02h)."""
 
@@ -102,7 +161,12 @@ class NvmeSmartLog:
 
     @property
     def temperature_celsius(self) -> int:
-        """Convert Kelvin temperature to Celsius."""
+        """Convert Kelvin temperature to Celsius.
+
+        Uses the same 273 K offset nvme-cli prints rather than the exact 273.15,
+        so reported values match what "nvme smart-log" shows on the node. The
+        0.15 degree approximation is irrelevant against a 70 degree threshold.
+        """
         return self.temperature_kelvin - 273 if self.temperature_kelvin > 0 else 0
 
     @property
@@ -120,19 +184,27 @@ class NvmeSmartLog:
 
 @dataclass
 class NvmeErrorLogEntry:
-    """A single entry from the NVMe Error Information Log."""
+    """A single entry from the NVMe Error Information Log (Log Identifier 01h)."""
 
     error_count: int = 0
     submission_queue_id: int = 0
     command_id: int = 0
+    # Bits 15:1 of the on-disk Status Field; bit 0 is split out as phase_tag.
     status_field: int = 0
+    phase_tag: int = 0
     parm_error_location: int = 0
     lba: int = 0
     nsid: int = 0
+    # "Vendor Specific Information Available": the log page identifier holding
+    # extra vendor data (0h = none), not the vendor data itself.
     vendor_specific: int = 0
     transport_type: int = 0
     command_specific: int = 0
-    opcode: int = 0
+    # csi and opcode are only meaningful when log_page_version is 1; None means
+    # the controller did not report them rather than "opcode 0".
+    command_set_indicator: int | None = None
+    opcode: int | None = None
+    log_page_version: int = 0
 
 
 @dataclass
@@ -233,398 +305,181 @@ def _parse_device_entry(entry: dict) -> NvmeDevice | None:
     )
 
 
-def parse_smart_log_output(device_path: str, raw_output: str) -> NvmeSmartLog | None:
-    """Parse the output of ``nvme smart-log <device>`` (human-readable format).
+# ---------------------------------------------------------------------------
+# Log page parsing
+#
+# Log page layouts are fixed by the NVMe Base Specification and are stable
+# across revisions; only the way nvme-cli renders them changes between its
+# versions. Parsing the raw pages therefore removes a whole class of bugs that
+# text/JSON scraping is prone to: inline value descriptions
+# ("status_field : 0x2001 (Invalid Command Opcode: ...)"), the temperature unit
+# order flipping between nvme-cli 1.x and 2.x, and the field renaming due in
+# nvme-cli 3.0.
+#
+# Offsets below were cross-checked against libnvme v1.16 (struct nvme_smart_log,
+# struct nvme_error_log_page, struct nvme_st_result), the Linux kernel's
+# include/linux/nvme.h and SPDK's include/spdk/nvme_spec.h, which agree.
+# ---------------------------------------------------------------------------
 
-    Handles both the human-readable key/value format and JSON output.
+# Get Log Page - Log Page Identifiers.
+LOG_PAGE_ERROR_INFORMATION = 0x01
+LOG_PAGE_SMART_HEALTH = 0x02
+LOG_PAGE_DEVICE_SELF_TEST = 0x06
 
-    Args:
-        device_path: The NVMe device path (e.g. "/dev/nvme0n1").
-        raw_output: Raw command output from ``nvme smart-log``.
+SMART_LOG_PAGE_LEN = 512
+ERROR_LOG_ENTRY_LEN = 64
+SELF_TEST_LOG_PAGE_LEN = 564
+SELF_TEST_RESULT_LEN = 28
+SELF_TEST_MAX_RESULTS = 20
+IDENTIFY_CONTROLLER_LEN = 4096
 
-    Returns:
-        NvmeSmartLog instance, or None if parsing fails completely.
+# Identify Controller offsets.
+IDCTRL_OACS_OFFSET = 256  # Optional Admin Command Support, 2 bytes
+IDCTRL_ELPE_OFFSET = 262  # Error Log Page Entries, 1 byte, 0's based
+
+# OACS bit 4: "Device Self-test command supported". The same bit gates log page
+# 06h, so one read covers both the trigger and the result read.
+OACS_DEVICE_SELF_TEST = 0x10
+
+# Error Information Log Entry: csi and opcode only carry meaning when the entry's
+# Log Page Version is 1h. Controllers predating that revision leave those bytes
+# reserved, and nvme-cli prints them regardless - which is why the collected
+# artifacts showed "opcode=0x00" on hardware that never populated the field.
+ERROR_LOG_PAGE_VERSION_WITH_OPCODE = 0x1
+
+# Self-test result code 0xf means "entry not used" (no test recorded).
+SELF_TEST_RESULT_NOT_USED = 0xF
+
+
+def _le_uint(buf: bytes, offset: int, size: int) -> int:
+    """Read a little-endian unsigned integer of ``size`` bytes at ``offset``."""
+    return int.from_bytes(buf[offset : offset + size], "little")
+
+
+def parse_smart_log_page(device_path: str, buf: bytes) -> NvmeSmartLog:
+    """Parse the SMART / Health Information log page (02h, 512 bytes).
+
+    Composite Temperature is in Kelvin by definition, so no unit guessing is
+    needed. Data Units Read/Written are counted in thousands of 512-byte units
+    and Controller Busy Time in minutes; both are reported raw, in the units the
+    spec defines.
     """
-    if not raw_output or not raw_output.strip():
-        return None
-
-    # Try JSON first (if user passed -o json)
-    try:
-        data = json.loads(raw_output)
-        return _parse_smart_log_json(device_path, data)
-    except json.JSONDecodeError, ValueError:
-        pass
-
-    # Fall back to human-readable key:value parsing
-    return _parse_smart_log_text(device_path, raw_output)
-
-
-def _parse_smart_log_json(device_path: str, data: dict) -> NvmeSmartLog:
-    """Parse SMART log from JSON output."""
     return NvmeSmartLog(
         device_path=device_path,
-        critical_warning=data.get("critical_warning", 0),
-        temperature_kelvin=data.get("temperature", data.get("temperature_sensor_1", 0)),
-        available_spare=data.get("avail_spare", data.get("available_spare", 100)),
-        available_spare_threshold=data.get("spare_thresh", data.get("available_spare_threshold", 0)),
-        percentage_used=data.get("percent_used", data.get("percentage_used", 0)),
-        data_units_read=data.get("data_units_read", 0),
-        data_units_written=data.get("data_units_written", 0),
-        host_read_commands=data.get("host_read_commands", data.get("host_reads", 0)),
-        host_write_commands=data.get("host_write_commands", data.get("host_writes", 0)),
-        controller_busy_time=data.get("controller_busy_time", 0),
-        power_cycles=data.get("power_cycles", 0),
-        power_on_hours=data.get("power_on_hours", 0),
-        unsafe_shutdowns=data.get("unsafe_shutdowns", 0),
-        media_errors=data.get("media_errors", 0),
-        num_err_log_entries=data.get("num_err_log_entries", 0),
+        critical_warning=buf[0],
+        temperature_kelvin=_le_uint(buf, 1, 2),
+        available_spare=buf[3],
+        available_spare_threshold=buf[4],
+        percentage_used=buf[5],
+        data_units_read=_le_uint(buf, 32, 16),
+        data_units_written=_le_uint(buf, 48, 16),
+        host_read_commands=_le_uint(buf, 64, 16),
+        host_write_commands=_le_uint(buf, 80, 16),
+        controller_busy_time=_le_uint(buf, 96, 16),
+        power_cycles=_le_uint(buf, 112, 16),
+        power_on_hours=_le_uint(buf, 128, 16),
+        unsafe_shutdowns=_le_uint(buf, 144, 16),
+        media_errors=_le_uint(buf, 160, 16),
+        num_err_log_entries=_le_uint(buf, 176, 16),
     )
 
 
-# Regex patterns for human-readable smart-log output.
-# Lines look like: "critical_warning                        : 0" or
-#                  "temperature                             : 315 K (42 Celsius)"
-_SMART_KEY_VALUE_RE = re.compile(r"^\s*(.+?)\s*:\s*(.+?)\s*$", re.MULTILINE)
+def parse_error_log_entry(buf: bytes) -> NvmeErrorLogEntry | None:
+    """Parse one 64-byte Error Information Log entry.
 
-# Map from human-readable field names to NvmeSmartLog attribute names.
-# nvme-cli uses slightly different names across versions, so we handle variants.
-_SMART_FIELD_MAP = {
-    "critical_warning": "critical_warning",
-    "critical warning": "critical_warning",
-    "temperature": "temperature_kelvin",
-    "available spare": "available_spare",
-    "available_spare": "available_spare",
-    "available spare threshold": "available_spare_threshold",
-    "available_spare_threshold": "available_spare_threshold",
-    "percentage used": "percentage_used",
-    "percentage_used": "percentage_used",
-    "percent_used": "percentage_used",
-    "data units read": "data_units_read",
-    "data_units_read": "data_units_read",
-    "data units written": "data_units_written",
-    "data_units_written": "data_units_written",
-    "host read commands": "host_read_commands",
-    "host_read_commands": "host_read_commands",
-    "host_reads": "host_read_commands",
-    "host write commands": "host_write_commands",
-    "host_write_commands": "host_write_commands",
-    "host_writes": "host_write_commands",
-    "controller busy time": "controller_busy_time",
-    "controller_busy_time": "controller_busy_time",
-    "power cycles": "power_cycles",
-    "power_cycles": "power_cycles",
-    "power on hours": "power_on_hours",
-    "power_on_hours": "power_on_hours",
-    "unsafe shutdowns": "unsafe_shutdowns",
-    "unsafe_shutdowns": "unsafe_shutdowns",
-    "media errors": "media_errors",
-    "media_errors": "media_errors",
-    "media and data integrity errors": "media_errors",
-    "num err log entries": "num_err_log_entries",
-    "num_err_log_entries": "num_err_log_entries",
-    "number of error log entries": "num_err_log_entries",
-    "number of error information log entries": "num_err_log_entries",
-}
-
-
-# Hex values as printed by nvme-cli, e.g. "0x1" or "0x00001234".
-_HEX_VALUE_RE = re.compile(r"0[xX]([\da-fA-F]+)")
-
-
-def _extract_numeric(value_str: str) -> int:
-    """Extract the first integer from a value string.
-
-    Handles formats like "315 K (42 Celsius)", "100%", "0", "1,234", etc.
-    nvme-cli prints some fields (e.g. ``critical_warning``) in hex, so "0x1"
-    must be parsed as a whole - a plain digit search would return 0 for it and
-    silently hide the warning.
+    Returns None for an entry the spec defines as invalid: an Error Count of 0h
+    marks an unused slot or a lost entry. ``nvme get-log`` always returns every
+    slot the controller supports, most of them unused, so this is what keeps the
+    collected artifact down to the entries that carry information.
     """
-    # Remove commas used as thousands separator
-    cleaned = value_str.replace(",", "").strip()
-    hex_match = _HEX_VALUE_RE.match(cleaned)
-    if hex_match:
-        return int(hex_match.group(1), 16)
-    # Find first integer-like token
-    match = re.search(r"\d+", cleaned)
-    return int(match.group()) if match else 0
-
-
-def _parse_smart_log_text(device_path: str, raw_output: str) -> NvmeSmartLog:
-    """Parse SMART log from human-readable text output."""
-    kwargs: dict = {"device_path": device_path}
-
-    for match in _SMART_KEY_VALUE_RE.finditer(raw_output):
-        key = match.group(1).lower().strip()
-        value_str = match.group(2).strip()
-
-        attr_name = _SMART_FIELD_MAP.get(key)
-        if attr_name:
-            kwargs[attr_name] = _extract_numeric(value_str)
-
-    return NvmeSmartLog(**kwargs)
-
-
-def parse_error_log_output(raw_output: str) -> list[NvmeErrorLogEntry]:
-    """Parse the output of ``nvme error-log <device>``.
-
-    Handles both JSON and human-readable formats.
-
-    Args:
-        raw_output: Raw command output from ``nvme error-log``.
-
-    Returns:
-        List of NvmeErrorLogEntry instances. Returns empty list if no errors
-        or parsing fails.
-    """
-    if not raw_output or not raw_output.strip():
-        return []
-
-    # Try JSON first
-    try:
-        data = json.loads(raw_output)
-        return _parse_error_log_json(data)
-    except json.JSONDecodeError, ValueError:
-        pass
-
-    # Fall back to human-readable parsing
-    return _parse_error_log_text(raw_output)
-
-
-def _parse_error_log_json(data: list | dict) -> list[NvmeErrorLogEntry]:
-    """Parse error log entries from JSON output."""
-    entries_list = data if isinstance(data, list) else data.get("errors", [])
-    results = []
-    for entry in entries_list:
-        results.append(
-            NvmeErrorLogEntry(
-                error_count=entry.get("error_count", entry.get("err_count", 0)),
-                submission_queue_id=entry.get("sqid", 0),
-                command_id=entry.get("cmdid", entry.get("cid", 0)),
-                status_field=entry.get("status_field", entry.get("status", 0)),
-                parm_error_location=entry.get("parm_error_location", entry.get("pel", 0)),
-                lba=entry.get("lba", 0),
-                nsid=entry.get("nsid", 0),
-                vendor_specific=entry.get("vs", entry.get("vendor_specific", 0)),
-                transport_type=entry.get("trtype", entry.get("transport_type", 0)),
-                command_specific=entry.get("cs", entry.get("command_specific", 0)),
-                opcode=entry.get("opcode", entry.get("opc", 0)),
-            )
-        )
-    return results
-
-
-# Regex for error log entries in text format.
-# Each entry starts with "Entry[N]" or "Error Log Entry N:" followed by key:value lines.
-# nvme-cli pads the index ("Entry[ 0]"), so spaces inside the brackets are allowed.
-_ERROR_ENTRY_HEADER_RE = re.compile(r"(?:Entry\[\s*|\bError Log Entry\s*)(\d+)", re.IGNORECASE)
-_ERROR_ENTRY_SPLIT_RE = re.compile(r"(?:Entry\[\s*\d+\s*\]|\bError Log Entry\s*\d+)", re.IGNORECASE)
-_ERROR_KEY_VALUE_RE = re.compile(r"^\s*(.+?)\s*:\s*(0x[\da-fA-F]+|\d+)\s*$", re.MULTILINE)
-
-
-def _parse_error_log_text(raw_output: str) -> list[NvmeErrorLogEntry]:
-    """Parse error log from human-readable text output."""
-    # Split on entry headers
-    entries = _ERROR_ENTRY_SPLIT_RE.split(raw_output)
-    results = []
-
-    for entry_text in entries[1:]:  # Skip text before first entry
-        entry = _parse_single_error_entry(entry_text)
-        if entry:
-            results.append(entry)
-
-    return results
-
-
-_ERROR_FIELD_MAP = {
-    "error count": "error_count",
-    "error_count": "error_count",
-    "sqid": "submission_queue_id",
-    "submission queue id": "submission_queue_id",
-    "cmdid": "command_id",
-    "cid": "command_id",
-    "command id": "command_id",
-    "status field": "status_field",
-    "status_field": "status_field",
-    "status": "status_field",
-    "parm error location": "parm_error_location",
-    "parm_error_location": "parm_error_location",
-    "parameter error location": "parm_error_location",
-    "lba": "lba",
-    "nsid": "nsid",
-    "namespace id": "nsid",
-    "vs": "vendor_specific",
-    "vendor specific": "vendor_specific",
-    "trtype": "transport_type",
-    "transport type": "transport_type",
-    "cs": "command_specific",
-    "command specific": "command_specific",
-    "opcode": "opcode",
-    "opc": "opcode",
-}
-
-
-def _parse_hex_or_int(value_str: str) -> int:
-    """Parse a value that may be hex (0x...) or decimal."""
-    value_str = value_str.strip()
-    if value_str.startswith(("0x", "0X")):
-        return int(value_str, 16)
-    return int(value_str)
-
-
-def _parse_single_error_entry(entry_text: str) -> NvmeErrorLogEntry | None:
-    """Parse a single error log entry from text."""
-    kwargs: dict = {}
-    for match in _ERROR_KEY_VALUE_RE.finditer(entry_text):
-        key = match.group(1).lower().strip()
-        value_str = match.group(2).strip()
-
-        attr_name = _ERROR_FIELD_MAP.get(key)
-        if attr_name:
-            kwargs[attr_name] = _parse_hex_or_int(value_str)
-
-    if not kwargs:
-        return None
-    return NvmeErrorLogEntry(**kwargs)
-
-
-def parse_self_test_log_output(device_path: str, raw_output: str) -> NvmeSelfTestLog | None:
-    """Parse the output of ``nvme self-test-log <device>``.
-
-    Handles both JSON and human-readable formats.
-
-    Args:
-        device_path: The NVMe device path.
-        raw_output: Raw command output from ``nvme self-test-log``.
-
-    Returns:
-        NvmeSelfTestLog instance, or None if parsing fails completely.
-    """
-    if not raw_output or not raw_output.strip():
+    error_count = _le_uint(buf, 0, 8)
+    if error_count == 0:
         return None
 
-    # Try JSON first
-    try:
-        data = json.loads(raw_output)
-        return _parse_self_test_log_json(device_path, data)
-    except json.JSONDecodeError, ValueError:
-        pass
+    # Bits 15:1 are the Status Field; bit 0 is the Phase Tag.
+    status = _le_uint(buf, 12, 2)
+    log_page_version = buf[63]
+    extended_fields_valid = log_page_version == ERROR_LOG_PAGE_VERSION_WITH_OPCODE
 
-    # Fall back to human-readable parsing
-    return _parse_self_test_log_text(device_path, raw_output)
+    return NvmeErrorLogEntry(
+        error_count=error_count,
+        submission_queue_id=_le_uint(buf, 8, 2),
+        command_id=_le_uint(buf, 10, 2),
+        status_field=status >> 1,
+        phase_tag=status & 0x1,
+        parm_error_location=_le_uint(buf, 14, 2),
+        lba=_le_uint(buf, 16, 8),
+        nsid=_le_uint(buf, 24, 4),
+        vendor_specific=buf[28],
+        transport_type=buf[29],
+        command_set_indicator=buf[30] if extended_fields_valid else None,
+        opcode=buf[31] if extended_fields_valid else None,
+        command_specific=_le_uint(buf, 32, 8),
+        log_page_version=log_page_version,
+    )
 
 
-def _parse_self_test_log_json(device_path: str, data: dict) -> NvmeSelfTestLog:
-    """Parse self-test log from JSON output."""
-    current_op = data.get("current_operation", data.get("crnt_dev_selftest_oprn", 0))
-    current_completion = data.get("current_completion", data.get("crnt_dev_selftest_compln", 0))
+def parse_error_log_page(buf: bytes) -> list[NvmeErrorLogEntry]:
+    """Parse the Error Information log page (01h) into its populated entries."""
+    entries = []
+    for offset in range(0, len(buf) - ERROR_LOG_ENTRY_LEN + 1, ERROR_LOG_ENTRY_LEN):
+        entry = parse_error_log_entry(buf[offset : offset + ERROR_LOG_ENTRY_LEN])
+        if entry is not None:
+            entries.append(entry)
+    return entries
 
+
+def parse_self_test_log_page(device_path: str, buf: bytes) -> NvmeSelfTestLog:
+    """Parse the Device Self-test log page (06h, 564 bytes).
+
+    Byte 0 holds the operation currently running (0 = none) in bits 3:0, byte 1
+    its completion percentage in bits 6:0, and 20 result entries of 28 bytes
+    follow from offset 4 - 4 + 20 * 28 is the page's fixed 564 bytes, so every
+    slot is present in a page that was read in full. Entries marked "not used"
+    (result code 0xf) are skipped.
+    """
     results = []
-    for entry in data.get("results", data.get("self_test_result", [])):
+    for index in range(SELF_TEST_MAX_RESULTS):
+        offset = 4 + index * SELF_TEST_RESULT_LEN
+        entry = buf[offset : offset + SELF_TEST_RESULT_LEN]
+
+        # Device Self-test Status: bits 3:0 result, bits 7:4 the test type run.
+        dsts = entry[0]
+        result_code = dsts & 0xF
+        if result_code == SELF_TEST_RESULT_NOT_USED:
+            continue
+
         results.append(
             NvmeSelfTestResult(
-                result_code=entry.get("result", entry.get("dsts", 0) & 0x0F),
-                self_test_code=entry.get("self_test_code", entry.get("code", 0)),
-                segment_number=entry.get("segment", entry.get("seg", 0)),
-                power_on_hours=entry.get("power_on_hours", entry.get("poh", 0)),
-                nsid=entry.get("nsid", 0),
-                failing_lba=entry.get("failing_lba", entry.get("flba", 0)),
-                status_code_type=entry.get("sct", entry.get("status_code_type", 0)),
-                status_code=entry.get("sc", entry.get("status_code", 0)),
+                result_code=result_code,
+                self_test_code=dsts >> 4,
+                segment_number=entry[1],
+                power_on_hours=_le_uint(entry, 4, 8),
+                nsid=_le_uint(entry, 12, 4),
+                failing_lba=_le_uint(entry, 16, 8),
+                status_code_type=entry[24],
+                status_code=entry[25],
             )
         )
 
     return NvmeSelfTestLog(
         device_path=device_path,
-        current_operation=current_op,
-        current_completion=current_completion,
+        current_operation=buf[0] & 0xF,
+        current_completion=buf[1] & 0x7F,
         results=results,
     )
 
 
-# nvme-cli prints "Current operation" in hex ("Current operation : 0x2"), so both
-# notations must be accepted - otherwise an in-progress test is read as "no test".
-_SELF_TEST_CURRENT_OP_RE = re.compile(
-    r"(?:current\s+operation|crnt_dev_selftest_oprn)\s*:\s*(0x[\da-fA-F]+|\d+)", re.IGNORECASE
-)
-_SELF_TEST_COMPLETION_RE = re.compile(
-    r"(?:current\s+completion|crnt_dev_selftest_compln)\s*:\s*(0x[\da-fA-F]+|\d+)", re.IGNORECASE
-)
-_SELF_TEST_RESULT_HEADER_RE = re.compile(r"(?:Self Test Result\s*\[|Result\s*\[)\s*(\d+)\s*\]", re.IGNORECASE)
+def parse_identify_controller(buf: bytes) -> NvmeControllerInfo:
+    """Parse the fields this module uses out of Identify Controller (4096 bytes).
 
-
-def _parse_self_test_log_text(device_path: str, raw_output: str) -> NvmeSelfTestLog:
-    """Parse self-test log from human-readable text output."""
-    current_op = 0
-    current_completion = 0
-
-    op_match = _SELF_TEST_CURRENT_OP_RE.search(raw_output)
-    if op_match:
-        current_op = _parse_hex_or_int(op_match.group(1))
-
-    comp_match = _SELF_TEST_COMPLETION_RE.search(raw_output)
-    if comp_match:
-        current_completion = _parse_hex_or_int(comp_match.group(1))
-
-    # Split on result entry headers
-    entries = re.split(r"(?:Self Test Result|Result)\s*\[\s*\d+\s*\]", raw_output, flags=re.IGNORECASE)
-    results = []
-
-    for entry_text in entries[1:]:  # Skip text before first result
-        result = _parse_single_self_test_result(entry_text)
-        if result:
-            results.append(result)
-
-    return NvmeSelfTestLog(
-        device_path=device_path,
-        current_operation=current_op,
-        current_completion=current_completion,
-        results=results,
+    ELPE is 0's based on the wire, so it is normalised here to the entry count
+    ``get-log`` has to be asked for.
+    """
+    return NvmeControllerInfo(
+        oacs=_le_uint(buf, IDCTRL_OACS_OFFSET, 2),
+        error_log_entries=buf[IDCTRL_ELPE_OFFSET] + 1,
     )
-
-
-_SELF_TEST_FIELD_MAP = {
-    "result": "result_code",
-    "device self-test status": "result_code",
-    "operation result": "result_code",
-    "dsts": "result_code",
-    "self test code": "self_test_code",
-    "self_test_code": "self_test_code",
-    "code": "self_test_code",
-    "segment number": "segment_number",
-    "seg": "segment_number",
-    "segment": "segment_number",
-    "power on hours": "power_on_hours",
-    "power on hours (poh)": "power_on_hours",
-    "power_on_hours": "power_on_hours",
-    "poh": "power_on_hours",
-    "nsid": "nsid",
-    "namespace id": "nsid",
-    "namespace identifier": "nsid",
-    "failing lba": "failing_lba",
-    "flba": "failing_lba",
-    "sct": "status_code_type",
-    "status code type": "status_code_type",
-    "sc": "status_code",
-    "status code": "status_code",
-}
-
-_SELF_TEST_KEY_VALUE_RE = re.compile(r"^\s*(.+?)\s*:\s*(0x[\da-fA-F]+|\d+)\s*$", re.MULTILINE)
-
-
-def _parse_single_self_test_result(entry_text: str) -> NvmeSelfTestResult | None:
-    """Parse a single self-test result entry from text."""
-    kwargs: dict = {}
-    for match in _SELF_TEST_KEY_VALUE_RE.finditer(entry_text):
-        key = match.group(1).lower().strip()
-        value_str = match.group(2).strip()
-
-        attr_name = _SELF_TEST_FIELD_MAP.get(key)
-        if attr_name:
-            kwargs[attr_name] = _parse_hex_or_int(value_str)
-
-    if not kwargs:
-        return None
-    return NvmeSelfTestResult(**kwargs)
 
 
 # ---------------------------------------------------------------------------
@@ -725,6 +580,97 @@ def is_nvme_cli_available(node: "BaseNode") -> bool:
     return result.ok
 
 
+def _read_raw(node: "BaseNode", command: str, length: int, what: str) -> bytes | None:
+    """Run an nvme-cli command that emits binary and return its bytes.
+
+    The payload is base64-encoded on the node because the remoter returns text.
+    The length check is the entire contract: either the structure was read in
+    full or it was not. There is no notion of a "missing field" in a fixed-layout
+    NVMe structure, so nothing here can silently degrade into a healthy-looking
+    default the way scraping formatted output could.
+
+    Args:
+        node: SCT node with remoter.
+        command: nvme-cli command emitting binary on stdout (without ``sudo``).
+        length: Exact number of bytes the structure must contain.
+        what: Human-readable name used in log messages.
+
+    Returns:
+        Exactly ``length`` bytes, or None if the read failed or came up short.
+    """
+    result = node.remoter.sudo(f"{command} | base64 -w0", ignore_status=True, timeout=NVME_CMD_TIMEOUT)
+    if result.failed:
+        node.log.warning("Reading %s failed: %s", what, result.stderr.strip())
+        return None
+
+    try:
+        buf = base64.b64decode(result.stdout.strip(), validate=True)
+    except (binascii.Error, ValueError) as exc:
+        node.log.warning("Reading %s returned undecodable output: %s", what, exc)
+        return None
+
+    if len(buf) != length:
+        # nvme writes its diagnostics to stderr, so it still explains a short read
+        # even though the pipeline's exit status comes from base64.
+        node.log.warning(
+            "Reading %s returned %d bytes, expected %d: %s",
+            what,
+            len(buf),
+            length,
+            result.stderr.strip(),
+        )
+        return None
+
+    return buf
+
+
+def read_log_page(node: "BaseNode", device_path: str, log_id: int, length: int) -> bytes | None:
+    """Read a raw NVMe log page via ``nvme get-log``."""
+    return _read_raw(
+        node,
+        f"nvme get-log {device_path} --log-id={log_id} --log-len={length} -b",
+        length,
+        what=f"log page {log_id:#04x} on {device_path}",
+    )
+
+
+def read_identify_controller(node: "BaseNode", device_path: str) -> bytes | None:
+    """Read the raw Identify Controller data structure.
+
+    Identify is mandatory for every NVMe controller, so unlike an optional
+    command it can never be rejected as an unsupported opcode - which is why it
+    is safe to use for capability probing: it cannot add an Error Information
+    Log entry the way probing with the real command would.
+    """
+    return _read_raw(
+        node,
+        f"nvme id-ctrl {device_path} -b",
+        IDENTIFY_CONTROLLER_LEN,
+        what=f"Identify Controller for {device_path}",
+    )
+
+
+def get_controller_info(node: "BaseNode", device_path: str) -> NvmeControllerInfo | None:
+    """Read the controller's capabilities and log-page geometry in one Identify.
+
+    Both fields this module needs live in the same 4096-byte structure, so they
+    are read and parsed together rather than once per caller.
+
+    Args:
+        node: SCT node with remoter.
+        device_path: NVMe device path (e.g. "/dev/nvme0n1").
+
+    Returns:
+        Parsed NvmeControllerInfo, or None when Identify Controller could not
+        be read.
+    """
+    buf = read_identify_controller(node, device_path)
+    if buf is None:
+        node.log.warning("Could not read Identify Controller for %s", device_path)
+        return None
+    return parse_identify_controller(buf)
+
+
 def list_nvme_devices(node: "BaseNode") -> list[NvmeDevice]:
     """Discover NVMe devices on a node using ``nvme list -o json``.
 
@@ -764,52 +710,67 @@ def get_smart_log(node: "BaseNode", device_path: str) -> NvmeSmartLog | None:
     Returns:
         NvmeSmartLog instance, or None on failure.
     """
-    result = node.remoter.sudo(
-        f"nvme smart-log {device_path}",
-        ignore_status=True,
-        timeout=NVME_CMD_TIMEOUT,
-    )
-    if result.failed:
-        node.log.warning("'nvme smart-log %s' failed: %s", device_path, result.stderr)
+    buf = read_log_page(node, device_path, LOG_PAGE_SMART_HEALTH, SMART_LOG_PAGE_LEN)
+    if buf is None:
         return None
 
-    return parse_smart_log_output(device_path, result.stdout)
+    return parse_smart_log_page(device_path, buf)
 
 
-def get_error_log(node: "BaseNode", device_path: str, max_entries: int = 64) -> list[NvmeErrorLogEntry]:
-    """Collect error log for a single NVMe device.
+def get_error_log(node: "BaseNode", device_path: str, max_entries: int) -> list[NvmeErrorLogEntry] | None:
+    """Collect the populated Error Information Log entries for a device.
+
+    Asking ``get-log`` for more entries than the controller supports can be
+    rejected outright, so the page length must come from the device rather than
+    from a fixed guess. The caller supplies it (Identify Controller ELPE, via
+    NvmeControllerInfo.error_log_entries) so that this function performs exactly
+    one read and issues no Identify of its own.
 
     Args:
         node: SCT node with remoter.
         device_path: NVMe device path (e.g. "/dev/nvme0n1").
-        max_entries: Maximum number of error log entries to retrieve.
+        max_entries: Number of entries to request, from
+            NvmeControllerInfo.error_log_entries.
 
     Returns:
-        List of NvmeErrorLogEntry instances. Empty list on failure.
+        The populated entries with the unused slots omitted - an empty list
+        when the controller's log holds none. None when the log could not be
+        read, so a failed read is never reported as a clean device.
     """
-    result = node.remoter.sudo(
-        f"nvme error-log {device_path} -e {max_entries}",
-        ignore_status=True,
-        timeout=NVME_CMD_TIMEOUT,
-    )
-    if result.failed:
-        node.log.warning("'nvme error-log %s' failed: %s", device_path, result.stderr)
-        return []
+    buf = read_log_page(node, device_path, LOG_PAGE_ERROR_INFORMATION, max_entries * ERROR_LOG_ENTRY_LEN)
+    if buf is None:
+        return None
 
-    return parse_error_log_output(result.stdout)
+    return parse_error_log_page(buf)
 
 
-def run_self_test(node: "BaseNode", device_path: str, test_type: SelfTestType = SelfTestType.SHORT) -> bool:
+def run_self_test(
+    node: "BaseNode",
+    device_path: str,
+    controller_info: NvmeControllerInfo,
+    test_type: SelfTestType = SelfTestType.SHORT,
+) -> bool:
     """Trigger a device self-test on an NVMe device.
+
+    Controllers that do not implement the command are skipped rather than
+    probed: see NvmeControllerInfo.supports_self_test for why issuing it
+    blindly corrupts the very error-log counters this module reports on. The
+    controller info is read by the caller so that a node running self-tests on
+    several disks issues one Identify per device and no more.
 
     Args:
         node: SCT node with remoter.
         device_path: NVMe device path (e.g. "/dev/nvme0n1").
+        controller_info: Already-read Identify Controller fields for the device.
         test_type: Type of self-test to run (SHORT=1, EXTENDED=2).
 
     Returns:
         True if the self-test was triggered successfully, False otherwise.
     """
+    if not controller_info.supports_self_test:
+        node.log.info("Skipping self-test on %s: controller does not support it", device_path)
+        return False
+
     result = node.remoter.sudo(
         f"nvme device-self-test -s {int(test_type)} {device_path}",
         ignore_status=True,
@@ -817,7 +778,7 @@ def run_self_test(node: "BaseNode", device_path: str, test_type: SelfTestType = 
     )
     if result.failed:
         node.log.warning(
-            "'nvme device-self-test' on %s failed (may not be supported): %s",
+            "'nvme device-self-test' on %s failed: %s",
             device_path,
             result.stderr,
         )
@@ -867,16 +828,11 @@ def get_self_test_log(node: "BaseNode", device_path: str) -> NvmeSelfTestLog | N
     Returns:
         NvmeSelfTestLog instance, or None on failure.
     """
-    result = node.remoter.sudo(
-        f"nvme self-test-log {device_path}",
-        ignore_status=True,
-        timeout=NVME_CMD_TIMEOUT,
-    )
-    if result.failed:
-        node.log.warning("'nvme self-test-log %s' failed: %s", device_path, result.stderr)
+    buf = read_log_page(node, device_path, LOG_PAGE_DEVICE_SELF_TEST, SELF_TEST_LOG_PAGE_LEN)
+    if buf is None:
         return None
 
-    return parse_self_test_log_output(device_path, result.stdout)
+    return parse_self_test_log_page(device_path, buf)
 
 
 def collect_all_smart_logs(node: "BaseNode") -> list[NvmeSmartLog]:
@@ -909,6 +865,29 @@ def collect_all_smart_logs(node: "BaseNode") -> list[NvmeSmartLog]:
     return smart_logs
 
 
+# Node attribute holding the SMART logs captured at node setup, keyed by device
+# path. Error and media counters are lifetime totals, so only the growth since
+# this baseline says anything about the test that just ran.
+NVME_BASELINE_ATTR = "nvme_baseline_smart_logs"
+
+
+def store_baseline_smart_logs(node: "BaseNode", smart_logs: list[NvmeSmartLog]) -> None:
+    """Record the node's SMART logs as the baseline for later delta checks."""
+    setattr(node, NVME_BASELINE_ATTR, {log.device_path: log for log in smart_logs})
+
+
+def get_baseline_smart_log(node: "BaseNode", device_path: str) -> NvmeSmartLog | None:
+    """Return the baseline SMART log for a device, or None if none was captured.
+
+    A missing baseline is normal: node setup skips it when nvme-cli could not be
+    installed, and reused clusters never ran it at all.
+    """
+    baseline = getattr(node, NVME_BASELINE_ATTR, None)
+    if not isinstance(baseline, dict):
+        return None
+    return baseline.get(device_path)
+
+
 # ---------------------------------------------------------------------------
 # Health check thresholds
 # ---------------------------------------------------------------------------
@@ -937,12 +916,15 @@ def check_nvme_health(
 
     Collects SMART logs for all NVMe data disks on the node and evaluates
     them against health thresholds. Automatically collects error logs when
-    media errors or error log entries are detected.
+    media errors or error log entries appeared during the test.
 
     Severity mapping:
         - critical_warning != 0 -> CRITICAL
-        - media_errors > 0 -> ERROR
-        - num_err_log_entries > 0 -> WARNING (also collects error log)
+        - media_errors above the setup baseline -> ERROR
+        - num_err_log_entries above the setup baseline -> WARNING
+          (also collects error log)
+        - both baseline-relative checks are skipped when no setup baseline was
+          captured for the device
         - percentage_used > threshold -> WARNING
         - available_spare < available_spare_threshold -> WARNING
         - temperature > threshold -> WARNING
@@ -985,24 +967,47 @@ def _check_single_device_health(
             error=f"NVMe {device}: critical_warning={smart_log.critical_warning} (non-zero indicates hardware issue)",
         )
 
-    # media_errors > 0 -> ERROR
-    if smart_log.has_media_errors:
+    # media_errors and num_err_log_entries are lifetime counters: a fresh cloud
+    # instance can already carry entries from before the test started. Only the
+    # growth over the setup baseline says something happened during this run.
+    #
+    # Without a baseline there is nothing to subtract, and a missing baseline is
+    # a normal case (see get_baseline_smart_log). Treating it as zero would
+    # report the device's whole lifetime history as errors from this run - the
+    # exact false positive the baseline was introduced to remove - so the two
+    # delta checks are skipped instead of guessed at.
+    baseline = get_baseline_smart_log(current_node, device)
+    if baseline is None:
+        current_node.log.debug(
+            "No NVMe baseline captured for %s, skipping the media_errors and num_err_log_entries delta checks",
+            device,
+        )
+        new_media_errors = new_error_entries = 0
+    else:
+        new_media_errors = smart_log.media_errors - baseline.media_errors
+        new_error_entries = smart_log.num_err_log_entries - baseline.num_err_log_entries
+
+    # media errors appeared during the test -> ERROR
+    if new_media_errors > 0:
         yield ClusterHealthValidatorEvent.NvmeHealth(
             severity=Severity.ERROR,
             node=current_node.name,
-            error=f"NVMe {device}: media_errors={smart_log.media_errors}",
+            error=(f"NVMe {device}: {new_media_errors} new media_errors during test (total={smart_log.media_errors})"),
         )
         _collect_error_log_with_timestamp(current_node, device)
 
-    # num_err_log_entries > 0 -> WARNING (also collect error log)
-    if smart_log.has_error_log_entries:
+    # error log entries appeared during the test -> WARNING (also collect error log)
+    if new_error_entries > 0:
         yield ClusterHealthValidatorEvent.NvmeHealth(
             severity=Severity.WARNING,
             node=current_node.name,
-            message=f"NVMe {device}: num_err_log_entries={smart_log.num_err_log_entries}",
+            message=(
+                f"NVMe {device}: {new_error_entries} new error log entries during test "
+                f"(total={smart_log.num_err_log_entries})"
+            ),
         )
-        if not smart_log.has_media_errors:
-            # Only collect if not already collected above
+        if new_media_errors == 0:
+            # the media-errors branch above already collected the log
             _collect_error_log_with_timestamp(current_node, device)
 
     # percentage_used > threshold -> WARNING
@@ -1038,28 +1043,46 @@ def _check_single_device_health(
 def _collect_error_log_with_timestamp(node: "BaseNode", device_path: str) -> None:
     """Collect NVMe error log and save with timestamp for post-mortem analysis.
 
-    Saves the raw error log output to the node's log directory with a
-    timestamped filename for correlation with test events.
+    Saves a summary of the populated error log entries to the node's log
+    directory with a timestamped filename for correlation with test events.
+    The full unparsed output is collected separately as ``nvme_error_log.log``.
     """
     timestamp = datetime.now(tz=timezone.utc).strftime("%Y%m%d_%H%M%S")
     device_name = device_path.replace("/dev/", "")
     filename = f"nvme_error_log_{device_name}_{timestamp}.log"
 
-    entries = get_error_log(node, device_path)
-    if not entries:
-        node.log.debug("NVMe error log for %s is empty", device_path)
-        return
-
-    lines = []
-    for entry in entries:
-        lines.append(
-            f"error_count={entry.error_count} sqid={entry.submission_queue_id} "
-            f"cmdid={entry.command_id} status=0x{entry.status_field:04x} "
-            f"lba=0x{entry.lba:x} nsid={entry.nsid} opcode=0x{entry.opcode:02x}"
-        )
-    content = "\n".join(lines) + "\n"
-
+    # This runs inside the teardown health check, so a collection failure must
+    # never take the health check down with it.
     try:
+        # The Identify read happens here, where the error log is actually read,
+        # so a healthy device costs no extra admin command: this is the only
+        # place in the health check that needs the log page's length.
+        controller_info = get_controller_info(node, device_path)
+        if controller_info is None:
+            return
+
+        # get_error_log already drops the unused slots: the spec defines an
+        # Error Count of 0h as an invalid entry. None means the page could not
+        # be read at all, which is not the same as a device with a clean log.
+        entries = get_error_log(node, device_path, controller_info.error_log_entries)
+        if entries is None:
+            node.log.warning("Could not read the NVMe error log for %s, nothing collected", device_path)
+            return
+        if not entries:
+            node.log.debug("NVMe error log for %s has no populated entries", device_path)
+            return
+
+        lines = []
+        for entry in entries:
+            # opcode is only reported when the entry's log page version is 1
+            opcode = "n/a" if entry.opcode is None else f"0x{entry.opcode:02x}"
+            lines.append(
+                f"error_count={entry.error_count} sqid={entry.submission_queue_id} "
+                f"cmdid={entry.command_id} status=0x{entry.status_field:04x} "
+                f"lba=0x{entry.lba:x} nsid={entry.nsid} opcode={opcode}"
+            )
+        content = "\n".join(lines) + "\n"
+
         log_dir = node.logdir
         if log_dir:
             filepath = f"{log_dir}/{filename}"
@@ -1067,7 +1090,7 @@ def _collect_error_log_with_timestamp(node: "BaseNode", device_path: str) -> Non
                 fobj.write(content)
             node.log.info("NVMe error log saved to %s (%d entries)", filepath, len(entries))
     except Exception as exc:  # noqa: BLE001
-        node.log.warning("Failed to save NVMe error log: %s", exc)
+        node.log.warning("Failed to collect NVMe error log for %s: %s", device_path, exc)
 
 
 # ---------------------------------------------------------------------------
@@ -1250,7 +1273,13 @@ def run_self_test_on_all_devices(
 
     started_disks = []
     for disk in data_disks:
-        if run_self_test(node, disk.device_path, test_type):
+        # one Identify per device, here rather than inside run_self_test, so the
+        # capability probe stays visible at the level that drives the devices
+        controller_info = get_controller_info(node, disk.device_path)
+        if controller_info is None:
+            node.log.warning("Could not read controller info for %s, skipping self-test", disk.device_path)
+            continue
+        if run_self_test(node, disk.device_path, controller_info, test_type):
             started_disks.append(disk)
         else:
             node.log.warning("Failed to trigger self-test on %s, skipping", disk.device_path)

--- a/unit_tests/unit/test_nvme.py
+++ b/unit_tests/unit/test_nvme.py
@@ -19,6 +19,7 @@ JSON and human-readable formats across different nvme-cli versions.
 
 from __future__ import annotations
 
+import base64
 import json
 from unittest.mock import MagicMock, PropertyMock
 
@@ -26,30 +27,46 @@ from unittest.mock import MagicMock, PropertyMock
 from sdcm.cluster import BaseScyllaCluster
 from sdcm.sct_events import Severity
 from sdcm.utils.nvme_diagnostics import (
+    ERROR_LOG_ENTRY_LEN,
+    IDCTRL_ELPE_OFFSET,
+    IDCTRL_OACS_OFFSET,
+    IDENTIFY_CONTROLLER_LEN,
+    LOG_PAGE_ERROR_INFORMATION,
+    LOG_PAGE_SMART_HEALTH,
+    OACS_DEVICE_SELF_TEST,
+    SELF_TEST_LOG_PAGE_LEN,
+    SELF_TEST_RESULT_LEN,
+    SMART_LOG_PAGE_LEN,
+    NvmeControllerInfo,
     NvmeDevice,
     NvmeSelfTestLog,
     NvmeSelfTestResult,
     NvmeSmartLog,
     SelfTestType,
     _check_single_device_health,
+    _collect_error_log_with_timestamp,
     abort_self_test,
     check_nvme_health,
     check_self_test_results,
     collect_all_smart_logs,
     filter_data_disks,
+    get_controller_info,
     get_error_log,
     get_self_test_log,
     get_smart_log,
     install_nvme_cli,
     is_nvme_cli_available,
     list_nvme_devices,
-    parse_error_log_output,
+    parse_error_log_entry,
+    parse_error_log_page,
+    parse_identify_controller,
     parse_nvme_list_output,
-    parse_self_test_log_output,
-    parse_smart_log_output,
+    parse_self_test_log_page,
+    parse_smart_log_page,
     poll_self_test_completion,
     run_self_test,
     run_self_test_on_all_devices,
+    store_baseline_smart_logs,
 )
 
 
@@ -115,92 +132,6 @@ NVME_LIST_JSON_FLAT = json.dumps(
 
 NVME_LIST_EMPTY_JSON = json.dumps({"Devices": []})
 
-SMART_LOG_TEXT_OUTPUT = """\
-Smart Log for NVME device:nvme1n1 namespace-id:ffffffff
-critical_warning                        : 0
-temperature                             : 315 K (42 Celsius)
-available_spare                         : 100%
-available_spare_threshold               : 10%
-percentage_used                         : 2%
-data_units_read                         : 1,234,567
-data_units_written                      : 9,876,543
-host_read_commands                      : 50,000,000
-host_write_commands                     : 30,000,000
-controller_busy_time                    : 120
-power_cycles                            : 15
-power_on_hours                          : 8760
-unsafe_shutdowns                        : 3
-media_errors                            : 0
-num_err_log_entries                     : 5
-"""
-
-SMART_LOG_TEXT_WITH_ERRORS = """\
-Smart Log for NVME device:nvme1n1 namespace-id:ffffffff
-critical_warning                        : 4
-temperature                             : 345 K (72 Celsius)
-available_spare                         : 5%
-available_spare_threshold               : 10%
-percentage_used                         : 95%
-data_units_read                         : 10,000,000
-data_units_written                      : 50,000,000
-host_read_commands                      : 100,000,000
-host_write_commands                     : 200,000,000
-controller_busy_time                    : 5000
-power_cycles                            : 50
-power_on_hours                          : 20000
-unsafe_shutdowns                        : 10
-media_errors                            : 42
-num_err_log_entries                     : 100
-"""
-
-SMART_LOG_JSON_OUTPUT = json.dumps(
-    {
-        "critical_warning": 0,
-        "temperature": 310,
-        "avail_spare": 95,
-        "spare_thresh": 10,
-        "percent_used": 5,
-        "data_units_read": 500000,
-        "data_units_written": 300000,
-        "host_read_commands": 10000000,
-        "host_write_commands": 8000000,
-        "controller_busy_time": 60,
-        "power_cycles": 8,
-        "power_on_hours": 4000,
-        "unsafe_shutdowns": 1,
-        "media_errors": 0,
-        "num_err_log_entries": 0,
-    }
-)
-
-ERROR_LOG_TEXT_OUTPUT = """\
-Error Log Entries for device:nvme1n1 entries:2
-Entry[0]
-error_count                    : 5
-submission queue id            : 0
-command id                     : 0x0012
-status field                   : 0x4004
-parm error location            : 0x0000
-lba                            : 0x00000000
-nsid                           : 1
-vs                             : 0
-transport type                 : 0
-command specific               : 0
-opcode                         : 0x02
-Entry[1]
-error_count                    : 4
-submission queue id            : 0
-command id                     : 0x000a
-status field                   : 0x4004
-parm error location            : 0x0000
-lba                            : 0x00001000
-nsid                           : 1
-vs                             : 0
-transport type                 : 0
-command specific               : 0
-opcode                         : 0x01
-"""
-
 # nvme-cli pads the entry index and prints hex values with a "0x" prefix
 ERROR_LOG_TEXT_PADDED_OUTPUT = """\
 Error Log Entries for device:nvme1n1 entries:2
@@ -234,61 +165,6 @@ opcode	: 0x1
 .................
 """
 
-ERROR_LOG_JSON_OUTPUT = json.dumps(
-    [
-        {
-            "error_count": 3,
-            "sqid": 0,
-            "cmdid": 18,
-            "status_field": 16388,
-            "parm_error_location": 0,
-            "lba": 0,
-            "nsid": 1,
-            "vs": 0,
-            "trtype": 0,
-            "cs": 0,
-            "opcode": 2,
-        },
-        {
-            "error_count": 2,
-            "sqid": 1,
-            "cmdid": 5,
-            "status_field": 16388,
-            "parm_error_location": 0,
-            "lba": 4096,
-            "nsid": 1,
-            "vs": 0,
-            "trtype": 0,
-            "cs": 0,
-            "opcode": 1,
-        },
-    ]
-)
-
-SELF_TEST_LOG_TEXT_OUTPUT = """\
-Device Self Test Log for NVME device:nvme1n1
-Current operation  : 0
-Current Completion : 0
-Self Test Result[0]
-Device Self-test Status             : 0
-Self Test Code                      : 1
-Segment Number                      : 0
-Power On Hours                      : 8760
-nsid                                : 1
-Failing LBA                         : 0
-SCT                                 : 0
-SC                                  : 0
-Self Test Result[1]
-Device Self-test Status             : 2
-Self Test Code                      : 2
-Segment Number                      : 1
-Power On Hours                      : 8500
-nsid                                : 1
-Failing LBA                         : 0x00001234
-SCT                                 : 0
-SC                                  : 0
-"""
-
 # Format printed by nvme-cli itself: hex values and its own field names
 SELF_TEST_LOG_TEXT_NVME_CLI_OUTPUT = """\
 Device Self Test Log for NVME device:nvme1n1
@@ -315,35 +191,6 @@ Self Test Result[1]:
   Status Code                  : 0x3
   Segment Number               : 0x2
 """
-
-SELF_TEST_LOG_JSON_OUTPUT = json.dumps(
-    {
-        "current_operation": 1,
-        "current_completion": 45,
-        "results": [
-            {
-                "result": 0,
-                "self_test_code": 1,
-                "segment": 0,
-                "power_on_hours": 9000,
-                "nsid": 1,
-                "failing_lba": 0,
-                "sct": 0,
-                "sc": 0,
-            },
-            {
-                "result": 1,
-                "self_test_code": 2,
-                "segment": 0,
-                "power_on_hours": 8900,
-                "nsid": 1,
-                "failing_lba": 512,
-                "sct": 1,
-                "sc": 3,
-            },
-        ],
-    }
-)
 
 SELF_TEST_LOG_IN_PROGRESS_TEXT = """\
 Device Self Test Log for NVME device:nvme1n1
@@ -412,246 +259,10 @@ def test_parse_nvme_list_output_whitespace_only():
 # ---------------------------------------------------------------------------
 
 
-def test_parse_smart_log_text_normal():
-    """Parse human-readable SMART log with normal values."""
-    smart = parse_smart_log_output("/dev/nvme1n1", SMART_LOG_TEXT_OUTPUT)
-    assert smart is not None
-    assert smart.device_path == "/dev/nvme1n1"
-    assert smart.critical_warning == 0
-    assert smart.temperature_kelvin == 315
-    assert smart.temperature_celsius == 42
-    assert smart.available_spare == 100
-    assert smart.available_spare_threshold == 10
-    assert smart.percentage_used == 2
-    assert smart.data_units_read == 1234567
-    assert smart.data_units_written == 9876543
-    assert smart.host_read_commands == 50000000
-    assert smart.host_write_commands == 30000000
-    assert smart.controller_busy_time == 120
-    assert smart.power_cycles == 15
-    assert smart.power_on_hours == 8760
-    assert smart.unsafe_shutdowns == 3
-    assert smart.media_errors == 0
-    assert smart.num_err_log_entries == 5
-    assert not smart.has_critical_warning
-    assert not smart.has_media_errors
-    assert smart.has_error_log_entries
-
-
-def test_parse_smart_log_text_with_errors():
-    """Parse SMART log showing critical conditions."""
-    smart = parse_smart_log_output("/dev/nvme1n1", SMART_LOG_TEXT_WITH_ERRORS)
-    assert smart is not None
-    assert smart.critical_warning == 4
-    assert smart.temperature_kelvin == 345
-    assert smart.temperature_celsius == 72
-    assert smart.available_spare == 5
-    assert smart.percentage_used == 95
-    assert smart.media_errors == 42
-    assert smart.num_err_log_entries == 100
-    assert smart.has_critical_warning
-    assert smart.has_media_errors
-    assert smart.has_error_log_entries
-
-
-def test_parse_smart_log_json():
-    """Parse JSON format SMART log."""
-    smart = parse_smart_log_output("/dev/nvme0n1", SMART_LOG_JSON_OUTPUT)
-    assert smart is not None
-    assert smart.device_path == "/dev/nvme0n1"
-    assert smart.critical_warning == 0
-    assert smart.temperature_kelvin == 310
-    assert smart.available_spare == 95
-    assert smart.available_spare_threshold == 10
-    assert smart.percentage_used == 5
-    assert smart.power_on_hours == 4000
-    assert smart.media_errors == 0
-    assert smart.num_err_log_entries == 0
-
-
-def test_parse_smart_log_empty_input():
-    """Empty input returns None."""
-    assert parse_smart_log_output("/dev/nvme0n1", "") is None
-    assert parse_smart_log_output("/dev/nvme0n1", None) is None
-
-
 def test_parse_smart_log_temperature_celsius_zero_kelvin():
     """Temperature conversion handles zero kelvin gracefully."""
     smart = NvmeSmartLog(device_path="/dev/nvme0n1", temperature_kelvin=0)
     assert smart.temperature_celsius == 0
-
-
-def test_parse_smart_log_text_hex_critical_warning():
-    """Hex values are parsed as hex, not as their leading "0"."""
-    output = (
-        "Smart Log for NVME device:nvme1n1 namespace-id:ffffffff\n"
-        "critical_warning                        : 0x1\n"
-        "temperature                             : 315 K (42 Celsius)\n"
-        "media_errors                            : 0xa\n"
-    )
-    smart = parse_smart_log_output("/dev/nvme1n1", output)
-    assert smart is not None
-    assert smart.critical_warning == 1
-    assert smart.media_errors == 10
-    assert smart.temperature_kelvin == 315
-
-
-# ---------------------------------------------------------------------------
-# Tests: parse_error_log_output
-# ---------------------------------------------------------------------------
-
-
-def test_parse_error_log_text():
-    """Parse human-readable error log with two entries."""
-    entries = parse_error_log_output(ERROR_LOG_TEXT_OUTPUT)
-    assert len(entries) == 2
-
-    assert entries[0].error_count == 5
-    assert entries[0].command_id == 0x0012
-    assert entries[0].status_field == 0x4004
-    assert entries[0].lba == 0
-    assert entries[0].nsid == 1
-    assert entries[0].opcode == 0x02
-
-    assert entries[1].error_count == 4
-    assert entries[1].command_id == 0x000A
-    assert entries[1].lba == 0x1000
-    assert entries[1].opcode == 0x01
-
-
-def test_parse_error_log_text_padded_entry_headers():
-    """Parse nvme-cli output where the entry index is padded ("Entry[ 0]")."""
-    entries = parse_error_log_output(ERROR_LOG_TEXT_PADDED_OUTPUT)
-    assert len(entries) == 2
-
-    assert entries[0].error_count == 7
-    assert entries[0].command_id == 0x12
-    assert entries[0].status_field == 0x4004
-    assert entries[0].nsid == 1
-    assert entries[0].opcode == 0x2
-
-    assert entries[1].error_count == 6
-    assert entries[1].command_id == 0xA
-    assert entries[1].lba == 0x1000
-    assert entries[1].opcode == 0x1
-
-
-def test_parse_error_log_json():
-    """Parse JSON format error log."""
-    entries = parse_error_log_output(ERROR_LOG_JSON_OUTPUT)
-    assert len(entries) == 2
-
-    assert entries[0].error_count == 3
-    assert entries[0].submission_queue_id == 0
-    assert entries[0].command_id == 18
-    assert entries[0].status_field == 16388
-    assert entries[0].lba == 0
-    assert entries[0].nsid == 1
-    assert entries[0].opcode == 2
-
-    assert entries[1].error_count == 2
-    assert entries[1].submission_queue_id == 1
-    assert entries[1].lba == 4096
-    assert entries[1].opcode == 1
-
-
-def test_parse_error_log_empty_input():
-    """Empty input returns empty list."""
-    assert parse_error_log_output("") == []
-    assert parse_error_log_output(None) == []
-
-
-def test_parse_error_log_no_entries():
-    """Output with header but no entries returns empty list."""
-    output = "Error Log Entries for device:nvme0n1 entries:0\n"
-    assert parse_error_log_output(output) == []
-
-
-# ---------------------------------------------------------------------------
-# Tests: parse_self_test_log_output
-# ---------------------------------------------------------------------------
-
-
-def test_parse_self_test_log_text():
-    """Parse human-readable self-test log with two result entries."""
-    log = parse_self_test_log_output("/dev/nvme1n1", SELF_TEST_LOG_TEXT_OUTPUT)
-    assert log is not None
-    assert log.device_path == "/dev/nvme1n1"
-    assert log.current_operation == 0
-    assert log.current_completion == 0
-    assert not log.test_in_progress
-    assert len(log.results) == 2
-
-    assert log.results[0].result_code == 0
-    assert log.results[0].self_test_code == 1
-    assert log.results[0].power_on_hours == 8760
-    assert log.results[0].passed
-
-    assert log.results[1].result_code == 2
-    assert log.results[1].self_test_code == 2
-    assert log.results[1].power_on_hours == 8500
-    assert log.results[1].failing_lba == 0x1234
-    assert not log.results[1].passed
-
-
-def test_parse_self_test_log_text_nvme_cli_format():
-    """Parse nvme-cli output: hex current operation and its own field names."""
-    log = parse_self_test_log_output("/dev/nvme1n1", SELF_TEST_LOG_TEXT_NVME_CLI_OUTPUT)
-    assert log is not None
-    assert log.current_operation == 2
-    assert log.current_completion == 67
-    assert log.test_in_progress
-    assert len(log.results) == 2
-
-    assert log.results[0].result_code == 0
-    assert log.results[0].self_test_code == 1
-    assert log.results[0].power_on_hours == 0x2238
-    assert log.results[0].nsid == 1
-    assert log.results[0].passed
-
-    assert log.results[1].result_code == 7
-    assert log.results[1].failing_lba == 0x1234
-    assert log.results[1].status_code_type == 1
-    assert log.results[1].status_code == 3
-    assert not log.results[1].passed
-
-
-def test_parse_self_test_log_json():
-    """Parse JSON format self-test log with test in progress."""
-    log = parse_self_test_log_output("/dev/nvme1n1", SELF_TEST_LOG_JSON_OUTPUT)
-    assert log is not None
-    assert log.current_operation == 1
-    assert log.current_completion == 45
-    assert log.test_in_progress
-    assert len(log.results) == 2
-
-    assert log.results[0].result_code == 0
-    assert log.results[0].self_test_code == 1
-    assert log.results[0].power_on_hours == 9000
-    assert log.results[0].passed
-
-    assert log.results[1].result_code == 1
-    assert log.results[1].self_test_code == 2
-    assert log.results[1].failing_lba == 512
-    assert log.results[1].status_code_type == 1
-    assert log.results[1].status_code == 3
-    assert not log.results[1].passed
-
-
-def test_parse_self_test_log_in_progress():
-    """Parse self-test log showing test in progress, no results."""
-    log = parse_self_test_log_output("/dev/nvme1n1", SELF_TEST_LOG_IN_PROGRESS_TEXT)
-    assert log is not None
-    assert log.current_operation == 2
-    assert log.current_completion == 67
-    assert log.test_in_progress
-    assert log.results == []
-
-
-def test_parse_self_test_log_empty_input():
-    """Empty input returns None."""
-    assert parse_self_test_log_output("/dev/nvme0n1", "") is None
-    assert parse_self_test_log_output("/dev/nvme0n1", None) is None
 
 
 # ---------------------------------------------------------------------------
@@ -814,6 +425,17 @@ def _make_mock_node():
     return node
 
 
+# A controller that advertises Device Self-test (OACS bit 4) and a 64-entry
+# Error Information Log. Callers read Identify once and pass this down, so the
+# tests hand it over the same way production code does.
+_SELF_TEST_CAPABLE = NvmeControllerInfo(oacs=OACS_DEVICE_SELF_TEST, error_log_entries=64)
+
+
+def _stub_controller_info(monkeypatch, info=_SELF_TEST_CAPABLE):
+    """Stub the single Identify read the error-log collector performs."""
+    monkeypatch.setattr("sdcm.utils.nvme_diagnostics.get_controller_info", lambda n, d: info)
+
+
 def _make_result(stdout="", stderr="", exited=0):
     """Create a mock command result."""
     result = MagicMock()
@@ -918,17 +540,6 @@ def test_list_nvme_devices_command_fails():
     assert devices == []
 
 
-def test_get_smart_log_success():
-    """get_smart_log returns parsed SMART data."""
-    node = _make_mock_node()
-    node.remoter.sudo.return_value = _make_result(stdout=SMART_LOG_TEXT_OUTPUT)
-
-    smart = get_smart_log(node, "/dev/nvme1n1")
-    assert smart is not None
-    assert smart.power_on_hours == 8760
-    assert smart.media_errors == 0
-
-
 def test_get_smart_log_failure():
     """get_smart_log returns None when command fails."""
     node = _make_mock_node()
@@ -938,22 +549,12 @@ def test_get_smart_log_failure():
     assert smart is None
 
 
-def test_get_error_log_success():
-    """get_error_log returns parsed entries."""
-    node = _make_mock_node()
-    node.remoter.sudo.return_value = _make_result(stdout=ERROR_LOG_TEXT_OUTPUT)
-
-    entries = get_error_log(node, "/dev/nvme1n1")
-    assert len(entries) == 2
-
-
 def test_get_error_log_failure():
-    """get_error_log returns empty list when command fails."""
+    """A failed read returns None, which is not the same as an empty log."""
     node = _make_mock_node()
     node.remoter.sudo.return_value = _make_result(exited=1, stderr="error")
 
-    entries = get_error_log(node, "/dev/nvme99n1")
-    assert entries == []
+    assert get_error_log(node, "/dev/nvme99n1", 64) is None
 
 
 def test_run_self_test_success():
@@ -961,7 +562,7 @@ def test_run_self_test_success():
     node = _make_mock_node()
     node.remoter.sudo.return_value = _make_result()
 
-    result = run_self_test(node, "/dev/nvme1n1", SelfTestType.SHORT)
+    result = run_self_test(node, "/dev/nvme1n1", _SELF_TEST_CAPABLE, SelfTestType.SHORT)
     assert result is True
     node.remoter.sudo.assert_called_once_with(
         "nvme device-self-test -s 1 /dev/nvme1n1",
@@ -975,7 +576,7 @@ def test_run_self_test_extended():
     node = _make_mock_node()
     node.remoter.sudo.return_value = _make_result()
 
-    result = run_self_test(node, "/dev/nvme1n1", SelfTestType.EXTENDED)
+    result = run_self_test(node, "/dev/nvme1n1", _SELF_TEST_CAPABLE, SelfTestType.EXTENDED)
     assert result is True
     node.remoter.sudo.assert_called_once_with(
         "nvme device-self-test -s 2 /dev/nvme1n1",
@@ -984,13 +585,27 @@ def test_run_self_test_extended():
     )
 
 
-def test_run_self_test_not_supported():
-    """run_self_test returns False when device doesn't support self-test."""
+def test_run_self_test_command_rejected():
+    """run_self_test returns False when a supported controller rejects the command."""
     node = _make_mock_node()
     node.remoter.sudo.return_value = _make_result(exited=1, stderr="not supported")
 
-    result = run_self_test(node, "/dev/nvme1n1")
+    result = run_self_test(node, "/dev/nvme1n1", _SELF_TEST_CAPABLE)
     assert result is False
+
+
+def test_run_self_test_skipped_when_controller_lacks_support():
+    """The self-test command is never issued to a controller that does not implement it.
+
+    Issuing it anyway records an entry in the device Error Information Log and
+    increments num_err_log_entries, so the diagnostic would report an anomaly
+    it created itself.
+    """
+    node = _make_mock_node()
+    unsupported = NvmeControllerInfo(oacs=0x8, error_log_entries=64)
+
+    assert run_self_test(node, "/dev/nvme1n1", unsupported) is False
+    node.remoter.sudo.assert_not_called()
 
 
 def test_abort_self_test_success():
@@ -1017,16 +632,6 @@ def test_abort_self_test_failure():
     node.log.warning.assert_called()
 
 
-def test_get_self_test_log_success():
-    """get_self_test_log returns parsed log."""
-    node = _make_mock_node()
-    node.remoter.sudo.return_value = _make_result(stdout=SELF_TEST_LOG_TEXT_OUTPUT)
-
-    log = get_self_test_log(node, "/dev/nvme1n1")
-    assert log is not None
-    assert len(log.results) == 2
-
-
 def test_get_self_test_log_failure():
     """get_self_test_log returns None when command fails."""
     node = _make_mock_node()
@@ -1034,23 +639,6 @@ def test_get_self_test_log_failure():
 
     log = get_self_test_log(node, "/dev/nvme1n1")
     assert log is None
-
-
-def test_collect_all_smart_logs_full_pipeline():
-    """collect_all_smart_logs performs discovery -> filter -> collect."""
-    node = _make_mock_node()
-    # is_nvme_cli_available check (via run "which nvme")
-    node.remoter.run.return_value = _make_result(stdout="/usr/sbin/nvme")
-    # nvme list returns one EBS + one instance store
-    node.remoter.sudo.side_effect = [
-        _make_result(stdout=NVME_LIST_JSON_V2),  # nvme list
-        _make_result(stdout=SMART_LOG_TEXT_OUTPUT),  # smart-log for instance store
-    ]
-
-    smart_logs = collect_all_smart_logs(node)
-    # Only the instance store disk (not EBS) should be collected
-    assert len(smart_logs) == 1
-    assert smart_logs[0].device_path == "/dev/nvme1n1"
 
 
 def test_collect_all_smart_logs_no_devices():
@@ -1197,27 +785,29 @@ def test_threshold_critical_warning_yields_critical():
 
 
 def test_threshold_media_errors_yields_error():
-    """media_errors > 0 yields an ERROR event."""
+    """media_errors above the baseline yields an ERROR event."""
     node = _make_mock_node()
     node.logdir = "/tmp/opencode/test_logdir"
+    store_baseline_smart_logs(node, [_make_smart_log()])
     smart = _make_smart_log(media_errors=42)
     events = list(_check_single_device_health(node, smart, DEFAULT_THRESHOLDS))
 
     error_events = [e for e in events if e.severity == Severity.ERROR]
     assert len(error_events) == 1
-    assert "media_errors=42" in error_events[0].error
+    assert "42 new media_errors" in error_events[0].error
 
 
 def test_threshold_error_log_entries_yields_warning():
-    """num_err_log_entries > 0 yields a WARNING event."""
+    """num_err_log_entries above the baseline yields a WARNING event."""
     node = _make_mock_node()
     node.logdir = "/tmp/opencode/test_logdir"
+    store_baseline_smart_logs(node, [_make_smart_log()])
     smart = _make_smart_log(num_err_log_entries=5)
     events = list(_check_single_device_health(node, smart, DEFAULT_THRESHOLDS))
 
     warning_events = [e for e in events if e.severity == Severity.WARNING]
     assert len(warning_events) == 1
-    assert "num_err_log_entries=5" in warning_events[0].message
+    assert "5 new error log entries" in warning_events[0].message
 
 
 def test_threshold_percentage_used_above_threshold_yields_warning():
@@ -1273,6 +863,7 @@ def test_threshold_multiple_issues_yields_multiple_events():
     """A device with multiple issues yields one event per issue."""
     node = _make_mock_node()
     node.logdir = "/tmp/opencode/test_logdir"
+    store_baseline_smart_logs(node, [_make_smart_log()])
     smart = _make_smart_log(
         critical_warning=1,
         media_errors=10,
@@ -1348,10 +939,11 @@ def test_check_nvme_health_yields_events_for_errors(monkeypatch):
     node.parent_cluster.params.get.return_value = True
     node.logdir = "/tmp/opencode/test_logdir"
 
+    store_baseline_smart_logs(node, [_make_smart_log()])
     smart = _make_smart_log(media_errors=5)
     monkeypatch.setattr("sdcm.utils.nvme_diagnostics.is_nvme_cli_available", lambda n: True)
     monkeypatch.setattr("sdcm.utils.nvme_diagnostics.collect_all_smart_logs", lambda n: [smart])
-    monkeypatch.setattr("sdcm.utils.nvme_diagnostics.get_error_log", lambda n, d, **kw: [])
+    monkeypatch.setattr("sdcm.utils.nvme_diagnostics.get_error_log", lambda n, d, max_entries: [])
 
     events = list(check_nvme_health(current_node=node))
     assert len(events) == 1
@@ -1506,8 +1098,12 @@ def test_run_self_test_on_all_devices_triggers_all_before_polling(monkeypatch):
     monkeypatch.setattr("sdcm.utils.nvme_diagnostics.list_nvme_devices", lambda n: disks)
     monkeypatch.setattr("sdcm.utils.nvme_diagnostics.filter_data_disks", lambda devices, **kwargs: disks)
     monkeypatch.setattr(
+        "sdcm.utils.nvme_diagnostics.get_controller_info",
+        lambda n, device_path: calls.append(("id-ctrl", device_path)) or _SELF_TEST_CAPABLE,
+    )
+    monkeypatch.setattr(
         "sdcm.utils.nvme_diagnostics.run_self_test",
-        lambda n, device_path, test_type: calls.append(("trigger", device_path)) is None,
+        lambda n, device_path, controller_info, test_type: calls.append(("trigger", device_path)) is None,
     )
     monkeypatch.setattr(
         "sdcm.utils.nvme_diagnostics.poll_self_test_completion",
@@ -1518,7 +1114,42 @@ def test_run_self_test_on_all_devices_triggers_all_before_polling(monkeypatch):
 
     assert result == []
     assert [device_path for action, device_path in calls if action == "trigger"] == [d.device_path for d in disks]
-    assert [action for action, _ in calls] == ["trigger"] * 3 + ["poll"] * 3
+    assert [action for action, _ in calls] == ["id-ctrl", "trigger"] * 3 + ["poll"] * 3
+    # exactly one Identify per device: the capability probe is not repeated
+    assert [device_path for action, device_path in calls if action == "id-ctrl"] == [d.device_path for d in disks]
+
+
+def test_run_self_test_on_all_devices_skips_device_with_unreadable_identify(monkeypatch):
+    """A device whose Identify cannot be read is skipped, not probed blindly.
+
+    Without OACS there is no way to know whether the self-test command is
+    implemented, and issuing it to a controller that does not implement it
+    adds an entry to the device Error Information Log.
+    """
+    node = _make_mock_node()
+    disk = NvmeDevice(
+        device_path="/dev/nvme1n1",
+        model="Amazon EC2 NVMe Instance Storage",
+        serial="AWS1",
+        firmware="0",
+        size_bytes=1900000000000,
+        used_bytes=0,
+        sector_size=512,
+        is_data_disk=True,
+    )
+    triggered = []
+
+    monkeypatch.setattr("sdcm.utils.nvme_diagnostics.is_nvme_cli_available", lambda n: True)
+    monkeypatch.setattr("sdcm.utils.nvme_diagnostics.list_nvme_devices", lambda n: [disk])
+    monkeypatch.setattr("sdcm.utils.nvme_diagnostics.filter_data_disks", lambda devices, **kwargs: [disk])
+    monkeypatch.setattr("sdcm.utils.nvme_diagnostics.get_controller_info", lambda n, device_path: None)
+    monkeypatch.setattr(
+        "sdcm.utils.nvme_diagnostics.run_self_test",
+        lambda n, device_path, controller_info, test_type: triggered.append(device_path) is None,
+    )
+
+    assert run_self_test_on_all_devices(node, SelfTestType.SHORT) == []
+    assert triggered == []
 
 
 def test_run_self_test_on_all_devices_no_devices(monkeypatch):
@@ -1529,3 +1160,511 @@ def test_run_self_test_on_all_devices_no_devices(monkeypatch):
 
     result = run_self_test_on_all_devices(node)
     assert result == []
+
+
+# ---------------------------------------------------------------------------
+# Tests: baseline delta reporting
+# ---------------------------------------------------------------------------
+
+
+def test_error_entries_present_at_baseline_yield_no_event():
+    """Entries that already existed before the test are not reported as new.
+
+    A fresh cloud instance can arrive with a non-empty error log, so an absolute
+    "num_err_log_entries > 0" check fires on healthy nodes on every run.
+    """
+    node = _make_mock_node()
+    node.logdir = None
+    store_baseline_smart_logs(node, [_make_smart_log(num_err_log_entries=2, media_errors=1)])
+    smart = _make_smart_log(num_err_log_entries=2, media_errors=1)
+
+    assert list(_check_single_device_health(node, smart, DEFAULT_THRESHOLDS)) == []
+
+
+def test_error_entries_above_baseline_yield_warning(monkeypatch):
+    """Only growth over the baseline is reported, and it reports the delta."""
+    node = _make_mock_node()
+    node.logdir = None
+    monkeypatch.setattr("sdcm.utils.nvme_diagnostics.get_error_log", lambda n, d, max_entries: [])
+    store_baseline_smart_logs(node, [_make_smart_log(num_err_log_entries=2)])
+    smart = _make_smart_log(num_err_log_entries=5)
+
+    events = list(_check_single_device_health(node, smart, DEFAULT_THRESHOLDS))
+
+    assert len(events) == 1
+    assert events[0].severity == Severity.WARNING
+    assert "3 new error log entries" in events[0].message
+    assert "total=5" in events[0].message
+
+
+def test_missing_baseline_skips_the_delta_checks(monkeypatch):
+    """With no baseline there is nothing to subtract, so nothing is reported.
+
+    A missing baseline is a normal case (nvme-cli not installable at setup,
+    reused clusters). Comparing the lifetime counters against zero would report
+    the device's whole history as errors from this run.
+    """
+    node = _make_mock_node()
+    node.logdir = None
+    monkeypatch.setattr("sdcm.utils.nvme_diagnostics.get_error_log", lambda n, d, max_entries: [])
+    smart = _make_smart_log(num_err_log_entries=3, media_errors=2)
+
+    assert list(_check_single_device_health(node, smart, DEFAULT_THRESHOLDS)) == []
+
+
+# ---------------------------------------------------------------------------
+# Raw log page builders
+#
+# Pages are assembled at the offsets the NVMe Base Specification defines, so a
+# test failure means a parser offset drifted from the spec, not that a fixture
+# was captured from a differently-behaved nvme-cli.
+# ---------------------------------------------------------------------------
+
+
+def _put(buf: bytearray, offset: int, value: int, size: int) -> None:
+    buf[offset : offset + size] = value.to_bytes(size, "little")
+
+
+def _make_smart_page(**fields) -> bytes:
+    """Build a 512-byte SMART / Health Information log page (02h)."""
+    layout = {
+        "critical_warning": (0, 1),
+        "temperature_kelvin": (1, 2),
+        "available_spare": (3, 1),
+        "available_spare_threshold": (4, 1),
+        "percentage_used": (5, 1),
+        "data_units_read": (32, 16),
+        "data_units_written": (48, 16),
+        "host_read_commands": (64, 16),
+        "host_write_commands": (80, 16),
+        "controller_busy_time": (96, 16),
+        "power_cycles": (112, 16),
+        "power_on_hours": (128, 16),
+        "unsafe_shutdowns": (144, 16),
+        "media_errors": (160, 16),
+        "num_err_log_entries": (176, 16),
+    }
+    buf = bytearray(SMART_LOG_PAGE_LEN)
+    for name, value in fields.items():
+        offset, size = layout[name]
+        _put(buf, offset, value, size)
+    return bytes(buf)
+
+
+def _make_error_entry(**fields) -> bytes:
+    """Build one 64-byte Error Information Log entry (01h).
+
+    ``status_field`` and ``phase_tag`` are given separately and packed into the
+    single on-wire field, where bits 15:1 are the status and bit 0 the phase tag.
+    """
+    layout = {
+        "error_count": (0, 8),
+        "sqid": (8, 2),
+        "cmdid": (10, 2),
+        "parm_error_location": (14, 2),
+        "lba": (16, 8),
+        "nsid": (24, 4),
+        "vs": (28, 1),
+        "trtype": (29, 1),
+        "csi": (30, 1),
+        "opcode": (31, 1),
+        "cs": (32, 8),
+        "log_page_version": (63, 1),
+    }
+    buf = bytearray(ERROR_LOG_ENTRY_LEN)
+    _put(buf, 0, fields.pop("error_count", 1), 8)
+    status_field = fields.pop("status_field", 0)
+    phase_tag = fields.pop("phase_tag", 0)
+    _put(buf, 12, (status_field << 1) | phase_tag, 2)
+    for name, value in fields.items():
+        offset, size = layout[name]
+        _put(buf, offset, value, size)
+    return bytes(buf)
+
+
+def _make_self_test_page(current_operation=0, current_completion=0, results=()) -> bytes:
+    """Build a 564-byte Device Self-test log page (06h)."""
+    buf = bytearray(SELF_TEST_LOG_PAGE_LEN)
+    buf[0] = current_operation
+    buf[1] = current_completion
+    # Unused result slots are marked 0xf ("entry not used").
+    for index in range(20):
+        buf[4 + index * SELF_TEST_RESULT_LEN] = 0x0F
+    for index, res in enumerate(results):
+        offset = 4 + index * SELF_TEST_RESULT_LEN
+        buf[offset] = (res.get("self_test_code", 1) << 4) | res.get("result_code", 0)
+        buf[offset + 1] = res.get("segment_number", 0)
+        _put(buf, offset + 4, res.get("power_on_hours", 0), 8)
+        _put(buf, offset + 12, res.get("nsid", 0), 4)
+        _put(buf, offset + 16, res.get("failing_lba", 0), 8)
+        buf[offset + 24] = res.get("status_code_type", 0)
+        buf[offset + 25] = res.get("status_code", 0)
+    return bytes(buf)
+
+
+def _make_id_ctrl(oacs=0, elpe_zero_based=63) -> bytes:
+    buf = bytearray(IDENTIFY_CONTROLLER_LEN)
+    _put(buf, IDCTRL_OACS_OFFSET, oacs, 2)
+    buf[IDCTRL_ELPE_OFFSET] = elpe_zero_based
+    return bytes(buf)
+
+
+def _b64_result(payload: bytes):
+    return _make_result(stdout=base64.b64encode(payload).decode())
+
+
+# ---------------------------------------------------------------------------
+# Tests: SMART page parsing
+# ---------------------------------------------------------------------------
+
+
+def test_parse_smart_page_reads_spec_offsets():
+    """Every field is decoded from its spec-defined offset."""
+    page = _make_smart_page(
+        critical_warning=0x1,
+        temperature_kelvin=315,
+        available_spare=100,
+        available_spare_threshold=10,
+        percentage_used=2,
+        data_units_read=8041270,
+        data_units_written=12219712,
+        host_read_commands=52368094,
+        host_write_commands=49760027,
+        controller_busy_time=120,
+        power_cycles=15,
+        power_on_hours=8760,
+        unsafe_shutdowns=3,
+        media_errors=10,
+        num_err_log_entries=5,
+    )
+    smart = parse_smart_log_page("/dev/nvme1n1", page)
+
+    assert smart.device_path == "/dev/nvme1n1"
+    assert smart.critical_warning == 1
+    assert smart.temperature_kelvin == 315
+    assert smart.temperature_celsius == 42
+    assert smart.available_spare == 100
+    assert smart.available_spare_threshold == 10
+    assert smart.percentage_used == 2
+    assert smart.data_units_read == 8041270
+    assert smart.data_units_written == 12219712
+    assert smart.host_read_commands == 52368094
+    assert smart.host_write_commands == 49760027
+    assert smart.controller_busy_time == 120
+    assert smart.power_cycles == 15
+    assert smart.power_on_hours == 8760
+    assert smart.unsafe_shutdowns == 3
+    assert smart.media_errors == 10
+    assert smart.num_err_log_entries == 5
+
+
+def test_parse_smart_page_temperature_is_kelvin_by_definition():
+    """Composite Temperature is Kelvin on the wire, so no unit guessing is possible.
+
+    The text parser had to infer the unit, and nvme-cli 1.x/2.x disagree on the
+    order ("315 K (42 Celsius)" vs "42 C (315 K, 107 F)"), which silently made
+    the over-temperature check unreachable.
+    """
+    assert parse_smart_log_page("/dev/nvme1n1", _make_smart_page(temperature_kelvin=315)).temperature_celsius == 42
+
+
+def test_parse_smart_page_handles_128_bit_counters():
+    """The 16-byte counters are decoded whole, not truncated to 64 bits."""
+    huge = 2**100 + 12345
+    smart = parse_smart_log_page("/dev/nvme1n1", _make_smart_page(data_units_read=huge))
+    assert smart.data_units_read == huge
+
+
+# ---------------------------------------------------------------------------
+# Tests: error log page parsing
+# ---------------------------------------------------------------------------
+
+
+def test_parse_error_entry_splits_status_field_and_phase_tag():
+    """Bits 15:1 are the status field, bit 0 the phase tag.
+
+    0x2001 is the status the AWS Nitro controller reported for the rejected
+    'nvme device-self-test' - the value the previous text parser zeroed out.
+    """
+    entry = parse_error_log_entry(_make_error_entry(error_count=2, status_field=0x2001, phase_tag=1))
+
+    assert entry.status_field == 0x2001
+    assert entry.phase_tag == 1
+
+
+def test_parse_error_entry_reads_spec_offsets():
+    entry = parse_error_log_entry(
+        _make_error_entry(
+            error_count=2,
+            sqid=0,
+            cmdid=0x4,
+            status_field=0x2001,
+            parm_error_location=0x105,
+            lba=0xDEADBEEF,
+            nsid=0xFFFFFFFF,
+            vs=0x80,
+            trtype=1,
+            cs=0x1234,
+        )
+    )
+
+    assert entry.error_count == 2
+    assert entry.command_id == 0x4
+    assert entry.parm_error_location == 0x105
+    assert entry.lba == 0xDEADBEEF
+    assert entry.nsid == 0xFFFFFFFF
+    assert entry.vendor_specific == 0x80
+    assert entry.transport_type == 1
+    assert entry.command_specific == 0x1234
+
+
+def test_parse_error_entry_opcode_requires_log_page_version_1():
+    """csi and opcode are reserved bytes unless Log Page Version is 1h.
+
+    All 64 entries captured from an i4i node report log_page_version 0, so the
+    'opcode=0x00' nvme-cli prints there is a reserved byte, not an opcode.
+    """
+    without = parse_error_log_entry(_make_error_entry(csi=0x2, opcode=0x14, log_page_version=0))
+    assert without.opcode is None
+    assert without.command_set_indicator is None
+
+    with_version = parse_error_log_entry(_make_error_entry(csi=0x2, opcode=0x14, log_page_version=1))
+    assert with_version.opcode == 0x14
+    assert with_version.command_set_indicator == 0x2
+
+
+def test_parse_error_entry_zero_error_count_is_an_invalid_entry():
+    """Spec: an Error Count of 0h marks an unused slot or a lost entry."""
+    assert parse_error_log_entry(_make_error_entry(error_count=0, status_field=0x2001)) is None
+
+
+def test_parse_error_log_page_drops_unused_slots():
+    """A full page of slots yields only the populated entries.
+
+    'nvme get-log' always returns every slot the controller supports; a 64-slot
+    page with two real errors previously produced 64 rows in the collected
+    artifact, 62 of them identical zeros.
+    """
+    page = (
+        _make_error_entry(error_count=2, cmdid=0x4, status_field=0x2001)
+        + _make_error_entry(error_count=1, cmdid=0x14, status_field=0x2002)
+        + _make_error_entry(error_count=0) * 62
+    )
+    entries = parse_error_log_page(page)
+
+    assert len(entries) == 2
+    assert [e.status_field for e in entries] == [0x2001, 0x2002]
+
+
+# ---------------------------------------------------------------------------
+# Tests: self-test log page parsing
+# ---------------------------------------------------------------------------
+
+
+def test_parse_self_test_page_reads_results():
+    page = _make_self_test_page(
+        results=[
+            {"result_code": 0, "self_test_code": 1, "power_on_hours": 8760, "nsid": 1},
+            {
+                "result_code": 7,
+                "self_test_code": 2,
+                "segment_number": 3,
+                "power_on_hours": 8500,
+                "nsid": 1,
+                "failing_lba": 0x1234,
+                "status_code_type": 2,
+                "status_code": 0x81,
+            },
+        ]
+    )
+    log = parse_self_test_log_page("/dev/nvme1n1", page)
+
+    assert not log.test_in_progress
+    assert len(log.results) == 2
+    assert log.results[0].passed
+    assert log.results[0].self_test_code == 1
+    assert log.results[0].power_on_hours == 8760
+    assert log.results[1].result_code == 7
+    assert log.results[1].segment_number == 3
+    assert log.results[1].failing_lba == 0x1234
+    assert log.results[1].status_code == 0x81
+
+
+def test_parse_self_test_page_skips_unused_entries():
+    """Result code 0xf means the slot holds no test result."""
+    assert parse_self_test_log_page("/dev/nvme1n1", _make_self_test_page()).results == []
+
+
+def test_parse_self_test_page_reports_test_in_progress():
+    page = _make_self_test_page(current_operation=2, current_completion=45)
+    log = parse_self_test_log_page("/dev/nvme1n1", page)
+
+    assert log.test_in_progress
+    assert log.current_operation == 2
+    assert log.current_completion == 45
+
+
+# ---------------------------------------------------------------------------
+# Tests: raw page reads
+# ---------------------------------------------------------------------------
+
+
+def test_get_smart_log_reads_raw_log_page():
+    node = _make_mock_node()
+    node.remoter.sudo.return_value = _b64_result(_make_smart_page(temperature_kelvin=315, media_errors=2))
+
+    smart = get_smart_log(node, "/dev/nvme1n1")
+
+    assert smart.temperature_kelvin == 315
+    assert smart.media_errors == 2
+    node.remoter.sudo.assert_called_once_with(
+        f"nvme get-log /dev/nvme1n1 --log-id={LOG_PAGE_SMART_HEALTH} --log-len={SMART_LOG_PAGE_LEN} -b | base64 -w0",
+        ignore_status=True,
+        timeout=30,
+    )
+
+
+def test_get_smart_log_rejects_short_read():
+    """A truncated page is a failed read, never a partially-trusted one."""
+    node = _make_mock_node()
+    node.remoter.sudo.return_value = _b64_result(b"\x00" * 128)
+
+    assert get_smart_log(node, "/dev/nvme1n1") is None
+    node.log.warning.assert_called()
+
+
+def test_get_smart_log_rejects_undecodable_output():
+    node = _make_mock_node()
+    node.remoter.sudo.return_value = _make_result(stdout="not base64 !!!")
+
+    assert get_smart_log(node, "/dev/nvme1n1") is None
+    node.log.warning.assert_called()
+
+
+def test_get_error_log_sizes_the_page_from_elpe():
+    """The page length comes from the controller, not from a fixed guess.
+
+    Asking get-log for more entries than the controller supports can be
+    rejected outright, so ELPE (0's based) decides the length. The caller reads
+    Identify once and hands the count down.
+    """
+    node = _make_mock_node()
+    node.remoter.sudo.side_effect = [
+        _b64_result(_make_id_ctrl(elpe_zero_based=3)),  # id-ctrl -> 4 entries
+        _b64_result(_make_error_entry(error_count=2, status_field=0x2001) + _make_error_entry(error_count=0) * 3),
+    ]
+
+    controller_info = get_controller_info(node, "/dev/nvme1n1")
+    entries = get_error_log(node, "/dev/nvme1n1", controller_info.error_log_entries)
+
+    assert len(entries) == 1
+    assert entries[0].status_field == 0x2001
+    log_page_cmd = node.remoter.sudo.call_args_list[1][0][0]
+    assert f"--log-id={LOG_PAGE_ERROR_INFORMATION}" in log_page_cmd
+    assert f"--log-len={4 * ERROR_LOG_ENTRY_LEN}" in log_page_cmd
+
+
+def test_error_log_entry_count_is_zero_based():
+    assert parse_identify_controller(_make_id_ctrl(elpe_zero_based=63)).error_log_entries == 64
+
+
+def test_supports_self_test_reads_oacs_bit_4():
+    info = parse_identify_controller(_make_id_ctrl(oacs=OACS_DEVICE_SELF_TEST | 0x8))
+
+    assert info.supports_self_test is True
+
+
+def test_supports_self_test_false_for_aws_oacs():
+    """oacs=0x8 (Namespace Management only) is what AWS Nitro controllers report."""
+    assert parse_identify_controller(_make_id_ctrl(oacs=0x8)).supports_self_test is False
+
+
+def test_get_controller_info_reads_both_fields_in_one_identify():
+    """OACS and ELPE come from the same structure, so one read serves both."""
+    node = _make_mock_node()
+    node.remoter.sudo.return_value = _b64_result(_make_id_ctrl(oacs=OACS_DEVICE_SELF_TEST, elpe_zero_based=3))
+
+    info = get_controller_info(node, "/dev/nvme1n1")
+
+    assert info is not None
+    assert info.supports_self_test is True
+    assert info.error_log_entries == 4
+    node.remoter.sudo.assert_called_once()
+
+
+def test_get_controller_info_none_when_identify_unreadable():
+    node = _make_mock_node()
+    node.remoter.sudo.return_value = _make_result(exited=1, stderr="error")
+
+    assert get_controller_info(node, "/dev/nvme1n1") is None
+
+
+def test_get_self_test_log_reads_raw_log_page():
+    node = _make_mock_node()
+    node.remoter.sudo.return_value = _b64_result(
+        _make_self_test_page(results=[{"result_code": 0, "self_test_code": 1}])
+    )
+
+    log = get_self_test_log(node, "/dev/nvme1n1")
+
+    assert log is not None
+    assert len(log.results) == 1
+    assert f"--log-len={SELF_TEST_LOG_PAGE_LEN}" in node.remoter.sudo.call_args[0][0]
+
+
+def test_collected_artifact_marks_opcode_unavailable(monkeypatch, tmp_path):
+    """opcode is written as n/a when the controller did not report one."""
+    node = _make_mock_node()
+    node.logdir = str(tmp_path)
+    entry = parse_error_log_entry(_make_error_entry(error_count=2, cmdid=0x4, status_field=0x2001, opcode=0x14))
+    _stub_controller_info(monkeypatch)
+    monkeypatch.setattr("sdcm.utils.nvme_diagnostics.get_error_log", lambda n, d, max_entries: [entry])
+
+    _collect_error_log_with_timestamp(node, "/dev/nvme1n1")
+
+    written = list(tmp_path.glob("nvme_error_log_nvme1n1_*.log"))
+    assert len(written) == 1
+    line = written[0].read_text().strip()
+    assert "status=0x2001" in line
+    assert "opcode=n/a" in line
+
+
+def test_collect_error_log_writes_nothing_when_no_populated_entries(monkeypatch, tmp_path):
+    """No artifact is produced when the page holds only unused slots."""
+    node = _make_mock_node()
+    node.logdir = str(tmp_path)
+    _stub_controller_info(monkeypatch)
+    monkeypatch.setattr("sdcm.utils.nvme_diagnostics.get_error_log", lambda n, d, max_entries: [])
+
+    _collect_error_log_with_timestamp(node, "/dev/nvme1n1")
+
+    assert list(tmp_path.glob("nvme_error_log_*.log")) == []
+
+    node.log.warning.assert_not_called()
+
+
+def test_collect_error_log_warns_when_the_page_could_not_be_read(monkeypatch, tmp_path):
+    """A failed read is reported as such, not as a device with a clean log."""
+    node = _make_mock_node()
+    node.logdir = str(tmp_path)
+    _stub_controller_info(monkeypatch)
+    monkeypatch.setattr("sdcm.utils.nvme_diagnostics.get_error_log", lambda n, d, max_entries: None)
+
+    _collect_error_log_with_timestamp(node, "/dev/nvme1n1")
+
+    assert list(tmp_path.glob("nvme_error_log_*.log")) == []
+    node.log.warning.assert_called_once()
+
+
+def test_collect_error_log_reads_nothing_when_identify_fails(monkeypatch, tmp_path):
+    """Without ELPE there is no defensible page length, so nothing is read."""
+    node = _make_mock_node()
+    node.logdir = str(tmp_path)
+    reads = []
+    _stub_controller_info(monkeypatch, info=None)
+    monkeypatch.setattr("sdcm.utils.nvme_diagnostics.get_error_log", lambda n, d, max_entries: reads.append(d))
+
+    _collect_error_log_with_timestamp(node, "/dev/nvme1n1")
+
+    assert reads == []
+    assert list(tmp_path.glob("nvme_error_log_*.log")) == []


### PR DESCRIPTION
Fixes the problems raised in review of the NVMe diagnostics feature: https://github.com/scylladb/scylla-cluster-tests/pull/15225#issuecomment-5476435315

The reviewer's concern was that we support multiple nvme-cli output layouts implicitly while missing fields are silently replaced with healthy-looking defaults. The collected artifacts from run 0ac4f1d3 confirm it: every entry in nvme_error_log_nvme1n1_*.log reads

    error_count=0 sqid=0 cmdid=0 status=0x0000 lba=0x0 nsid=0 opcode=0x00

while the device had reported error_count 2 with status_field 0x2001. Feeding that run's raw error-log output back through the parser reproduces the file byte for byte.

Two independent defects produced it:

- The value regex was anchored to end-of-line, so nvme-cli's annotated fields ("status_field : 0x2001 (Invalid Command Opcode: ...)") never matched and fell back to the dataclass default of 0. status_field and trtype were the only two fields lost, i.e. exactly the ones that say what went wrong.
- Missing fields were indistinguishable from a genuine zero.

The errors being reported were also our own doing. AWS Nitro instance-store SSDs do not implement Device Self-test, and the rejected admin command is recorded in the Error Information Log: node setup logged num_err_log_entries 1, we issued 'nvme device-self-test', and the teardown check then read 2 with the new entry carrying the self-test's own 0x2001 status.

Changes:

- Prefer '-o json' for smart-log, error-log and self-test-log; JSON carries raw integers, so no field is lost to inline descriptions or to the version dependent temperature rendering. Text parsing stays as a logged fallback.
- Require the fields the checks act on (error_count/status_field for entries, critical_warning/media_errors/num_err_log_entries for SMART) and drop the record with a warning instead of reporting fabricated zeros.
- Un-anchor the error-log and self-test-log value regexes.
- Match the temperature unit explicitly: nvme-cli 1.x prints "315 K (42 Celsius)" and 2.x prints "42 C (315 K, 107 F)", so taking the first number read Celsius as Kelvin and made the over-temperature check unreachable.
- Gate 'nvme device-self-test' and the self-test-log read on Identify Controller OACS bit 4, in the health check and in log collection, so we stop writing error-log entries on controllers that do not support the command.
- Report growth over the setup baseline rather than an absolute count; a fresh i4i already carries error-log entries, so "> 0" fired on healthy nodes.
- Drop unused log slots from the collected artifact and never let collection failure break the teardown health check.

**Self-test availability** is documented where it is relevant. Device Self-test is
optional in the NVMe spec, advertised by Identify Controller OACS bit 4, and AWS
implements it on neither disk type. Measured on i4i.4xlarge:

    /dev/nvme0n1  "Amazon Elastic Block Store"        OACS bit 4 clear
    /dev/nvme1n1  "Amazon EC2 NVMe Instance Storage"  oacs=0x8
    
Both are presented by the Nitro card rather than by the physical SSD's own
controller, and EBS is network-attached with no local medium at all, so
nvme_self_test_type has no effect on AWS and the self-test code paths never run
there. What remains is the passive evidence: the SMART counters AWS does
populate (media_errors, critical_warning, available_spare, percentage_used) and
the Error Information Log. AWS leaves temperature, power_on_hours, power_cycles,
unsafe_shutdowns and controller_busy_time at placeholder zeros, so those are not
usable as health signals there. Support on other instance families and other
backends is unverified, which is why this is a runtime probe rather than a
hardcoded backend check - the feature activates by itself on hardware that
implements it.

Tests use a verbatim excerpt of node-1's error-log output from run 0ac4f1d3 and
fail against the previous parser.


### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [perf-regression-predefined-throughput-steps-sanity-vnodes](https://argus.scylladb.com/tests/scylla-cluster-tests/ad063529-8450-49c0-ae98-9aff3240e177)
- [x] [longevity_test.LongevityTest.test_custom_time](https://argus.scylladb.com/tests/scylla-cluster-tests/9197eb0b-ac4e-4f76-8bc8-1f827d874163)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
