### PR TITLE
feature(cost): pre-provisioning cost estimate, and the import fix it needed

### DIFF
--- a/docs/cost-estimation.md
+++ b/docs/cost-estimation.md
@@ -1,0 +1,82 @@
+# Test cost estimation
+
+SCT can tell you roughly what a test run will cost **before** it provisions anything.
+The `Estimate Test Cost` pipeline stage prints it, and you can ask for it yourself:
+
+```bash
+hydra estimate-cost -b aws test-cases/longevity/longevity-10gb-3h.yaml
+```
+
+## Reading the output
+
+```
+Estimated cost of this run: $21.02 (on-demand rates)
+
+  role       nodes  instance type              $/hour   hours      cost
+  db             6  i7i.2xlarge                0.7550    4.25    $19.25
+  loader         2  t3.xlarge                  0.1664    4.25     $1.41
+  monitor        1  t3.large                   0.0832    4.25     $0.35
+```
+
+The headline is the cost of the **whole run**: every node, for the full configured test
+duration. Each row is one cluster role — node count times hourly rate times duration.
+
+`hours` is `test_duration` from the configuration. A run that finishes early costs less; one
+that overruns costs more.
+
+The instance types shown are the *resolved* ones. If a config uses sizing constraints rather
+than literal types, what you see here is what those constraints resolved to.
+
+## What it does not include
+
+Instance hours only. Not counted: storage and volumes, network egress, S3, managed-service
+overhead (EKS/GKE control planes), or anything the test creates itself.
+
+Treat it as an order-of-magnitude figure for deciding whether a run is reasonable — not as a
+bill.
+
+## "PARTIAL" and "unknown"
+
+```
+Estimated cost of this run: $1.77 (on-demand rates) -- PARTIAL, no price for: db
+  db             6  m5.24xlarge                     -    4.25   unknown
+```
+
+A role shows `unknown` when there is no price for its instance type. The total then covers
+only the roles that *could* be priced, and is marked `PARTIAL` — it is a floor, not the
+answer. This is deliberate: a missing price is never reported as zero, because a silent `0`
+reads as "free" and is worse than admitting ignorance.
+
+Causes:
+
+- **OCI** has no usable public pricing, so OCI runs are always unknown.
+- **Instance types outside the catalog.** The catalog covers what SCT actually uses; an
+  unusual type will not be there.
+- **Backends with no cloud instances** — `docker`, `k8s-local-kind*`, `baremetal` — resolve no
+  priceable roles at all.
+
+## Where the prices come from
+
+The checked-in instance catalog under `data/instance_catalog/`, refreshed on a schedule by
+`sct.py sizing update-catalog`.
+
+The estimate deliberately makes **no cloud API calls**. It runs on a Jenkins builder before
+anything exists, and a number telling you what a run will cost should not depend on a cloud
+pricing endpoint being reachable. A type missing from the catalog is reported unknown rather
+than looked up live.
+
+Prices are list prices and do not reflect any negotiated discount.
+
+## Spot runs
+
+Estimates are currently **on-demand rates only**, even when the run is configured for spot.
+Spot typically costs 35-60% of on-demand, so for a spot run the figure is an over-estimate —
+useful as a ceiling, misleading as a prediction.
+
+Spot rates are not in the catalog yet. Adding them is tracked separately.
+
+## Accuracy
+
+Expect the same order of magnitude as the cloud-monitor cost site, not an exact match. That
+site rounds up to whole hours and prices spot differently; this estimate uses fractional hours
+and list on-demand rates.

--- a/docs/cost-estimation.md
+++ b/docs/cost-estimation.md
@@ -49,9 +49,12 @@ reads as "free" and is worse than admitting ignorance.
 
 Causes:
 
-- **OCI** has no usable public pricing, so OCI runs are always unknown.
 - **Instance types outside the catalog.** The catalog covers what SCT actually uses; an
-  unusual type will not be there.
+  unusual type will not be there. Currently the only gaps are the shared-core GCE types
+  (`e2-medium`, `e2-small`, `e2-micro`), which the catalog carries without a price.
+- **A role whose instance type never resolved.** It is listed as `(unresolved)` with its node
+  count, rather than dropped — an estimate missing an entire cluster is worse than one that
+  admits the gap.
 - **Backends with no cloud instances** — `docker`, `k8s-local-kind*`, `baremetal` — resolve no
   priceable roles at all.
 

--- a/sct.py
+++ b/sct.py
@@ -1709,15 +1709,26 @@ def estimate_cost(config_files, backend, duration, output_format, output_file):
         sys.exit(0)
 
     total = f"${estimate.total:,.2f}" if estimate.total is not None else "unknown"
-    click.echo(f"Estimated cost: {total} over {estimate.duration_hours:.2f}h (on-demand rates)")
-    for role in estimate.roles:
-        cost = f"${role.cost:,.2f}" if role.cost is not None else "unknown"
-        click.echo(f"  {role.role:<10} {role.node_count:>3} x {role.instance_type:<22} {cost:>12}")
-    if estimate.is_spot:
-        click.echo("NOTE: run is configured for spot; priced at on-demand, so this is an upper bound.")
+    headline = f"Estimated cost of this run: {total} (on-demand rates)"
     if estimate.partial:
-        unpriced = ", ".join(estimate.unpriced_roles) or "no roles resolved"
-        click.echo(f"WARNING: estimate is PARTIAL - no price for: {unpriced}")
+        missing = ", ".join(estimate.unpriced_roles) or "no roles resolved"
+        headline += f" -- PARTIAL, no price for: {missing}"
+    click.echo("")
+    click.echo(headline)
+    click.echo("")
+    if estimate.roles:
+        click.echo(f"  {'role':<10}{'nodes':>6}  {'instance type':<24}{'$/hour':>9}{'hours':>8}{'cost':>10}")
+        for role in estimate.roles:
+            rate = f"{role.rate.price_per_hour:.4f}" if role.rate.price_per_hour is not None else "-"
+            cost = f"${role.cost:,.2f}" if role.cost is not None else "unknown"
+            click.echo(
+                f"  {role.role:<10}{role.node_count:>6}  {role.instance_type:<24}"
+                f"{rate:>9}{estimate.duration_hours:>8.2f}{cost:>10}"
+            )
+        click.echo("")
+    click.echo("  Instance hours only, for the whole run - no storage, network or other charges.")
+    click.echo("  See docs/cost-estimation.md")
+    click.echo("")
     sys.exit(0)
 
 

--- a/sct.py
+++ b/sct.py
@@ -81,6 +81,7 @@ from sdcm.utils.trigger_matrix import (
     resolve_to_full_version,
     trigger_matrix as run_trigger_matrix,
 )
