### PR TITLE
fix(rolling-upgrade): pin base versions to 2024.1 and 2025.1

### DIFF
--- a/jenkins-pipelines/oss/rolling-upgrade/rolling-upgrade-alternator.jenkinsfile
+++ b/jenkins-pipelines/oss/rolling-upgrade/rolling-upgrade-alternator.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 rollingUpgradePipeline(
     backend: 'gce',
-    base_versions: '',  // auto mode
+    base_versions: '2024.1,2025.1',  // SCYLLADB-3508: skip bases whose images point at pruned repo snapshots
     linux_distro: 'ubuntu-jammy',
     gce_image_db: 'https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/family/ubuntu-2204-lts',
 

--- a/jenkins-pipelines/oss/rolling-upgrade/rolling-upgrade-ami-arm.jenkinsfile
+++ b/jenkins-pipelines/oss/rolling-upgrade/rolling-upgrade-ami-arm.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 rollingUpgradePipeline(
     backend: 'aws',
-    base_versions: '',  // auto mode
+    base_versions: '2024.1,2025.1',  // SCYLLADB-3508: skip bases whose images point at pruned repo snapshots
     linux_distro: 'ubuntu-focal',
     use_preinstalled_scylla: true,
     test_name: 'upgrade_test.UpgradeTest.test_rolling_upgrade',

--- a/jenkins-pipelines/oss/rolling-upgrade/rolling-upgrade-ami.jenkinsfile
+++ b/jenkins-pipelines/oss/rolling-upgrade/rolling-upgrade-ami.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 rollingUpgradePipeline(
     backend: 'aws',
-    base_versions: '',  // auto mode
+    base_versions: '2024.1,2025.1',  // SCYLLADB-3508: skip bases whose images point at pruned repo snapshots
     linux_distro: 'ubuntu-focal',
     use_preinstalled_scylla: true,
     test_name: 'upgrade_test.UpgradeTest.test_rolling_upgrade',

--- a/jenkins-pipelines/oss/rolling-upgrade/rolling-upgrade-azure-image.jenkinsfile
+++ b/jenkins-pipelines/oss/rolling-upgrade/rolling-upgrade-azure-image.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 rollingUpgradePipeline(
     backend: 'azure',
-    base_versions: '',  // auto mode,
+    base_versions: '2024.1,2025.1',  // SCYLLADB-3508: skip bases whose images point at pruned repo snapshots
     linux_distro: 'ubuntu-focal',
     use_preinstalled_scylla: true,
     test_name: 'upgrade_test.UpgradeTest.test_rolling_upgrade',

--- a/jenkins-pipelines/oss/rolling-upgrade/rolling-upgrade-centos9.jenkinsfile
+++ b/jenkins-pipelines/oss/rolling-upgrade/rolling-upgrade-centos9.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 rollingUpgradePipeline(
     backend: 'gce',
-    base_versions: '',  // auto mode
+    base_versions: '2024.1,2025.1',  // SCYLLADB-3508: skip bases whose images point at pruned repo snapshots
     linux_distro: 'centos-9',
     gce_image_db: 'https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-stream-9',
 

--- a/jenkins-pipelines/oss/rolling-upgrade/rolling-upgrade-debian11.jenkinsfile
+++ b/jenkins-pipelines/oss/rolling-upgrade/rolling-upgrade-debian11.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 rollingUpgradePipeline(
     backend: 'gce',
-    base_versions: '',  // auto mode
+    base_versions: '2024.1,2025.1',  // SCYLLADB-3508: skip bases whose images point at pruned repo snapshots
     linux_distro: 'debian-bullseye',
     gce_image_db: 'https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/family/debian-11',
 

--- a/jenkins-pipelines/oss/rolling-upgrade/rolling-upgrade-gce-image.jenkinsfile
+++ b/jenkins-pipelines/oss/rolling-upgrade/rolling-upgrade-gce-image.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 rollingUpgradePipeline(
     backend: 'gce',
-    base_versions: '',  // auto mode
+    base_versions: '2024.1,2025.1',  // SCYLLADB-3508: skip bases whose images point at pruned repo snapshots
     linux_distro: 'ubuntu-focal',
     use_preinstalled_scylla: true,
     test_name: 'upgrade_test.UpgradeTest.test_rolling_upgrade',

--- a/jenkins-pipelines/oss/rolling-upgrade/rolling-upgrade-multidc.jenkinsfile
+++ b/jenkins-pipelines/oss/rolling-upgrade/rolling-upgrade-multidc.jenkinsfile
@@ -6,7 +6,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 rollingUpgradePipeline(
     backend: 'aws',
     region: '["eu-west-1", "eu-west-2"]',
-    base_versions: '',  // auto mode
+    base_versions: '2024.1,2025.1',  // SCYLLADB-3508: skip bases whose images point at pruned repo snapshots
     linux_distro: 'ubuntu-focal',
 
     test_name: 'upgrade_test.UpgradeTest.test_generic_cluster_upgrade',

--- a/jenkins-pipelines/oss/rolling-upgrade/rolling-upgrade-ubuntu22.04-ldap-authorization.jenkinsfile
+++ b/jenkins-pipelines/oss/rolling-upgrade/rolling-upgrade-ubuntu22.04-ldap-authorization.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 rollingUpgradePipeline(
     backend: 'gce',
-    base_versions: '',  // auto mode
+    base_versions: '2024.1,2025.1',  // SCYLLADB-3508: skip bases whose images point at pruned repo snapshots
     linux_distro: 'ubuntu-focal',
     gce_image_db: 'https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/family/ubuntu-2204-lts',
 

--- a/jenkins-pipelines/oss/rolling-upgrade/rolling-upgrade-ubuntu2204.jenkinsfile
+++ b/jenkins-pipelines/oss/rolling-upgrade/rolling-upgrade-ubuntu2204.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 rollingUpgradePipeline(
     backend: 'gce',
-    base_versions: '',  // auto mode
+    base_versions: '2024.1,2025.1',  // SCYLLADB-3508: skip bases whose images point at pruned repo snapshots
     linux_distro: 'ubuntu-jammy',
     gce_image_db: 'https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/family/ubuntu-2204-lts',
     test_name: 'upgrade_test.UpgradeTest.test_generic_cluster_upgrade',

--- a/jenkins-pipelines/oss/rolling-upgrade/rolling-upgrade-ubuntu2404.jenkinsfile
+++ b/jenkins-pipelines/oss/rolling-upgrade/rolling-upgrade-ubuntu2404.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 rollingUpgradePipeline(
     backend: 'gce',
-    base_versions: '',  // auto mode
+    base_versions: '2024.1,2025.1',  // SCYLLADB-3508: skip bases whose images point at pruned repo snapshots
     linux_distro: 'ubuntu-noble',
     gce_image_db: 'https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/family/ubuntu-2404-lts-amd64',
     test_name: 'upgrade_test.UpgradeTest.test_generic_cluster_upgrade',

--- a/jenkins-pipelines/oss/rolling-upgrade/rolling-upgrade-with-enable-tablets.jenkinsfile
+++ b/jenkins-pipelines/oss/rolling-upgrade/rolling-upgrade-with-enable-tablets.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 rollingUpgradePipeline(
     backend: 'gce',
-    base_versions: '',  // auto mode
+    base_versions: '2024.1,2025.1',  // SCYLLADB-3508: skip bases whose images point at pruned repo snapshots
     linux_distro: 'ubuntu-focal',
     use_preinstalled_scylla: true,
     test_name: 'upgrade_test.UpgradeTest.test_rolling_upgrade',

--- a/jenkins-pipelines/oss/rolling-upgrade/rolling-upgrade-with-null-inserts.jenkinsfile
+++ b/jenkins-pipelines/oss/rolling-upgrade/rolling-upgrade-with-null-inserts.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 rollingUpgradePipeline(
     backend: 'gce',
-    base_versions: '',  // auto mode
+    base_versions: '2024.1,2025.1',  // SCYLLADB-3508: skip bases whose images point at pruned repo snapshots
     linux_distro: 'centos-8',
     gce_image_db: 'https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-stream-8',
 

--- a/jenkins-pipelines/oss/rolling-upgrade/rolling-upgrade-with-sla-no-shares.jenkinsfile
+++ b/jenkins-pipelines/oss/rolling-upgrade/rolling-upgrade-with-sla-no-shares.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 rollingUpgradePipeline(
     backend: 'gce',
-    base_versions: '',  // auto mode
+    base_versions: '2024.1,2025.1',  // SCYLLADB-3508: skip bases whose images point at pruned repo snapshots
     linux_distro: 'ubuntu-jammy',
     gce_image_db: 'https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/family/ubuntu-2204-lts',
     test_name: 'upgrade_test.UpgradeTest.test_generic_cluster_upgrade',

--- a/jenkins-pipelines/oss/rolling-upgrade/rolling-upgrade-with-sla.jenkinsfile
+++ b/jenkins-pipelines/oss/rolling-upgrade/rolling-upgrade-with-sla.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 rollingUpgradePipeline(
     backend: 'gce',
-    base_versions: '',  // auto mode
+    base_versions: '2024.1,2025.1',  // SCYLLADB-3508: skip bases whose images point at pruned repo snapshots
     linux_distro: 'ubuntu-jammy',
     gce_image_db: 'https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/family/ubuntu-2204-lts',
     test_name: 'upgrade_test.UpgradeTest.test_generic_cluster_upgrade',

--- a/jenkins-pipelines/oss/rolling-upgrade/upgrade_custom/rolling-sequential-upgrade-custom_d1.jenkinsfile
+++ b/jenkins-pipelines/oss/rolling-upgrade/upgrade_custom/rolling-sequential-upgrade-custom_d1.jenkinsfile
@@ -6,7 +6,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 rollingUpgradePipeline(
     backend: 'gce',
     linux_distro: 'ubuntu-focal',
-    base_versions: '',
+    base_versions: '2024.1,2025.1',  // SCYLLADB-3508: skip bases whose images point at pruned repo snapshots
     test_name: 'upgrade_test.UpgradeCustomTest.test_custom_profile_sequential_rolling_upgrade',
     test_config: '''["test-cases/upgrades/customer-profile/rolling-upgrade-custom-d1.yaml", "configurations/auth_cassandra.yaml"]''',
 )

--- a/jenkins-pipelines/oss/rolling-upgrade/upgrade_custom/rolling-upgrade-custom-d1-w2-latency-regression.jenkinsfile
+++ b/jenkins-pipelines/oss/rolling-upgrade/upgrade_custom/rolling-upgrade-custom-d1-w2-latency-regression.jenkinsfile
@@ -7,7 +7,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 rollingUpgradePipeline(
     backend: 'gce',
     region: 'us-east1',
-    base_versions: '',
+    base_versions: '2024.1,2025.1',  // SCYLLADB-3508: skip bases whose images point at pruned repo snapshots
     linux_distro: 'ubuntu-jammy',
     test_name: 'upgrade_test.UpgradeTest.test_cluster_upgrade_latency_regression',
     test_config: '''["test-cases/upgrades/rolling-upgrade-latency-regression.yaml", "configurations/auth_cassandra.yaml"]''',

--- a/jenkins-pipelines/oss/rolling-upgrade/upgrade_custom/rolling-upgrade-custom_d1.jenkinsfile
+++ b/jenkins-pipelines/oss/rolling-upgrade/upgrade_custom/rolling-upgrade-custom_d1.jenkinsfile
@@ -6,7 +6,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 rollingUpgradePipeline(
     backend: 'gce',
     linux_distro: 'ubuntu-focal',
-    base_versions: '',
+    base_versions: '2024.1,2025.1',  // SCYLLADB-3508: skip bases whose images point at pruned repo snapshots
     test_name: 'upgrade_test.UpgradeCustomTest.test_custom_profile_rolling_upgrade',
     test_config: '''["test-cases/upgrades/customer-profile/rolling-upgrade-custom-d1.yaml", "configurations/auth_cassandra.yaml"]''',
 )


### PR DESCRIPTION
### Problem

Rolling upgrade jobs on `branch-2025.1` run with `base_versions: ''` (auto mode), so
they also fan out to base versions we no longer keep alive (2024.2 / 2025.2).

Images of those releases carry a **baked-in unstable repo snapshot URL**
(e.g. `.../unstable/scylla-enterprise/enterprise-2024.1/deb/unified/2026-01-25T21:27:42Z/...`).
Those snapshots get pruned from S3 after a few months, so during the rollback step:

1. the restored `scylla.list` points at a pruned snapshot → `apt-get update` fails with `404 Not Found`,
2. apt's index is therefore stale (still the new unified repo),
3. `apt-get install scylla-enterprise scylla-enterprise-machine-image` fails with
   `E: Unable to locate package scylla-enterprise`, leaving the node with no ScyllaDB installed.

Recent occurrences: [rolling-upgrade-ami-test #31](https://jenkins.scylladb.com/job/scylla-2025.1/job/rolling-upgrade/job/rolling-upgrade-ami-test/31/) (2024.1 → 2025.1),
[rolling-upgrade-ami-arm-test #34](https://jenkins.scylladb.com/job/scylla-2025.1/job/rolling-upgrade/job/rolling-upgrade-ami-arm-test/34/).

### Change

Pin every rolling upgrade pipeline on this branch to `base_versions: '2024.1,2025.1'` —
2024.1 is kept since it is still under extended support (@roydahan), 2025.1 upgrades from itself.
2024.2 and 2025.2 are dropped.

Jenkins users can still override the `base_versions` job parameter for a one-off run.

Fixes SCYLLADB-3508

### Note on the 2024.1 image-based jobs

The repo-based jobs are fine — the released 2024.1 repo file
(`https://s3.amazonaws.com/downloads.scylladb.com/deb/ubuntu/scylla-2024.1.list`) is alive.

The image-based jobs (`use_preinstalled_scylla: true`: ami, ami-arm, gce-image, azure-image,
with-enable-tablets) will still hit the rollback failure until the snapshot baked into the
latest 2024.1 AMI is restored. As of today the latest released image is
**ScyllaDB Enterprise 2024.1.22** (`ami-08f95dda4def7e589`, 2026-01-29), and its repo path
still 404s:

```
https://downloads.scylladb.com/unstable/scylla-enterprise/enterprise-2024.1/deb/unified/2026-01-25T21:27:42Z/scylladb-2024.1
```

The only snapshot left under `enterprise-2024.1/deb/unified/` is `2026-06-04T14:17:43Z`
(that one resolves fine, but no AMI was released from it).

### Testing

- Jenkinsfile defaults only; no SCT code paths changed.
- `pre-commit run --files <changed>` passes.