### PR TITLE
fix(oci): list only the instances of the provisioner's availability domains

### DIFF
--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -1913,7 +1913,14 @@ class Collector:
     def create_collecting_nodes(self):
         try:
             provisioners = provisioner_factory.discover_provisioners(backend=self.backend, test_id=self.test_id)
-            instances = sum([provisioner.list_instances() for provisioner in provisioners], [])
+            # NOTE: discovered provisioners may report overlapping sets of instances, i.e. when there is
+            #       one provisioner per availability zone of the same region. Collecting one node more
+            #       than once makes the parallel collectors race for the same remote archive paths and
+            #       corrupt them, so keep a single entry per instance name.
+            instances = {}
+            for provisioner in provisioners:
+                for instance in provisioner.list_instances():
+                    instances.setdefault(instance.name, instance)
             collecting_nodes = [
                 CollectingNode(
                     name=instance.name,
@@ -1926,7 +1933,7 @@ class Collector:
                     global_ip=instance.public_ip_address,
                     tags=instance.tags,
                 )
-                for instance in instances
+                for instance in instances.values()
             ]
             for c_node in collecting_nodes:
                 match c_node.tags.get("NodeType"):

--- a/sdcm/provision/oci/virtual_machine_provider.py
+++ b/sdcm/provision/oci/virtual_machine_provider.py
@@ -60,6 +60,65 @@ class VirtualMachineProvider:
         self._identity_client = self._oci_service.get_identity_client(self._region)
         self._network_client = self._oci_service.get_network_client(self._region)
         self._bs_client = self._oci_service.get_block_storage_client(self._region)
+        self._availability_domains: Optional[List] = None
+
+    def _list_availability_domains(self) -> List:
+        """Availability domains of the compartment, sorted by name. Cached, the list never changes."""
+        if self._availability_domains is None:
+            ads = self._identity_client.list_availability_domains(self._compartment_id).data
+            self._availability_domains = sorted(ads, key=lambda x: x.name)
+        return self._availability_domains
+
+    def _az_list(self) -> List[str]:
+        """AZ identifiers this provider is configured with. self._az may hold a list, i.e. "a,b,c"."""
+        return [x.strip() for x in str(self._az).split(",")]
+
+    @staticmethod
+    def _match_availability_domain(az: str, ads: List) -> Optional[str]:
+        """Resolve a single AZ identifier ("1", "a" or a full AD name) to a full AD name."""
+        # Check if it's already a full AD name
+        for ad in ads:
+            if ad.name == az:
+                return ad.name
+
+        # Try index mapping
+        index = -1
+        if az.isdigit():
+            index = int(az) - 1
+        elif len(az) == 1 and az.isalpha():
+            index = ord(az.lower()) - ord("a")
+        if 0 <= index < len(ads):
+            return ads[index].name
+
+        # Try suffix matching
+        for ad in ads:
+            if ad.name.endswith(str(az)):
+                return ad.name
+
+        return None
+
+    def _availability_domains_in_scope(self) -> set:
+        """Full names of the availability domains this provider is responsible for.
+
+        An empty set means "not scoped to any AD", i.e. the whole region.
+        """
+        if not str(self._az).strip():
+            return set()
+        ads = self._list_availability_domains()
+        in_scope = set()
+        for az in self._az_list():
+            if ad_name := self._match_availability_domain(az, ads):
+                in_scope.add(ad_name)
+            else:
+                LOGGER.warning(
+                    "Failed to resolve the '%s' availability zone (derived from configuration '%s') "
+                    "in the '%s' region. Available domains: %s",
+                    az,
+                    self._az,
+                    self._region,
+                    [ad.name for ad in ads],
+                )
+        return in_scope
 
     def _get_availability_domain(self, definition: Optional[InstanceDefinition] = None) -> str:
         """
@@ -67,9 +126,8 @@ class VirtualMachineProvider:
         Uses self._az which can be a single value ("1"), a list ("1,2,3"), or letters ("a,b,c").
         If a list is provided, distributes based on definition's NodeIndex.
         """
