### PR TITLE
fix(nemesis): skip node_operations cleanups when the target node was destroyed

### DIFF
--- a/sdcm/nemesis/utils/node_operations.py
+++ b/sdcm/nemesis/utils/node_operations.py
@@ -8,6 +8,11 @@ from sdcm.cluster import BaseNode
 LOGGER = logging.getLogger(__name__)
 
 
+def is_node_destroyed(node: BaseNode) -> bool:
+    """Whether the node object outlived the instance it represents."""
+    return node.destroyed or not node.remoter
+
+
 @contextlib.contextmanager
 def block_scylla_ports(target_node: BaseNode, ports: list[int] | None = None):
     ports = ports or [7001, 7000, 9042, 9142, 19042, 19142]
@@ -20,6 +25,10 @@ def block_scylla_ports(target_node: BaseNode, ports: list[int] | None = None):
         target_node.remoter.sudo(f"ip6tables -A INPUT -p tcp --dport {port} -j DROP")
         target_node.remoter.sudo(f"ip6tables -A OUTPUT -p tcp --dport {port} -j DROP")
     yield
+
+    if is_node_destroyed(target_node):
+        target_node.log.debug("Node %s was destroyed, skipping iptables cleanup", target_node.name)
+        return
     target_node.log.debug("Remove all iptable rules %s", target_node.name)
     for port in ports:
         target_node.remoter.sudo(f"iptables -D INPUT -p tcp --dport {port} -j DROP")
@@ -34,6 +43,10 @@ def pause_scylla_with_sigstop(target_node: BaseNode):
     target_node.log.debug("Send signal SIGSTOP to scylla process on node %s", target_node.name)
     target_node.remoter.sudo("pkill --signal SIGSTOP -e scylla", timeout=60)
     yield
+
+    if is_node_destroyed(target_node):
+        target_node.log.debug("Node %s was destroyed, skipping SIGCONT", target_node.name)
+        return
     target_node.log.debug("Send signal SIGCONT to scylla process on node %s", target_node.name)
     target_node.remoter.sudo(cmd="pkill --signal SIGCONT -e scylla", timeout=60)
 
@@ -61,7 +74,11 @@ def block_loaders_payload_for_scylla_node(scylla_node: BaseNode, loader_nodes: l
             f"ip6tables -A INPUT -s {','.join(blocking_ips)} -p tcp --dport {port} -j DROP", ignore_status=True
         )
     yield
