### PR TITLE
fix(nemesis): MultipleHardRebootNode: don't verify the rebooted node through itself (SCT-953)

### DIFF
--- a/sdcm/nemesis/__init__.py
+++ b/sdcm/nemesis/__init__.py
@@ -834,7 +834,13 @@ class NemesisRunner:
             else:
                 self.log.info("Waiting JMX services to start after node reboot")
                 self.target_node.wait_jmx_up()
-            self.cluster.wait_for_nodes_up_and_normal(nodes=[self.target_node])
+            # The target node is still booting and cannot answer for its own state - it serves 404 on
+            # /storage_service/load_map until storage_service registers its REST routes (SCT-953).
+            # Reserve a peer for the duration of the check and verify through it.
+            with self.node_allocator.run_nemesis(
+                nemesis_label="MultipleHardRebootNode verification"
+            ) as verification_node:
+                self.cluster.wait_for_nodes_up_and_normal(nodes=[self.target_node], verification_node=verification_node)
             found_cdc_error = list(cdc_expected_error)
             if found_cdc_error:
                 # if cdc error message "cdc - Could not update CDC description..."

--- a/unit_tests/unit/nemesis/monkey/test_multiple_hard_reboot.py
+++ b/unit_tests/unit/nemesis/monkey/test_multiple_hard_reboot.py
@@ -1,0 +1,128 @@
+"""Tests for NemesisRunner.disrupt_multiple_hard_reboot_node (SCT-953)."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from sdcm.nemesis import NemesisRunner
+from sdcm.nemesis.utils.node_allocator import NemesisNodeAllocator
+from sdcm.utils.metaclasses import Singleton
+from unit_tests.unit.nemesis import make_mock_node
+
+pytestmark = pytest.mark.usefixtures("events")
+
+
+@pytest.fixture(autouse=True)
+def clear_node_allocator_singleton():
+    """Drop the NemesisNodeAllocator Singleton after each test to prevent cross-test pollution."""
+    yield
+    Singleton._instances.pop(NemesisNodeAllocator, None)
+
+
+@pytest.fixture()
+def instant_reboot_loop(monkeypatch):
+    """Run the reboot loop a fixed number of times without sleeping between iterations.
+
+    ``disrupt_multiple_hard_reboot_node`` draws both its reboot count and its inter-reboot
+    sleep from ``random.randint``, so the factory pins the count and neutralises the sleep.
+
+    Returns:
+        A factory taking the desired number of reboots.
+    """
+
+    def _setup(reboots):
+        monkeypatch.setattr("sdcm.nemesis.random.randint", lambda *_: reboots)
+        monkeypatch.setattr("sdcm.nemesis.time.sleep", lambda *_: None)
+
+    return _setup
+
+
+@pytest.fixture()
+def runner(base_runner):
+    """Build a runner with a mocked allocator, for asserting on how it is called.
+
+    The target node's system-log followers report no CDC error, so the reboot loop runs
+    to completion instead of diverting into the CDC-failure branch.
+    """
+    base_runner.node_allocator = MagicMock()
+    base_runner.reboot_node = MagicMock()
+    base_runner.target_node = make_mock_node(name="node1", rack="rack1")
+    base_runner.target_node.follow_system_log.return_value = []
+    base_runner.cluster.nodes = [base_runner.target_node, base_runner.cluster.data_nodes[1]]
+    return base_runner
+
+
+@pytest.fixture()
+def verification_node(runner):
+    """The node the mocked allocator yields from its ``run_nemesis`` context."""
+    return runner.node_allocator.run_nemesis.return_value.__enter__.return_value
+
+
+@pytest.fixture()
+def real_allocator_runner(base_runner):
+    """Build a runner driven by a real NemesisNodeAllocator over a three-node pool.
+
+    The target is reserved the way ``NemesisRunner.set_target_node`` reserves it, so the
+    allocator is obliged to hand out one of the other two nodes for verification.
+    """
+    nodes = [make_mock_node(name=f"node{i}") for i in range(1, 4)]
+    for node in nodes:
+        # a bare MagicMock attribute is truthy, which would empty the data_nodes pool
+        node._is_zero_token_node = False
+        node.follow_system_log.return_value = []
+
+    tester = MagicMock()
+    tester.all_db_nodes = nodes
+    allocator = NemesisNodeAllocator(tester)
+    assert allocator.set_running_nemesis(nodes[0], "MultipleHardRebootNodeMonkey")
+
+    base_runner.node_allocator = allocator
+    base_runner.target_node = nodes[0]
+    base_runner.reboot_node = MagicMock()
+    base_runner.cluster.data_nodes = nodes
+    base_runner.cluster.nodes = nodes
+    return base_runner
+
+
+def test_multiple_hard_reboot_verifies_through_an_allocated_peer(runner, verification_node, instant_reboot_loop):
+    """The rebooted node must never be asked to confirm its own UN state."""
+    instant_reboot_loop(reboots=2)
+
+    NemesisRunner.disrupt_multiple_hard_reboot_node(runner)
+
+    calls = runner.cluster.wait_for_nodes_up_and_normal.call_args_list
+    assert len(calls) == 2, "one up-and-normal check per reboot"
+    for call in calls:
+        assert call.kwargs["nodes"] == [runner.target_node]
+        assert call.kwargs["verification_node"] is verification_node
+        assert call.kwargs["verification_node"] is not runner.target_node
+
+
+def test_multiple_hard_reboot_allocates_a_verification_node_per_reboot(runner, instant_reboot_loop):
+    """The peer is reserved and released around each check, not held for the whole loop."""
+    instant_reboot_loop(reboots=3)
+
+    NemesisRunner.disrupt_multiple_hard_reboot_node(runner)
+
+    assert runner.node_allocator.run_nemesis.call_count == 3
+    for call in runner.node_allocator.run_nemesis.call_args_list:
+        assert call.kwargs == {"nemesis_label": "MultipleHardRebootNode verification"}
+    # the context manager is exited each iteration, so the peer is handed back
+    assert runner.node_allocator.run_nemesis.return_value.__exit__.call_count == 3
+
+
+def test_multiple_hard_reboot_real_allocator_never_hands_back_the_target(real_allocator_runner, instant_reboot_loop):
+    """A real allocator holding the target reserved hands out only other nodes."""
+    instant_reboot_loop(reboots=4)
+    runner = real_allocator_runner
+    target = runner.target_node
+    peers = [node for node in runner.cluster.data_nodes if node is not target]
+
+    NemesisRunner.disrupt_multiple_hard_reboot_node(runner)
+
+    used = [call.kwargs["verification_node"] for call in runner.cluster.wait_for_nodes_up_and_normal.call_args_list]
+    assert len(used) == 4
+    assert target not in used, "the rebooting node must never verify itself"
+    assert set(used) <= set(peers)
+    # every reservation was released, leaving only the disruption's own target held
+    assert runner.node_allocator.active_nemesis_on_nodes == {target: "MultipleHardRebootNodeMonkey"}


### PR DESCRIPTION
`MultipleHardRebootNodeMonkey` verifies the node it has just hard-rebooted by calling
`wait_for_nodes_up_and_normal(nodes=[self.target_node])` without a verification node.
`check_nodes_up_and_normal` forwards `verification_node=None` down to `get_nodetool_status`,
which falls back to `random.choice(self.nodes)` over *every* node of the cluster - including
the target node that is still booting. On the reported run the roll landed on the target
itself, all three inner retries re-rolled onto it again, and the wait was abandoned ~37
seconds before the node actually reached NORMAL.

This PR fixes only that nemesis: a disruptive nemesis must never ask its own target node
about the state of the cluster. A peer is reserved from the nemesis node allocator around
each up-and-normal check and the verification goes through it. The target node stays in
`active_nemesis_on_nodes` for the whole disruption, so `select_target_node` can never hand
it back. The reservation is taken and released per reboot iteration rather than held for the
whole loop, matching how `node_isolation` obtains a working node.

The unsafe `random.choice(self.nodes)` default in `get_nodetool_status` is a framework-wide
problem that affects every caller that omits `verification_node`, not only this nemesis. It
is addressed separately in a follow-up PR; this one stays small so the sanity jobs that
`MultipleHardRebootNodeMonkey` is currently breaking can be unblocked with a limited
testing surface.

Add unit tests for this nemesis, which had none. One drives a real `NemesisNodeAllocator` to
cover the guarantee that the peer is never the target; the other two assert on how the
allocator is called.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ job passed](https://argus.scylladb.com/tests/scylla-cluster-tests/c3ad76b7-63f4-4559-b787-de8a3bd9f7c0)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
