### PR TITLE
fix(scylla-doctor): stop a stuck node from hanging tearDown

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -255,6 +255,9 @@ except ImportError:
 
 TEST_LOG = logging.getLogger(__name__)
 
+# timeout for the full scylla-doctor collection during failure handling
+SCYLLA_DOCTOR_TEARDOWN_TIMEOUT = 30 * 60
+
 PYTHON_THREAD_LIST = (KafkaCDCReaderThread, KafkaProducerThread, KafkaValidatorThread)
 
 
@@ -4231,15 +4234,26 @@ class ClusterTester(unittest.TestCase):
                 # per node and can take tens of minutes per node, so a serial pass over a large
                 # cluster (e.g. 60 nodes) previously took 40+ minutes. Workers are capped to avoid
                 # spawning an unbounded number of threads/SSH sessions on very large clusters.
-                with ThreadPoolExecutor(max_workers=min(len(ready_nodes), 20)) as executor:
-                    for future in as_completed(
-                        executor.submit(run_scylla_doctor_on_node, node) for node in ready_nodes
-                    ):
+                # Timed out nodes are reported and skipped so tearDown can continue collecting logs
+                executor = ThreadPoolExecutor(max_workers=min(len(ready_nodes), 20))
+                futures = {executor.submit(run_scylla_doctor_on_node, node): node for node in ready_nodes}
+                try:
+                    for future in as_completed(futures, timeout=SCYLLA_DOCTOR_TEARDOWN_TIMEOUT):
                         # run_scylla_doctor_on_node handles its own errors; guard against unexpected ones.
                         try:
                             future.result()
                         except Exception as exc:  # noqa: BLE001
-                            self.log.warning("Unexpected error running scylla-doctor on a node: %s", exc)
+                            self.log.warning(
+                                "Unexpected error running scylla-doctor on node %s: %s", futures[future].name, exc
+                            )
+                except TimeoutError:
+                    self.log.warning(
+                        "scylla-doctor did not finish within %s seconds on nodes %s, giving up on them",
+                        SCYLLA_DOCTOR_TEARDOWN_TIMEOUT,
+                        [node.name for future, node in futures.items() if not future.done()],
+                    )
+                finally:
+                    executor.shutdown(wait=False, cancel_futures=True)
             except Exception as exc:  # noqa: BLE001
                 self.log.warning("Unexpected error when collecting scylla-doctor info: %s", exc)
 

--- a/unit_tests/test_scylla_doctor.py
+++ b/unit_tests/test_scylla_doctor.py
@@ -659,3 +659,21 @@ def test_run_analysis_phase_report_not_created(mock_node, mock_test_config):
 
     with pytest.raises(ScyllaDoctorException, match="Analysis report file"):
         doc.run_analysis_phase()
+
+
+# --- run() timeout tests ---
+
+
+@pytest.mark.parametrize(
+    "is_nonroot_install,remoter_method",
+    [
+        pytest.param(False, "sudo", id="root_install_runs_via_sudo"),
+        pytest.param(True, "run", id="nonroot_install_runs_via_login_shell"),
+    ],
+)
+def test_run_passes_run_timeout_to_the_remoter(doctor, is_nonroot_install, remoter_method):
+    """Doctor commands must be time-bounded to avoid hanging on an unresponsive Scylla."""
+    doctor.node.is_nonroot_install = is_nonroot_install
+    doctor.run(sd_command="scylla-doctor --save-vitals node.vitals.json")
+    _args, kwargs = getattr(doctor.node.remoter, remoter_method).call_args
+    assert kwargs["timeout"] == ScyllaDoctor.RUN_TIMEOUT

--- a/unit_tests/unit/test_tester.py
+++ b/unit_tests/unit/test_tester.py
@@ -12,6 +12,7 @@
 # Copyright (c) 2020 ScyllaDB
 import json
 import logging
+import threading
 import time
 import types
 import unittest.mock
