### PR TITLE
fix(jenkins-jobs): escape XML in generated job descriptions

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -2710,6 +2710,7 @@ def create_operator_test_release_jobs(branch, username, password, sct_branch, sc
         create_freestyle_jobs=triggers,
         template_context={"release_version": get_latest_scylla_release(product="scylla-enterprise")},
     )
+    server.raise_on_failures()
 
 
 @cli.command("create-manager-test-release-jobs", help="Create pipeline jobs for a new scylla-manager branch/release")
@@ -2730,6 +2731,7 @@ def create_manager_test_release_jobs(branch, username, password, sct_branch, sct
         create_freestyle_jobs=triggers,
         template_context={"release_version": get_latest_scylla_release(product="scylla-enterprise")},
     )
+    server.raise_on_failures()
 
 
 @cli.command("create-qa-tools-jobs", help="Create pipeline jobs for a new scylla-operator branch/release")
@@ -2748,6 +2750,7 @@ def create_qa_tools_jobs(username, password, sct_branch, sct_repo, triggers):
     server.create_job_tree(
         f"{server.base_sct_dir}/jenkins-pipelines/qa", create_freestyle_jobs=triggers, job_name_suffix=""
     )
+    server.raise_on_failures()
 
 
 @cli.command("create-performance-jobs", help="Create pipeline jobs for performance")
@@ -2769,6 +2772,7 @@ def create_performance_jobs(username, password, sct_branch, sct_repo, triggers):
         create_freestyle_jobs=triggers,
         job_name_suffix="",
     )
+    server.raise_on_failures()
 
 
 @cli.command("create-nemesis-yaml")
@@ -2821,6 +2825,9 @@ def create_test_release_jobs(branch, username, password, sct_branch, sct_repo):
     if branch == "scylla-master":
         base_path = f"{server.base_sct_dir}/jenkins-pipelines/master-triggers"
         server.create_job_tree(base_path)
