### PR TITLE
docs(skills): plans should describe behaviour, not code

### DIFF
--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -1,12 +1,15 @@
 ---
 name: writing-plans
 description: >-
-  Use when asked to generate an implementation plan, draft a plan, save a plan,
-  or design a feature rollout for the SCT repository. Supports two formats:
-  full 7-section plans for multi-phase work (1K+ LOC, tracked in MASTER.md)
-  and lightweight mini-plans for single-PR changes (under 1K LOC, stored in
-  docs/plans/mini-plans/). Routes automatically based on PR plans label,
-  user input, or task size estimate.
+  Write, review, or restructure an implementation plan for the SCT repository.
+  Triggers: "create a plan", "write a plan", "draft a plan", "save a plan",
+  "make a plan for", "generate an implementation plan", "planning document",
+  "design doc", "implementation roadmap", "feature rollout", "mini-plan",
+  "break this into phases", "plan before implementing", or reviewing and
+  shortening an existing plan. Supports two formats: full 7-section plans for
+  multi-phase work (1K+ LOC, tracked in MASTER.md) and lightweight mini-plans
+  for single-PR changes (under 1K LOC, in docs/plans/mini-plans/). Routes
+  automatically based on PR plans label, user input, or task size estimate.
 ---
 
 # Writing Implementation Plans for SCT
@@ -21,11 +24,23 @@ Create well-structured implementation plans that follow SCT's 7-section format a
 
 This skill supplements — not replaces — the official instructions. Always read `docs/plans/INSTRUCTIONS.md` before writing a plan. If there is a conflict between this skill and `INSTRUCTIONS.md`, follow `INSTRUCTIONS.md`.
 
+### Behaviour Over Code
+
+**A plan describes intended behaviour and design goals — not the code that will implement them.**
+
+Write what should happen and why; leave the "how" to the PR. No line numbers, no snippets of internal logic, no file-internal detail. Test: if a sentence would have to change because someone refactored a function *without changing its behaviour*, it does not belong in the plan. This is the most common review complaint on SCT plans — see [PAP-1, PAP-9, PAP-10, PAP-11](references/anti-patterns.md) for what to cut and how.
+
+### One Plan, One Concern
+
+**If part of the plan could ship as its own independent effort, split it into its own plan.**
+
+A cluster of open questions in one area is the signal that the area is separable — and that it is blocking review of the part that is ready. See [PAP-12](references/anti-patterns.md).
+
 ### Code-Verified Current State
 
 **The Current State section must reference real files, classes, and methods.**
 
-Use file-reading tools to inspect actual code before writing Current State. Do not guess or hallucinate file names. Every path mentioned must resolve to an existing file in the repository.
+Use file-reading tools to inspect actual code before writing Current State. Do not guess or hallucinate file names. Every path mentioned must resolve to an existing file in the repository. Reference by symbol (`file.py:ClassName`), never by line number — see "Behaviour Over Code" above.
 
 ### PR-Scoped Phases
 
@@ -203,6 +218,7 @@ See [anti-patterns.md](references/anti-patterns.md) for the full catalog with be
 - [ ] Follows the 7-section structure from `docs/plans/INSTRUCTIONS.md`
 - [ ] Has a Problem Statement with measurable pain points
 - [ ] Has a Current State section with verified file/class/method references
+- [ ] Describes behaviour, not code: no line-number refs (`grep -nE ':[0-9]+'` clean), no snippets beyond interfaces/config/API contracts, lifecycle stated once, one concern per plan (≈400 lines)
 - [ ] Has numbered, measurable goals
 - [ ] Has PR-scoped implementation phases (≤200 LOC each) with Importance levels and Definition of Done
 - [ ] Includes a documentation update phase or deliverable (docs, config regeneration, guides)
@@ -220,6 +236,7 @@ See [anti-patterns.md](references/anti-patterns.md) for the full catalog with be
 - [ ] Has exactly 4 sections: Problem, Approach, Files to Modify, Verification
 - [ ] Has no YAML frontmatter
 - [ ] All file paths in "Files to Modify" are code-verified (or marked as new)
