### PR TITLE
fix(unit_tests): de-flake TestGrafana, the events publisher is the bottleneck

### DIFF
--- a/unit_tests/lib/events_utils.py
+++ b/unit_tests/lib/events_utils.py
@@ -18,7 +18,7 @@ import unittest.mock
 from contextlib import contextmanager
 
 from sdcm.sct_events.setup import EVENTS_DEVICE_START_DELAY, start_events_device, stop_events_device
-from sdcm.sct_events.events_device import start_events_main_device, get_events_main_device
+from sdcm.sct_events.events_device import SUB_POLLING_TIMEOUT, start_events_main_device, get_events_main_device
 from sdcm.sct_events.file_logger import get_events_logger
 from sdcm.sct_events.events_processes import EventsProcessesRegistry
 from sdcm.sct_events.event_counter import get_events_counter
@@ -69,15 +69,34 @@ class EventsUtilsMixin:
 
     @contextmanager
     def wait_for_n_events(self, subscriber, count: int, timeout: float = 1, last_event_processing_delay: float = 0.5):
-        last_event_n = subscriber.events_counter + count
-        end_time = time.perf_counter() + timeout
+        """Wait for `subscriber` to receive `count` more events, tolerating a stalled publisher.
+
+        `timeout` is the patience for a *single* event rather than for the whole batch:
+        `EventsDevice` sends one event at a time and waits for a delivery confirmation on its own
+        SUB socket after each `send()`, giving up only after `SUB_POLLING_TIMEOUT`.  A confirmation
+        that gets lost -- routine when CI packs several pytest-xdist workers onto one builder --
+        therefore stalls the publisher for a whole second before it even sends the next event, so a
+        batch of `count` events can trickle in over `count * SUB_POLLING_TIMEOUT` no matter how
+        fast the subscriber is.  Restarting the countdown on every event received keeps a pipeline
+        that delivers nothing failing fast, while no longer failing one that is merely slow.
+        """
+        events_before = subscriber.events_counter
+        last_event_n = events_before + count
+        per_event_timeout = max(timeout, 2 * SUB_POLLING_TIMEOUT / 1000)
 
         yield
 
-        while time.perf_counter() < end_time and subscriber.events_counter < last_event_n:
+        end_time = time.perf_counter() + per_event_timeout
+        events_seen = subscriber.events_counter
+        while events_seen < last_event_n and time.perf_counter() < end_time:
             time.sleep(0.1)
+            if (events_now := subscriber.events_counter) > events_seen:
+                events_seen = events_now
+                end_time = time.perf_counter() + per_event_timeout
+
         assert last_event_n <= subscriber.events_counter, (
-            f"Subscriber {subscriber} didn't receive {count} events in {timeout} seconds"
+            f"Subscriber {subscriber} received {subscriber.events_counter - events_before} of {count} events "
+            f"and then stalled for {per_event_timeout} seconds"
         )
 
         # Give a chance to the subscriber to handle last event received.

--- a/unit_tests/unit/test_sct_events_grafana.py
+++ b/unit_tests/unit/test_sct_events_grafana.py
@@ -69,23 +69,31 @@ class TestGrafana(EventsUtilsMixin):
             assert grafana_postman._registry == self.events_main_device._registry
             assert grafana_postman._registry == self.events_processes_registry
 
-            grafana_aggregator.time_window = 1
+            # The aggregator's default 90 s time window is kept as-is, so every event published
+            # below is aggregated inside one window and only the first `max_duplicates` of them
+            # are posted.  Shortening the window made the expected count depend on where the wall
+            # clock happened to fall while a batch was being delivered; the rollover between
+            # windows is covered by TestGrafanaAggregatorTimeWindow instead.
+            published_events = 3 * 10
+            expected_annotations = grafana_aggregator.max_duplicates
 
             set_grafana_url("http://localhost", _registry=self.events_processes_registry)
             with unittest.mock.patch("requests.post") as mock:
