### PR TITLE
fix(minicloud): apply firewalld trusted zone from the host, not hydra

### DIFF
--- a/docs/minicloud.md
+++ b/docs/minicloud.md
@@ -131,8 +131,13 @@ Guest IMDS traffic is DNATed through the TUN device into the host INPUT chain, a
 zone blocks it.  If that traffic is blocked, guests still boot, but never receive their SSH key,
 so login fails with `AuthenticationError`.
 
-Startup applies this automatically at runtime and re-applies it on every run, because
-`firewall-cmd --reload` clears the setting.
+`scripts/minicloud-firewalld-zone.sh` applies this at runtime and is re-run on every start,
+because `firewall-cmd --reload` clears the setting. It runs on the host rather than inside the
+hydra container: the TUN device can be created from the container (it is privileged and shares
+the host's network namespace), but firewalld is a host daemon accessed over D-Bus and
+`firewall-cmd` is not in the hydra image. `scripts/run-minicloud-test.sh` and the *Start
+Minicloud* pipeline stage both call it; a direct (non-containerised) `sct.py start-minicloud`
+does the same work in `sdcm/utils/minicloud/networking.py`.
 If you configure networking with a boot-time unit, that unit must include:
 `firewall-cmd --zone=trusted --change-interface=minicloud0`.
 
@@ -239,7 +244,7 @@ the regular `clean-resources` path.
 | `SnapshotNotFound` from `ListSnapshotBlocks` | dev AMI whose snapshot is not shared with the QA account - use a released version |
 | "memory per shard too low" in a guest's Scylla log | `minicloud_lightweight_memory` set below ~3 GiB |
 | start aborts with "could not extract minicloud-setup.sh" or "minicloud-setup.sh failed" | host networking could not be configured - pre-create the `minicloud0` device or grant passwordless sudo |
-| guests boot and get DHCP, but SSH fails with `AuthenticationError` until the timeout | the host firewall blocks the guests' IMDS requests, so no SSH key was injected - on firewalld hosts the start moves `minicloud0` into the `trusted` zone itself; hitting this means it could not (no `firewall-cmd`-compatible firewall, or no passwordless sudo) |
+| guests boot and get DHCP, but SSH fails with `AuthenticationError` until the timeout | the host firewall blocks the guests' IMDS requests, so no SSH key was injected - on firewalld hosts `scripts/minicloud-firewalld-zone.sh` moves `minicloud0` into the `trusted` zone at every start and fails the build when it cannot, so either the script never ran - check that the *Start Minicloud* stage called it, or run it by hand on the host - or the block comes from a non-firewalld firewall (ufw, plain nftables), which the script deliberately leaves alone |
 | `clean-resources` refuses to run: "minicloud is not reachable" | the container died; collect its logs (`docker logs minicloud`) - cleanup against a fresh emulator would only pretend to succeed |
 
 The container's own log is the emulator's view of the run: `docker logs minicloud`, and
@@ -294,8 +299,9 @@ independent of minicloud; see [sct-pipelines](./sct-pipelines.md).
 A lab agent serving `minicloud-kvm-builders-v1` needs: the agent user in `kvm` and `docker`
 groups (restart the agent process after `usermod`, reconnecting is not enough); `minicloud0`
 pre-created by a boot-time unit (preferred - no sudo needed at run time) or passwordless sudo;
-on firewalld hosts, `minicloud0` in the `trusted` zone (done by the run itself given sudo, or
-by the boot-time unit - see [Running locally](#running-locally));
+on firewalld hosts, `minicloud0` in the `trusted` zone (done on the agent by
+`scripts/minicloud-firewalld-zone.sh` given passwordless sudo, or by the boot-time unit - see
+[Running locally](#running-locally));
 `USER`/`HOME` set and `$HOME` writable with >=80 GiB free; `numExecutors=1` + exclusive mode,
 which is what serialises the host singletons (port 5000, the container name, `minicloud0`);
 egress to docker.io, ghcr.io, github.com, amazonaws.com, argus.scylladb.com,

--- a/scripts/minicloud-firewalld-zone.sh
+++ b/scripts/minicloud-firewalld-zone.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# Put minicloud TUN device in firewalld trusted zone (host-side script).
+#
+# Why this is a host script:
+# Minicloud0 can be created from the privileged hydra container because it shares the host
+# network namespace, but `firewall-cmd` is not in that image. So CI/containerized SCT runs use
+# this script, while direct host runs (`sct.py start-minicloud`) do the same assignment in
+# `sdcm/utils/minicloud/networking.py`.
+#
+# Why this matters:
+# If minicloud0 stays in the default zone, firewalld blocks guest IMDS traffic DNATed into the
+# host INPUT chain. DHCP and NTP still work, so guests boot and get addresses, but SSH key fetch
+# fails and logins end with `AuthenticationError` after about 1500 seconds.
+#
+# This runs on every start because the assignment is runtime-only, and
+# `firewall-cmd --reload` clears runtime interface-zone bindings.
+#
+# State and zone checks run unprivileged first, then retry with `sudo -n` when needed.
+# On Fedora jenkins agents, polkit can block unprivileged reads. Hosts without passwordless
+# sudo can still pass if a boot-time unit already set the zone. Only zone writes need root.
+#
+# Exit behavior:
+# - 0: no firewalld, firewalld stopped, no TUN yet, or already trusted
+# - non-zero: zone assignment was required but failed (never silent)
+set -uo pipefail
+
+TUN=minicloud0
+ZONE=trusted
+
+no_op() {
+    echo "$1"
+    exit 0
+}
+
+# run a read-only firewall-cmd query, retrying with sudo -n when polkit denies the caller
+fw_read() {
+    local out rc
+    out="$(firewall-cmd "$@" 2>&1)"
+    rc=$?
+
+    if [[ ${rc} -ne 0 && "${out}" != *"not running"* ]]; then
+        out="$(sudo -n firewall-cmd "$@" 2>&1)"
+        rc=$?
+    fi
+
+    echo "${out}"
+    return ${rc}
+}
+
+if ! command -v firewall-cmd >/dev/null 2>&1; then
+    no_op "firewalld is not installed - no zone assignment needed for ${TUN}"
+fi
+
+if ! state="$(fw_read --state)"; then
+    if [[ "${state}" == *"not running"* ]]; then
+        no_op "firewalld is not running - no zone assignment needed for ${TUN}"
+    fi
+    echo "ERROR: firewalld is installed but its state could not be queried, unprivileged or" \
+         "via passwordless sudo (${state})" >&2
+    exit 1
+fi
+
+if ! ip link show "${TUN}" >/dev/null 2>&1; then
+    no_op "${TUN} does not exist on this host - nothing to zone"
+fi
+
+if [[ "$(fw_read --get-zone-of-interface="${TUN}")" == "${ZONE}" ]]; then
+    no_op "${TUN} is already in firewalld's ${ZONE} zone"
+fi
+
+# the write needs root: -n fails fast if passwordless sudo is unavailable
+if ! output="$(sudo -n firewall-cmd --zone="${ZONE}" --change-interface="${TUN}" 2>&1)"; then
+    echo "ERROR: could not move ${TUN} into firewalld's ${ZONE} zone (${output}) - the change" \
+         "needs passwordless sudo, unless a boot-time unit pre-assigns the zone; without it" \
+         "guests boot and get DHCP but never fetch their SSH key, failing every login with" \
+         "AuthenticationError" >&2
+    exit 1
+fi
+
+echo "moved ${TUN} into firewalld's ${ZONE} zone (runtime-only, re-applied every run)"

--- a/scripts/run-minicloud-test.sh
+++ b/scripts/run-minicloud-test.sh
@@ -144,4 +144,8 @@ echo "=== configs: ${CONFIGS[*]} ==="
 
 "${RUNNER[@]}" start-minicloud -b "$BACKEND" "${CONFIG_ARGS[@]}"
 
+# minicloud0 exists now.
+# In hydra mode, apply the firewalld zone from the host; direct mode already handled it.
+scripts/minicloud-firewalld-zone.sh
+
 "${RUNNER[@]}" run-test "$TEST" --backend "$BACKEND" "${CONFIG_ARGS[@]}"

--- a/sdcm/utils/minicloud/networking.py
+++ b/sdcm/utils/minicloud/networking.py
@@ -62,6 +62,12 @@ def _ensure_tun_in_firewalld_trusted_zone() -> None:
     clears runtime zone bindings.
     """
     if shutil.which("firewall-cmd") is None:
+        LOGGER.info(
+            "firewall-cmd is not available here - if this host runs firewalld, %s must be moved "
+            "into the %s zone from the host (scripts/minicloud-firewalld-zone.sh)",
+            TUN_NAME,
+            FIREWALLD_TRUSTED_ZONE,
+        )
         return
 
     firewalld_cmd = ["sudo", "-n", "firewall-cmd"]

--- a/unit_tests/unit/minicloud/test_firewalld_zone_script.py
+++ b/unit_tests/unit/minicloud/test_firewalld_zone_script.py
@@ -1,0 +1,105 @@
+"""Tests for host-side firewalld zone assignment in `scripts/minicloud-firewalld-zone.sh`."""
+
+import os
+import shutil
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).parents[3] / "scripts" / "minicloud-firewalld-zone.sh"
+# resolve bash before reducing PATH to only stub binaries
+BASH = shutil.which("bash")
+
+FAKE_FIREWALL_CMD = """#!/bin/bash
+echo "firewall-cmd${FAKE_CALLER:+ (sudo)} $*" >> "${FAKE_LOG}"
+# FAKE_POLKIT_DENIES: reject read queries unless invoked through the sudo stub, like Fedora
+# polkit does for non-console users
+deny() {
+    [[ -n "${FAKE_POLKIT_DENIES:-}" && -z "${FAKE_CALLER:-}" ]]
+}
+case "$1" in
+  --state)
+      deny && { echo "Authorization failed." >&2; exit 4; }
+      echo running; exit 0 ;;
+  --get-zone-of-interface=*)
+      deny && { echo "Authorization failed." >&2; exit 4; }
+      echo "${FAKE_ZONE:-FedoraServer}"; exit 0 ;;
+  --zone=trusted)
+      [[ -n "${FAKE_CHANGE_FAILS:-}" ]] && { echo "Authorization failed" >&2; exit 1; }
+      echo success; exit 0 ;;
+esac
+exit 3
+"""
+
+FAKE_SUDO_TRANSPARENT = """#!/bin/bash
+shift
+FAKE_CALLER=sudo exec "$@"
+"""
+
+FAKE_SUDO_NEEDS_PASSWORD = """#!/bin/bash
+echo "sudo: a password is required" >&2
+exit 1
+"""
+
+FAKE_IP = """#!/bin/bash
+echo minicloud0
+"""
+
+
+def _run(tmp_path, sudo=FAKE_SUDO_TRANSPARENT, **env):
+    """Run the script against stub executables; returns (CompletedProcess, firewall-cmd calls)."""
+    bindir = tmp_path / "bin"
+    bindir.mkdir(exist_ok=True)
+
+    for name, body in {"firewall-cmd": FAKE_FIREWALL_CMD, "sudo": sudo, "ip": FAKE_IP}.items():
+        stub = bindir / name
+        stub.write_text(body)
+        stub.chmod(stub.stat().st_mode | stat.S_IEXEC)
+
+    call_log = tmp_path / "firewall-cmd.calls"
+    call_log.touch()
+    result = subprocess.run(
+        [BASH, str(SCRIPT)],
+        capture_output=True,
+        text=True,
+        check=False,
+        env={**os.environ, "PATH": str(bindir), "FAKE_LOG": str(call_log), **env},
+    )
+    return result, call_log.read_text().splitlines()
+
+
+def test_unzoned_tun_is_moved_into_the_trusted_zone(tmp_path):
+    result, calls = _run(tmp_path)
+    assert result.returncode == 0, result.stderr
+    assert "firewall-cmd (sudo) --zone=trusted --change-interface=minicloud0" in calls
+
+
+def test_polkit_denied_reads_fall_back_to_sudo(tmp_path):
+    # if polkit blocks unprivileged reads, the script must retry with sudo and still apply the zone
+    result, calls = _run(tmp_path, FAKE_POLKIT_DENIES="1")
+    assert result.returncode == 0, result.stderr
+    assert "firewall-cmd (sudo) --zone=trusted --change-interface=minicloud0" in calls
+
+
+def test_boot_unit_topology_needs_no_sudo(tmp_path):
+    result, calls = _run(tmp_path, sudo=FAKE_SUDO_NEEDS_PASSWORD, FAKE_ZONE="trusted")
+    assert result.returncode == 0, result.stderr
+    assert not [call for call in calls if "--change-interface" in call]
+
+
+@pytest.mark.parametrize(
+    "kwargs, expected_stderr",
+    [
+        ({"sudo": FAKE_SUDO_NEEDS_PASSWORD}, "sudo: a password is required"),
+        ({"FAKE_CHANGE_FAILS": "1"}, "Authorization failed"),
+    ],
+    ids=["no-passwordless-sudo", "change-interface-rejected"],
+)
+def test_failure_to_apply_the_zone_is_loud(tmp_path, kwargs, expected_stderr):
+    result, _ = _run(tmp_path, **kwargs)
+    assert result.returncode != 0, f"expected a non-zero exit, got: {result.stdout}"
+    assert "could not move minicloud0" in result.stderr
+    assert expected_stderr in result.stderr
+    assert "AuthenticationError" in result.stderr

--- a/vars/startMinicloud.groovy
+++ b/vars/startMinicloud.groovy
@@ -189,6 +189,8 @@ def call(Map params) {
         ./docker/env/hydra.sh --execute-on-runner \${RUNNER_IP} start-minicloud -b "${params.backend}"
     else
         ./docker/env/hydra.sh start-minicloud -b "${params.backend}"
+        # local-agent only: hydra has no firewall-cmd, so assign minicloud0 to trusted zone on the host.
+        ./scripts/minicloud-firewalld-zone.sh
     fi
     """
 }


### PR DESCRIPTION
The zone assignment fix (80d839dcc) is run inside the hydra container, which has no `firewall-cmd`, so it silently does nothing on SCT run. On firewalld lab agents minicloud guests are booted but never got their SSH key from IMDS, and logins fail with AuthenticationError.

The fix adds scripts/minicloud-firewalld-zone.sh script to do it on the host instead. The script runs right after start-minicloud, needs sudo only for the zone change.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :green_circle: [mc-artifacts-ami-test](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/mc/job/mc-artifacts-ami-test/8/)
- [x] :green_circle: [mc-rolling-upgrade-ubuntu2404-test](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/mc/job/mc-rolling-upgrade-ubuntu2404-test/7/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code