### PR TITLE
fix(latte): clamp gauss sample at the last valid key index

### DIFF
--- a/data_dir/latte/latte_cs_alike.rn
+++ b/data_dir/latte/latte_cs_alike.rn
@@ -193,7 +193,7 @@ async fn prepare_gauss_distribution(db) {
 async fn get_partition_idx(db, i) {
     if db.data.gauss_enabled {
         let current_idx = normal(i, db.data.gauss_mean, db.data.gauss_stddev) as i64;
-        if current_idx > OFFSET + ROW_COUNT {
+        if current_idx >= OFFSET + ROW_COUNT {
             current_idx = OFFSET + ROW_COUNT - 1;
         } else if current_idx < OFFSET {
             current_idx = OFFSET;


### PR DESCRIPTION
The gauss/normal distribution clamp in `get_partition_idx` allowed `current_idx == OFFSET + ROW_COUNT`, which is one past the last populated key (`OFFSET + ROW_COUNT - 1`). A gauss sample landing exactly on the boundary produced a key that was never written, so reads on it returned no data.

Use `>=` so the boundary sample is clamped to the last valid index.

Split out of #15608 per review request, so it can be merged independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)