+- [ ] Describes behaviour, not code: no line numbers, no snippets of internal logic, lifecycle stated once, one concern per plan (≈150 lines)
 - [ ] Verification checklist has concrete, runnable checks
 - [ ] Includes `uv run sct.py pre-commit` in verification
 - [ ] Is saved as `docs/plans/mini-plans/YYYY-MM-DD-kebab-case-name.md`

--- a/skills/writing-plans/references/anti-patterns.md
+++ b/skills/writing-plans/references/anti-patterns.md
@@ -14,6 +14,20 @@ Common mistakes when writing SCT implementation plans. Each entry includes the s
 
 **Fix:** Use short code snippets (5-15 lines) only to illustrate interfaces, configuration formats, or API contracts. Describe behavior in prose; let the implementation phase produce the real code.
 
+**What belongs in a plan:**
+
+- **What should happen, and why** — the observable behaviour, the sequence of events, the contract with other systems
+- **Design decisions and their tradeoffs** — what was chosen, and what was rejected
+- **Module-level file paths** in "Files to Modify" / "Current State", so a reader knows where the work lands
+
+**What does not:**
+
+- **Line numbers** (`sct.py:1670`, `pricing.py:238`) — see PAP-9
+- **Code snippets of internals** — function bodies, control flow, error handling
+- **File-internal detail** — private attribute names, import order, which helper calls which. That is the implementer's job and the PR's review surface
+
+**Rule of thumb:** if a sentence would have to change because someone refactored a function *without changing its behaviour*, it does not belong in the plan.
+
 **Before:**
 ```markdown
 ### Phase 2: Implement Health Check
@@ -213,6 +227,99 @@ than adding a new enum parameter, to balance configurability with simplicity.
 
 ---
 
+### PAP-9: Line-Number References
+
+**Symptom:** The plan cites code by line number — `sct.py:1670`, `pricing.py:238`, "add after line 1842", "annotate `cluster_cloud.py:328` as out of scope".
+
+**Why it's wrong:** Line numbers go stale as soon as anything above them moves, so every plan review turns into a re-verification pass over references that carry no design meaning. Worse, they shift the reviewer's attention from *is this the right behaviour* to *is this the right line* — reviewers start reviewing a diff that has not been written yet. In [#15979](https://github.com/scylladb/scylla-cluster-tests/pull/15979) an automated reviewer used a stale line reference to "fix" a deliberate, lint-enforced construct.
+
+**Fix:** Reference code by stable symbol: `file.py:ClassName` or `file.py:method_name`. If the point does not need a symbol at all, just name the module.
+
+**Before:**
+```markdown
+- `sdcm/utils/cloud_catalog/pricing.py:11` imports `InstanceLifecycle` from
+  `sdcm/utils/cloud_monitor/common.py:34`, and `sct.py:1670` reads the arch.
+- Add the timeout at `pricing.py:238`.
+```
+
+**After:**
+```markdown
+- `sdcm/utils/cloud_catalog/pricing.py` — depends on `cloud_monitor.common` for
+  `InstanceLifecycle`, which makes it un-importable on its own
+- `sdcm/utils/cloud_catalog/pricing.py:AzurePricing` — Azure catalog fetch has no
+  request timeout
+```
+
+---
+
+### PAP-10: Plan Too Long to Review
+
+**Symptom:** The plan runs to several hundred lines. Reviewers comment on the first sections only, or say outright that they could not read all of it.
+
+**Why it's wrong:** A plan exists to get agreement on a design *before* code is written. A plan nobody finishes reading gets no agreement — it gets a rubber stamp or silence, and the disagreement surfaces later in implementation review, when changing course is expensive.
+
+**Fix:** Length is a symptom, not the disease. Cut the causes, in this order:
+
+1. **Code detail** — snippets, control flow, line numbers, file-internal names (PAP-1, PAP-3, PAP-9). This is usually most of the excess.
+2. **Separable efforts** — if a section could ship as its own plan, split it out and link it in one sentence. Open questions concentrated in one area are the tell.
+3. **Findings and investigation logs** — "I ran X and discovered Y" is valuable, but it belongs in the PR discussion or an issue, not in the plan. Keep the *conclusion* if it changed the design; drop the narrative.
+4. **Restated rules** — state a rule once, at the place that owns it, instead of at every call site that must honour it.
+
+**Rough budgets:** a mini-plan should fit in ~150 lines; a full 7-section plan in ~400. Over budget is a prompt to re-read this list, not a hard failure.
+
+---
+
+### PAP-11: Lifecycle Scattered Across Phases
+
+**Symptom:** The change has a lifecycle or a multi-step flow, but the plan only describes each step where that step's code gets written. The end-to-end sequence exists nowhere in one piece.
+
+**Why it's wrong:** Reviewers reason about a flow by following it. Made to reconstruct it from per-phase descriptions, they either give up or agree to something they have not actually understood — and gaps in the flow (a step with no owner, a value computed after the thing that needs it is gone) stay invisible. On [#15979](https://github.com/scylladb/scylla-cluster-tests/pull/15979) a reviewer had to write the sequence out himself in a comment to check the design held.
+
+**Fix:** State the whole sequence **once**, up front — in Goals or ahead of the phases for a full plan, in Approach for a mini-plan. One arrow chain is usually enough; use a diagram if branches matter (PAP-2). Then let each phase reference its position in that flow instead of re-describing it.
+
+**Before:**
+```markdown
+### Phase 2: Report rate on create
+Hook the create path and send the hourly rate.
+
+### Phase 4: Report cost on terminate
+Hook the terminate path, compute cost, send it.
+
+### Phase 6: Run total
+Sum and send at test end.
+```
+
+**After:**
+```markdown
+## Flow
+
+resource created -> rate calculated -> rate reported to Argus ->
+resource terminated -> cost computed from rate and duration ->
+cost reported -> run total sent at test end
+
+Rate calculation lives in a standalone module so out-of-band cleanup
+scripts can compute a cost for leaked resources they terminate.
+```
+
+---
+
+### PAP-12: Multiple Concerns in One Plan
+
+**Symptom:** The plan covers two or more efforts that could each ship on their own — and typically one of them is where all the unresolved questions sit.
+
+**Why it's wrong:** The ready half cannot be approved until the unready half is settled, so the whole plan stalls. It is also longer than either half needs to be, which triggers PAP-10. A reviewer's "shouldn't this be a separate task?" is the same observation arriving late.
+
+**Fix:** Split the separable effort into its own plan and reference it in **one sentence**, only where it explains a constraint on this one. The open questions move with it. Check for this before finalizing: for each group of phases, ask whether it would still make sense as a standalone PR chain if the rest were dropped.
+
+**Signals a split is due:**
+- Open questions cluster in one area rather than spreading evenly
+- One area's phases have no dependency on the others' — only on shared groundwork
+- A reviewer asks "is this a separate task/effort?"
+
+On [#15979](https://github.com/scylladb/scylla-cluster-tests/pull/15979) the approval-gate half moved to its own plan; the two open questions went with it, and the "not a complete plan" objection resolved without answering them.
+
+---
+
 ## Structure Anti-Patterns
 
 ### PAP-6: Missing "Current State" Code References
@@ -221,7 +328,7 @@ than adding a new enum parameter, to balance configurability with simplicity.
 
 **Why it's wrong:** Without code references, reviewers cannot verify the analysis is accurate. The implementer may look at the wrong code. The plan may describe outdated behavior.
 
-**Fix:** Every claim about current behavior must cite a specific file path and optionally a class or method. Verify each reference exists using file-reading tools.
+**Fix:** Every claim about current behavior must cite a specific file path and optionally a class or method. Verify each reference exists using file-reading tools. Cite by symbol, never by line number (PAP-9), and describe the *behaviour* the code produces rather than how it is written (PAP-1).
 
 **Before:**
 ```markdown