-    # if scylla_node is alive, then delete the iptables rules
+
+    if is_node_destroyed(scylla_node):
+        scylla_node.log.debug("Node %s was destroyed, skipping iptables cleanup", scylla_node.name)
+        return
+
     if scylla_node.remoter.is_up():
         for port in ports:
             scylla_node.remoter.sudo(

--- a/unit_tests/unit/nemesis/__init__.py
+++ b/unit_tests/unit/nemesis/__init__.py
@@ -7,6 +7,56 @@ from sdcm.nemesis import NemesisRunner
 from sdcm.nemesis.registry import NemesisRegistry
 
 
+def make_mock_node(name="node1", rack="rack1", is_seed=False, dc_idx=0, ip_address=None):
+    """Create a ``MagicMock`` that behaves like a minimal *live* cluster node.
+
+    Nemesis code calls arbitrary methods on every node it touches (``run_nodetool``,
+    ``stop_scylla``, ``get_list_of_sstables``, ...), so a plain dataclass is not
+    sufficient - ``MagicMock`` auto-stubs all of them.
+
+    ``destroyed`` and ``remoter.is_up()`` are pinned explicitly rather than left to
+    auto-stubbing: a bare ``MagicMock`` attribute is truthy, so an auto-stubbed node reads
+    as *destroyed*, which would make every "skip cleanup on a destroyed node" guard bypass
+    the code under test and let the assertions pass vacuously.
+
+    Args:
+        name: Node name, as reported by ``node.name``.
+        rack: Rack the node belongs to.
+        is_seed: Whether the node is a seed node.
+        dc_idx: Index of the data center the node belongs to.
+        ip_address: Node IP. Left auto-stubbed when ``None``, since most tests never
+            read it and a shared default would give every node the same address.
+
+    Returns:
+        MagicMock: A mock configured to look like a live node.
+    """
+    node = MagicMock()
+    node.name = name
+    node.rack = rack
+    node.is_seed = is_seed
+    node.dc_idx = dc_idx
+    node.destroyed = False
+    node.remoter.is_up.return_value = True
+    if ip_address is not None:
+        node.ip_address = ip_address
+    return node
+
+
+def sudo_commands(remoter):
+    """Flatten a mock remoter's ``sudo`` calls into the plain command strings issued.
+
+    Takes the remoter rather than the node so it still works for a node destroyed
+    mid-test, since ``BaseNode.destroy()`` sets ``node.remoter`` to ``None``.
+
+    Args:
+        remoter: Mock remoter whose ``sudo`` calls should be collected.
+
+    Returns:
+        list: Commands passed to ``sudo``, positionally or via the ``cmd`` keyword.
+    """
+    return [call.args[0] if call.args else call.kwargs.get("cmd") for call in remoter.sudo.call_args_list]
+
+
 class TestRunner:
     """Lightweight mock runner for nemesis unit tests.
 

--- a/unit_tests/unit/nemesis/monkey/conftest.py
+++ b/unit_tests/unit/nemesis/monkey/conftest.py
@@ -4,25 +4,9 @@ Provides a ``base_runner`` fixture with a pre-configured ``TestRunner``
 that individual test modules can extend for their specific needs.
 """
 
-from unittest.mock import MagicMock
-
 import pytest
 
-from unit_tests.unit.nemesis import TestRunner
-
-
-def make_mock_node(name="node1", rack="rack1", is_seed=False):
-    """Create a ``MagicMock`` that behaves like a minimal cluster node.
-
-    Monkey code calls arbitrary methods on every node in ``data_nodes``
-    (``run_nodetool``, ``stop_scylla``, ``get_list_of_sstables``, …), so a
-    plain dataclass is not sufficient — ``MagicMock`` auto-stubs all of them.
-    """
-    node = MagicMock()
-    node.name = name
-    node.rack = rack
-    node.is_seed = is_seed
-    return node
+from unit_tests.unit.nemesis import TestRunner, make_mock_node
 
 
 @pytest.fixture()

--- a/unit_tests/unit/nemesis/monkey/test_node_isolation.py
+++ b/unit_tests/unit/nemesis/monkey/test_node_isolation.py
@@ -12,21 +12,9 @@ from sdcm.nemesis.monkey.node_isolation import (
     refuse_connection_from_banned_node,
     switch_target_node_to_another_rack,
 )
+from unit_tests.unit.nemesis import make_mock_node, sudo_commands
 
 pytestmark = pytest.mark.usefixtures("events")
-
-
-def _node(name="node1", rack="rack1", dc_idx=0):
-    node = MagicMock()
-    node.name = name
-    node.rack = rack
-    node.dc_idx = dc_idx
-    return node
-
-
-def _sudo_commands(node):
-    """Flatten node.remoter.sudo call args/kwargs into the plain command strings issued."""
-    return [call.args[0] if call.args else call.kwargs.get("cmd") for call in node.remoter.sudo.call_args_list]
 
 
 def _working_node(runner):
@@ -50,9 +38,9 @@ def _instant_wait_for(func, step=1, text=None, timeout=None, throw_exc=True, sto
 
 def test_is_single_node_in_rack(base_runner):
     """A node counts as alone only when no other data node shares both its rack and dc."""
-    target = _node("node1", rack="rack1", dc_idx=0)
-    peer_same_rack = _node("node2", rack="rack1", dc_idx=0)
-    peer_other_dc = _node("node3", rack="rack1", dc_idx=1)
+    target = make_mock_node("node1", rack="rack1", dc_idx=0)
+    peer_same_rack = make_mock_node("node2", rack="rack1", dc_idx=0)
+    peer_other_dc = make_mock_node("node3", rack="rack1", dc_idx=1)
     base_runner.cluster.data_nodes = [target, peer_same_rack, peer_other_dc]
 
     assert not is_single_node_in_rack(base_runner, target)
@@ -66,11 +54,11 @@ def test_switch_target_node_to_another_rack(base_runner):
     base_runner.cluster.params = {"rack_aware_loader": True}
     base_runner.target_node.parent_cluster.racks_count = 2
     base_runner.loaders = MagicMock()
-    base_runner.loaders.nodes = [_node("loader1", rack="rack1")]
+    base_runner.loaders.nodes = [make_mock_node("loader1", rack="rack1")]
     base_runner.set_target_node = MagicMock()
     base_runner.cluster.nodes = [
-        _node("node1", rack="rack1"),
-        _node("node2", rack="rack2"),
+        make_mock_node("node1", rack="rack1"),
+        make_mock_node("node2", rack="rack2"),
     ]
 
     switch_target_node_to_another_rack(base_runner)
@@ -177,10 +165,8 @@ def test_open_driver_issue_triggers_rack_switch(mock_skip_per_issues, runner):
 
     runner.cluster.params.get.return_value = True  # rack_aware_loader on
     runner.target_node.parent_cluster.racks_count = 2
-    loader = _node("loader1", rack="rack1")
-    loader.ip_address = "10.0.0.2"
-    runner.loaders.nodes = [loader]
-    runner.cluster.nodes = [runner.target_node, _node("node-other-rack", rack="rack2")]
+    runner.loaders.nodes = [make_mock_node("loader1", rack="rack1", ip_address="10.0.0.2")]
+    runner.cluster.nodes = [runner.target_node, make_mock_node("node-other-rack", rack="rack2")]
     runner.set_target_node = MagicMock()
 
     refuse_connection_from_banned_node(runner, use_iptables=True)
@@ -279,7 +265,7 @@ def test_iptables_path_blocks_and_unblocks_every_scylla_port(runner):
 
     runner.node_allocator.run_nemesis.assert_called_once_with(nemesis_label="block_scylla_ports")
 
-    commands = _sudo_commands(runner.target_node)
+    commands = sudo_commands(runner.target_node.remoter)
     for port in (7000, 7001, 9042, 9142, 19042, 19142):
         for table, action in (("iptables", "A"), ("iptables", "D"), ("ip6tables", "A"), ("ip6tables", "D")):
             assert commands.count(f"{table} -{action} INPUT -p tcp --dport {port} -j DROP") == 1
@@ -293,6 +279,41 @@ def test_iptables_path_blocks_and_unblocks_every_scylla_port(runner):
     )
 
 
+def test_loader_unblock_is_skipped_when_removal_destroyed_the_target_node(runner):
+    """SCT-920: ``ExitStack`` unwinds LIFO, so ``_finalizer`` — pushed *after*
+    ``block_loaders_payload_for_scylla_node`` was entered — runs *before* that context
+    manager's cleanup. ``_finalizer`` calls ``_remove_node_add_node``, which terminates the
+    target instance and calls ``BaseNode.destroy()``, dropping ``node.remoter`` to ``None``.
+
+    The loader-unblock cleanup must notice the node is gone and skip, instead of raising
+    ``AttributeError: 'NoneType' object has no attribute 'is_up'`` and reporting a false
+    nemesis failure for a disruption that actually succeeded.
+    """
+    target = runner.target_node
+    target_remoter = target.remoter  # captured: `destroy()` will null out target.remoter
+    runner.loaders.nodes = [make_mock_node("loader1", rack="rack1", ip_address="10.0.0.2")]
+
+    def _destroy_target_node(**_):
+        """Mirror what BaseNode.destroy() does to a node terminated by removenode."""
+        target.remoter = None
+        target.destroyed = True
+
+    runner._remove_node_add_node.side_effect = _destroy_target_node
+
+    IsolateNodeWithIptableRuleNemesis(runner).disrupt()
+
+    runner._remove_node_add_node.assert_called_once()
+    commands = sudo_commands(target_remoter)
+    for port in (9042, 9142, 19042, 19142):
+        rule = f"INPUT -s 10.0.0.2 -p tcp --dport {port} -j DROP"
+        # loaders were blocked while the node was alive ...
+        assert commands.count(f"iptables -A {rule}") == 1
+        assert commands.count(f"ip6tables -A {rule}") == 1
+        # ... but no unblock is attempted on the terminated instance
+        assert f"iptables -D {rule}" not in commands
+        assert f"ip6tables -D {rule}" not in commands
+
+
 def test_sigstop_path_pauses_scylla_and_only_blocks_gossip_ports_during_removal(runner):
     """``IsolateNodeWithProcessSignalNemesis`` (use_iptables=False) must SIGSTOP/SIGCONT
     the scylla process, and additionally DROP only the inter-node ports (7000/7001)
@@ -302,7 +323,7 @@ def test_sigstop_path_pauses_scylla_and_only_blocks_gossip_ports_during_removal(
 
     runner.node_allocator.run_nemesis.assert_called_once_with(nemesis_label="pause_scylla_with_sigstop")
 
-    commands = _sudo_commands(runner.target_node)
+    commands = sudo_commands(runner.target_node.remoter)
     assert commands.count("pkill --signal SIGSTOP -e scylla") == 1
     assert commands.count("pkill --signal SIGCONT -e scylla") == 1
 

--- a/unit_tests/unit/nemesis/test_node_operations.py
+++ b/unit_tests/unit/nemesis/test_node_operations.py
@@ -1,0 +1,190 @@
+"""Tests for sdcm.nemesis.utils.node_operations module."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from sdcm.nemesis.utils.node_operations import (
+    block_loaders_payload_for_scylla_node,
+    block_scylla_ports,
+    is_node_destroyed,
+    pause_scylla_with_sigstop,
+)
+from unit_tests.unit.nemesis import make_mock_node, sudo_commands
+
+LOADER_IPS = "10.0.0.2,10.0.0.3"
+CQL_PORTS = (9042, 9142, 19042, 19142)
+GOSSIP_PORTS = (7000, 7001)
+
+
+@pytest.fixture()
+def scylla_node():
+    """The live Scylla node that the context managers under test act on."""
+    return make_mock_node("node1")
+
+
+@pytest.fixture()
+def loader_nodes():
+    """Loaders whose payload gets blocked; their addresses make up ``LOADER_IPS``."""
+    return [
+        make_mock_node("loader1", ip_address="10.0.0.2"),
+        make_mock_node("loader2", ip_address="10.0.0.3"),
+    ]
+
+
+def _loader_rules(commands, action):
+    """Loader-blocking INPUT rules issued with the given iptables action (``A`` or ``D``)."""
+    return [cmd for cmd in commands if cmd and f" -{action} INPUT -s {LOADER_IPS} " in cmd]
+
+
+def _destroy(node):
+    """Apply to ``node`` what ``BaseNode.destroy()`` does to a terminated instance."""
+    node.remoter = None
+    node.destroyed = True
+
+
+# ---------------------------------------------------------------------------
+# is_node_destroyed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "destroyed,has_remoter,expected",
+    [
+        pytest.param(False, True, False, id="live-node"),
+        pytest.param(True, False, True, id="destroyed-node"),
+        pytest.param(True, True, True, id="flag-set-before-remoter-dropped"),
+        pytest.param(False, False, True, id="remoter-dropped-before-flag-set"),
+    ],
+)
+def test_is_node_destroyed_detects_either_half_of_destroy(destroyed, has_remoter, expected):
+    """``BaseNode.destroy()`` drops the remoter and raises the ``destroyed`` flag in two
+    separate statements, so a reader can observe either one first. Both must count."""
+    node = make_mock_node("node1")
+    node.destroyed = destroyed
+    node.remoter = MagicMock() if has_remoter else None
+
+    assert is_node_destroyed(node) is expected
+
+
+# ---------------------------------------------------------------------------
+# block_loaders_payload_for_scylla_node
+# ---------------------------------------------------------------------------
+
+
+def test_block_loaders_payload_live_node_removes_every_rule(scylla_node, loader_nodes):
+    """The happy path: every CQL port is DROPped for the loader IPs on enter and the
+    matching rule is deleted on exit, after which the iptables service is stopped."""
+    remoter = scylla_node.remoter
+
+    with block_loaders_payload_for_scylla_node(scylla_node, loader_nodes=loader_nodes):
+        pass
+
+    commands = sudo_commands(remoter)
+    for port in CQL_PORTS:
+        rule = f"INPUT -s {LOADER_IPS} -p tcp --dport {port} -j DROP"
+        assert commands.count(f"iptables -A {rule}") == 1
+        assert commands.count(f"ip6tables -A {rule}") == 1
+        assert commands.count(f"iptables -D {rule}") == 1
+        assert commands.count(f"ip6tables -D {rule}") == 1
+    scylla_node.install_package.assert_called_once_with("iptables")
+    scylla_node.stop_service.assert_called_once_with("iptables", ignore_status=True)
+
+
+def test_block_loaders_payload_destroyed_node_skips_cleanup(scylla_node, loader_nodes):
+    """SCT-920: the node may be removed from the cluster and terminated inside the ``with``
+    block. Cleanup must then skip rather than raise ``AttributeError: 'NoneType' object has
+    no attribute 'is_up'`` on the dropped remoter."""
+    remoter = scylla_node.remoter
+
+    with block_loaders_payload_for_scylla_node(scylla_node, loader_nodes=loader_nodes):
+        _destroy(scylla_node)
+
+    commands = sudo_commands(remoter)
+    assert len(_loader_rules(commands, "A")) == 2 * len(CQL_PORTS)  # iptables + ip6tables
+    assert _loader_rules(commands, "D") == []
+    scylla_node.stop_service.assert_not_called()
+
+
+def test_block_loaders_payload_destroy_flag_only_skips_cleanup(scylla_node, loader_nodes):
+    """``destroyed`` alone is enough to skip: the instance is gone, so its iptables rules
+    went with it even if the remoter object happens to still be around."""
+    with block_loaders_payload_for_scylla_node(scylla_node, loader_nodes=loader_nodes):
+        scylla_node.destroyed = True
+
+    assert _loader_rules(sudo_commands(scylla_node.remoter), "D") == []
+    scylla_node.remoter.is_up.assert_not_called()
+    scylla_node.stop_service.assert_not_called()
+
+
+def test_block_loaders_payload_unreachable_node_skips_cleanup(scylla_node, loader_nodes):
+    """Pre-existing behaviour, kept intact by the SCT-920 guard: a node that still has a
+    remoter but is not reachable gets no cleanup commands either."""
+    scylla_node.remoter.is_up.return_value = False
+
+    with block_loaders_payload_for_scylla_node(scylla_node, loader_nodes=loader_nodes):
+        pass
+
+    assert _loader_rules(sudo_commands(scylla_node.remoter), "D") == []
+    scylla_node.stop_service.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# block_scylla_ports
+# ---------------------------------------------------------------------------
+
+
+def test_block_scylla_ports_live_node_removes_every_rule(scylla_node):
+    """Every requested port is DROPped in both directions and both IP families on enter,
+    and each rule is deleted again on exit."""
+    remoter = scylla_node.remoter
+
+    with block_scylla_ports(scylla_node, ports=list(GOSSIP_PORTS)):
+        pass
+
+    commands = sudo_commands(remoter)
+    for port in GOSSIP_PORTS:
+        for table in ("iptables", "ip6tables"):
+            for chain in ("INPUT", "OUTPUT"):
+                assert commands.count(f"{table} -A {chain} -p tcp --dport {port} -j DROP") == 1
+                assert commands.count(f"{table} -D {chain} -p tcp --dport {port} -j DROP") == 1
+    scylla_node.stop_service.assert_called_once_with("iptables", ignore_status=True)
+
+
+def test_block_scylla_ports_destroyed_node_skips_cleanup(scylla_node):
+    """Hardening against the SCT-920 failure mode: a caller that removes and terminates the
+    node it just blocked must not make the unblock step raise on the dropped remoter."""
+    remoter = scylla_node.remoter
+
+    with block_scylla_ports(scylla_node, ports=list(GOSSIP_PORTS)):
+        _destroy(scylla_node)
+
+    assert [cmd for cmd in sudo_commands(remoter) if cmd and " -D " in cmd] == []
+    scylla_node.stop_service.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# pause_scylla_with_sigstop
+# ---------------------------------------------------------------------------
+
+
+def test_pause_scylla_with_sigstop_live_node_sends_sigcont(scylla_node):
+    """The paused scylla process is resumed again once the block exits."""
+    with pause_scylla_with_sigstop(scylla_node):
+        pass
+
+    assert sudo_commands(scylla_node.remoter) == [
+        "pkill --signal SIGSTOP -e scylla",
+        "pkill --signal SIGCONT -e scylla",
+    ]
+
+
+def test_pause_scylla_with_sigstop_destroyed_node_skips_sigcont(scylla_node):
+    """Hardening against the SCT-920 failure mode: there is no process left to resume once
+    the instance has been terminated."""
+    remoter = scylla_node.remoter
+
+    with pause_scylla_with_sigstop(scylla_node):
+        _destroy(scylla_node)
+
+    assert sudo_commands(remoter) == ["pkill --signal SIGSTOP -e scylla"]


