### PR TITLE
fix(microbenchmark): give perf-cql-raw enough memory to start

### DIFF
--- a/microbenchmarking_test.py
+++ b/microbenchmarking_test.py
@@ -85,6 +85,10 @@ class PerfCqlRawTest(MicrobenchmarkTest):
     * The standard ports, plus memory and cpus. The node's own scylla-server already holds
       native_transport_port 9042 and api_port 10000, so it is stopped for the duration of the run
       and started again afterwards.
+    * I/O scheduler properties. Outside developer mode scylla refuses to start unless one of
+      --io-properties / --io-properties-file is given, so the node's own iotune output is passed
+      in. It describes the data disk while --workdir is on /tmp, which is fine: seastar registers
+      a placeholder queue for devid 0 and routes any unconfigured device to it.
 
     The command line matches what the tool's developers run, so results stay comparable with
     theirs. Changing RESOURCE_OPTIONS or DURATION invalidates the Argus baseline, which is why
@@ -92,7 +96,12 @@ class PerfCqlRawTest(MicrobenchmarkTest):
     """
 
     WORKDIR = "/tmp/scylla-perf-cql-raw-workdir"
-    RESOURCE_OPTIONS = "--smp 2 --cpus 0,1 -m 2G"
+    IO_PROPERTIES_FILE = "/etc/scylla.d/io_properties.yaml"
+    # -m must cover 1 GiB per shard plus the 50 MiB per shard scylla takes out of it for wasm
+    # UDFs, or it refuses to start: 2G over 2 shards left 974 MiB/shard and died. 3G leaves
+    # 1486 MiB/shard. The instance must be big enough for that too - seastar reserves a flat
+    # 1.5 GiB for the OS, which is why the test-cases ask for xlarge rather than large.
+    RESOURCE_OPTIONS = "--smp 2 --cpus 0,1 -m 3G"
     DURATION = 60
 
     # Only long standing options are set, so this stays valid across the scylla versions the
@@ -112,6 +121,7 @@ endpoint_snitch: SimpleSnitch
     def run_workload(self, workload: str) -> None:
         node = self.db_cluster.nodes[0]
         scylla_bin = node.add_install_prefix("/usr/bin/scylla")
+        io_properties_file = node.add_install_prefix(self.IO_PROPERTIES_FILE)
         result_file = "perf-cql-raw-result.json"
         conf_file = f"{self.WORKDIR}/conf/scylla.yaml"
 
@@ -129,6 +139,7 @@ endpoint_snitch: SimpleSnitch
             results = node.remoter.run(
                 f"{scylla_bin} perf-cql-raw --json-result {result_file}"
                 f" --workdir {self.WORKDIR} --options-file {conf_file}"
+                f" --io-properties-file {io_properties_file}"
                 f" {self.RESOURCE_OPTIONS} --workload {workload} --duration {self.DURATION}"
             )
             if results.ok:

--- a/test-cases/microbenchmarking/amazon_perf_cql_raw_ARM.yaml
+++ b/test-cases/microbenchmarking/amazon_perf_cql_raw_ARM.yaml
@@ -7,7 +7,7 @@ n_monitor_nodes: 0
 n_db_nodes: 1
 use_mgmt: false
 
-instance_type_db: 'c8g.large'
+instance_type_db: 'c8g.xlarge'
 data_volume_disk_num: 1
 user_prefix: 'perf-cql-raw-amazon-ARM'
 argus_email_report_template: email_report_performance_microbenchmarks.yaml

--- a/test-cases/microbenchmarking/amazon_perf_cql_raw_x86.yaml
+++ b/test-cases/microbenchmarking/amazon_perf_cql_raw_x86.yaml
@@ -1,2 +1,2 @@
-instance_type_db: 'c8i.large'
+instance_type_db: 'c8i.xlarge'
 user_prefix: 'perf-cql-raw-amazon-x86'


### PR DESCRIPTION
perf-cql-raw boots a full scylla server in process, so it goes through the same startup checks as scylla-server. Three of those - the NOFILE rlimit, the memory per shard and the I/O scheduler configuration - only warn when scylla runs in developer mode, and throw otherwise (main.cc:923-925). The tool's own example command line in test/perf/perf_cql_raw.cc passes --developer-mode 1, which is why the benchmark used to start while that flag was still on the command line here. Developer mode does not make the configuration correct, it makes scylla tolerate an incorrect one, and its own description warns it "can reduce performance and reliability significantly" - not something a performance benchmark should run under. So the checks have to be satisfied for real, and without the flag scylla fails to start until they are.

The first one to fail is the memory check:

```Only 974 MiB per shard; this is below the recommended minimum of 1 GiB/shard; terminating. Startup failed: std::runtime_error (configuration (memory per shard too low))```

Scylla takes db::config::wasm_udf_reserved_memory (50 MiB) per shard out of -m before splitting it, so 2G over two shards leaves 974 MiB each - 50 MiB under the floor verify_adequate_memory_per_shard() enforces. -m is an absolute cap, so this failed identically on c8i.large, c7i.large and c8i.xlarge.

Raise -m to 3G, which leaves 1486 MiB/shard. The instance types have to grow with it: seastar reserves a flat 1.5 GiB for the OS, which caps -m at about 2.2 GiB on a 4 GiB node, so the request would be rejected there as insufficient physical memory instead. On xlarge the cap is about 6 GiB.

Second of the startup checks that only warn under developer mode. With enough memory to get past verify_adequate_memory_per_shard(), perf-cql-raw stops at verify_seastar_io_scheduler() instead:

I/O Scheduler is not properly configured! This is a non-supported setup, and performance is expected to be unpredictably bad.
Reason found: none of --io-properties and --io-properties-file are set. Startup failed: std::runtime_error (Bad I/O Scheduler configuration)

Outside developer mode scylla refuses to start rather than run with an unconfigured I/O scheduler. The check only tests that one of the two options is present, so pass the node's own iotune output. That is also what a benchmark wants: it now runs with the disk's measured properties rather than with none.

Follow up for https://github.com/scylladb/scylla-cluster-tests/pull/15812

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [test read, x86_64](https://argus.scylladb.com/tests/scylla-cluster-tests/bd29fa29-8495-4ebd-8dfb-6112712a8ef4)
- [x] [test write, x86_64](https://argus.scylladb.com/tests/scylla-cluster-tests/3f4d47ed-7d16-4d0b-a3c0-0954d8f6c102)
- [x] [test read, arm64](https://argus.scylladb.com/tests/scylla-cluster-tests/f59a1f09-d697-44cc-aed5-bf3bbf100351)
- [x] [test write, arm64](https://argus.scylladb.com/tests/scylla-cluster-tests/3f4f397c-3f86-4507-8363-2e983000fab5)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
