### PR TITLE
fix(hydra): install google-cloud-cli, the sdk names are gone from the repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,10 +49,12 @@ COPY --from=apt_repos /etc/apt/keyrings/docker.asc /etc/apt/keyrings/docker.asc
 COPY --from=apt_repos /etc/apt/sources.list.d/docker.list /etc/apt/sources.list.d/docker.list
 COPY --from=apt_repos /usr/share/keyrings/cloud.google.gpg /usr/share/keyrings/cloud.google.gpg
 COPY --from=apt_repos /etc/apt/sources.list.d/google-cloud-sdk.list /etc/apt/sources.list.d/google-cloud-sdk.list
+# The google-cloud-sdk* names were transitional since 467.0.0 and have now been
+# dropped from the cloud-sdk repo; google-cloud-cli* are the only ones published.
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
     apt-get install -y --no-install-recommends \
-        google-cloud-sdk \
-        google-cloud-sdk-gke-gcloud-auth-plugin \
+        google-cloud-cli \
+        google-cloud-cli-gke-gcloud-auth-plugin \
         binutils \
         curl \
         gettext \


### PR DESCRIPTION
The hydra image build is broken on every branch. Any PR labelled **New Hydra Version** now fails with:

```
E: Package 'google-cloud-sdk' has no installation candidate
E: Package 'google-cloud-sdk-gke-gcloud-auth-plugin' has no installation candidate
```

Last green hydra build was 2026-09-02 06:26 UTC; the first failure was 10:11 UTC the same day. Nothing
changed on our side in between — the packages disappeared from Google's apt repo.

## Cause

Google renamed the whole family at 467.0.0 as part of the Cloud SDK → gcloud CLI rebrand, keeping
`google-cloud-sdk*` as transitional packages. Those stubs have now been dropped. Probing the live repo:

| component | `Release` | `google-cloud-sdk*` | `google-cloud-cli` |
|---|---|---|---|
| `cloud-sdk` | 200 | **0** | 49 versions |
| `cloud-sdk-trixie` / `-bookworm` / `-bullseye` / `-jammy` | 200 | **0** | 49 versions |

So it was *not* moved to another repo — the name is retired everywhere. The suite name `cloud-sdk` and
the `sources.list` line are unchanged; only the package names moved. The lineage is still visible in the
new package's own metadata:

```
Package: google-cloud-cli
Replaces: google-cloud-sdk (<< 467.0.0-0)

Package: google-cloud-cli-gke-gcloud-auth-plugin
Replaces: google-cloud-sdk-gke-gcloud-auth-plugin (<< 467.0.0-0)
```

That `Replaces` is why apt could *name* the replacement in its error while still having nothing to install.

## Fix

Use the `google-cloud-cli` names. This also aligns the Dockerfile with `sdcm/mgmt/operations.py:158`,
which already installed `google-cloud-cli` — only the Dockerfile had lagged.

## Testing

Built the `apt_repos` stage from this repo's own Dockerfile, then installed both renamed packages against
the live repo from the sources.list it generates:

```
Setting up google-cloud-cli-gke-gcloud-auth-plugin (583.0.0-0) ...
Setting up google-cloud-cli (583.0.0-0) ...
Google Cloud SDK 583.0.0
gke-gcloud-auth-plugin 0.5.19
```

Also verified end-to-end on #15937, where the full **New Hydra Version** build went green with this commit
and published `scylladb/hydra:v1.146-PR15937-a744fac`.

## Backporting

Split out of #15937 precisely so it can go back to every release branch. All six active targets need it,
but in **two different layouts** — the bot will not manage all of them unaided:

| branch | file | bot backport |
|---|---|---|
| `branch-2026.3` / `2026.2` / `2026.1` / `perf-v17` | `Dockerfile` | should apply |
| `branch-2025.1` | `docker/env/Dockerfile` | **will conflict — different path** |
| `branch-2024.1` | `docker/env/Dockerfile` | **will conflict — different path** |

Two more things worth knowing for those two:

- `branch-2025.1`'s workflow `paths:` filter already lists `docker/env/Dockerfile`, so the label will
  trigger a build there once the fix lands.
- `branch-2024.1` has **no** `build-docker-image.yaml` at all, so it has no label-driven build — its
  image has to be produced manually via `docker/env/build_n_push.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