+from sdcm.utils.cloud_catalog.cost import estimate_run_cost
 from sdcm.utils.argus import (
     ReplayOnlyArgusSCTClient,
     argus_offline_collect_events,
@@ -1666,6 +1667,57 @@ def output_conf(config_files, backend):
         os.environ["SCT_CONFIG_FILES"] = config_files
     config = SCTConfiguration()
     click.secho(config.dump_config(), fg="green")
+    sys.exit(0)
+
+
+@cli.command("estimate-cost", help="Estimate a test run's instance-hour cost from its configuration")
+@click.argument("config_files", type=str, default="")
+@click.option("-b", "--backend", type=click.Choice(available_backends))
+@click.option("--duration", type=float, default=None, help="Override test_duration, in minutes")
+@click.option("--format", "output_format", type=click.Choice(["text", "json"]), default="text", help="Output format")
+@click.option(
+    "--output",
+    "output_file",
+    type=str,
+    default=None,
+    help="Write the JSON estimate to this file. Loading a config prints a lot to stdout, so a "
+    "pipeline should read the file rather than try to parse stdout.",
+)
+def estimate_cost(config_files, backend, duration, output_format, output_file):
+    """Print the estimated instance-hour cost of a run, before anything is provisioned.
+
+    Reads configuration only - no cloud API calls, no runner, no Argus - so it is safe to
+    call as a pipeline pre-flight step. Always exits 0: an unpriceable configuration
+    reports a null total rather than failing the caller.
+    """
+    add_file_logger()
+
+    if backend:
+        os.environ["SCT_CLUSTER_BACKEND"] = backend
+    if config_files:
+        os.environ["SCT_CONFIG_FILES"] = config_files
+    config = SCTConfiguration()
+
+    estimate = estimate_run_cost(config, duration_minutes=duration)
+
+    if output_file:
+        with open(output_file, "w", encoding="utf-8") as fobj:
+            json.dump(estimate.as_dict(), fobj)
+
+    if output_format == "json":
+        click.echo(json.dumps(estimate.as_dict()))
+        sys.exit(0)
+
+    total = f"${estimate.total:,.2f}" if estimate.total is not None else "unknown"
+    click.echo(f"Estimated cost: {total} over {estimate.duration_hours:.2f}h (on-demand rates)")
+    for role in estimate.roles:
+        cost = f"${role.cost:,.2f}" if role.cost is not None else "unknown"
+        click.echo(f"  {role.role:<10} {role.node_count:>3} x {role.instance_type:<22} {cost:>12}")
+    if estimate.is_spot:
+        click.echo("NOTE: run is configured for spot; priced at on-demand, so this is an upper bound.")
+    if estimate.partial:
+        unpriced = ", ".join(estimate.unpriced_roles) or "no roles resolved"
+        click.echo(f"WARNING: estimate is PARTIAL - no price for: {unpriced}")
     sys.exit(0)
 
 

--- a/sct.py
+++ b/sct.py
@@ -81,7 +81,7 @@ from sdcm.utils.trigger_matrix import (
     resolve_to_full_version,
     trigger_matrix as run_trigger_matrix,
 )
-from sdcm.utils.cloud_catalog.cost import estimate_run_cost
+from sdcm.utils.cloud_catalog.cost import RunCostEstimate, estimate_run_cost
 from sdcm.utils.argus import (
     ReplayOnlyArgusSCTClient,
     argus_offline_collect_events,
@@ -1696,7 +1696,19 @@ def estimate_cost(config_files, backend, duration, output_format, output_file):
         os.environ["SCT_CLUSTER_BACKEND"] = backend
     if config_files:
         os.environ["SCT_CONFIG_FILES"] = config_files
-    config = SCTConfiguration()
+
+    try:
+        config = SCTConfiguration()
+    except Exception as exc:  # noqa: BLE001
+        # This runs as a pipeline pre-flight step. A configuration SCT cannot load is a real
+        # problem, but it is not this command's problem to report - the run is about to fail
+        # on it anyway, with a better message, from the code that actually needs the config.
+        # Failing here would only turn an advisory stage into a second, noisier failure.
+        click.echo(f"\nCannot estimate cost: configuration could not be loaded ({exc})\n")
+        if output_file:
+            with open(output_file, "w", encoding="utf-8") as fobj:
+                json.dump(RunCostEstimate.unavailable().as_dict(), fobj)
+        sys.exit(0)
 
     estimate = estimate_run_cost(config, duration_minutes=duration)
 

--- a/sdcm/utils/cloud_catalog/cost.py
+++ b/sdcm/utils/cloud_catalog/cost.py
@@ -96,11 +96,30 @@ def _pricing_for(cloud: str):
     return {"aws": AWSPricing, "gce": GCEPricing, "azure": AzurePricing, "oci": OCIPricing}[cloud]()
 
 
-def get_hourly_rate(backend: str, region: str, instance_type: str, is_spot: bool = False) -> InstanceRate:
-    """Look up the hourly rate for one instance. Never raises, never blocks a test."""
+def get_hourly_rate(
+    backend: str, region: str, instance_type: str, is_spot: bool = False, catalog_only: bool = False
+) -> InstanceRate:
+    """Look up the hourly rate for one instance. Never raises, never blocks a test.
+
+    With `catalog_only`, answer purely from the checked-in catalog and report unknown on a
+    miss. The pricing classes fall through to live cloud pricing APIs when the catalog has no
+    entry, which is fine for a long-lived test process but not for a pre-flight estimate: that
+    runs on a builder before anything exists, and must not depend on a cloud API being
+    reachable to tell someone what a run will cost.
+    """
     cloud = BACKEND_TO_CLOUD.get(backend)
     if not cloud or not instance_type:
         return InstanceRate.unknown(is_spot=is_spot)
+
+    if catalog_only:
+        from sdcm.utils.cloud_catalog.pricing import _catalog_price  # noqa: PLC0415 — lazy, see _pricing_for
+
+        try:
+            raw = _catalog_price(cloud, region, instance_type)
+        except Exception:  # noqa: BLE001
+            LOGGER.warning("Catalog lookup failed for %s/%s in %s", cloud, instance_type, region, exc_info=True)
+            return InstanceRate.unknown(is_spot=is_spot)
+        return InstanceRate.from_raw(raw, is_spot=is_spot, source="catalog")
 
     lifecycle = InstanceLifecycle.SPOT if is_spot else InstanceLifecycle.ON_DEMAND
     try:
@@ -240,6 +259,9 @@ def estimate_run_cost(params: Any, duration_minutes: float | None = None) -> Run
     Spot rates are not knowable ahead of a run, so this deliberately prices everything at
     the on-demand rate and reports `is_spot` alongside: an upper bound is the safe
     direction for a number a gate may act on.
+
+    Rates come from the checked-in catalog only. No cloud pricing API is called, so this
+    cannot hang or fail on someone else's availability.
     """
     backend = str(params.get("cluster_backend") or "")
     cloud = BACKEND_TO_CLOUD.get(backend)
@@ -264,7 +286,7 @@ def estimate_run_cost(params: Any, duration_minutes: float | None = None) -> Run
         node_count = _sum_counts(params.get(count_param))
         if not instance_type or node_count <= 0:
             continue
-        rate = get_hourly_rate(backend, region, instance_type, is_spot=False)
+        rate = get_hourly_rate(backend, region, instance_type, is_spot=False, catalog_only=True)
         per_node = cost_for(rate, duration_hours * SECONDS_PER_HOUR)
         roles.append(
             RoleCost(

--- a/sdcm/utils/cloud_catalog/cost.py
+++ b/sdcm/utils/cloud_catalog/cost.py
@@ -96,6 +96,26 @@ def _pricing_for(cloud: str):
     return {"aws": AWSPricing, "gce": GCEPricing, "azure": AzurePricing, "oci": OCIPricing}[cloud]()
 
 
+def _catalog_lookup(cloud: str, region: str, instance_type: str) -> float | None:
+    """Catalog price for an instance type, resolving memory-customised flex shapes.
+
+    OCI flex shapes are configured as `<shape>:<ocpus>:<memory_gb>` but catalogued as
+    `<shape>:<ocpus>`, so an exact lookup misses and the resource looks unpriceable. Fall
+    back to the base shape, which is what `sct sizing preview` already does. The price is
+    then the base shape's default memory allocation — an over-estimate for a shape trimmed
+    to less memory, which is the safe direction for an estimate.
+    """
+    from sdcm.utils.cloud_catalog.pricing import _catalog_price  # noqa: PLC0415 — lazy, see _pricing_for
+
+    price = _catalog_price(cloud, region, instance_type)
+    if price is not None:
+        return price
+    parts = instance_type.split(":")
+    if len(parts) == 3:
+        return _catalog_price(cloud, region, f"{parts[0]}:{parts[1]}")
+    return None
+
+
 def get_hourly_rate(
     backend: str, region: str, instance_type: str, is_spot: bool = False, catalog_only: bool = False
 ) -> InstanceRate:
@@ -112,10 +132,8 @@ def get_hourly_rate(
         return InstanceRate.unknown(is_spot=is_spot)
 
     if catalog_only:
-        from sdcm.utils.cloud_catalog.pricing import _catalog_price  # noqa: PLC0415 — lazy, see _pricing_for
-
         try:
-            raw = _catalog_price(cloud, region, instance_type)
+            raw = _catalog_lookup(cloud, region, instance_type)
         except Exception:  # noqa: BLE001
             LOGGER.warning("Catalog lookup failed for %s/%s in %s", cloud, instance_type, region, exc_info=True)
             return InstanceRate.unknown(is_spot=is_spot)
@@ -285,11 +303,30 @@ def estimate_run_cost(params: Any, duration_minutes: float | None = None) -> Run
         )
 
     region = _first_region(params.get(_REGION_PARAMS[cloud]))
+    # An oracle cluster only exists for mixed runs, but its node count parameter still
+    # defaults to 1 - the same condition sdcm/sct_config.py applies when resolving sizing.
+    db_type = str(params.get("db_type") or "")
     roles: list[RoleCost] = []
     for role, (type_param, count_param) in _ROLE_PARAMS[cloud].items():
+        if role == "db_oracle" and db_type not in ("mixed_scylla", "mixed_cassandra"):
+            continue
         instance_type = str(params.get(type_param) or "").strip()
         node_count = _sum_counts(params.get(count_param))
-        if not instance_type or node_count <= 0:
+        if node_count <= 0:
+            continue
+        if not instance_type:
+            # Nodes are configured but their instance type never resolved. Skipping the role
+            # would drop them from the total silently, which is how you get a confident-looking
+            # estimate that is missing the db cluster. Report it as unpriced instead.
+            roles.append(
+                RoleCost(
+                    role=role,
+                    instance_type="(unresolved)",
+                    node_count=node_count,
+                    rate=InstanceRate.unknown(),
+                    cost=None,
+                )
+            )
             continue
         rate = get_hourly_rate(backend, region, instance_type, is_spot=False, catalog_only=True)
         per_node = cost_for(rate, duration_hours * SECONDS_PER_HOUR)

--- a/sdcm/utils/cloud_catalog/cost.py
+++ b/sdcm/utils/cloud_catalog/cost.py
@@ -1,0 +1,287 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2026 ScyllaDB
+
+"""Instance-hour cost estimation.
+
+Scope is deliberately narrow: `hourly_rate * running_time` per instance. No network
+egress, no storage, no managed-service overhead.
+
+The one rule that matters everywhere here: a price of `0` from the pricing layer means
+*unknown*, not *free* (OCI returns 0 unconditionally, GCE spot has no entry for families
+newer than n2d, and any catalog miss yields 0). Unknown must stay `None` all the way out,
+so a missing price is never reported as a zero cost.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import TYPE_CHECKING, Any
+
+from sdcm.utils.cloud_catalog.lifecycle import InstanceLifecycle
+
+if TYPE_CHECKING:
+    pass
+
+LOGGER = logging.getLogger(__name__)
+
+SECONDS_PER_HOUR = 3600.0
+
+#: SCT cluster_backend -> the cloud key used by the pricing classes and the catalog.
+BACKEND_TO_CLOUD = {
+    "aws": "aws",
+    "aws-siren": "aws",
+    "k8s-eks": "aws",
+    "gce": "gce",
+    "gce-siren": "gce",
+    "k8s-gke": "gce",
+    "azure": "azure",
+    "oci": "oci",
+}
+
+
+@dataclass(frozen=True)
+class InstanceRate:
+    """An hourly rate for one instance type, or an explicit "we don't know"."""
+
+    price_per_hour: float | None
+    is_spot: bool
+    source: str  # "catalog" | "spot-api" | "unknown"
+
+    @classmethod
+    def from_raw(cls, raw: Any, *, is_spot: bool, source: str) -> InstanceRate:
+        """The single place that owns the 0-means-unknown rule."""
+        try:
+            price = float(raw)
+        except TypeError, ValueError:
+            price = 0.0
+        if price <= 0:
+            return cls(price_per_hour=None, is_spot=is_spot, source="unknown")
+        return cls(price_per_hour=price, is_spot=is_spot, source=source)
+
+    @classmethod
+    def unknown(cls, *, is_spot: bool = False) -> InstanceRate:
+        return cls(price_per_hour=None, is_spot=is_spot, source="unknown")
+
+    @property
+    def known(self) -> bool:
+        return self.price_per_hour is not None
+
+
+@lru_cache(maxsize=None)
+def _pricing_for(cloud: str):
+    """Build a pricing class lazily.
+
+    Import-local on purpose: `AWSPricing.__init__` constructs a boto3 pricing client, so
+    instantiating eagerly would put a network client in the import path of every caller.
+    """
+    from sdcm.utils.cloud_catalog.pricing import (  # noqa: PLC0415 — see docstring
+        AWSPricing,
+        AzurePricing,
+        GCEPricing,
+        OCIPricing,
+    )
+
+    return {"aws": AWSPricing, "gce": GCEPricing, "azure": AzurePricing, "oci": OCIPricing}[cloud]()
+
+
+def get_hourly_rate(backend: str, region: str, instance_type: str, is_spot: bool = False) -> InstanceRate:
+    """Look up the hourly rate for one instance. Never raises, never blocks a test."""
+    cloud = BACKEND_TO_CLOUD.get(backend)
+    if not cloud or not instance_type:
+        return InstanceRate.unknown(is_spot=is_spot)
+
+    lifecycle = InstanceLifecycle.SPOT if is_spot else InstanceLifecycle.ON_DEMAND
+    try:
+        raw = _pricing_for(cloud).get_instance_price(
+            region=region, instance_type=instance_type, state="running", lifecycle=lifecycle
+        )
+    except Exception:  # noqa: BLE001 — a price is never worth failing a test over
+        LOGGER.warning("Could not price %s/%s in %s", cloud, instance_type, region, exc_info=True)
+        return InstanceRate.unknown(is_spot=is_spot)
+
+    return InstanceRate.from_raw(raw, is_spot=is_spot, source="spot-api" if is_spot else "catalog")
+
+
+def cost_for(rate: InstanceRate | None, seconds: float) -> float | None:
+    """Cost of running one instance at `rate` for `seconds`. Fractional hours, not whole ones."""
+    if rate is None or not rate.known or seconds is None or seconds < 0:
+        return None
+    return rate.price_per_hour * (seconds / SECONDS_PER_HOUR)
+
+
+#: cloud -> {role: (instance-type param, node-count param)}. Mirrors ROLE_PARAMS in
+#: sdcm/sct_config.py, which is what resolves sizing constraints into these very params.
+_ROLE_PARAMS: dict[str, dict[str, tuple[str, str]]] = {
+    "aws": {
+        "db": ("instance_type_db", "n_db_nodes"),
+        "db_oracle": ("instance_type_db_oracle", "n_test_oracle_db_nodes"),
+        "loader": ("instance_type_loader", "n_loaders"),
+        "monitor": ("instance_type_monitor", "n_monitor_nodes"),
+    },
+    "gce": {
+        "db": ("gce_instance_type_db", "n_db_nodes"),
+        "db_oracle": ("gce_instance_type_db_oracle", "n_test_oracle_db_nodes"),
+        "loader": ("gce_instance_type_loader", "n_loaders"),
+        "monitor": ("gce_instance_type_monitor", "n_monitor_nodes"),
+    },
+    "azure": {
+        "db": ("azure_instance_type_db", "n_db_nodes"),
+        "db_oracle": ("azure_instance_type_db_oracle", "n_test_oracle_db_nodes"),
+        "loader": ("azure_instance_type_loader", "n_loaders"),
+        "monitor": ("azure_instance_type_monitor", "n_monitor_nodes"),
+    },
+    "oci": {
+        "db": ("oci_instance_type_db", "n_db_nodes"),
+        "db_oracle": ("oci_instance_type_db_oracle", "n_test_oracle_db_nodes"),
+        "loader": ("oci_instance_type_loader", "n_loaders"),
+        "monitor": ("oci_instance_type_monitor", "n_monitor_nodes"),
+    },
+}
+
+_REGION_PARAMS = {
+    "aws": "region_name",
+    "gce": "gce_datacenter",
+    "azure": "azure_region_name",
+    "oci": "oci_region_name",
+}
+
+
+@dataclass(frozen=True)
+class RoleCost:
+    role: str
+    instance_type: str
+    node_count: int
+    rate: InstanceRate
+    cost: float | None
+
+    @property
+    def known(self) -> bool:
+        return self.cost is not None
+
+
+@dataclass(frozen=True)
+class RunCostEstimate:
+    """A pre-run estimate. `partial` means at least one role could not be priced."""
+
+    total: float | None
+    currency: str
+    duration_hours: float
+    is_spot: bool
+    roles: tuple[RoleCost, ...]
+    partial: bool
+
+    @property
+    def unpriced_roles(self) -> tuple[str, ...]:
+        return tuple(r.role for r in self.roles if not r.known)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "total": round(self.total, 4) if self.total is not None else None,
+            "currency": self.currency,
+            "duration_hours": round(self.duration_hours, 4),
+            "is_spot": self.is_spot,
+            "partial": self.partial,
+            "unpriced_roles": list(self.unpriced_roles),
+            "roles": [
+                {
+                    "role": r.role,
+                    "instance_type": r.instance_type,
+                    "node_count": r.node_count,
+                    "price_per_hour": r.rate.price_per_hour,
+                    "source": r.rate.source,
+                    "cost": round(r.cost, 4) if r.cost is not None else None,
+                }
+                for r in self.roles
+            ],
+        }
+
+
+def _sum_counts(value: Any) -> int:
+    """Node counts may be an int, "3", or "3 3" for a multi-DC/region layout."""
+    if value is None:
+        return 0
+    if isinstance(value, int):
+        return value
+    if isinstance(value, (list, tuple)):
+        return sum(_sum_counts(v) for v in value)
+    total = 0
+    for part in str(value).replace(",", " ").split():
+        try:
+            total += int(part)
+        except ValueError:
+            continue
+    return total
+
+
+def _first_region(value: Any) -> str:
+    if isinstance(value, (list, tuple)):
+        return str(value[0]) if value else ""
+    return str(value).split()[0] if value and str(value).split() else ""
+
+
+def estimate_run_cost(params: Any, duration_minutes: float | None = None) -> RunCostEstimate:
+    """Estimate a run's instance-hour cost from an already-resolved configuration.
+
+    Reads only config, so it works on a Jenkins builder before anything is provisioned —
+    which is what makes it usable as a pre-flight gate.
+
+    Spot rates are not knowable ahead of a run, so this deliberately prices everything at
+    the on-demand rate and reports `is_spot` alongside: an upper bound is the safe
+    direction for a number a gate may act on.
+    """
+    backend = str(params.get("cluster_backend") or "")
+    cloud = BACKEND_TO_CLOUD.get(backend)
+    duration_min = duration_minutes if duration_minutes is not None else params.get("test_duration") or 0
+    duration_hours = float(duration_min) / 60.0
+    is_spot = "spot" in str(params.get("instance_provision") or "").lower()
+
+    if not cloud:
+        return RunCostEstimate(
+            total=None,
+            currency="USD",
+            duration_hours=duration_hours,
+            is_spot=is_spot,
+            roles=(),
+            partial=True,
+        )
+
+    region = _first_region(params.get(_REGION_PARAMS[cloud]))
+    roles: list[RoleCost] = []
+    for role, (type_param, count_param) in _ROLE_PARAMS[cloud].items():
+        instance_type = str(params.get(type_param) or "").strip()
+        node_count = _sum_counts(params.get(count_param))
+        if not instance_type or node_count <= 0:
+            continue
+        rate = get_hourly_rate(backend, region, instance_type, is_spot=False)
+        per_node = cost_for(rate, duration_hours * SECONDS_PER_HOUR)
+        roles.append(
+            RoleCost(
+                role=role,
+                instance_type=instance_type,
+                node_count=node_count,
+                rate=rate,
+                cost=per_node * node_count if per_node is not None else None,
+            )
+        )
+
+    priced = [r.cost for r in roles if r.known]
+    return RunCostEstimate(
+        total=sum(priced) if priced else None,
+        currency="USD",
+        duration_hours=duration_hours,
+        is_spot=is_spot,
+        roles=tuple(roles),
+        partial=any(not r.known for r in roles) or not roles,
+    )

--- a/sdcm/utils/cloud_catalog/cost.py
+++ b/sdcm/utils/cloud_catalog/cost.py
@@ -201,6 +201,11 @@ class RunCostEstimate:
     roles: tuple[RoleCost, ...]
     partial: bool
 
+    @classmethod
+    def unavailable(cls) -> "RunCostEstimate":
+        """No estimate could be produced at all (e.g. the configuration would not load)."""
+        return cls(total=None, currency="USD", duration_hours=0.0, is_spot=False, roles=(), partial=True)
+
     @property
     def unpriced_roles(self) -> tuple[str, ...]:
         return tuple(r.role for r in self.roles if not r.known)

--- a/sdcm/utils/cloud_catalog/lifecycle.py
+++ b/sdcm/utils/cloud_catalog/lifecycle.py
@@ -1,0 +1,27 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2026 ScyllaDB
+
+"""Instance lifecycle (on-demand vs spot).
+
+Kept in its own leaf module, and deliberately free of imports: pricing lookups need it,
+and pulling it from `sdcm.utils.cloud_monitor.common` made `cloud_catalog.pricing`
+unimportable on its own — `cloud_monitor/__init__.py` eagerly imports the whole monitor
+stack, which imports back into `cloud_catalog.pricing`.
+"""
+
+from enum import Enum
+
+
+class InstanceLifecycle(Enum):
+    ON_DEMAND = "on-demand"
+    SPOT = "spot"

--- a/sdcm/utils/cloud_catalog/pricing.py
+++ b/sdcm/utils/cloud_catalog/pricing.py
@@ -8,7 +8,7 @@ import boto3
 import requests
 from mypy_boto3_pricing import PricingClient
 
-from sdcm.utils.cloud_monitor.common import InstanceLifecycle
+from sdcm.utils.cloud_catalog.lifecycle import InstanceLifecycle
 
 LOGGER = getLogger(__name__)
 

--- a/sdcm/utils/cloud_monitor/common.py
+++ b/sdcm/utils/cloud_monitor/common.py
@@ -1,9 +1,8 @@
-from enum import Enum
-
-
-class InstanceLifecycle(Enum):
-    ON_DEMAND = "on-demand"
-    SPOT = "spot"
-
+# Re-exported from its new home so this module stays the import site for existing callers.
+# It moved because `cloud_catalog.pricing` needs it, and reaching into `cloud_monitor` for it
+# created an import cycle via this package's eagerly-importing `__init__.py`.
+from sdcm.utils.cloud_catalog.lifecycle import InstanceLifecycle
 
 NA = "N/A"
+
+__all__ = ["InstanceLifecycle", "NA"]

--- a/unit_tests/unit/test_cost.py
+++ b/unit_tests/unit/test_cost.py
@@ -261,3 +261,55 @@ def test_unavailable_estimate_is_well_formed():
     assert payload["partial"] is True
     assert payload["roles"] == []
     assert payload["currency"] == "USD"
+
+
+# --- flex shapes and unresolved roles -----------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "instance_type, expected",
+    [
+        ("VM.Standard.E4.Flex:2", 0.098),  # catalogued form
+        ("VM.Standard.E4.Flex:2:8", 0.098),  # configured form: <shape>:<ocpus>:<memory_gb>
+        ("VM.Standard.E4.Flex:1:8", 0.049),
+    ],
+)
+def test_oci_flex_shapes_resolve_to_the_base_shape(instance_type, expected):
+    """OCI is priceable: flex shapes just need the memory suffix stripped.
+
+    Configs name them `<shape>:<ocpus>:<memory_gb>` while the catalog stores
+    `<shape>:<ocpus>`, so an exact-match-only lookup made every OCI run look unpriceable.
+    """
+    rate = get_hourly_rate("oci", "us-ashburn-1", instance_type, catalog_only=True)
+    assert rate.price_per_hour == pytest.approx(expected)
+
+
+def test_unknown_flex_shape_is_still_unknown():
+    assert get_hourly_rate("oci", "us-ashburn-1", "VM.Bogus.Flex:9:9", catalog_only=True).price_per_hour is None
+
+
+def test_configured_nodes_with_no_instance_type_are_reported_not_dropped():
+    """A role whose type never resolved must not vanish from the estimate.
+
+    Silently skipping it yields a confident-looking total that is missing an entire
+    cluster - far worse than admitting the gap.
+    """
+    est = estimate_run_cost(_aws_params(instance_type_db=""))
+    db = next(r for r in est.roles if r.role == "db")
+    assert db.node_count == 3
+    assert db.cost is None
+    assert est.partial
+    assert "db" in est.unpriced_roles
+
+
+def test_oracle_nodes_are_ignored_unless_the_run_is_mixed():
+    """`n_test_oracle_db_nodes` defaults to 1 even when no oracle cluster is used."""
+    plain = estimate_run_cost(_aws_params(n_test_oracle_db_nodes=1))
+    assert "db_oracle" not in {r.role for r in plain.roles}
+    assert not plain.partial
+
+    mixed = estimate_run_cost(
+        _aws_params(db_type="mixed_scylla", n_test_oracle_db_nodes=1, instance_type_db_oracle="i4i.4xlarge")
+    )
+    oracle = next(r for r in mixed.roles if r.role == "db_oracle")
+    assert oracle.cost == pytest.approx(1.373 * 1 * 2.0)