-                for runs in range(1, 4):
-                    with self.wait_for_n_events(grafana_annotator, count=10, timeout=1):
+                for _ in range(3):
+                    with self.wait_for_n_events(grafana_annotator, count=10):
                         for _ in range(10):
                             self.events_main_device.publish_event(
                                 ClusterHealthValidatorEvent.NodeStatus(severity=Severity.NORMAL)
                             )
-                    time.sleep(1)
+
+                # Nothing may be posted before the Grafana URL has been announced.
                 assert mock.call_count == 0
 
                 start_posting_grafana_annotations(_registry=self.events_processes_registry)
-                wait_for(lambda: mock.call_count == runs * 5, timeout=10, step=0.1, throw_exc=False)
+                wait_for(lambda: mock.call_count == expected_annotations, timeout=10, step=0.1, throw_exc=False)
 
-                assert mock.call_count == runs * 5
+                # Duplicates of the same annotation are capped at `max_duplicates` per time window.
+                assert mock.call_count == expected_annotations
                 assert mock.call_args.kwargs["json"]["tags"] == [
                     "ClusterHealthValidatorEvent",
                     "NORMAL",
@@ -93,9 +101,68 @@ class TestGrafana(EventsUtilsMixin):
                     "NodeStatus",
                 ]
 
+            # The suppressed duplicates still have to reach the aggregator, and only the first
+            # `max_duplicates` of them were posted, so wait for it to drain before counting.
+            wait_for(
+                lambda: grafana_aggregator.events_counter == published_events,
+                timeout=10,
+                step=0.1,
+                throw_exc=False,
+            )
+
             assert self.events_main_device.events_counter == grafana_annotator.events_counter
             assert grafana_annotator.events_counter == grafana_aggregator.events_counter
             assert grafana_postman.events_counter <= grafana_aggregator.events_counter
+        finally:
+            grafana_annotator.stop(timeout=1)
+            grafana_aggregator.stop(timeout=1)
+            grafana_postman.stop(timeout=1)
+
+
+class TestGrafanaAggregatorTimeWindow(EventsUtilsMixin):
+    """The duplicate cap is per time window, so a duplicate seen in the next one is posted again."""
+
+    time_window = 0.2
+
+    @classmethod
+    def setup_class(cls) -> None:
+        cls.setup_events_processes(events_device=False, events_main_device=True, registry_patcher=False)
+
+    @classmethod
+    def teardown_class(cls) -> None:
+        cls.teardown_events_processes()
+
+    def test_duplicate_in_the_next_time_window_is_posted_again(self):
+        start_grafana_pipeline(_registry=self.events_processes_registry)
+        grafana_annotator = get_events_process(EVENTS_GRAFANA_ANNOTATOR_ID, _registry=self.events_processes_registry)
+        grafana_aggregator = get_events_process(EVENTS_GRAFANA_AGGREGATOR_ID, _registry=self.events_processes_registry)
+        grafana_postman = get_grafana_postman(_registry=self.events_processes_registry)
+
+        time.sleep(EVENTS_SUBSCRIBERS_START_DELAY)
+
+        try:
+            # A single event fills a window, so no assertion here depends on a batch of events
+            # landing on the same side of a window boundary.
+            grafana_aggregator.max_duplicates = 1
+            grafana_aggregator.time_window = self.time_window
+
+            set_grafana_url("http://localhost", _registry=self.events_processes_registry)
+            start_posting_grafana_annotations(_registry=self.events_processes_registry)
+
+            with unittest.mock.patch("requests.post") as mock:
+                for _ in range(2):
+                    with self.wait_for_n_events(grafana_annotator, count=1):
+                        self.events_main_device.publish_event(
+                            ClusterHealthValidatorEvent.NodeStatus(severity=Severity.NORMAL)
+                        )
+                    # Outlast the window, so the next duplicate is counted against a fresh one.
+                    # `wait_for_n_events` already waited out `last_event_processing_delay` on top.
+                    time.sleep(self.time_window * 5)
+
+                wait_for(lambda: mock.call_count == 2, timeout=10, step=0.1, throw_exc=False)
+                assert mock.call_count == 2, (
+                    "a duplicate annotation seen after the time window expired must be posted again"
+                )
         finally:
             grafana_annotator.stop(timeout=1)
             grafana_aggregator.stop(timeout=1)


