### PR TITLE
Revert "Set monitoring image to scylladb-monitor-4-16-0-amd64-2026-08-31t09-45-49z"

### DIFF
--- a/defaults/aws_config.yaml
+++ b/defaults/aws_config.yaml
@@ -7,7 +7,7 @@ instance_type_loader: ''
 instance_type_monitor: ''
 ami_id_loader: 'resolve:ssm:/aws/service/canonical/ubuntu/server/26.04/stable/current/amd64/hvm/ebs-gp3/ami-id'
 # manual on updating monitor images see: docs/monitoring-images.md
-ami_id_monitor: 'scylladb-monitor-4-16-0-amd64-2026-08-31t09-45-49z'
+ami_id_monitor: 'scylladb-monitor-4-16-0-amd64-2026-08-30t08-46-39z'
 
 availability_zone: 'a'
 root_disk_size_monitor: 50  # GB, remove this field if default disk size should be used

--- a/defaults/gce_config.yaml
+++ b/defaults/gce_config.yaml
@@ -10,7 +10,7 @@ gce_project: '' # empty mean default one, can be overwritten to use different on
 
 gce_image_db: '' # so we can use `scylla_version` as needed
 gce_image_loader: 'https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/family/ubuntu-2604-lts-amd64'
-gce_image_monitor: 'https://www.googleapis.com/compute/v1/projects/scylla-images/global/images/scylladb-monitor-4-16-0-amd64-2026-08-31t09-45-49z'
+gce_image_monitor: 'https://www.googleapis.com/compute/v1/projects/scylla-images/global/images/scylladb-monitor-4-16-0-amd64-2026-08-30t08-46-39z'
 
 gce_image_username: 'scylla-test'
 

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -1350,7 +1350,7 @@ AMS AMI id to use for monitor node
 **type:** str (appendable)
 
 **backend overrides:**
-- `scylladb-monitor-4-16-0-amd64-2026-08-31t09-45-49z`: aws, aws-siren, k8s-local-kind-aws, k8s-eks
+- `scylladb-monitor-4-16-0-amd64-2026-08-30t08-46-39z`: aws, aws-siren, k8s-local-kind-aws, k8s-eks
 
 
 ## **ami_id_db_cassandra** / SCT_AMI_ID_DB_CASSANDRA
@@ -1654,7 +1654,7 @@ gce image to use for monitor nodes
 **type:** str (appendable)
 
 **backend overrides:**
-- `https://www.googleapis.com/compute/v1/projects/scylla-images/global/images/scylladb-monitor-4-16-0-amd64-2026-08-31t09-45-49z`: gce, gce-siren, k8s-gke
+- `https://www.googleapis.com/compute/v1/projects/scylla-images/global/images/scylladb-monitor-4-16-0-amd64-2026-08-30t08-46-39z`: gce, gce-siren, k8s-gke
 
 
 ## **scylla_network_config** / SCT_SCYLLA_NETWORK_CONFIG


### PR DESCRIPTION
Reverts commit 39f772b16287ae8705e4c6808c1432264d82c631 (#15904).

### Why

`scylladb-monitor-4-16-0-amd64-2026-08-31t09-45-49z` **was never published**. It does not exist as an AMI in any region SCT uses, and it does not exist in the GCE `scylla-images` project either. Only the *arm64* image from that build date made it into AWS — the amd64 half of the release is missing.

| region | `...2026-08-30t08-46-39z` (reverting to) | `...2026-08-31t09-45-49z` (merged) |
|---|---|---|
| us-east-1 | `ami-0e191612c9f34013c` | **missing** |
| us-west-2 | `ami-055b2691aca297317` | **missing** |
| eu-west-1 | `ami-08b1667b12dd0fe46` | **missing** |
| eu-west-2 | `ami-071a07303e2f5fcd8` | **missing** |
| eu-north-1 | `ami-0770c984cef233978` | **missing** |
| eu-central-1 | `ami-0d99acb17f8d56af0` | **missing** |
| GCE `scylla-images` | `READY` | **missing** |

Consequences on master and `branch-2026.3` (where #15908 already merged):

- every AWS/GCE run fails to provision the monitor node
- the `branch-2026.2` backport (#15909) times out its `lint test-cases` stage — that branch still runs the old `utils/lint_test_cases.sh`, which resolves the name against the real `DescribeImages` API for each of ~300 test-case YAMLs, so the stage blows past its 10 min timeout and the build is `ABORTED` ([build](https://jenkins.scylladb.com/job/sct-github-PRs-scan/job/scylla-cluster-tests/job/PR-15909/3/))

### Why CI didn't catch it

`sct.py lint-pipelines` stubs `convert_name_to_ami_if_needed` out (`sdcm/utils/lint/validator.py:49`), so any non-existent image name validates clean on master. Adding a real existence check across AWS regions and GCE is tracked separately.

### Follow-up

The open backports of #15904 (#15907, #15909, #15910, #15911) should be closed rather than merged — those branches never got the bad value.

### Testing

- verified image presence/absence with `aws ec2 describe-images` in all six regions from `utils/copy_ami_to_all_regions.sh`, and `gcloud compute images list --project scylla-images`
- `pre-commit` (incl. `update-conf-docs`) passes

### PR pre-checks (self review)
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code