--- a/unit_tests/unit/test_cost.py
+++ b/unit_tests/unit/test_cost.py
@@ -248,3 +248,16 @@ def test_estimate_never_calls_a_cloud_api(monkeypatch):
     assert "db" in unpriced.unpriced_roles
 
     assert not calls
+
+
+def test_unavailable_estimate_is_well_formed():
+    """A configuration that will not load must still yield a usable, honest result.
+
+    `estimate-cost` runs as a pipeline pre-flight step, so it reports the failure and exits 0
+    rather than turning an advisory stage into a second, noisier build failure.
+    """
+    payload = RunCostEstimate.unavailable().as_dict()
+    assert payload["total"] is None
+    assert payload["partial"] is True
+    assert payload["roles"] == []
+    assert payload["currency"] == "USD"

--- a/unit_tests/unit/test_cost.py
+++ b/unit_tests/unit/test_cost.py
@@ -1,0 +1,207 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2026 ScyllaDB
+
+"""Tests for instance-hour cost estimation.
+
+Deliberately offline: on-demand lookups are answered by the checked-in catalog under
+data/instance_catalog/, so these assert on real prices without touching the network.
+"""
+
+import pytest
+
+from sdcm.utils.cloud_catalog.cost import (
+    InstanceRate,
+    RunCostEstimate,
+    cost_for,
+    estimate_run_cost,
+    get_hourly_rate,
+)
+
+
+class FakeParams(dict):
+    """Stands in for SCTConfiguration: estimate_run_cost only ever calls .get()."""
+
+
+# --- the 0-means-unknown rule -------------------------------------------------------
+
+
+@pytest.mark.parametrize("raw", [0, 0.0, -1, None, "", "not-a-number"])
+def test_non_positive_price_is_unknown_not_free(raw):
+    rate = InstanceRate.from_raw(raw, is_spot=False, source="catalog")
+    assert rate.price_per_hour is None
+    assert rate.source == "unknown"
+    assert not rate.known
+    # The whole point: an unknown price must never become a zero cost.
+    assert cost_for(rate, 3600) is None
+
+
+def test_positive_price_is_kept():
+    rate = InstanceRate.from_raw(1.5, is_spot=True, source="spot-api")
+    assert rate.price_per_hour == 1.5
+    assert rate.is_spot is True
+    assert rate.known
+
+
+# --- rate lookup, against the real catalog ------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "backend, region, instance_type, expected",
+    [
+        ("aws", "eu-west-1", "i4i.4xlarge", 1.373),
+        ("gce", "us-east1", "n2-highmem-32", 2.096224),
+        ("azure", "eastus", "Standard_L8s_v3", 0.696),
+    ],
+)
+def test_on_demand_rate_from_catalog(backend, region, instance_type, expected):
+    rate = get_hourly_rate(backend, region, instance_type)
+    assert rate.price_per_hour == pytest.approx(expected)
+    assert rate.source == "catalog"
+    assert rate.is_spot is False
+
+
+def test_oci_has_no_pricing_and_reports_unknown():
+    # OCIPricing returns 0 unconditionally; that must surface as unknown, not as free.
+    assert get_hourly_rate("oci", "eu-frankfurt-1", "VM.Standard.E4.Flex").price_per_hour is None
+
+
+@pytest.mark.parametrize("instance_type", ["c3-standard-8", "c4-standard-8", "n4-standard-8", "t2a-standard-4"])
+def test_gce_spot_families_missing_from_the_table_are_unknown(instance_type):
+    # The hardcoded GCE spot table only covers c2/e2/f1/g1/m1/n1/n2/n2d.
+    rate = get_hourly_rate("gce", "us-east1", instance_type, is_spot=True)
+    assert rate.price_per_hour is None
+    assert rate.is_spot is True
+
+
+def test_gce_spot_family_present_in_the_table_is_priced():
+    # Guards the test above from passing for the wrong reason.
+    rate = get_hourly_rate("gce", "us-east1", "n2-highmem-32", is_spot=True)
+    assert rate.price_per_hour == pytest.approx(0.5073)
+
+
+@pytest.mark.parametrize("backend", ["docker", "k8s-local-kind", "unknown-backend", ""])
+def test_backends_without_pricing_report_unknown(backend):
+    assert get_hourly_rate(backend, "somewhere", "some.type").price_per_hour is None
+
+
+def test_unknown_instance_type_is_unknown():
+    assert get_hourly_rate("aws", "eu-west-1", "totally.made.up").price_per_hour is None
+
+
+def test_pricing_failure_never_propagates(monkeypatch):
+    def explode(*_args, **_kwargs):
+        raise RuntimeError("pricing API down")
+
+    monkeypatch.setattr("sdcm.utils.cloud_catalog.pricing.GCEPricing.get_instance_price", explode)
+    assert get_hourly_rate("gce", "us-east1", "n2-standard-8").price_per_hour is None
+
+
+# --- cost math ----------------------------------------------------------------------
+
+
+def test_cost_uses_fractional_hours_not_whole_ones():
+    rate = InstanceRate.from_raw(2.0, is_spot=False, source="catalog")
+    # 90 minutes at $2/h is $3, not $4 as a ceil-to-whole-hours implementation would give.
+    assert cost_for(rate, 90 * 60) == pytest.approx(3.0)
+
+
+@pytest.mark.parametrize("seconds", [0, 1, 12345.678])
+def test_cost_scales_linearly(seconds):
+    rate = InstanceRate.from_raw(3.0, is_spot=False, source="catalog")
+    assert cost_for(rate, seconds) == pytest.approx(3.0 * seconds / 3600)
+
+
+def test_cost_of_none_or_negative_is_none():
+    rate = InstanceRate.from_raw(1.0, is_spot=False, source="catalog")
+    assert cost_for(None, 3600) is None
+    assert cost_for(rate, -5) is None
+
+
+# --- run-level estimate -------------------------------------------------------------
+
+
+def _aws_params(**overrides):
+    params = FakeParams(
+        cluster_backend="aws",
+        region_name="eu-west-1",
+        test_duration=120,
+        instance_provision="on_demand",
+        instance_type_db="i4i.4xlarge",
+        n_db_nodes=3,
+        instance_type_loader="c6i.2xlarge",
+        n_loaders=2,
+        instance_type_monitor="t3.large",
+        n_monitor_nodes=1,
+    )
+    params.update(overrides)
+    return params
+
+
+def test_estimate_sums_nodes_times_rate_times_duration():
+    est = estimate_run_cost(_aws_params())
+    assert isinstance(est, RunCostEstimate)
+    assert est.duration_hours == pytest.approx(2.0)
+    assert not est.partial
+
+    db = next(r for r in est.roles if r.role == "db")
+    assert db.node_count == 3
+    assert db.cost == pytest.approx(1.373 * 3 * 2.0)
+    assert est.total == pytest.approx(sum(r.cost for r in est.roles))
+
+
+def test_multi_dc_node_counts_are_summed():
+    est = estimate_run_cost(_aws_params(n_db_nodes="3 3"))
+    assert next(r for r in est.roles if r.role == "db").node_count == 6
+
+
+def test_duration_override_wins_over_config():
+    est = estimate_run_cost(_aws_params(), duration_minutes=30)
+    assert est.duration_hours == pytest.approx(0.5)
+
+
+def test_unpriced_role_makes_the_estimate_partial_not_silently_low():
+    est = estimate_run_cost(_aws_params(instance_type_loader="totally.made.up"))
+    assert est.partial
+    assert "loader" in est.unpriced_roles
+    # The priced roles still contribute; the total is a floor, flagged as incomplete.
+    assert est.total == pytest.approx(sum(r.cost for r in est.roles if r.known))
+
+
+def test_roles_with_zero_nodes_are_skipped():
+    est = estimate_run_cost(_aws_params(n_loaders=0))
+    assert "loader" not in {r.role for r in est.roles}
+
+
+def test_spot_run_is_flagged_but_priced_at_on_demand():
+    on_demand = estimate_run_cost(_aws_params())
+    spot = estimate_run_cost(_aws_params(instance_provision="spot"))
+    assert spot.is_spot is True
+    # Priced identically: an upper bound is the safe direction for a gate.
+    assert spot.total == pytest.approx(on_demand.total)
+
+
+def test_backend_without_pricing_yields_an_unknown_total():
+    est = estimate_run_cost(FakeParams(cluster_backend="docker", test_duration=60))
+    assert est.total is None
+    assert est.partial
+
+
+def test_as_dict_is_json_serialisable_and_keeps_nulls():
+    import json  # noqa: PLC0415 — local to the one test that needs it
+
+    payload = json.loads(json.dumps(estimate_run_cost(_aws_params(instance_type_db="made.up")).as_dict()))
+    assert payload["currency"] == "USD"
+    assert payload["partial"] is True
+    assert "db" in payload["unpriced_roles"]
+    db = next(r for r in payload["roles"] if r["role"] == "db")
+    assert db["cost"] is None and db["price_per_hour"] is None

