### PR TITLE
improvement(perf trigger): add cql-raw weekly microbenchmark jobs

### DIFF
--- a/configurations/triggers/perf-regression.yaml
+++ b/configurations/triggers/perf-regression.yaml
@@ -185,6 +185,36 @@ jobs:
       region: "us-east-1"
       microbenchmark: "true"
 
+  - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-cql-raw-weekly-microbenchmark_x86_64"
+    backend: "aws"
+    labels: []
+    params:
+      region: "us-east-1"
+      microbenchmark: "true"
+
+  - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-cql-raw-weekly-microbenchmark_x86_64-write"
+    backend: "aws"
+    labels: []
+    params:
+      region: "us-east-1"
+      microbenchmark: "true"
+
+  - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-cql-raw-weekly-microbenchmark_arm64"
+    backend: "aws"
+    arch: "aarch64"
+    labels: []
+    params:
+      region: "us-east-1"
+      microbenchmark: "true"
+
+  - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-cql-raw-weekly-microbenchmark_arm64-write"
+    backend: "aws"
+    arch: "aarch64"
+    labels: []
+    params:
+      region: "us-east-1"
+      microbenchmark: "true"
+
   # === Daily sanity perf (master-only) ===
 
   - job_name: "/scylla-master/perf-regression/perf-regression-predefined-throughput-steps-sanity-vnodes"


### PR DESCRIPTION
Trigger the enterprise cql-raw weekly microbenchmarks (x86_64 and arm64, read and write) alongside the existing simple-query ones.

The entries carry an empty `labels` list on purpose. Every cron schedule in this matrix passes a `labels_selector`, and job filtering requires a job to carry all of the selector's labels, so a job with no labels never matches a cron. These jobs are therefore triggered only by release-version runs — the trigger invoked with a concrete scylla_version and no selector — which is what we want: the cql-raw microbenchmarks measure each release build rather than running on a fixed schedule against master.

The arm64 entries declare `arch: aarch64` so their versions resolve against ARM images; without it job_arch() falls back to x86_64.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