@@ -295,6 +402,10 @@ parallel execution in `BaseCluster.check_cluster_health`.
 | PAP-3 | Overly granular phases | Describe deliverables, not line-by-line changes |
 | PAP-4 | Vague or unmeasurable goals | Add measurable criteria or verifiable conditions |
 | PAP-5 | Conflicting requirements | Cross-check goals, phases, and risks for consistency |
+| PAP-9 | Line-number references | Cite `file.py:ClassName`, never `file.py:238` |
+| PAP-10 | Plan too long to review | Cut code detail, split separable efforts, drop investigation logs |
+| PAP-11 | Lifecycle scattered across phases | State the end-to-end sequence once, up front |
+| PAP-12 | Multiple concerns in one plan | Split the separable effort out; open questions move with it |
 | PAP-6 | Missing code references in Current State | Cite specific file paths, verify they exist |
 | PAP-7 | Phases without Definition of Done | Add checkbox criteria to every phase |
 | PAP-8 | Monolithic phase spanning multiple PRs | Split into single-PR-scoped phases |

--- a/skills/writing-plans/references/mini-plan-template.md
+++ b/skills/writing-plans/references/mini-plan-template.md
@@ -67,7 +67,11 @@ causing false negatives in cluster health reports during rolling restarts.
 
 ## Rules
 