--- a/unit_tests/unit/test_cost.py
+++ b/unit_tests/unit/test_cost.py
@@ -205,3 +205,46 @@ def test_as_dict_is_json_serialisable_and_keeps_nulls():
     assert "db" in payload["unpriced_roles"]
     db = next(r for r in payload["roles"] if r["role"] == "db")
     assert db["cost"] is None and db["price_per_hour"] is None
+
+
+# --- no cloud APIs ------------------------------------------------------------------
+
+
+def test_catalog_only_does_not_fall_through_to_a_pricing_api(monkeypatch):
+    def explode(*_args, **_kwargs):
+        raise AssertionError("a live pricing API was called")
+
+    monkeypatch.setattr("sdcm.utils.cloud_catalog.pricing.AWSPricing.get_on_demand_instance_price", explode)
+    # An instance type the catalog does not know: without catalog_only this would query AWS.
+    rate = get_hourly_rate("aws", "eu-west-1", "m5.24xlarge", catalog_only=True)
+    assert rate.price_per_hour is None
+    assert rate.source == "unknown"
+
+
+def test_estimate_never_calls_a_cloud_api(monkeypatch):
+    """The estimate runs on a builder before anything exists; it must not need the network.
+
+    Guards both directions: a catalog hit obviously must not call out, and a catalog *miss*
+    must report unknown rather than quietly falling through to a live pricing API.
+    """
+    calls = []
+
+    def record_boto(self, operation_name, *args, **kwargs):
+        calls.append(operation_name)
+        raise AssertionError(f"boto call during estimate: {operation_name}")
+
+    def record_http(self, method, url, *args, **kwargs):
+        calls.append(f"{method} {url}")
+        raise AssertionError(f"http call during estimate: {method} {url}")
+
+    monkeypatch.setattr("botocore.client.BaseClient._make_api_call", record_boto)
+    monkeypatch.setattr("requests.sessions.Session.request", record_http)
+
+    priced = estimate_run_cost(_aws_params())
+    assert priced.total is not None
+
+    unpriced = estimate_run_cost(_aws_params(instance_type_db="m5.24xlarge"))
+    assert unpriced.partial
+    assert "db" in unpriced.unpriced_roles
+
+    assert not calls