### PR DESCRIPTION
`refuse_connection_from_banned_node` registers two cleanups on the same `ExitStack`: `block_loaders_payload_for_scylla_node` is entered first, then a finalizer that calls `_remove_node_add_node`.  The finalizer always runs first - it removes the target node from the cluster, terminates the instance and calls `BaseNode.destroy()`, which sets `destroyed` and drops the remoter to `None`.

The loader-unblock cleanup then ran `scylla_node.remoter.is_up()` unconditionally and crashed with `AttributeError: 'NoneType' object has no attribute 'is_up'`, marking a disruption that had actually succeeded as failed.

This regressed in e2b38a5fc (fix for SCT-870): before it, `destroy()` kept the remoter object around and only stopped it, so `is_up()` returned False and cleanup was skipped gracefully. Restore that behaviour with an explicit `is_node_destroyed` guard - skipping is correct here, the terminated instance took its iptables rules with it. `block_scylla_ports` and `pause_scylla_with_sigstop` get the same guard: no current caller removes the node from inside those blocks, but the failure mode would be identical.

Tests: `make_mock_node` and `sudo_commands` move to `unit_tests/unit/nemesis/__init__.py` so the mock-node factory is not duplicated across the monkey conftest and two test files. The factory must pin `destroyed = False` - a bare `MagicMock` attribute is truthy, so an auto-stubbed node reads as destroyed and would make the new guards bypass the code under test, letting the assertions pass vacuously.

Fixes: SCT-920

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ Job is running ](https://argus.scylladb.com/tests/scylla-cluster-tests/e67c51e6-9379-4a37-a415-d1b106baea0f)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