-1. **File paths must be code-verified** -- use file-reading tools to confirm paths exist before listing them.
-2. **Verification must be concrete** -- every checkbox should be something a person can actually check or run.
-3. **No YAML frontmatter** -- mini-plans are intentionally lightweight.
-4. **No MASTER.md or progress.json** -- mini-plans are not tracked in the plan registry.
+1. **Describe behaviour, not code** -- the Approach section says what should happen and in what order, not how it is coded. No line numbers, no code snippets of internals, no file-internal detail (private attributes, import order, which helper calls which). Reference code by symbol: `file.py:ClassName`. See PAP-1, PAP-9 and PAP-10 in [anti-patterns.md](anti-patterns.md).
+2. **State the flow once, end to end** -- if the change has a lifecycle or a multi-step sequence, write it as a single arrow chain in Approach (e.g. `instance created -> rate calculated -> rate reported -> instance terminated -> cost computed -> cost reported -> run total sent`), not spread over the step bullets. See PAP-11.
+3. **File paths must be code-verified** -- use file-reading tools to confirm paths exist before listing them. Module-level paths only; "Files to Modify" is the one place file paths belong.
+4. **Keep it under ~150 lines** -- a mini-plan is a single-PR change. If it does not fit, either it is a full plan, or it is carrying code detail and separable efforts that should come out (PAP-10).
+5. **One concern per plan** -- if part of it could ship as its own effort, split it into its own mini-plan and reference it in one sentence. A cluster of open questions in one area is the signal that it is separable (PAP-12).
+6. **Verification must be concrete** -- every checkbox should be something a person can actually check or run.
+7. **No YAML frontmatter** -- mini-plans are intentionally lightweight.
+8. **No MASTER.md or progress.json** -- mini-plans are not tracked in the plan registry.

--- a/skills/writing-plans/references/plan-templates.md
+++ b/skills/writing-plans/references/plan-templates.md
@@ -160,6 +160,11 @@ The bad example lacks specifics: no measurable problem, no root cause, no justif
 - What needs to change
 - Technical debt or limitations
 