--- a/vars/estimateTestCost.groovy
+++ b/vars/estimateTestCost.groovy
@@ -1,0 +1,79 @@
+#!groovy
+
+/**
+ * Print what this run is expected to cost, before anything is provisioned.
+ *
+ * Reads configuration only - the estimate is answered from the checked-in instance
+ * catalog and calls no cloud pricing API - so this cannot hang or fail the build on
+ * someone else's availability. Never throws: a cost estimate is not worth failing a run
+ * over, so an unusable result is reported and the pipeline carries on.
+ *
+ * Returns the parsed estimate as a Map, or null when it could not be produced.
+ */
+Map call(Map params, String region) {
+    def current_region = initAwsRegionParam(params.region, region)
+    def current_oci_region = ""
+    if (params.oci_region_name) {
+        current_oci_region = initAwsRegionParam(params.oci_region_name, region)
+    }
+    def test_config = groovy.json.JsonOutput.toJson(params.test_config)
+    def estimate_file = "cost_estimate_${env.BUILD_NUMBER ?: 'local'}.json"
+
+    try {
+        // Loading a config prints heavily to stdout, so the estimate is written to a file
+        // rather than parsed back out of the log.
+        def cmd = """#!/bin/bash
+        export SCT_CLUSTER_BACKEND="${params.backend}"
+        export SCT_CONFIG_FILES=${test_config}
+        if [[ -n "${params.region ? params.region : ''}" ]] ; then
+            export SCT_REGION_NAME=${current_region}
+        fi
+
+        if [[ -n "${params.gce_datacenter ? params.gce_datacenter : ''}" ]] ; then
+            export SCT_GCE_DATACENTER='${params.gce_datacenter}'
+        fi
+
+        if [[ -n "${params.azure_region_name ? params.azure_region_name : ''}" ]] ; then
+            export SCT_AZURE_REGION_NAME=${groovy.json.JsonOutput.toJson(params.azure_region_name)}
+        fi
+
+        if [[ -n "${params.oci_region_name ? params.oci_region_name : ''}" ]] ; then
+            export SCT_OCI_REGION_NAME=${current_oci_region}
+        fi
+
+        if [[ -n "${params.instance_provision ? params.instance_provision : ''}" ]] ; then
+            export SCT_INSTANCE_PROVISION="${params.instance_provision}"
+        fi
+
+        ./docker/env/hydra.sh estimate-cost -b "${params.backend}" --output "${estimate_file}"
+        """
+        sh(script: cmd)
+
+        def estimate = readJSON(file: estimate_file)
+        def total = estimate.total
+        if (total == null) {
+            echo "Estimated cost: unknown - no price for: ${estimate.unpriced_roles.join(', ')}"
+            return estimate
+        }
+
+        def summary = String.format("Estimated cost: \$%.2f over %.2fh", total as Double,
+                                    estimate.duration_hours as Double)
+        if (estimate.is_spot) {
+            summary += " (priced at on-demand; spot run, so this is an upper bound)"
+        }
+        if (estimate.partial) {
+            summary += " [PARTIAL - no price for: ${estimate.unpriced_roles.join(', ')}]"
+        }
+        echo summary
+        estimate.roles.each { role ->
+            echo String.format("  %-10s %3d x %-24s %s", role.role, role.node_count as Integer,
+                               role.instance_type,
+                               role.cost == null ? "unknown" : String.format("\$%.2f", role.cost as Double))
+        }
+        currentBuild.description = ((currentBuild.description ?: '') + "\n" + summary).trim()
+        return estimate
+    } catch (Exception ex) {
+        echo "Could not estimate test cost: ${ex.getMessage()}"
+        return null
+    }
+}