@@ -807,3 +808,54 @@ def test_get_cluster_docker_nonzero_monitor_nodes_builds_monitor_set_docker(tmp_
 
     cluster_docker_mock.MonitorSetDocker.assert_called_once()
     assert tester.monitors is cluster_docker_mock.MonitorSetDocker.return_value
+
+
+# --- scylla-doctor gather_failure_statistics tests ---
+
+
+def _make_ready_node(name):
+    node = MagicMock()
+    node.name = name
+    node.is_nonroot_install = False
+    node._is_node_ready_run_scylla_commands.return_value = True
+    node.run_nodetool.return_value = MagicMock(ok=True, stdout="nodetool output", stderr="")
+    return node
+
+
+def test_gather_failure_statistics_scylla_doctor_stuck_node_does_not_block_teardown(tmp_path, monkeypatch, caplog):
+    """A scylla-doctor run that never returns on one node must not stall the rest of tearDown."""
+    release = threading.Event()
+    stuck_node, fast_node = _make_ready_node("stuck-node"), _make_ready_node("fast-node")
+
+    def fake_scylla_doctor(node, test_config, offline_install):  # noqa: ARG001
+        doctor = MagicMock(json_result_file="", scylla_logs_file="", is_full_edition=False)
+        doctor.install_scylla_doctor.side_effect = release.wait if node.name == "stuck-node" else None
+        return doctor
+
+    monkeypatch.setattr("utils.scylla_doctor.ScyllaDoctor", fake_scylla_doctor)
+    monkeypatch.setattr("sdcm.tester.SCYLLA_DOCTOR_TEARDOWN_TIMEOUT", 1)
+
+    tester = ClusterTesterForTests()
+    tester._init_logging(tmp_path / "test_scylla_doctor_stuck_node")
+    tester.logdir = str(tmp_path)
+    tester.db_cluster = MagicMock()
+    tester.db_cluster.nodes = [stuck_node, fast_node]
+    tester.params = MagicMock()
+    tester.params.get.side_effect = lambda key, default=None: {"use_scylla_doctor_on_failure": True}.get(key, default)
+
+    worker = threading.Thread(target=tester.gather_failure_statistics, daemon=True)
+    with caplog.at_level(logging.INFO):
+        worker.start()
+        worker.join(timeout=15)
+        finished = not worker.is_alive()
+    release.set()  # let the stuck doctor thread go so it does not outlive the test
+    worker.join(timeout=15)
+
+    assert finished, "gather_failure_statistics was still blocked on the stuck node after 15 s"
+    assert "Scylla-doctor completed for node fast-node" in caplog.text
+    assert "Failure statistics collection completed" in caplog.text
+    assert [
+        record.getMessage()
+        for record in caplog.records
+        if record.levelno == logging.WARNING and "stuck-node" in record.getMessage()
+    ], "the node whose scylla-doctor never finished was not reported"

--- a/utils/scylla_doctor.py
+++ b/utils/scylla_doctor.py
@@ -31,6 +31,7 @@ class ScyllaDoctor:
     SCYLLA_DOCTOR_OFFLINE_BUCKET_PREFIX = "downloads/scylla-doctor/tar/"
     SCYLLA_DOCTOR_OFFLINE_BIN = "scylla_doctor.pyz"
     SCYLLA_DOCTOR_OFFLINE_CONF = "scylla_doctor.conf"
+    RUN_TIMEOUT = 20 * 60
     SCYLLA_DOCTOR_DISABLED_OFFLINE_COLLECTORS = dedent("""
         [GossipInfoCollector]
         ; Doesn't work with systemd-user service
@@ -137,9 +138,9 @@ class ScyllaDoctor:
         if self.python3_path:
             sd_command = f"{self.python3_path} {sd_command}"
         if not self.node.is_nonroot_install:
-            result = self.node.remoter.sudo(sd_command, verbose=False)
+            result = self.node.remoter.sudo(sd_command, verbose=False, timeout=self.RUN_TIMEOUT)
         else:
-            result = self.node.remoter.run(f"bash -lce '{sd_command}'", verbose=False)
+            result = self.node.remoter.run(f"bash -lce '{sd_command}'", verbose=False, timeout=self.RUN_TIMEOUT)
         return result.stdout.strip()
 
     @cached_property


### PR DESCRIPTION
ScyllaDoctor.run has no remote command execution timeout and tearDown can wait on the doctor thread pool without a limit, so one node where Scylla does not answer can hold tearDown until the Jenkins stage timeout. The fix adds to each doctor invocation a 20 min timeout, and bounds the whole collection to 30 min. Logs the nodes that did not finish and shuts the pool down without waiting.

Refs: SCT-810

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] few runs of AWS sanity longevity test on minicloud - job [mc-longevity-10gb-1h](https://jenkins.scylladb.com/job/scylla-staging/job/dimakr/job/mc/job/mc-longevity-10gb-1h/).
Builds 22-24 with this fix  were able to finish SCT teardown, opposite to build 21 which stuck on teardown with the issue in question (the builds 22-24 are red due to known limitations of minicloud, where not all nemeses are supported yet).

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code