### PR TITLE
alternator: add tablets_initial_scale_factor=1 to a test

### DIFF
--- a/test-cases/longevity/longevity-alternator-3h.yaml
+++ b/test-cases/longevity/longevity-alternator-3h.yaml
@@ -53,3 +53,9 @@ alternator_port: 8080
 dynamodb_primarykey_type: HASH_AND_RANGE
 
 docker_network: 'ycsb_net'
+
+append_scylla_yaml:
+  # Needed because cluster has small amount of data (~50GB), which generates a lot of small (~100MB) tablets
+  # which hurt performance and cause timing (things take too much time) issues in the test. Workaround,
+  # problem is known to tablets team.
+  tablets_initial_scale_factor: 1


### PR DESCRIPTION
Add tablets_initial_scale_factor: 1 entry to Alternator's longevity test. The test contains small (~50GB) cluster and does time tablet move throughput. The default (10) value for scale factor creates large pool of small tablets, which prevents scylla from reaching "normal" performance and thus fails the test.

The solution here is preferred to simply increase cluster's data size, which would increase test duration unnecesarily.

Previous solution (see commit 7b2d235810) solved the issue, but did not add required change to all longecity test files - this one adds to missing ones.

### Testing

The original solution works, this one adds the change to additional yaml configuration files.
