### PR TITLE
fix(triggers): propagate requested_by_user to downstream jobs

### DIFF
--- a/vars/managerPipeline.groovy
+++ b/vars/managerPipeline.groovy
@@ -454,14 +454,16 @@ def call(Map pipelineParams) {
                                         [$class: 'StringParameterValue', name: 'target_scylla_mgmt_server_address', value: params.scylla_mgmt_address],
                                         [$class: 'StringParameterValue', name: 'target_scylla_mgmt_agent_address', value: params.scylla_mgmt_agent_address],
                                         [$class: 'StringParameterValue', name: 'TARGET_MANAGER_VERSION', value: params.manager_version],
-                                        [$class: 'StringParameterValue', name: 'provision_type', value: params.provision_type]
+                                        [$class: 'StringParameterValue', name: 'provision_type', value: params.provision_type],
+                                        [$class: 'StringParameterValue', name: 'requested_by_user', value: params.requested_by_user]
                                     ]
                                 } else {
                                     repoParams = [
                                         [$class: 'StringParameterValue', name: 'scylla_mgmt_address', value: params.scylla_mgmt_address],
                                         [$class: 'StringParameterValue', name: 'scylla_mgmt_agent_address', value: params.scylla_mgmt_agent_address],
                                         [$class: 'StringParameterValue', name: 'manager_version', value: params.manager_version],
-                                        [$class: 'StringParameterValue', name: 'provision_type', value: params.provision_type]
+                                        [$class: 'StringParameterValue', name: 'provision_type', value: params.provision_type],
+                                        [$class: 'StringParameterValue', name: 'requested_by_user', value: params.requested_by_user]
                                     ]
                                 }
                                 triggerJob(fullJobPath, repoParams)

--- a/vars/simpleTrigger.groovy
+++ b/vars/simpleTrigger.groovy
@@ -22,6 +22,11 @@ def call(List jobs) {
             string(name: "post_behavior_k8s_cluster",
                    defaultValue: "destroy",
                    description: "keep|keep-on-failure|destroy")
+            // Forwarded to every triggered job by the params.collect{} below, so the
+            // downstream run keeps the requester of the trigger that started it.
+            string(name: "requested_by_user",
+                   defaultValue: "",
+                   description: "Actual user requesting job start, for automated job builds (e.g. through Argus)")
         }
         stages {
             stage("Trigger Tests") {

--- a/vars/simpleTrigger.groovy
+++ b/vars/simpleTrigger.groovy
@@ -22,9 +22,6 @@ def call(List jobs) {
             string(name: "post_behavior_k8s_cluster",
                    defaultValue: "destroy",
                    description: "keep|keep-on-failure|destroy")
-            string(name: "post_behavior_k8s_cluster",
-                    defaultValue: "destroy",
-                    description: "keep|keep-on-failure|destroy")
         }
         stages {
             stage("Trigger Tests") {


### PR DESCRIPTION
Fixes [SCT-951](https://scylladb.atlassian.net/browse/SCT-951).

Two Groovy dispatch sites launch downstream jobs without forwarding `requested_by_user`, so those runs arrive with an upstream build cause and no record of who asked for them.

- `vars/simpleTrigger.groovy` forwards its whole `params` map to every job it triggers, but never declared `requested_by_user` — so there was nothing in the map to forward. Declaring it is enough; the existing `params.collect { ... }` picks it up.
- `vars/managerPipeline.groovy` declares the parameter but omits it from the `repoParams` lists handed to `triggerJob()`, in both the upgrade and non-upgrade branches.

## Why it matters

The cost-approval gate planned under [SCT-851](https://scylladb.atlassian.net/browse/SCT-851) has to know who requested a run so it can stop that person approving it themselves. When a run is started by a bot, a timer, or an upstream job there is no authenticated Jenkins identity, and `requested_by_user` is the only requester signal there is.

Sampling recent builds on the controller, counting only jobs that declare the parameter:

| Build cause | builds | populated |
| --- | --- | --- |
| `UserIdCause` | 23 | 23 |
| `BuildUpstreamCause` | 172 | 0 |
| `UpstreamCause` | 17 | 0 |

Populated exactly where Jenkins already knows the user and it is redundant; empty exactly where it is the only signal.

## Not touched

- The trigger-matrix path already propagates correctly (`triggerMatrixPipeline` passes `--requested-by-user`, `sct.py` puts it in `overrides`, `trigger_matrix()` merges it into downstream params).
- `perfSimpleQueryOfflineInstallerTrigger{X86,Arm}` and `perfRegressionParallelPipelinebyRegion` already pass it explicitly.
- `vars/byoScylladb.groovy` also drops it, but it triggers a ScyllaDB *build* job rather than an SCT test run, so no cost gate applies. Left alone deliberately.

## Drive-by

First commit removes a duplicated `post_behavior_k8s_cluster` declaration in `simpleTrigger`'s `parameters` block — the same parameter was declared twice, differing only in indentation. Kept separate so it can be reviewed or dropped on its own.

## Testing

The `lint-pipelines` hook does not compile `vars/*.groovy`, so a syntax error here would only surface when Jenkins loads the library. Both modified files were parsed for real with `GroovyShell.parse` in a `groovy:4.0-jdk17` container — both OK. `sct.py pre-commit` passes.

Not yet exercised on a live trigger run; worth confirming a trigger-launched build shows a populated `requested_by_user` before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SCT-951]: https://scylladb.atlassian.net/browse/SCT-951?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SCT-851]: https://scylladb.atlassian.net/browse/SCT-851?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