### PR TITLE
fix(sstable): limit the resources of the 'scylla sstable' dump tool

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -23,6 +23,7 @@ round_robin: false
 append_scylla_args: '--blocked-reactor-notify-ms 25 --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc --abort-on-internal-error 1 --abort-on-ebadf 1 --enable-sstable-key-validation 1'
 append_scylla_setup_args: ''
 append_scylla_node_exporter_args: ''
+sstable_dump_memory: '1G'
 append_scylla_yaml:
   rf_rack_valid_keyspaces: true
 experimental_features: []

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -1031,6 +1031,15 @@ More arguments to append to oracle command line
 **type:** str (appendable)
 
 
+## **sstable_dump_memory** / SCT_SSTABLE_DUMP_MEMORY
+
+Memory limit passed as --memory to the 'scylla sstable' tool when SCT dumps sstables<br>(upgrade sstable check, encryption checks, tombstone counting). The tool is a Seastar application and<br>without a limit it sizes itself from the total RAM, which gets it OOM-killed next to a running<br>scylla-server on small nodes. Dumping one sstable needs less than 100 MiB. Empty value sets no limit.
+
+**default:** 1G
+
+**type:** str (appendable)
+
+
 ## **append_scylla_yaml** / SCT_APPEND_SCYLLA_YAML
 
 More configuration to append to /etc/scylla/scylla.yaml

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1274,6 +1274,12 @@ class SCTConfiguration(BaseModel):
     append_scylla_args_oracle: String = SctField(
         description="More arguments to append to oracle command line",
     )
+    sstable_dump_memory: String = SctField(
+        description="""Memory limit passed as --memory to the 'scylla sstable' tool when SCT dumps sstables
+                (upgrade sstable check, encryption checks, tombstone counting). The tool is a Seastar application and
+                without a limit it sizes itself from the total RAM, which gets it OOM-killed next to a running
+                scylla-server on small nodes. Dumping one sstable needs less than 100 MiB. Empty value sets no limit.""",
+    )
     append_scylla_yaml: DictOrStrOrPydantic = SctField(
         description="More configuration to append to /etc/scylla/scylla.yaml",
     )

--- a/sdcm/utils/sstable/sstable_utils.py
+++ b/sdcm/utils/sstable/sstable_utils.py
@@ -401,10 +401,12 @@ def _generate_sstable_dump_command(node, command: str, keyspace: str, table: str
     :return: Base command string.
     """
     scylla_conf_dir = Path(node.add_install_prefix(SCYLLA_YAML_PATH)).parent
+    # without --memory option the sstable tool sizes itself from the total RAM and gets OOM-killed on small nodes
+    memory_option = f"--memory {memory} " if (memory := node.parent_cluster.params.get("sstable_dump_memory")) else ""
     return (
         f"SCYLLA_CONF={scylla_conf_dir} "
         f"{node.add_install_prefix('/usr/bin/scylla')} sstable {command} "
-        f"--keyspace {keyspace} --table {table} --sstables"
+        f"--keyspace {keyspace} --table {table} {memory_option}--sstables"
     )
 
 

--- a/unit_tests/unit/test_sstable_s3_uploader.py
+++ b/unit_tests/unit/test_sstable_s3_uploader.py
@@ -11,13 +11,17 @@
 #
 # Copyright (c) 2026 ScyllaDB
 
-"""Tests for the S3 uploads which stream the files over an SSH session to the node."""
+"""Tests for sdcm.utils.sstable: the S3 uploads which stream the files over an SSH session to
+the node, and the commands built for the "scylla sstable" dump tool."""
 
 from unittest.mock import MagicMock, Mock, patch
+
+import pytest
 
 from sdcm.cluster import BaseNode
 from sdcm.cluster_k8s import BasePodContainer
 from sdcm.utils.sstable.s3_uploader import upload_sstables_to_s3, upload_system_table_to_s3
+from sdcm.utils.sstable.sstable_utils import get_sstable_data_dump_command, get_sstable_metadata_dump_command
 
 TEST_ID = "4352b7b6-0630-4ceb-ac5b-3ba5bd44ceba"
 S3_LINK = "https://cloudius-jenkins-test.s3.amazonaws.com/fake-upload.tar.gz"
@@ -90,3 +94,27 @@ def test_upload_sstables_to_s3_uploads_from_ssh_node():
     assert any(cmd.startswith("nodetool snapshot -t sct-") for cmd in commands)
     assert any(cmd.startswith("find /var/lib/scylla/data ") for cmd in commands)
     assert any(cmd.startswith("nodetool clearsnapshot -t sct-") for cmd in commands)
+
+
+def make_sstable_dump_node(sstable_dump_memory: str = "1G") -> Mock:
+    """A node reporting a Scylla version new enough for the "scylla sstable" tool."""
+    node = Mock(spec=BaseNode)
+    node.is_enterprise = True
+    node.scylla_version = "2026.2"
+    node.add_install_prefix.side_effect = lambda path: path
+    node.parent_cluster = Mock(params={"sstable_dump_memory": sstable_dump_memory})
+    return node
+
+
+@pytest.mark.parametrize("dump_command_builder", [get_sstable_data_dump_command, get_sstable_metadata_dump_command])
+def test_dump_command_limits_memory_from_config_before_the_sstables_argument(dump_command_builder):
+    command = dump_command_builder(make_sstable_dump_node("2G"), keyspace="keyspace1", table="standard1")
+    assert "--memory 2G" in command
+    assert command.endswith("--sstables")
+    assert command.index("--memory") < command.index("--sstables")
+
+
+def test_dump_command_without_configured_memory_sets_no_limit():
+    command = get_sstable_data_dump_command(make_sstable_dump_node(""), keyspace="keyspace1", table="standard1")
+    assert "--memory" not in command
+    assert command.endswith("--sstables")


### PR DESCRIPTION
The sstable dump step of test_rolling_upgrade runs the Scylla binary in tool mode. configure_tool_mode() pins smp and the reactor options but never sets memory, so the tool assumes the whole machine RAM is its to use and gets OOM-killed on environments with tighter HW resources (can for instance kill the minicloud based rolling upgrade).

The fix is to pass `--memory 1G` and `--smp 1` explicitly.

Fixes: SCT-956

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [rolling-upgrade-ami-test/ on minicloud](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/mc/job/rolling-upgrade-ami-test/10/)
The test itself failed, but due to it was aborted by test duration timeout (running the test on scarce resources of minicloud VMs make the test run longer compared to AWS). But the step of sstable dump is executing sucessfully now, compared to like it was failing before the fix on small minicloud VMs:
```
19:09:59  < t:2026-09-07 17:09:59,306 f:action_logger.py l:46   c:sdcm.utils.action_logger p:INFO  >  source: tester, action: Starting sstabledump to verify correctness of sstables
...
19:10:01  < t:2026-09-07 17:10:00,903 f:action_logger.py l:46   c:sdcm.utils.action_logger p:INFO  >  source: tester, action: Step8 - Run stress and verify after upgrading entire cluster
```
- [x] [regression check: pr-provision-test with EnableDisableTableEncryptionAwsKmsProviderWithoutRotationMonkey nemesis enabled, which executes sstable dump (84 dumps total during the test)](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/pr-provision-test-new/329/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code