### PR TITLE
fix(upgrade): stop using 2025.2 as an upgrade base version

### DIFF
--- a/unit_tests/integration/test_base_version.py
+++ b/unit_tests/integration/test_base_version.py
@@ -257,6 +257,10 @@ def test_upgrade_matrix_stages(test_case):
     - When target_rc_only is True, it simulates that only RC versions exist for the target branch
     - When target_rc_only is False, it simulates that stable releases exist for the target branch
     - The upgrade matrix should return appropriate versions based on upgrade compatibility rules
+
+    ``unsupported_versions`` is emptied for the duration of the test so the cases keep describing
+    the selection algorithm alone: skipping a specific release (see ``test_unsupported_version_is_skipped``)
+    is an operational decision that changes over time and must not silently rewrite these expectations.
     """
     target_branch = test_case["target_branch"]
     target_rc_only = test_case["target_rc_only"]
@@ -277,11 +281,33 @@ def test_upgrade_matrix_stages(test_case):
     with (
         patch("utils.get_supported_scylla_base_versions.get_all_versions", return_value=mock_versions),
         patch("utils.get_supported_scylla_base_versions.get_s3_scylla_repos_mapping", return_value=mock_repo_map),
+        patch("utils.get_supported_scylla_base_versions.unsupported_versions", []),
     ):
         version_list = general_test(
             scylla_repo, linux_distro, base_version_all_sts_versions=base_version_all_sts_versions
         )
     assert set(version_list) == expected_version_set
+
+
+def test_unsupported_version_is_skipped():
+    """A release listed in ``unsupported_versions`` is never returned as an upgrade base version.
+
+    2025.2 is skipped that way: its images carry a baked-in unstable repo snapshot that is pruned
+    from S3 by now, so the rollback step of the rolling upgrade test cannot reinstall it (SCYLLADB-3508).
+    """
+    target_branch = "2026.1"
+    supported_versions = ["2024.1", "2024.2", "2025.1", "2025.2", "2025.3", "2025.4", "2026.1"]
+    scylla_repo = url_base + f"/branch-{target_branch}/deb/unified/latest/scylladb-{target_branch}/scylla.list"
+    mock_repo_map = {v: f"mock_url/{v}" for v in supported_versions}
+
+    with (
+        patch("utils.get_supported_scylla_base_versions.get_all_versions", return_value=supported_versions),
+        patch("utils.get_supported_scylla_base_versions.get_s3_scylla_repos_mapping", return_value=mock_repo_map),
+        patch("utils.get_supported_scylla_base_versions.unsupported_versions", ["2025.2"]),
+    ):
+        version_list = general_test(scylla_repo, "ubuntu-focal", base_version_all_sts_versions=True)
+
+    assert set(version_list) == {"2025.1", "2025.3", "2025.4", "2026.1"}
 
 
 def test_master_all_sts_versions():
@@ -304,6 +330,8 @@ def test_master_all_sts_versions():
             return_value=["2024.1", "2024.2", "2025.1", "2025.2", "2025.3", "2025.4", "2026.1"],
         ),
         patch("utils.get_supported_scylla_base_versions.get_s3_scylla_repos_mapping", return_value=mock_repo_map),
+        # keep this an algorithm test: the real skip list changes over time, see test_unsupported_version_is_skipped
+        patch("utils.get_supported_scylla_base_versions.unsupported_versions", []),
     ):
         version_detector = UpgradeBaseVersion(scylla_repo, linux_distro, None, base_version_all_sts_versions=True)
         version_detector.set_start_support_version(None)

--- a/utils/get_supported_scylla_base_versions.py
+++ b/utils/get_supported_scylla_base_versions.py
@@ -39,9 +39,12 @@ start_support_versions = {
 }
 start_support_backend = {"azure": {"scylla": "5.2", "enterprise": "2023.1"}}
 
-# list of version that are available, but aren't supported, and we should test upgrades from
+# list of versions that are available, but aren't supported, and we shouldn't test upgrades from
 unsupported_versions = [
     "5.3",
+    # images of this release have a baked-in unstable repo snapshot which was already pruned from S3,
+    # so the rollback step of the rolling upgrade test can't reinstall it back (SCYLLADB-3508)
+    "2025.2",
 ]
 
 


### PR DESCRIPTION
### Problem

Rolling upgrade jobs pick their base versions automatically. For 2026.1 that currently
includes **2025.2**, whose images carry a baked-in *unstable* repo snapshot URL
(`.../unstable/scylla/branch-2025.2/deb/unified/2025-12-09T00:15:30Z/...`).

Those snapshots are pruned from S3 after a few months, so during the rollback step:

1. the restored `scylla.list` points at a pruned snapshot → `apt-get update` fails with `404 Not Found`,
2. apt's index stays stale (the new unified repo),
3. `apt-get install scylla-enterprise scylla-enterprise-machine-image` fails with
   `E: Unable to locate package scylla-enterprise`, leaving the node with no ScyllaDB installed.

See [rolling-upgrade-ami-test #23](https://jenkins.scylladb.com/job/scylla-2026.1/job/rolling-upgrade/job/rolling-upgrade-ami-test/23/) and
[#26](https://jenkins.scylladb.com/job/scylla-2026.1/job/rolling-upgrade/job/rolling-upgrade-ami-test/26/).

2025.2 is EOL anyway — it is listed as `Not supported` in the docs-homepage
[supported_versions.json](https://raw.githubusercontent.com/scylladb/scylladb-docs-homepage/main/docs/_static/data/supported_versions.json).

### Change

Add `2025.2` to `unsupported_versions`, so it is never selected as an upgrade base version.

Base versions resolved after the change (verified by running `sct.py get-scylla-base-versions`
against `branch-2026.1`):

| job flavor | base versions |
| --- | --- |
| `base_version_all_sts_versions: true` | `2026.1 2025.4 2025.3 2025.1` |
| default | `2026.1 2025.4 2025.1` |

which is what we want to keep testing for 2026.1.

The parametrized upgrade-matrix cases describe the LTS/STS selection algorithm over a mocked
release set, so they now empty the skip list for their duration — otherwise an operational
decision like this one silently rewrites their expectations. Skipping itself is covered by the
new `test_unsupported_version_is_skipped`.

Fixes SCYLLADB-3508

### Testing

```
pytest unit_tests/integration/test_base_version.py   # 14 passed (incl. the network-backed ones)
sct.py get-scylla-base-versions --scylla-repo <branch-2026.1 repo> --base_version_all_sts_versions
# Base Versions: 2026.1 2025.3 2025.1 2025.4
```