### PR TITLE
improvement(perf skill): add cql-raw weekly microbenchmarks to test registry

### DIFF
--- a/skills/perf-weekly-status-report/SKILL.md
+++ b/skills/perf-weekly-status-report/SKILL.md
@@ -60,7 +60,7 @@ This violates the repo-wide rule that commands must be non-interactive, and in a
 argus run list --test-id <ANY_TEST_ID> --limit 1 --url https://argus.scylladb.com
 ```
 
-If the output contains `Waiting for login...`, tell the user a browser login is required and wait for it to complete before proceeding. Never launch the 16-test collection loop as the first Argus call -- a login prompt mid-fan-out produces confusing partial failures.
+If the output contains `Waiting for login...`, tell the user a browser login is required and wait for it to complete before proceeding. Never launch the 20-test collection loop as the first Argus call -- a login prompt mid-fan-out produces confusing partial failures.
 
 ### Gmail-Compatible HTML
 
@@ -254,6 +254,20 @@ These are the enterprise performance tests tracked in the weekly report:
 | simple-query-weekly-microbenchmark_arm64-write | dcc1afa0-2225-468c-9f45-5cfc8486f7f8 | Microbenchmarks |
 | simple-query-weekly-microbenchmark_x86_64 | 03464849-60e8-46c8-91b9-955cdeb07ea6 | Microbenchmarks |
 | simple-query-weekly-microbenchmark_x86_64-write | 6e745123-cb53-482b-836c-0609bd36a4e6 | Microbenchmarks |
+| cql-raw-weekly-microbenchmark_arm64 | 474ac937-cbc7-45d1-9375-746b8328f51b | Microbenchmarks |
+| cql-raw-weekly-microbenchmark_arm64-write | 68b9d59b-bf4e-4aa1-abea-032e0fd7fa8d | Microbenchmarks |
+| cql-raw-weekly-microbenchmark_x86_64 | e62a078f-924b-4662-a77b-bd9daa6e2241 | Microbenchmarks |
+| cql-raw-weekly-microbenchmark_x86_64-write | 006ddbcc-b344-4bb5-ac1b-374588305aa4 | Microbenchmarks |
+
+Test names in this table are the Jenkins job names with the `scylla-enterprise-perf-` prefix
+stripped; the jobs live under `scylla-enterprise/perf-regression/` and their pipeline definitions
+under `jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/`.
+
+> **`cql-raw` vs `simple-query`:** these are different tests, not architecture variants of one.
+> `cql-raw` runs `microbenchmarking_test.PerfCqlRawTest`, `simple-query` runs `PerfSimpleQueryTest`.
+> Beware the `scylla-staging/yulia/...` copies of the cql-raw jobs: they default `test_name` to
+> `PerfSimpleQueryTest`, so a staging run can silently be a different test. Confirm via the run's
+> `test_method` field before treating a cql-raw run as a cql-raw result.
 
 **Most of this registry is usually empty for a given week, and that is expected.** These tests are not all scheduled weekly, and several run predominantly on release branches -- their runs get filtered out by the master-only rule. It is normal for whole categories (i8g Vnodes, i4i Tablets, i4i Vnodes) to contribute zero rows because they only ran release builds such as `2026.2.2` / `2026.1.9`.
 

--- a/skills/perf-weekly-status-report/workflows/generate-report.md
+++ b/skills/perf-weekly-status-report/workflows/generate-report.md
@@ -48,7 +48,7 @@ Step-by-step process for generating the Gmail-compatible HTML performance report
    - `build_number`
    - `packages[]` (installed packages)
 
-**Exit criteria:** JSON data collected for all 16 tests.
+**Exit criteria:** JSON data collected for all 20 tests.
 
 ## Phase 1a: Ask Build Type (if not specified)
 
@@ -537,7 +537,7 @@ argus run list --test-id d6ebf1a5-135f-43fc-a7ba-0716b60dfa94 --limit 1 \
 DAYS=${DAYS:-7}
 AFTER=$(date -d "${DAYS} days ago" +%s)
 
-# 2. Collect data for one test (repeat for all 16)
+# 2. Collect data for one test (repeat for all 20)
 argus run list \
   --test-id d6ebf1a5-135f-43fc-a7ba-0716b60dfa94 \
   --after $AFTER \
@@ -547,7 +547,7 @@ argus run list \
 
 # 3. Filter master (~dev) versions (in Python/jq)
 # Keep only runs where scylla_version matches ^\d{4}\.\d+\.\d+.+dev$
-# Expect most of the 16 tests to yield zero master runs -- that is normal.
+# Expect most of the 20 tests to yield zero master runs -- that is normal.
 
 # 4. Fetch results per filtered run
 argus run results \


### PR DESCRIPTION
Adds the four `scylla-enterprise-perf-cql-raw-weekly-microbenchmark` jobs (arm64, arm64-write, x86_64, x86_64-write) to the `perf-weekly-status-report` skill's test registry, taking it from 16 to 20 tracked tests. Without this the weekly report silently omitted them.

| Test Name | Test ID |
|---|---|
| cql-raw-weekly-microbenchmark_arm64 | `474ac937-cbc7-45d1-9375-746b8328f51b` |
| cql-raw-weekly-microbenchmark_arm64-write | `68b9d59b-bf4e-4aa1-abea-032e0fd7fa8d` |
| cql-raw-weekly-microbenchmark_x86_64 | `e62a078f-924b-4662-a77b-bd9daa6e2241` |
| cql-raw-weekly-microbenchmark_x86_64-write | `006ddbcc-b344-4bb5-ac1b-374588305aa4` |

## How the test IDs were obtained

The `argus` CLI has no test-search command, so they were resolved via Jenkins: each job's latest build description carries the Argus run link, and `argus run get --run-id <id>` maps that run to its `test_id`. Every ID was then verified by running the registry's own query against it:

```
argus run list --test-id <ID> --after <ts> --limit 200 --full --no-cache --url https://argus.scylladb.com
```

All four return runs, and each run's `test_method` confirms `microbenchmarking_test.PerfCqlRawTest`.

## Documentation added

Two things that cost time while adding these, now recorded under the registry table:

- The registry naming convention -- entries are the Jenkins job name with the `scylla-enterprise-perf-` prefix stripped -- plus where the jobs and their pipeline definitions live.
- That `cql-raw` and `simple-query` are **different tests**, not architecture variants of one, and that the `scylla-staging/yulia/...` copies of the cql-raw jobs default `test_name` to `PerfSimpleQueryTest`. A run's `test_method` must be checked before it is treated as a cql-raw result.

Also updates the three stale "16 tests" references in `SKILL.md` and `workflows/generate-report.md`.

## Testing

Verified by generating the weekly report over 2026-08-26..2026-09-06 with the updated registry: all four new tests were picked up, contributing 9 master (`2026.4.0~dev`) runs that the previous 16-test registry missed entirely.

Docs-only change to a skill directory -- no runtime code paths touched.