### PR DESCRIPTION
## Problem

`unit_tests/unit/test_sct_events_grafana.py::TestGrafana::test_grafana` failed the `unittest` stage
on [PR-15860 #47](https://jenkins.scylladb.com/job/sct-github-PRs-scan/job/scylla-cluster-tests/job/PR-15860/47/)
— a PR that touches nothing in `sdcm/sct_events/`:

```
FAILED unit_tests/unit/test_sct_events_grafana.py::TestGrafana::test_grafana
- AssertionError: Subscriber <GrafanaAnnotator(Thread-609, started daemon 127805654304448)>
  didn't receive 10 events in 1 seconds
```

The bottleneck is the **publisher**, not the `GrafanaAnnotator`. `EventsDevice` sends one event at
a time and, after each `pub.send()`, waits for a delivery confirmation on its own SUB socket,
giving up only after `SUB_POLLING_TIMEOUT` (1 s):

```python
if sub.poll(timeout=self.sub_polling_timeout) and sub.recv(zmq.NOBLOCK) == event:
    continue  # everything is OK, we can go to send next event in the queue.
```

A confirmation that gets lost — routine when CI packs four pytest-xdist workers onto one builder —
therefore stalls the publisher for a whole second *before it even sends the next event*, so a batch
of 10 events can trickle in over ~10 s however fast the subscriber is. The 1 s budget the test gave
the whole batch could not hold. (For scale: the same test passed in build #46 taking `10.00s` — it
was the slowest test in the entire unit suite.)

## Fix

**`wait_for_n_events()` spends its `timeout` per event instead of per batch.** The countdown
restarts whenever an event lands, and never allows less than the publisher's own stall window. A
pipeline that delivers nothing still fails just as fast, and the assertion now reports how many
events actually arrived instead of only that some were missing. Every caller of the helper
benefits — several use similarly tight budgets (`count=15, timeout=3`) — and a healthy run pays
nothing, since the loop still exits as soon as the events show up.

**`test_grafana` no longer shortens the aggregator's time window to 1 s.** This matters: merely
widening the wait would have traded one flake for another. The old test asserted
`mock.call_count == runs * 5`, which only holds if each 10-event batch is delivered entirely
*inside* one 1-second aggregation window — a batch straddling a boundary resets
`time_window_counters` mid-batch and lets more than `max_duplicates` annotations through. Slow
delivery, the very condition that caused this failure, is exactly what makes a batch straddle. With
the default 90 s window all 30 events are aggregated in one window and exactly `max_duplicates`
are posted, with no wall-clock dependency left.

The window rollover the 1 s window used to exercise is now covered deterministically by a new
`TestGrafanaAggregatorTimeWindow`, which publishes one event per window with `max_duplicates = 1` —
a single event cannot straddle a boundary, so that assertion cannot race either.

## Testing

The exact CI assertion was reproduced locally by forcing the delivery confirmation to time out, which
makes the publisher emit one event per second:

```python
def _slow_init(self, *args, **kwargs):
    _orig_init(self, *args, **kwargs)
    self.sub_polling_timeout = 0      # verification always times out immediately
    self.pub_queue_events_rate = 1.0  # ... then wait a second before the next send
```

* Against **master**, this fails with the console log's assertion verbatim:
  `AssertionError: Subscriber <GrafanaAnnotator(...)> didn't receive 10 events in 1 seconds`
* Against **this branch**, both tests pass under the same injection (`test_grafana` takes 33 s,
  publishing its 30 events at 1/s).

Also:

* `unit_tests/unit` in full on 4 xdist workers (the CI configuration): `2637 passed, 31 skipped`.
  `test_grafana` is no longer the slowest test in the suite.
* All 40 tests across the other `wait_for_n_events` callers (`test_events.py`,
  `test_sct_events_file_logger.py`, `test_sct_events_events_analyzer.py`,
  `test_sct_events_events_handler.py`): green.
* `test_sct_events_grafana.py` on its own, 5 consecutive runs: green.

Fixes: SCT-963