+**Must not include**:
+- **Line numbers** — `pricing.py:238` is stale as soon as anything above it moves, and it turns plan review into diff review. Cite `file.py:ClassName` or `file.py:method_name` (PAP-9)
+- **File-internal detail** — private attribute names, import order, which helper calls which. Describe the *behaviour* the code produces, not how it is written (PAP-1)
+- **Investigation narrative** — "I ran X and found Y" belongs in the PR discussion. Keep only the conclusion, and only if it changed the design
+
 **Good example** (from `docs/plans/nemesis/nemesis-rework.md`):
 ```markdown
 ## Current State

--- a/skills/writing-plans/workflows/create-a-mini-plan.md
+++ b/skills/writing-plans/workflows/create-a-mini-plan.md
@@ -44,6 +44,8 @@ A 3-phase lightweight workflow for writing a mini-plan for small, single-PR chan
 
 3. **Write the Approach section.** Bulleted list of steps in execution order. Each bullet should be a concrete action, not a vague goal.
 
+   Describe **behaviour, not code**: what should happen and why, not how it is written. No line numbers, no snippets of internal logic, no file-internal detail — reference code by symbol (`file.py:ClassName`) and leave the "how" to the PR (PAP-1, PAP-9). If the change has a lifecycle, state the whole sequence once as an arrow chain rather than spreading it over bullets (PAP-11).
+
 4. **Write the Files to Modify section.** For each file:
    - **Verify the path exists** using file-reading tools before listing it
    - Describe what changes in that file
@@ -76,6 +78,11 @@ A 3-phase lightweight workflow for writing a mini-plan for small, single-PR chan
    - progress.json entry
    - More than 4 sections
 
-4. **Run pre-commit (if available).** Execute `uv run sct.py pre-commit` to check formatting.
+4. **Check reviewability.** Run `wc -l` on the file:
+   - Over ~150 lines -> cut code detail first (PAP-1, PAP-9), then split out any separable effort into its own mini-plan (PAP-12), then drop investigation narrative and restated rules (PAP-10)
+   - `grep -nE ':[0-9]+' <file>` -> any hit is a line-number reference; replace it with a symbol reference (PAP-9)
+   - Any fenced code block that is not an interface, config format, or API contract -> replace with a prose description of the behaviour
+
+5. **Run pre-commit (if available).** Execute `uv run sct.py pre-commit` to check formatting.
 
 **Exit:** Mini-plan is validated, saved in `docs/plans/mini-plans/`, and ready to use.

--- a/skills/writing-plans/workflows/create-a-plan.md
+++ b/skills/writing-plans/workflows/create-a-plan.md
@@ -55,10 +55,12 @@ Before beginning Phase 1, determine whether this task needs a full plan or a min
 
 2. **Write the Current State section.** This is the most research-intensive section:
    - Reference specific files, classes, and methods (verify they exist)
-   - Describe how things currently work
+   - Reference by symbol (`file.py:ClassName`), **never by line number** — line refs go stale and pull reviewers into reviewing code instead of design (PAP-9)
+   - Describe how things currently work — the *behaviour* the code produces, not how it is written
    - Identify what needs to change
    - Document technical debt or limitations
    - **Never guess file names** — use tools to locate and verify
+   - Research findings ("I ran X and discovered Y") belong in the PR discussion; keep only the conclusion that changed the design
 
 3. **Write the Goals section.** Define 3-6 specific, measurable objectives:
    - Number each goal with a bold title
@@ -84,25 +86,29 @@ Before beginning Phase 1, determine whether this task needs a full plan or a min
 
 3. **For each phase, write:**
    - **Importance**: Critical/Important/Nice-to-have (see heuristics in templates)
-   - **Description**: What will be implemented and why
+   - **Description**: What will be implemented and why — the intended behaviour and the design decisions behind it, not the code. No line numbers, no snippets of internal logic, no file-internal detail (PAP-1, PAP-3, PAP-9)
    - **Dependencies**: Which phases must be complete first
    - **Deliverables**: Concrete outputs (files, features, configurations)
    - **Definition of Done**: Verifiable criteria using checkboxes — these serve as the success criteria for the phase
 
-4. **Mark uncertain steps.** If a requirement or dependency is unclear, mark it as "Needs Investigation" rather than making assumptions.
+   If the feature has a lifecycle or multi-step flow, state the end-to-end sequence **once**, in Goals or ahead of the phases — not reconstructed across per-phase descriptions (PAP-11).
 
-5. **Include a documentation update phase.** Every plan should have a phase (or phase deliverable) covering:
+4. **Check the plan is one concern.** If a group of phases could ship as an independent effort — especially if that is where the open questions cluster — split it into its own plan and reference it in one sentence where it constrains this one (PAP-12).
+
+5. **Mark uncertain steps.** If a requirement or dependency is unclear, mark it as "Needs Investigation" rather than making assumptions.
+
+6. **Include a documentation update phase.** Every plan should have a phase (or phase deliverable) covering:
    - Updated or new entries in `docs/` for user-facing changes
    - Configuration documentation regenerated via `uv run sct.py pre-commit`
    - README or guide updates if the feature changes user workflows
 
-6. **Include SCT-specific details:**
+7. **Include SCT-specific details:**
    - Backend-specific impact (which backends are affected?)
    - Configuration changes (`sdcm/sct_config.py` parameters)
    - Default values in `defaults/test_default.yaml`
    - Test case YAML files in `test-cases/`
 
-7. **Add separation lines** (`---`) between phases for readability.
+8. **Add separation lines** (`---`) between phases for readability.
 
 **Exit:** Implementation Phases section complete with Definition of Done for each phase.
 
@@ -155,22 +161,27 @@ Before beginning Phase 1, determine whether this task needs a full plan or a min
 
 2. **Verify all code references.** Every file path mentioned in Current State must point to a real file. Use file-reading tools to confirm.
 
-3. **Check phase dependencies.** Ensure no phase references work from a later phase. Foundational work comes first.
+3. **Check reviewability.** A plan nobody finishes reading gets no agreement (PAP-10):
+   - `grep -nE ':[0-9]+' <file>` — every hit is a line-number reference; replace it with a symbol reference (PAP-9)
+   - Every fenced code block must be an interface, config format, or API contract. Function bodies and control flow come out (PAP-1)
+   - `wc -l <file>` over ~400 lines — cut code detail, split separable efforts into their own plans, drop investigation narrative, and state each rule once instead of at every call site
 
-4. **Check for open questions.** If any requirement is unclear, it should be marked as "Needs Investigation" — not assumed.
+4. **Check phase dependencies.** Ensure no phase references work from a later phase. Foundational work comes first.
 
-5. **Check Definition of Done criteria.** Each criterion should be verifiable (someone can check it off), not vague ("it works").
+5. **Check for open questions.** If any requirement is unclear, it should be marked as "Needs Investigation" — not assumed.
 
-6. **Review against an existing plan.** Compare structure and quality with `docs/plans/infrastructure/health-check-optimization.md` or another reference plan.
+6. **Check Definition of Done criteria.** Each criterion should be verifiable (someone can check it off), not vague ("it works").
 
-7. **Verify filename.** Plan should be saved as `docs/plans/<kebab-case-name>.md` with a descriptive name.
+7. **Review against an existing plan.** Compare structure and quality with `docs/plans/infrastructure/health-check-optimization.md` or another reference plan.
 
-8. **Verify YAML frontmatter.** Confirm the plan starts with valid frontmatter containing `status`, `domain`, `created`, `last_updated`, and `owner` fields. See [frontmatter-fields.md](../references/frontmatter-fields.md) for valid values.
+8. **Verify filename.** Plan should be saved as `docs/plans/<kebab-case-name>.md` with a descriptive name.
 
-9. **Register in MASTER.md.** Add the plan to the correct domain table in `docs/plans/MASTER.md` with appropriate status.
+9. **Verify YAML frontmatter.** Confirm the plan starts with valid frontmatter containing `status`, `domain`, `created`, `last_updated`, and `owner` fields. See [frontmatter-fields.md](../references/frontmatter-fields.md) for valid values.
 
-10. **Add progress.json entry.** Add an entry to `docs/plans/progress.json` with the plan's id, title, file, domain, status, created date, phases_total, and phases_done.
+10. **Register in MASTER.md.** Add the plan to the correct domain table in `docs/plans/MASTER.md` with appropriate status.
 
-11. **Run pre-commit (if available).** Execute `uv run sct.py pre-commit` to verify no formatting issues. If unavailable, manually check trailing whitespace and end-of-file newlines.
+11. **Add progress.json entry.** Add an entry to `docs/plans/progress.json` with the plan's id, title, file, domain, status, created date, phases_total, and phases_done.
+
+12. **Run pre-commit (if available).** Execute `uv run sct.py pre-commit` to verify no formatting issues. If unavailable, manually check trailing whitespace and end-of-file newlines.
 
 **Exit:** All 7 sections present, code references verified, phases ordered correctly, plan saved in `docs/plans/`, registered in MASTER.md, and tracked in progress.json.


### PR DESCRIPTION
Skill-only change — no framework code. Updates `skills/writing-plans/`.

## Why

Review feedback on #15979 (@soyacz):

> I think those plans should describe more the behavior instead of code. This way it would be shorter and easier for review (I could not read all).

That plan went from 500+ lines to 128 by cutting code detail, line references and snippets, and the follow-up was "appreciated, this way it's easier to follow it and add more comments". The rule worked, but it lived only in that PR thread — the skill still told plans to carry code references and said nothing about length. This encodes it so the next plan starts there instead of being rewritten into it.

The same thread also asked whether a separable effort ("shouldn't it be separate task/effort") belongs in its own plan. Splitting the approval gate out into #15995 is what resolved the "not a complete plan" objection, since the open questions moved with it — so that is captured too.

## What changed

**Four new anti-patterns** in `references/anti-patterns.md` carry the substance. That is where the skill already keeps its worked examples, and reference files cost nothing until loaded:

| ID | Anti-pattern | Fix |
|----|-------------|-----|
| PAP-9 | Line-number references | Cite `file.py:ClassName`, never `file.py:238` |
| PAP-10 | Plan too long to review | Length is a symptom — ordered cut list, ~150/~400 line budgets |
| PAP-11 | Lifecycle scattered across phases | State the end-to-end sequence once, up front |
| PAP-12 | Multiple concerns in one plan | Split the separable effort out; open questions move with it |

- **PAP-9** includes the concrete cost from #15979: an automated reviewer used a stale line ref to "fix" a deliberate, lint-enforced PEP 758 `except` group.
- **PAP-11** uses @soyacz's own chain from the thread as its worked example (`created -> rate calculated -> rate reported -> terminated -> cost computed -> cost reported -> run total`). A reviewer can check a design from that one line; he had to write it out himself in a comment to do so.
- **PAP-12** lists the signals that a split is due, the strongest being open questions clustering in one area rather than spreading evenly.

**PAP-1** ("too much code in the plan") grows explicit belongs / does-not-belong lists and the rule of thumb: *if a sentence would have to change because someone refactored a function without changing its behaviour, it does not belong in the plan.* **PAP-6** ("missing code references in Current State") now says cite by symbol and describe behaviour, so it no longer pulls against PAP-9.

**`SKILL.md`** stays lean — two short principles, **Behaviour Over Code** and **One Plan, One Concern**, each a couple of sentences pointing at the entries above. The existing "Code-Verified Current State" cross-references them so the two don't read as conflicting. The new success criteria fold into one line per format, so the body ends up *shorter* than the surrounding sections it sits between despite covering more ground. The `description` also grows explicit trigger phrases ("write a plan", "planning document", "design doc", "implementation roadmap", "break this into phases", …) so activation matches varied phrasings.

**Both formats carry the rules through:**

- Mini-plan template Rules grew from 4 to 8 (behaviour-not-code, state the flow once, ~150 lines, one concern)
- Full-plan template's Current State gained a "Must not include" block, including "investigation narrative belongs in the PR discussion"
- Both workflows gained a reviewability check — `grep -nE ':[0-9]+'` for line refs, `wc -l` against budget, and a pass over fenced blocks to confirm each is an interface, config format or API contract
- Success-criteria checklists updated for both formats

## Verification

- `uv run sct.py pre-commit` passes
- Every `PAP-N` referenced across the skill resolves to an entry in the catalog
- The only line-number references left anywhere in the skill are inside PAP-9's own "Before" example

Refs #15979.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