--- a/vars/estimateTestCost.groovy
+++ b/vars/estimateTestCost.groovy
@@ -49,26 +49,15 @@ Map call(Map params, String region) {
         """
         sh(script: cmd)
 
+        // The command prints the human-readable table itself; re-printing it here only
+        // doubled it in the log. Read the JSON purely for the build description and for
+        // whatever later decides to act on the number.
         def estimate = readJSON(file: estimate_file)
-        def total = estimate.total
-        if (total == null) {
-            echo "Estimated cost: unknown - no price for: ${estimate.unpriced_roles.join(', ')}"
-            return estimate
-        }
-
-        def summary = String.format("Estimated cost: \$%.2f over %.2fh", total as Double,
-                                    estimate.duration_hours as Double)
-        if (estimate.is_spot) {
-            summary += " (priced at on-demand; spot run, so this is an upper bound)"
-        }
+        def summary = estimate.total == null
+            ? "Estimated cost: unknown"
+            : String.format("Estimated cost: \$%.2f (on-demand)", estimate.total as Double)
         if (estimate.partial) {
-            summary += " [PARTIAL - no price for: ${estimate.unpriced_roles.join(', ')}]"
-        }
-        echo summary
-        estimate.roles.each { role ->
-            echo String.format("  %-10s %3d x %-24s %s", role.role, role.node_count as Integer,
-                               role.instance_type,
-                               role.cost == null ? "unknown" : String.format("\$%.2f", role.cost as Double))
+            summary += " [partial]"
         }
         currentBuild.description = ((currentBuild.description ?: '') + "\n" + summary).trim()
         return estimate

--- a/vars/longevityPipeline.groovy
+++ b/vars/longevityPipeline.groovy
@@ -392,6 +392,24 @@ def call(Map pipelineParams) {
                     }
                 }
             }
+            // Deliberately before 'Create SCT Runner': nothing is provisioned yet, not even
+            // the runner, so the number is available while abandoning the run is still free.
+            // This is the point a future approval gate would hook into.
+            stage('Estimate Test Cost') {
+                steps {
+                    catchError(stageResult: 'SUCCESS') {
+                        timeout(time: 5, unit: 'MINUTES') {
+                            script {
+                                wrap([$class: 'BuildUser']) {
+                                    dir('scylla-cluster-tests') {
+                                        estimateTestCost(params, builder.region)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
             stage('BYO Scylladb [optional]') {
                 steps {
                     catchError(stageResult: 'FAILURE') {


### PR DESCRIPTION
First implementation slice of [SCT-852](https://scylladb.atlassian.net/browse/SCT-852) — the half that needs nothing from Argus. Plan: #15979.

## 1. `fix(cloud_catalog): break the pricing import cycle`

`sdcm.utils.cloud_catalog.pricing` could not be imported on its own:

```
$ python -c "import sdcm.utils.cloud_catalog.pricing"
ImportError: cannot import name 'AWSPricing' from partially initialized module
```

`pricing` imported `InstanceLifecycle` from `cloud_monitor.common` → ran `cloud_monitor/__init__.py` → `cloud_monitor.py` → `resources/instances.py` → back into `pricing`. It resolved only if `cloud_monitor` happened to be imported first, and that path builds a `boto3.client("pricing")` at class-body time — so anything wanting a price inherited a network client it never asked for.

The cycle had exactly one edge (`pricing.py` was the only reference to `cloud_monitor` anywhere under `cloud_catalog/`). The enum moves to a leaf module with no imports of its own, re-exported from `cloud_monitor/common.py` so both existing import sites keep working.

Worth noting `scripts/detect_cyclic_imports.py` does **not** catch this class of cycle: it models module→module edges, but the loop closes through the implicit *package `__init__`* execution that importing `pkg.sub` triggers. Its `_add_target` prunes ancestor edges as "implicit, never a real cycle", which holds for a module importing its own ancestor but not for an outside module importing into a package whose `__init__` eagerly re-exports. Happy to file that separately if useful.

## 2. `feature(cost): estimate a run's instance-hour cost before provisioning`

`sdcm/utils/cloud_catalog/cost.py` plus `sct.py estimate-cost`. Prices a run from configuration alone — no provisioning, no runner, no Argus — so it can run as a pipeline pre-flight step, which is what the approval gate in the epic will need.

```
$ ./sct.py estimate-cost -b aws test-cases/longevity/longevity-10gb-3h.yaml
Estimated cost: $21.02 over 4.25h (on-demand rates)
  db           6 x i7i.2xlarge                  $19.25
  loader       2 x t3.xlarge                     $1.41
  monitor      1 x t3.large                      $0.35
NOTE: run is configured for spot; priced at on-demand, so this is an upper bound.
```

Design points worth review:

- **`0` means unknown, not free.** The pricing classes return `0` for OCI (always), GCE spot for families newer than n2d, and any catalog miss. `InstanceRate.from_raw` is the single place that maps that to `None`; an unpriced role marks the estimate `partial` instead of quietly lowering the total.
- **Spot is priced at on-demand and flagged.** Spot rates aren't knowable ahead of a run, and for a number a gate may act on, an upper bound is the safe direction to be wrong in.
- **`--output FILE`** writes clean JSON. Loading a config prints a lot to stdout — `byoScylladb.groovy:48` already works around exactly this for `get-db-arch` — so a pipeline should read the file rather than parse around the noise.
- Pricing lookups are wrapped: a failure yields "unknown", never an exception into a caller.

## Testing

35 unit tests, all offline — on-demand lookups are answered by the checked-in catalog, so they assert real prices rather than mocks. Covers the `0`→`None` rule, per-cloud catalog hits, the GCE spot families that *are* and *are not* in the hardcoded table, fractional-hour math, multi-DC node counts, partial estimates, and JSON round-tripping.

**One limitation found while testing, worth knowing:** `sct.py estimate-cost` needs AWS credentials, not because of `cost.py` but because `SCTConfiguration()` itself fetches from Secrets Manager. With credentials genuinely absent it retries for minutes and then fails with `NoCredentialsError`. Fine for a Jenkins builder, which has them — but a pre-flight stage should carry a timeout, and the unit tests deliberately avoid `SCTConfiguration` for this reason.

Not included here, and blocked on argus#1071 + a client release: sending rate/cost to Argus, the runner and cleanup paths, and `submit_cost_estimate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SCT-852]: https://scylladb.atlassian.net/browse/SCT-852?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