-        ads = self._identity_client.list_availability_domains(self._compartment_id).data
-        ads.sort(key=lambda x: x.name)
-        az_list = [x.strip() for x in str(self._az).split(",")]
+        ads = self._list_availability_domains()
+        az_list = self._az_list()
         az_to_use = az_list[0]
         if definition and len(az_list) > 1:
             try:
@@ -85,24 +143,8 @@ class VirtualMachineProvider:
                     az_to_use,
                 )
 
-        # Check if it's already a full AD name
-        for ad in ads:
-            if ad.name == az_to_use:
-                return ad.name
-
-        # Try index mapping
-        index = -1
-        if az_to_use.isdigit():
-            index = int(az_to_use) - 1
-        elif len(az_to_use) == 1 and az_to_use.isalpha():
-            index = ord(az_to_use.lower()) - ord("a")
-        if 0 <= index < len(ads):
-            return ads[index].name
-
-        # Try suffix matching
-        for ad in ads:
-            if ad.name.endswith(str(az_to_use)):
-                return ad.name
+        if ad_name := self._match_availability_domain(az_to_use, ads):
+            return ad_name
 
         raise ProvisionError(
             f"Invalid or not found Availability Zone identifier '{az_to_use}' (derived from configuration '{self._az}') "
@@ -166,13 +208,22 @@ class VirtualMachineProvider:
         ).data
 
     def list_instances(self, test_id: str) -> List[Instance]:
-        """List instances in the compartment, optionally filtered by tags (test_id)."""
+        """List instances of this provider's availability domains, optionally filtered by tags (test_id).
+
+        NOTE: the OCI compute API is regional, so instances must be filtered by availability domain
+              here. Without it every per-AD provider of a region reports all the region's instances,
+              and callers which merge multiple providers get each instance as many times as there
+              are ADs in use.
+        """
+        ads_in_scope = self._availability_domains_in_scope()
         all_instances = oci.pagination.list_call_get_all_results(
             self._compute_client.list_instances, compartment_id=self._compartment_id
         ).data
         filtered = []
         for inst in all_instances:
             if inst.lifecycle_state == Instance.LIFECYCLE_STATE_TERMINATED:
+                continue
+            if ads_in_scope and inst.availability_domain not in ads_in_scope:
                 continue
             tags = (inst.defined_tags or {}).get(TAG_NAMESPACE, {})
             if test_id and tags.get("TestId") != test_id and test_id not in inst.display_name:

--- a/unit_tests/unit/test_log_collector.py
+++ b/unit_tests/unit/test_log_collector.py
@@ -89,6 +89,33 @@ def test_create_collecting_nodes(test_id, tmp_path_factory):
         assert collecting_node.name == v_m.name
 
 
+def test_create_collecting_nodes_deduplicates_overlapping_provisioners(test_id, tmp_path_factory):
+    """Test that a node discovered by several provisioners is collected only once.
+
+    Provisioners of the same region may report overlapping sets of instances (OCI discovers one
+    provisioner per availability domain of a region). Duplicated nodes make the parallel collectors
+    of a cluster run against the same host at once, racing for the same remote archive paths and
+    corrupting them.
+    """
+    test_dir = tmp_path_factory.mktemp("log-collector-duplicates")
+    prepare_fake_region(test_id, "region_1", n_db_nodes=3, n_loaders=2, n_monitor_nodes=1)
+    collector = Collector(
+        test_id=test_id, test_dir=test_dir, params={"cluster_backend": "fake", "use_cloud_manager": False}
+    )
+    provisioner = provisioner_factory.discover_provisioners(backend="fake", test_id=test_id)[0]
+
+    with patch.object(provisioner_factory, "discover_provisioners", return_value=[provisioner] * 3):
+        collector.create_collecting_nodes()
+
+    for cluster_set in (collector.db_cluster, collector.loader_set, collector.monitor_set):
+        names = [node.name for node in cluster_set]
+        assert len(names) == len(set(names)), f"Duplicated nodes to collect logs from: {names}"
+
+    expected = {v_m.name for v_m in provisioner.list_instances()}
+    collected = {node.name for node in collector.db_cluster + collector.loader_set + collector.monitor_set}
+    assert collected == expected
+
+
 def test_base_sct_log_collector_raises_when_no_local_files(tmp_path):
     """Test that BaseSCTLogCollector raises FileNotFoundError when no local files are found."""
     test_id = str(uuid.uuid4())