+
+    # every tree is walked before failing, so one bad job never hides the others
+    server.raise_on_failures()
 
 
 @cli.command(

--- a/unit_tests/unit/test_job_xml_generation.py
+++ b/unit_tests/unit/test_job_xml_generation.py
@@ -7,6 +7,7 @@ which aborted the whole ``create-test-release-jobs`` run on the first offending
 job.
 """
 
+import logging
 import xml.etree.ElementTree as ET
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -78,3 +79,41 @@ def test_markup_in_test_metadata_description_is_escaped(jenkins_pipelines, tmp_p
 )
 def test_every_pipeline_renders_valid_xml(jenkins_pipelines, jenkins_file):
     ET.fromstring(_render(jenkins_pipelines, jenkins_file))
+
+
+def test_tree_walk_continues_past_a_failing_job(jenkins_pipelines, tmp_path, caplog):
+    """One unrenderable job must not stop the walk, and must be named in the log."""
+    pipelines = tmp_path / "jenkins-pipelines" / "oss" / "fake"
+    pipelines.mkdir(parents=True)
+    for name in ("aaa", "bbb", "ccc"):
+        (pipelines / f"{name}.jenkinsfile").write_text("longevityPipeline()\n", encoding="utf-8")
+
+    original = jenkins_pipelines.create_pipeline_job
+
+    def explode_on_bbb(jenkins_file, **kwargs):
+        if Path(jenkins_file).stem == "bbb":
+            raise ValueError("boom")
+        return original(jenkins_file, **kwargs)
+
+    jenkins_pipelines.create_pipeline_job = explode_on_bbb
+    jenkins_pipelines.base_sct_dir = tmp_path
+    with (
+        patch("utils.build_system.create_test_release_jobs.get_sct_root_path", return_value=tmp_path),
+        caplog.at_level(logging.ERROR),
+    ):
+        jenkins_pipelines.create_job_tree(tmp_path / "jenkins-pipelines" / "oss")
+
+    created = [call[0][0] for call in jenkins_pipelines.jenkins.create_job.call_args_list]
+    assert any(name.endswith("/aaa-test") for name in created)
+    assert any(name.endswith("/ccc-test") for name in created)
+    assert not any(name.endswith("/bbb-test") for name in created)
+
+    assert [str(source) for source, _ in jenkins_pipelines.failures] == ["jenkins-pipelines/oss/fake/bbb.jenkinsfile"]
+    assert "jenkins-pipelines/oss/fake/bbb.jenkinsfile" in caplog.text
+
+    with pytest.raises(RuntimeError, match="1 job\\(s\\) could not be created"):
+        jenkins_pipelines.raise_on_failures()
+
+
+def test_raise_on_failures_is_quiet_when_everything_worked(jenkins_pipelines):
+    jenkins_pipelines.raise_on_failures()

--- a/unit_tests/unit/test_job_xml_generation.py
+++ b/unit_tests/unit/test_job_xml_generation.py
@@ -1,0 +1,80 @@
+"""Guard the XML rendered for Jenkins pipeline jobs against unescaped markup.
+
+Job descriptions are built from free text (``test_metadata.description`` in the
+test-case YAML, ``_folder_definitions.yaml`` dumps) and interpolated into
+``template.xml``. Any ``<``/``&`` in that text used to land in the XML verbatim,
+which aborted the whole ``create-test-release-jobs`` run on the first offending
+job.
+"""
+
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from sdcm.utils.common import get_sct_root_path
+from utils.build_system.create_test_release_jobs import JenkinsPipelines
+
+SCT_ROOT = Path(get_sct_root_path())
+PIPELINES_DIR = SCT_ROOT / "jenkins-pipelines"
+
+
+@pytest.fixture()
+def jenkins_pipelines():
+    with (
+        patch("utils.build_system.create_test_release_jobs.KeyStore"),
+        patch("utils.build_system.create_test_release_jobs.jenkins.Jenkins"),
+    ):
+        jp = JenkinsPipelines(
+            base_job_dir="scylla-master",
+            sct_branch_name="master",
+            sct_repo="git@github.com:scylladb/scylla-cluster-tests.git",
+            username="test",
+            password="test",
+        )
+        jp.jenkins = MagicMock()
+        jp.jenkins.job_exists.return_value = False
+        jp.build_job_and_wait_completion = MagicMock()
+        yield jp
+
+
+def _render(jenkins_pipelines, jenkins_file: Path) -> str:
+    jenkins_pipelines.jenkins.create_job.reset_mock()
+    jenkins_pipelines.create_pipeline_job(jenkins_file, group_name="")
+    return jenkins_pipelines.jenkins.create_job.call_args[0][1]
+
+
+def test_markup_in_test_metadata_description_is_escaped(jenkins_pipelines, tmp_path):
+    """A description holding ``<backend>`` must not open a bogus XML tag."""
+    test_case = tmp_path / "test-cases" / "fake" / "fake.yaml"
+    test_case.parent.mkdir(parents=True)
+    test_case.write_text(
+        "test_metadata:\n"
+        "  description: run via configurations/<backend>/fake.yaml overlays & friends\n"
+        "  tier: tier1\n"
+        "  test_type: longevity\n"
+        "  duration_class: short\n"
+        "  supported_backends:\n"
+        "    - aws\n",
+        encoding="utf-8",
+    )
+    jenkins_file = tmp_path / "jenkins-pipelines" / "oss" / "fake" / "fake.jenkinsfile"
+    jenkins_file.parent.mkdir(parents=True)
+    jenkins_file.write_text(f"longevityPipeline(\n    test_config: '{test_case.relative_to(tmp_path)}',\n)\n")
+
+    with patch("utils.build_system.create_test_release_jobs.get_sct_root_path", return_value=tmp_path):
+        xml_data = _render(jenkins_pipelines, jenkins_file)
+
+    root = ET.fromstring(xml_data)
+    assert "<backend>" in root.find("description").text
+    assert root.find("testMetadata/tier").text == "tier1"
+
+
+@pytest.mark.parametrize(
+    "jenkins_file",
+    sorted(PIPELINES_DIR.rglob("*.jenkinsfile")),
+    ids=lambda path: str(path.relative_to(PIPELINES_DIR)),
+)
+def test_every_pipeline_renders_valid_xml(jenkins_pipelines, jenkins_file):
+    ET.fromstring(_render(jenkins_pipelines, jenkins_file))

--- a/utils/build_system/create_test_release_jobs.py
+++ b/utils/build_system/create_test_release_jobs.py
@@ -11,6 +11,7 @@
 #
 # Copyright (c) 2021 ScyllaDB
 
+import contextlib
 import os
 import logging
 from pathlib import Path
@@ -44,6 +45,9 @@ class JenkinsPipelines:
         self.base_job_dir = base_job_dir
         self.sct_branch_name = sct_branch_name
         self.sct_repo = sct_repo
+        # (source file, error) for every job this run could not create/reconfigure.
+        # Collected instead of raised so one bad job can't hide the rest of the tree.
+        self.failures: list[tuple[Path, str]] = []
 
     def reconfig_job(self, new_path, dir_xml_data):
         self.jenkins.reconfig_job(new_path, dir_xml_data)
@@ -443,6 +447,31 @@ class JenkinsPipelines:
             LOGGER.warning("Could not inject testMetadata XML from %s", jenkins_file, exc_info=True)
             return xml_data
 
+    @contextlib.contextmanager
+    def _collect_failure(self, source_file: Path):
+        """Log and record a failing job, then carry on with the rest of the tree.
+
+        A single unrenderable job used to abort the whole walk, silently skipping every
+        folder ordered after it. Failures are collected here and re-raised together by
+        raise_on_failures(), so the run still goes red but reports all of them at once.
+        """
+        try:
+            yield
+        except Exception as ex:  # noqa: BLE001 - one bad job must not stop the tree
+            rel = source_file
+            with contextlib.suppress(ValueError):
+                rel = source_file.relative_to(self.base_sct_dir)
+            LOGGER.error("FAILED to create job from %s: %s: %s", rel, type(ex).__name__, ex, exc_info=True)
+            self.failures.append((rel, f"{type(ex).__name__}: {ex}"))
+
+    def raise_on_failures(self):
+        """Fail the run if any job could not be created, naming every one of them."""
+        if not self.failures:
+            return
+        summary = "\n".join(f"  {source} -> {error}" for source, error in self.failures)
+        LOGGER.error("%d job(s) could not be created:\n%s", len(self.failures), summary)
+        raise RuntimeError(f"{len(self.failures)} job(s) could not be created:\n{summary}")
+
     def create_job_tree(
         self,
         local_path: str | Path,
@@ -476,14 +505,17 @@ class JenkinsPipelines:
                 job_file = Path(root) / job_file  # noqa: PLW2901
                 if (job_file.suffix == ".jenkinsfile") and create_pipelines_jobs:
                     suffix = "" if job_file.stem.endswith("-trigger") else job_name_suffix
-                    self.create_pipeline_job(
-                        job_file,
-                        group_name=jenkins_path,
-                        job_name_suffix=suffix,
-                        defines={**defines, **self.locate_job_overrides(job_file.stem, job_overrides)},
-                    )
+                    with self._collect_failure(job_file):
+                        self.create_pipeline_job(
+                            job_file,
+                            group_name=jenkins_path,
+                            job_name_suffix=suffix,
+                            defines={**defines, **self.locate_job_overrides(job_file.stem, job_overrides)},
+                        )
                 if (job_file.suffix == ".xml") and create_freestyle_jobs:
-                    self.create_freestyle_job(job_file, group_name=jenkins_path, template_context=template_context)
+                    with self._collect_failure(job_file):
+                        self.create_freestyle_job(job_file, group_name=jenkins_path, template_context=template_context)
 
             if create_pipelines_jobs:
-                self.process_symlinks(Path(root), jenkins_path, job_name_suffix, defines)
+                with self._collect_failure(Path(root) / "_symlinks.yaml"):
+                    self.process_symlinks(Path(root), jenkins_path, job_name_suffix, defines)

--- a/utils/build_system/create_test_release_jobs.py
+++ b/utils/build_system/create_test_release_jobs.py
@@ -16,6 +16,7 @@ import logging
 from pathlib import Path
 import re
 import xml.etree.ElementTree as ET
+from xml.sax.saxutils import escape as xml_escape
 
 import jenkins
 import yaml
@@ -59,7 +60,9 @@ class JenkinsPipelines:
 
     def create_directory(self, name: Path | str, display_name: str, description: str = ""):
         try:
-            dir_xml_data = DIR_TEMPLATE % dict(sct_display_name=display_name, sct_description=description)
+            dir_xml_data = DIR_TEMPLATE % dict(
+                sct_display_name=xml_escape(display_name), sct_description=xml_escape(description)
+            )
             new_path = str(Path(self.base_job_dir) / name)
 
             if self.jenkins.job_exists(new_path):
@@ -122,8 +125,8 @@ class JenkinsPipelines:
             description = f"{description}\n\n{metadata_block}"
 
         xml_data = JOB_TEMPLATE % dict(
-            sct_display_name=f"{base_name}{job_name_suffix}",
-            sct_description=description,
+            sct_display_name=xml_escape(f"{base_name}{job_name_suffix}"),
+            sct_description=xml_escape(description),
             sct_repo=self.sct_repo,
             sct_branch_name=self.sct_branch_name,
             sct_jenkinsfile=sct_jenkinsfile,
@@ -436,8 +439,8 @@ class JenkinsPipelines:
                 for backend in meta["supported_backends"]:
                     ET.SubElement(backends_elem, "backend").text = str(backend)
             return ET.tostring(root, encoding="unicode", xml_declaration=True)
-        except OSError, KeyError, ValueError, TypeError:
-            LOGGER.debug("Could not inject testMetadata XML from %s", jenkins_file, exc_info=True)
+        except OSError, KeyError, ValueError, TypeError, ET.ParseError:
+            LOGGER.warning("Could not inject testMetadata XML from %s", jenkins_file, exc_info=True)
             return xml_data
 
     def create_job_tree(


### PR DESCRIPTION
## What

`QA-tools/create-sct-test-jobs-for-branch` has been failing since [#961](https://jenkins.scylladb.com/job/QA-tools/job/create-sct-test-jobs-for-branch/961/) / [#962](https://jenkins.scylladb.com/view/QA/job/QA-tools/job/create-sct-test-jobs-for-branch/962/), with nothing in the log but a bare traceback:

```
xml.etree.ElementTree.ParseError: mismatched tag: line 11, column 52
```

No job name, no file — just a stack ending in `_inject_test_metadata_xml`, out of ~980 jobs.

## Root cause

Job descriptions are assembled from free text — `test_metadata.description` in the test-case YAML, the `_folder_definitions.yaml` dump — and interpolated straight into `<description>` in `template.xml` with no escaping.

`test-cases/gemini/gemini-basic-3h.yaml` documents its per-backend overlays as:

```yaml
    via the configurations/<backend>/gemini-basic-3h.yaml sizing overlays.
```

so the rendered XML opens a `<backend>` tag that is never closed. `ET.fromstring` raises `ET.ParseError`, which subclasses `SyntaxError` — so none of `_inject_test_metadata_xml`'s `except OSError, KeyError, ValueError, TypeError` clauses caught it and the exception escaped all the way out of `create_job_tree`.

The tree is walked in `os.walk` order, and `gemini` comes before `features`, `artifacts-offline-install`, `artifacts` and `alternator` — so **the run died before reaching those four folders**. Nothing in them had been created or reconfigured since. That is why `scylla-master/artifacts/artifacts-debian13-test` was never created after #15978 merged.

## Which PR broke it

**#15854** — `feature(oracle): support the oracle cluster on GCE and Azure` (commit `d961e11a72`), which added that description line.

It went unnoticed because of the cadence. The job-creator's timer only fires weekly (Saturday ~01:56 UTC) and only for `scylla-master`, `scylla-master/releng-testing` and `branch-perf-v17`:

| Build | When | master rev | `<backend>` line present? | Result |
|---|---|---|---|---|
| #958 | 2026-08-30 01:56 | `496bb81299` | no | SUCCESS |
| — | 2026-08-31 11:58 | `d961e11a72` merged | — | — |
| #961/#962 | 2026-09-06 01:42/01:56 | `5fbbee4c66` | yes | FAILURE |

So there was exactly one green run between the PR merging and the first failure, six days later — and the failure surfaced in a cron job nobody was watching, not on the PR.

## Why CI didn't catch it

Nothing in CI renders a Jenkins job config. The `lint test-cases` stage runs `sct.py lint-pipelines`, which validates the SCT config and the `TestMetadata` pydantic model; the only check on `description` is **TD-002**, "non-empty and at least 20 characters" (`sdcm/utils/lint/docs_linter.py:62-66`). A description containing `<backend>` satisfies that perfectly.

`grep -rn "create_pipeline_job\|JOB_TEMPLATE\|create_job_tree"` across `Jenkinsfile`, `*.sh` and `*.groovy` returns nothing — job XML was only ever built inside the weekly Jenkins job itself. That stage is also wrapped in `catchError(buildResult: 'SUCCESS', ...)`, so even a lint failure would not have gone red on the PR.

This PR closes that gap: rendering now happens in the unit-test suite, on every PR.

## Changes

**1. Escape the interpolated text** (`0f479b40`)

- `xml_escape()` the description and display name in `create_pipeline_job` and `create_directory`. Nothing relies on HTML in a description — no jenkinsfile in the tree uses a `jobDescription` block, and no `_folder_definitions.yaml` sets `folder-description` — so escaping is safe.
- Catch `ET.ParseError` in `_inject_test_metadata_xml` and log at `warning` rather than `debug`, as a second layer: a malformed job degrades to "no `testMetadata` element" instead of aborting.

**2. Name the file, and finish the walk** (`fd130fe3`)

- Each per-job call is wrapped in `_collect_failure()`, which logs the offending **source file** with its exception and records it, then lets the walk continue.
- `raise_on_failures()` fails the run once at the end, listing **every** job that could not be created — not just the first. All five `sct.py create-*-jobs` commands call it after their last `create_job_tree`, so the `scylla-doctor` and `master-triggers` trees still get walked when `oss` has a bad job.

Replaying #962's tree with both guards removed now creates 977 jobs, reaches all four previously-skipped folders, and ends with:

```
1 job(s) could not be created:
  jenkins-pipelines/oss/gemini/gemini-3h.jenkinsfile -> ParseError: mismatched tag: line 11, column 52
```

With the fix in place: 978 jobs, 0 failures.

## Testing

- `unit_tests/unit/test_job_xml_generation.py` — 1157 tests. Renders every `jenkins-pipelines/**/*.jenkinsfile` through `create_pipeline_job` and asserts the result parses, plus focused cases for a description holding `<backend>`/`&`, for the walk continuing past a failure while naming it, and for `raise_on_failures()`.
- Confirmed the new tests **fail** without the fix, on exactly the offending job:
  ```
  FAILED test_job_xml_generation.py::test_markup_in_test_metadata_description_is_escaped
  FAILED test_job_xml_generation.py::test_every_pipeline_renders_valid_xml[oss/gemini/gemini-3h.jenkinsfile]
  ```
- Pre-commit clean (ruff, ruff-format, cyclic-imports, commitlint).
- Scanned `branch-2026.1` / `2026.2` / `2026.3` with the same renderer — 934 / 940 / 937 jenkinsfiles, 0 failures. The bad description is master-only, so no backport is needed.

> [!NOTE]
> The four folders skipped by the aborted runs still need a job-creation pass once this lands. The `scylla-2026.x` folders and their `releng-testing` mirrors have been brought up to date out-of-band; `scylla-master` and `scylla-master/releng-testing` have not.
