### PR TITLE
fix(perf trigger): make bi-weekly/3-weekly crons fire the intended number of times

### DIFF
--- a/configurations/triggers/perf-regression.yaml
+++ b/configurations/triggers/perf-regression.yaml
@@ -19,13 +19,18 @@ cron_triggers:
       job_folder: "scylla-master"
       labels_selector: "alternator-weekly"
       requested_by_user: "radoslawcybulski"
-  - schedule: "00 6 */14 * *"
+  # 1st and 16th of the month, 06:00 UTC — exactly 2 runs/month.
+  # NOT "*/14": day-of-month steps restart every month, so */14 fires on days
+  # 1, 15 AND 29 (3 runs/month), with the 29th only 2-3 days before the next 1st.
+  - schedule: "00 6 1,16 * *"
     params:
       scylla_version: "{branch}:latest"
       job_folder: "scylla-master"
       labels_selector: "master-2weeks"
       requested_by_user: "juliayakovlev"
-  - schedule: "0 23 */21 * *"
+  # 1st of the month, 23:00 UTC — 1 run/month.
+  # Was "*/21", which fires on days 1 and 22, i.e. 2 runs/month.
+  - schedule: "0 23 1 * *"
     params:
       scylla_version: "{branch}:latest"
       job_folder: "scylla-master"

--- a/docs/testing/trigger-matrix.md
+++ b/docs/testing/trigger-matrix.md
@@ -167,6 +167,13 @@ and already present on the perf-regression trigger.
 The two matrices are deliberately in **opposite phase**: tier1's heavier half shares a weekend with
 rolling-upgrade's lighter half.
 
+**Never use `*/N` in day-of-month.** The step restarts at day 1 of every month, so the interval is not
+kept across the month boundary and the run count varies with month length: `*/14` fires on days 1, 15
+and 29 — three runs a month, the last only two days before the next first — and `*/21` fires on days 1
+and 22, twice a month. When a schedule is *not* AND-ed with a day-of-week, spell the days out instead;
+`perf-regression.yaml` uses `00 6 1,16 * *` for `master-2weeks` (exactly two runs a month) and
+`0 23 1 * *` for `master-3weeks`.
+
 ### Backend Filtering
 
 ```bash

--- a/jenkins-pipelines/master-triggers/sct_triggers/perf-regression-trigger.jenkinsfile
+++ b/jenkins-pipelines/master-triggers/sct_triggers/perf-regression-trigger.jenkinsfile
@@ -6,8 +6,8 @@ triggerMatrixPipeline(
     matrix_file: 'configurations/triggers/perf-regression.yaml',
     cron: '''0 8 * * * % scylla_version={branch}:latest;job_folder=scylla-master;labels_selector=alternator-daily;requested_by_user=radoslawcybulski
 0 8 * * 6 % scylla_version={branch}:latest;job_folder=scylla-master;labels_selector=alternator-weekly;requested_by_user=radoslawcybulski
-00 6 */14 * * % scylla_version={branch}:latest;job_folder=scylla-master;labels_selector=master-2weeks;requested_by_user=juliayakovlev
-0 23 */21 * * % scylla_version={branch}:latest;job_folder=scylla-master;labels_selector=master-3weeks;requested_by_user=juliayakovlev
+00 6 1,16 * * % scylla_version={branch}:latest;job_folder=scylla-master;labels_selector=master-2weeks;requested_by_user=juliayakovlev
+0 23 1 * * % scylla_version={branch}:latest;job_folder=scylla-master;labels_selector=master-3weeks;requested_by_user=juliayakovlev
 0 6 1 * * % scylla_version={branch}:latest;job_folder=scylla-master;labels_selector=master-monthly;requested_by_user=juliayakovlev
 13 6 8-14 * 2 % scylla_version={branch}:latest;job_folder=scylla-master;labels_selector=gce-custom-monthly;requested_by_user=valerii.ponomarov'''
 )


### PR DESCRIPTION
`*/N` in the **day-of-month** field does not keep an N-day interval. Jenkins restarts the step at day 1 of every month, so the number of runs depends on month length and the last run of a month lands right before the first of the next one.

Reviewing the scheduled triggers that are meant to run every other week, two crons in `configurations/triggers/perf-regression.yaml` were affected:

| label | before | actually fired on | runs/month | after | runs/month |
|---|---|---|---|---|---|
| `master-2weeks` | `00 6 */14 * *` | 1, 15, **29** | 3 | `00 6 1,16 * *` | 2 |
| `master-3weeks` | `0 23 */21 * *` | 1, 22 | 2 | `0 23 1 * *` | 1 |

The bi-weekly cadence was introduced to halve the cost of the i8g latency/throughput perf jobs (SCT-715); firing three times a month gave back most of that saving. Spelling the days out makes the cadence exact and independent of month length.

### Notes

- `master-monthly` also fires on the 1st, at 06:00 — `master-3weeks` now runs the same day at 23:00. They select disjoint job sets (`labels_selector` is AND-matched), so nothing is triggered twice.
- `tier1.yaml` and `rolling-upgrade.yaml` are **not** affected: their `week-a`/`week-b` alternation (SCT-716) already avoids step syntax by AND-ing a day-of-month window with day-of-week (`00 06 1-7,15-21,29-31 * 6` / `00 06 8-14,22-28 * 6`).
- `vars/perfRegressionParallelPipelinebyRegion.groovy` still carries the pre-matrix inline cron block including a `*/21`, but no jenkinsfile calls that pipeline any more — left untouched.
- The `.jenkinsfile` change is generated by `utils/build_system/generate_trigger_jenkinsfiles.py` (pre-commit hook `generate-trigger-jenkinsfiles`), not hand-edited.
- `docs/testing/trigger-matrix.md` now states the `*/N` day-of-month rule explicitly, next to the existing `week-a`/`week-b` explanation.

### Testing

- `generate_trigger_jenkinsfiles.py` re-run is a no-op (exit 0) — YAML and generated Jenkinsfile in sync.
- `pytest unit_tests/trigger_matrix` — 269 passed.
- `pre-commit run --files <changed>` — clean.

Refs: https://scylladb.atlassian.net/browse/SCT-715

🤖 Generated with [Claude Code](https://claude.com/claude-code)