--- a/unit_tests/unit/test_oci_virtual_machine_provider.py
+++ b/unit_tests/unit/test_oci_virtual_machine_provider.py
@@ -172,3 +172,115 @@ def test_provision_instance_sends_boot_volume_size_to_oci(
     assert launch_details.source_details.boot_volume_size_in_gbs == 100
     assert launch_details.source_details.image_id == "ocid1.image.oc1..example"
     assert launch_details.image_id is None
+
+
+AVAILABILITY_DOMAINS = [
+    SimpleNamespace(name="ewbj:US-ASHBURN-AD-1"),
+    SimpleNamespace(name="ewbj:US-ASHBURN-AD-2"),
+    SimpleNamespace(name="ewbj:US-ASHBURN-AD-3"),
+]
+
+
+def _oci_instance(display_name: str, availability_domain: str, test_id: str = "test-id") -> SimpleNamespace:
+    return SimpleNamespace(
+        display_name=display_name,
+        availability_domain=availability_domain,
+        lifecycle_state="RUNNING",
+        defined_tags={"sct": {"TestId": test_id}},
+    )
+
+
+ALL_REGION_INSTANCES = [
+    _oci_instance("db-node-1", "ewbj:US-ASHBURN-AD-1"),
+    _oci_instance("db-node-2", "ewbj:US-ASHBURN-AD-2"),
+    _oci_instance("db-node-3", "ewbj:US-ASHBURN-AD-3"),
+    _oci_instance("monitor-node-1", "ewbj:US-ASHBURN-AD-1"),
+]
+
+
+def _make_provider(az: str) -> VirtualMachineProvider:
+    provider = VirtualMachineProvider(
+        _compartment_id="ocid1.compartment.oc1..example",
+        _region="us-ashburn-1",
+        _az=az,
+    )
+    provider._identity_client.list_availability_domains.return_value = SimpleNamespace(data=AVAILABILITY_DOMAINS)
+    return provider
+
+
+@pytest.mark.parametrize(
+    "az, expected_names",
+    [
+        pytest.param("1", ["db-node-1", "monitor-node-1"], id="single-numeric-az"),
+        pytest.param("b", ["db-node-2"], id="single-letter-az"),
+        pytest.param("ewbj:US-ASHBURN-AD-3", ["db-node-3"], id="full-ad-name"),
+        pytest.param("a,b,c", ["db-node-1", "db-node-2", "db-node-3", "monitor-node-1"], id="az-list"),
+        pytest.param("", ["db-node-1", "db-node-2", "db-node-3", "monitor-node-1"], id="no-az-scope"),
+    ],
+)
+@patch("oci.pagination.list_call_get_all_results", return_value=SimpleNamespace(data=ALL_REGION_INSTANCES))
+@patch("sdcm.utils.oci_utils.OciService.get_block_storage_client", return_value=MagicMock())
+@patch("sdcm.utils.oci_utils.OciService.get_network_client", return_value=MagicMock())
+@patch("sdcm.utils.oci_utils.OciService.get_identity_client", return_value=MagicMock())
+@patch("sdcm.utils.oci_utils.OciService.get_compute_client", return_value=MagicMock())
+def test_list_instances_is_scoped_to_the_provider_availability_domains(
+    mock_compute,
+    mock_identity,
+    mock_network,
+    mock_bs,
+    mock_pagination,
+    az,
+    expected_names,
+) -> None:
+    """Test that instances of other availability domains of the same region are not reported.
+
+    The OCI compute API is regional. Without an explicit AD filter each per-AD provisioner of a
+    region reports every node of the test, and callers merging provisioners (i.e. the log collector)
+    end up collecting each node once per AD in use, racing for the same remote archive paths.
+    """
+    provider = _make_provider(az)
+
+    instances = provider.list_instances(test_id="test-id")
+
+    assert [inst.display_name for inst in instances] == expected_names
+    assert sorted(provider._raw_cache) == sorted(expected_names)
+
+
+@patch("oci.pagination.list_call_get_all_results", return_value=SimpleNamespace(data=ALL_REGION_INSTANCES))
+@patch("sdcm.utils.oci_utils.OciService.get_block_storage_client", return_value=MagicMock())
+@patch("sdcm.utils.oci_utils.OciService.get_network_client", return_value=MagicMock())
+@patch("sdcm.utils.oci_utils.OciService.get_identity_client", return_value=MagicMock())
+@patch("sdcm.utils.oci_utils.OciService.get_compute_client", return_value=MagicMock())
+def test_per_availability_domain_providers_report_each_instance_once(
+    mock_compute,
+    mock_identity,
+    mock_network,
+    mock_bs,
+    mock_pagination,
+) -> None:
+    """Test that providers of all the region's ADs together report every instance exactly once."""
+    reported = [
+        inst.display_name for az in ("1", "2", "3") for inst in _make_provider(az).list_instances(test_id="test-id")
+    ]
+
+    assert sorted(reported) == ["db-node-1", "db-node-2", "db-node-3", "monitor-node-1"]
+
+
+@patch("oci.pagination.list_call_get_all_results", return_value=SimpleNamespace(data=ALL_REGION_INSTANCES))
+@patch("sdcm.utils.oci_utils.OciService.get_block_storage_client", return_value=MagicMock())
+@patch("sdcm.utils.oci_utils.OciService.get_network_client", return_value=MagicMock())
+@patch("sdcm.utils.oci_utils.OciService.get_identity_client", return_value=MagicMock())
+@patch("sdcm.utils.oci_utils.OciService.get_compute_client", return_value=MagicMock())
+def test_list_instances_keeps_the_whole_region_when_az_cannot_be_resolved(
+    mock_compute,
+    mock_identity,
+    mock_network,
+    mock_bs,
+    mock_pagination,
+) -> None:
+    """Test that an unresolvable AZ degrades to no filtering instead of hiding nodes from collection."""
+    provider = _make_provider("no-such-zone")
+
+    instances = provider.list_instances(test_id="test-id")
+
+    assert len(instances) == len(ALL_REGION_INSTANCES)


### PR DESCRIPTION
The OCI compute API is regional, but 'discover_regions()' creates one provisioner
per availability domain (AD) in use and 'list_instances()' never gets filtered by AD.

With the "availability_zone='a,b,c'", which is used almost always,
we get three provisioners each reporting the same nodes.
It makes the log collector code try to collect every node three times in parallel.
It is error prone because log collector change files.

Test run logs example:
```
  Start collect logs for cluster monitor-set
  Collecting logs on host: pr-provision-test-pr-1591-monitor-node-f2ce261e-us-ashburn-1-1
  Collecting logs on host: pr-provision-test-pr-1591-monitor-node-f2ce261e-us-ashburn-1-1
  Collecting logs on host: pr-provision-test-pr-1591-monitor-node-f2ce261e-us-ashburn-1-1
  ...
  Archive `/home/ubuntu/sct-monitoring/scylla-monitoring-data/snapshots/\
    prometheus_data_20260901_071008.tar.zst' is corrupted: \
    `tar --zstd -tf '/home/ubuntu/sct-monitoring/scylla-monitoring-data/\
    snapshots/prometheus_data_20260901_071008.tar.zst'' returns 2
  ...
  -- STDERR: --
  /*stdin*\ : Read error (39) : premature end
  tar: Unexpected EOF in archive
  tar: Error is not recoverable: exiting now
```

So, fix it in 2 parts:
- Log collectors: deduplicate list of target nodes by names
- OCI: filter by AD in the 'list_instances()'

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
