### PR TITLE
docs(plans): refresh health check optimization plan

### DIFF
--- a/docs/plans/MASTER.md
+++ b/docs/plans/MASTER.md
@@ -80,7 +80,8 @@ For plan writing guidelines, see [INSTRUCTIONS.md](INSTRUCTIONS.md).
 
 | Plan | Status | File / PR |
 |------|--------|-----------|
-| Health Check Optimization | `draft` | [health-check-optimization.md](infrastructure/health-check-optimization.md) |
+| Health Check Optimization | `in_progress` | [health-check-optimization.md](infrastructure/health-check-optimization.md) |
+| Health Check Node Sampling | `draft` | [health-check-sampling.md](infrastructure/health-check-sampling.md) |
 | Feature-Aware Adaptive Timeouts for Topology Operations | `draft` | [feature-aware-adaptive-topology-timeouts.md](infrastructure/feature-aware-adaptive-topology-timeouts.md) |
 | Full Version Tag Lookup | `draft` | [full-version-tag-lookup.md](config/full-version-tag-lookup.md) |
 | Keystore Improvements | `pending_pr` | [#14055](https://github.com/scylladb/scylla-cluster-tests/pull/14055) |
@@ -104,6 +105,7 @@ For plan writing guidelines, see [INSTRUCTIONS.md](INSTRUCTIONS.md).
 | Dependent Plan | Depends On | Relationship |
 |---------------|------------|--------------|
 | Nemesis Extraction Phase 3 | Nemesis Rework | Phase 3 continues the extraction started in Nemesis 2.0 |
+| Health Check Node Sampling | Health Check Optimization | Sampling is gated on the optimization plan's measured baseline; its go/no-go depends on how much time is left to win |
 | Pipeline Labeling and Documentation | Jenkins Pipeline Config Linter | Labeling complements structural config linting; may reuse Jenkinsfile parser |
 | SCT Config Follow-up Refactoring | SCT Config Validation and Lazy Images | Follow-up work after initial config validation |
 | Typed Config Access Migration | SCT Config Follow-up Refactoring | Type safety layer on top of refactored config |

--- a/docs/plans/assets/progress-roadmap.svg
+++ b/docs/plans/assets/progress-roadmap.svg
@@ -1,12 +1,12 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="840" height="988" viewBox="0 0 840 988">
-<rect width="840" height="988" fill="#0D1B2A" rx="8"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="840" height="960" viewBox="0 0 840 960">
+<rect width="840" height="960" fill="#0D1B2A" rx="8"/>
 <text x="420" y="60" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="22" font-weight="bold" fill="#00BCD4">SCT Implementation Plans</text>
 <text x="420" y="84" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="13" fill="#8899AA">32 plans across 9 domains</text>
 <rect x="30" y="120" width="780" height="50" rx="6" fill="#1B2A4A" stroke="#2A3F5F" stroke-width="1"/>
 <circle cx="50" cy="148" r="5" fill="#607D8B"/>
 <text x="60" y="152" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#E0E6ED">Draft: 11</text>
 <circle cx="180" cy="148" r="5" fill="#FFC107"/>
-<text x="190" y="152" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#E0E6ED">In Progress: 3</text>
+<text x="190" y="152" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#E0E6ED">In Progress: 4</text>
 <circle cx="310" cy="148" r="5" fill="#2196F3"/>
 <text x="320" y="152" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#E0E6ED">Approved: 0</text>
 <circle cx="440" cy="148" r="5" fill="#F44336"/>
@@ -14,16 +14,16 @@
 <circle cx="570" cy="148" r="5" fill="#4CAF50"/>
 <text x="580" y="152" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#E0E6ED">Complete: 5</text>
 <circle cx="700" cy="148" r="5" fill="#9E9E9E"/>
-<text x="710" y="152" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#E0E6ED">Pending PR: 13</text>
+<text x="710" y="152" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#E0E6ED">Pending PR: 12</text>
 <rect x="40" y="175" width="760" height="20" rx="10" fill="#1B2A4A" stroke="#2A3F5F" stroke-width="1"/>
 <rect x="40" y="175" width="118.75" height="20" rx="10" fill="#4CAF50"/>
 <text x="99.375" y="189" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="bold" fill="#0D1B2A">5</text>
-<rect x="158.75" y="175" width="71.25" height="20" rx="0" fill="#FFC107"/>
-<text x="194.375" y="189" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="bold" fill="#0D1B2A">3</text>
-<rect x="230.0" y="175" width="261.25" height="20" rx="0" fill="#607D8B"/>
-<text x="360.625" y="189" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="bold" fill="#0D1B2A">11</text>
-<rect x="491.25" y="175" width="308.75" height="20" rx="0" fill="#9E9E9E"/>
-<text x="645.625" y="189" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="bold" fill="#0D1B2A">13</text>
+<rect x="158.75" y="175" width="95.0" height="20" rx="0" fill="#FFC107"/>
+<text x="206.25" y="189" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="bold" fill="#0D1B2A">4</text>
+<rect x="253.75" y="175" width="261.25" height="20" rx="0" fill="#607D8B"/>
+<text x="384.375" y="189" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="bold" fill="#0D1B2A">11</text>
+<rect x="515.0" y="175" width="285.0" height="20" rx="0" fill="#9E9E9E"/>
+<text x="657.5" y="189" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="bold" fill="#0D1B2A">12</text>
 <rect x="30" y="220" width="380" height="32" rx="4" fill="#1B2A4A" stroke="#00BCD4" stroke-width="1"/>
 <text x="42" y="241" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="bold" fill="#00BCD4">cluster</text>
 <text x="398" y="241" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#8899AA">5 plans</text>
@@ -71,22 +71,25 @@
 <text x="398" y="654" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#9E9E9E">Pending PR</text>
 <rect x="30" y="680" width="380" height="32" rx="4" fill="#1B2A4A" stroke="#00BCD4" stroke-width="1"/>
 <text x="42" y="701" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="bold" fill="#00BCD4">framework</text>
-<text x="398" y="701" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#8899AA">4 plans</text>
+<text x="398" y="701" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#8899AA">5 plans</text>
 <circle cx="44" cy="726" r="4" fill="#607D8B"/>
 <text x="56" y="730" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">Full Version Tag Lookup</text>
 <text x="398" y="730" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#607D8B">Draft</text>
-<circle cx="44" cy="754" r="4" fill="#607D8B"/>
+<circle cx="44" cy="754" r="4" fill="#FFC107"/>
 <text x="56" y="758" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">Health Check Optimization</text>
-<text x="398" y="758" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#607D8B">Draft</text>
+<text x="398" y="758" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#FFC107">In Progress</text>
 <circle cx="44" cy="782" r="4" fill="#607D8B"/>
-<text x="56" y="786" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">Feature-Aware Adaptive Timeouts for T...</text>
+<text x="56" y="786" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">Health Check Node Sampling</text>
 <text x="398" y="786" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#607D8B">Draft</text>
-<circle cx="44" cy="810" r="4" fill="#9E9E9E"/>
-<text x="56" y="814" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">Keystore Improvements</text>
-<text x="398" y="814" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#9E9E9E">Pending PR</text>
+<circle cx="44" cy="810" r="4" fill="#607D8B"/>
+<text x="56" y="814" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">Feature-Aware Adaptive Timeouts for T...</text>
+<text x="398" y="814" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#607D8B">Draft</text>
+<circle cx="44" cy="838" r="4" fill="#9E9E9E"/>
+<text x="56" y="842" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">Keystore Improvements</text>
+<text x="398" y="842" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#9E9E9E">Pending PR</text>
 <rect x="430" y="220" width="380" height="32" rx="4" fill="#1B2A4A" stroke="#00BCD4" stroke-width="1"/>
 <text x="442" y="241" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="bold" fill="#00BCD4">nemesis</text>
-<text x="798" y="241" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#8899AA">4 plans</text>
+<text x="798" y="241" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#8899AA">3 plans</text>
 <circle cx="444" cy="266" r="4" fill="#FFC107"/>
 <text x="456" y="270" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">Nemesis Rework (Nemesis 2.0)</text>
 <text x="798" y="270" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#FFC107">In Progress</text>
@@ -96,56 +99,53 @@
 <circle cx="444" cy="322" r="4" fill="#FFC107"/>
 <text x="456" y="326" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">Nemesis Pre-Execution Skip Check (pre...</text>
 <text x="798" y="326" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#FFC107">In Progress</text>
-<circle cx="444" cy="350" r="4" fill="#9E9E9E"/>
-<text x="456" y="354" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">Nemesis Extraction Phase 3</text>
-<text x="798" y="354" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#9E9E9E">Pending PR</text>
-<rect x="430" y="380" width="380" height="32" rx="4" fill="#1B2A4A" stroke="#00BCD4" stroke-width="1"/>
-<text x="442" y="401" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="bold" fill="#00BCD4">stress-tools</text>
-<text x="798" y="401" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#8899AA">1 plans</text>
-<circle cx="444" cy="426" r="4" fill="#9E9E9E"/>
-<text x="456" y="430" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">Cassandra Oracle Cluster</text>
-<text x="798" y="430" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#9E9E9E">Pending PR</text>
-<rect x="430" y="456" width="380" height="32" rx="4" fill="#1B2A4A" stroke="#00BCD4" stroke-width="1"/>
-<text x="442" y="477" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="bold" fill="#00BCD4">config</text>
-<text x="798" y="477" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#8899AA">6 plans</text>
+<rect x="430" y="352" width="380" height="32" rx="4" fill="#1B2A4A" stroke="#00BCD4" stroke-width="1"/>
+<text x="442" y="373" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="bold" fill="#00BCD4">stress-tools</text>
+<text x="798" y="373" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#8899AA">1 plans</text>
+<circle cx="444" cy="398" r="4" fill="#9E9E9E"/>
+<text x="456" y="402" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">Cassandra Oracle Cluster</text>
+<text x="798" y="402" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#9E9E9E">Pending PR</text>
+<rect x="430" y="428" width="380" height="32" rx="4" fill="#1B2A4A" stroke="#00BCD4" stroke-width="1"/>
+<text x="442" y="449" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="bold" fill="#00BCD4">config</text>
+<text x="798" y="449" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#8899AA">6 plans</text>
+<circle cx="444" cy="474" r="4" fill="#4CAF50"/>
+<text x="456" y="478" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">Constraint-Based Instance Sizing</text>
+<text x="798" y="478" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#4CAF50">Complete</text>
 <circle cx="444" cy="502" r="4" fill="#4CAF50"/>
-<text x="456" y="506" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">Constraint-Based Instance Sizing</text>
+<text x="456" y="506" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">Config Type Normalization</text>
 <text x="798" y="506" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#4CAF50">Complete</text>
-<circle cx="444" cy="530" r="4" fill="#4CAF50"/>
-<text x="456" y="534" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">Config Type Normalization</text>
-<text x="798" y="534" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#4CAF50">Complete</text>
+<circle cx="444" cy="530" r="4" fill="#9E9E9E"/>
+<text x="456" y="534" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">Resilient Test Config Dependencies</text>
+<text x="798" y="534" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#9E9E9E">Pending PR</text>
 <circle cx="444" cy="558" r="4" fill="#9E9E9E"/>
-<text x="456" y="562" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">Resilient Test Config Dependencies</text>
+<text x="456" y="562" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">Typed Config Access Migration</text>
 <text x="798" y="562" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#9E9E9E">Pending PR</text>
 <circle cx="444" cy="586" r="4" fill="#9E9E9E"/>
-<text x="456" y="590" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">Typed Config Access Migration</text>
+<text x="456" y="590" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">SCT Config Validation and Lazy Images</text>
 <text x="798" y="590" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#9E9E9E">Pending PR</text>
 <circle cx="444" cy="614" r="4" fill="#9E9E9E"/>
-<text x="456" y="618" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">SCT Config Validation and Lazy Images</text>
+<text x="456" y="618" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">SCT Config Follow-up Refactoring</text>
 <text x="798" y="618" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#9E9E9E">Pending PR</text>
-<circle cx="444" cy="642" r="4" fill="#9E9E9E"/>
-<text x="456" y="646" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">SCT Config Follow-up Refactoring</text>
-<text x="798" y="646" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#9E9E9E">Pending PR</text>
-<rect x="430" y="672" width="380" height="32" rx="4" fill="#1B2A4A" stroke="#00BCD4" stroke-width="1"/>
-<text x="442" y="693" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="bold" fill="#00BCD4">k8s</text>
-<text x="798" y="693" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#8899AA">1 plans</text>
-<circle cx="444" cy="718" r="4" fill="#607D8B"/>
-<text x="456" y="722" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">K8s Multitenancy Dict Config</text>
-<text x="798" y="722" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#607D8B">Draft</text>
-<rect x="430" y="748" width="380" height="32" rx="4" fill="#1B2A4A" stroke="#00BCD4" stroke-width="1"/>
-<text x="442" y="769" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="bold" fill="#00BCD4">ai-tooling</text>
-<text x="798" y="769" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#8899AA">1 plans</text>
-<circle cx="444" cy="794" r="4" fill="#4CAF50"/>
-<text x="456" y="798" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">AI Skills Framework</text>
-<text x="798" y="798" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#4CAF50">Complete</text>
-<rect x="430" y="824" width="380" height="32" rx="4" fill="#1B2A4A" stroke="#00BCD4" stroke-width="1"/>
-<text x="442" y="845" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="bold" fill="#00BCD4">testing</text>
-<text x="798" y="845" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#8899AA">2 plans</text>
-<circle cx="444" cy="870" r="4" fill="#9E9E9E"/>
-<text x="456" y="874" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">MiniCloud Local Testing</text>
-<text x="798" y="874" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#9E9E9E">Pending PR</text>
-<circle cx="444" cy="898" r="4" fill="#4CAF50"/>
-<text x="456" y="902" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">Unit/Integration Test Separation</text>
-<text x="798" y="902" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#4CAF50">Complete</text>
-<text x="420" y="953" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#8899AA">Generated from docs/plans/progress.json</text>
+<rect x="430" y="644" width="380" height="32" rx="4" fill="#1B2A4A" stroke="#00BCD4" stroke-width="1"/>
+<text x="442" y="665" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="bold" fill="#00BCD4">k8s</text>
+<text x="798" y="665" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#8899AA">1 plans</text>
+<circle cx="444" cy="690" r="4" fill="#607D8B"/>
+<text x="456" y="694" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">K8s Multitenancy Dict Config</text>
+<text x="798" y="694" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#607D8B">Draft</text>
+<rect x="430" y="720" width="380" height="32" rx="4" fill="#1B2A4A" stroke="#00BCD4" stroke-width="1"/>
+<text x="442" y="741" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="bold" fill="#00BCD4">ai-tooling</text>
+<text x="798" y="741" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#8899AA">1 plans</text>
+<circle cx="444" cy="766" r="4" fill="#4CAF50"/>
+<text x="456" y="770" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">AI Skills Framework</text>
+<text x="798" y="770" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#4CAF50">Complete</text>
+<rect x="430" y="796" width="380" height="32" rx="4" fill="#1B2A4A" stroke="#00BCD4" stroke-width="1"/>
+<text x="442" y="817" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="bold" fill="#00BCD4">testing</text>
+<text x="798" y="817" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#8899AA">2 plans</text>
+<circle cx="444" cy="842" r="4" fill="#9E9E9E"/>
+<text x="456" y="846" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">MiniCloud Local Testing</text>
+<text x="798" y="846" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#9E9E9E">Pending PR</text>
+<circle cx="444" cy="870" r="4" fill="#4CAF50"/>
+<text x="456" y="874" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">Unit/Integration Test Separation</text>
+<text x="798" y="874" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#4CAF50">Complete</text>
+<text x="420" y="925" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#8899AA">Generated from docs/plans/progress.json</text>
 </svg>

--- a/docs/plans/infrastructure/health-check-optimization.md
+++ b/docs/plans/infrastructure/health-check-optimization.md
@@ -1,806 +1,384 @@
 ---
-status: draft
+status: in_progress
 domain: framework
 created: 2026-01-11
-last_updated: 2026-03-15
+last_updated: 2026-09-08
 owner: fruch
 ---
 
 # Health Check Optimization Plan
 
+Tracked as [SCT-523](https://scylladb.atlassian.net/browse/SCT-523). Originally
+reported as [#9547](https://github.com/scylladb/scylla-cluster-tests/issues/9547).
+
 ## Problem Statement
 
-Health checks take 2+ hours on 60-node clusters, running even for skipped nemesis operations. This significantly impacts test run time and efficiency.
+The cluster health check is the gate that runs between nemesis disruptions to
+decide whether the cluster is still fit to continue the test. On a 60-node,
+5-DC longevity run it took over two hours per gate — longer than the nemesis
+operations it was guarding — making it the dominant cost of the test rather
+than a cheap safety check.
 
-### Current Behavior
-- Sequential health checks on all 60 nodes
-- Each node check involves 5 expensive operations:
-  - `nodetool status` - cross-checked against all other nodes for split-brain detection
-  - `system.peers` CQL query - retrieves all columns
-  - `nodetool gossipinfo` - text parsing overhead
-  - Raft group0 membership check
-  - Token ring consistency check
-- Health checks run even when nemesis is skipped
-- Total time: ~120 minutes for 60-node cluster
+Two of the original causes have since been fixed (see Current State). What
+remains is a different and larger problem than the plan originally assumed.
 
-### Root Causes
-1. **Sequential execution**: Nodes checked one by one
-2. **Redundant checks**: Post-nemesis checks run even when nemesis was skipped
-3. **Cross-validation overhead**: Each node's status is validated against all other nodes to detect split-brain scenarios
-4. **No configurability**: Cannot choose lighter-weight checks for large clusters
-5. **No sampling**: All nodes always checked, even in stable scenarios
+**The remaining cost is waiting, not working.** A node that disagrees with the
+cluster is re-checked up to ten times with a fixed delay between attempts, and
+the checked state is *cluster-wide*: every node reports on every other node.
+So a single condition — one node held down by a nemesis, one node lagging in
+gossip — is detected independently by every node in the cluster, and every node
+then pays the full retry budget waiting for it to clear. The cost of one
+disagreement scales with cluster size even though there is only one thing wrong.
+
+This produces three distinct pain points:
+
+1. **Fixed delays dominate.** A node that will never agree within the gate
+   burns its entire retry budget in `time.sleep`. Multiplied across nodes, this
+   accounts for essentially all of the reported two hours.
+2. **Transient lag is charged at the full rate.** The retry delay is flat, with
+   no shorter first attempt. Gossip propagates schema roughly once a second, so
+   a disagreement that resolves almost immediately still costs a full delay.
+   Measured on a rolling-upgrade run, this consumed roughly half of an entire
+   test phase, with every single occurrence resolving on the first retry
+   ([SCT-808](https://scylladb.atlassian.net/browse/SCT-808)).
+3. **Nodes that are *supposed* to be down still trip the gate.** A node under
+   an active nemesis is legitimately unavailable, but every other node reports
+   it as down and retries over it. The framework's current answer is to disable
+   health checks entirely whenever more than one nemesis runs, which trades the
+   cost for a complete loss of the safety gate.
+
+## Current State
+
+### What the gate does
+
+`sdcm/cluster.py:BaseScyllaCluster.check_cluster_health` is invoked from
+`sdcm/nemesis/__init__.py:NemesisRunner.execute_nemesis`, at the *start* of each
+nemesis cycle. It is the only production caller. The end-to-end lifecycle is:
+
+> nemesis cycle begins -> health gate runs *before* the disruption -> each node
+> independently gathers cluster-wide state (nodetool status, `system.peers`,
+> gossip info, Raft group0 membership, token ring) -> per-node validators
+> compare that state against the rest of the cluster -> any disagreement
+> discards the result and re-gathers for that node after a delay -> the gate
+> either passes silently or publishes validation events on the final attempt ->
+> the disruption runs -> its outcome is recorded on the runner -> the next
+> cycle's gate consults that outcome and skips itself if the disruption was
+> skipped
+
+Per-node validation lives in `sdcm/utils/health_checker.py`
+(`check_nodes_status`, `check_node_status_in_gossip_and_nodetool_status`,
+`check_schema_version`, `check_nulls_in_peers`,
+`check_group0_tokenring_consistency`). The first of these fails on *any* node
+that is not in the `UN` state, from the point of view of the node doing the
+reporting — which is what makes one down node cost the whole cluster.
+
+`sdcm/cluster.py:BaseScyllaCluster.wait_for_schema_agreement` is a second,
+separate per-node loop that still runs sequentially and shares the same retry
+constants (`sdcm/utils/health_checker.py:check_schema_agreement_in_gossip_and_peers`).
+It is the path SCT-808 measured.
+
+### Already delivered
+
+- **Skip after a skipped nemesis** — the gate is suppressed when the previous
+  disruption on that runner was skipped, since nothing happened that could have
+  changed cluster health. Landed in
+  [#13522](https://github.com/scylladb/scylla-cluster-tests/pull/13522) after an
+  initial attempt was reverted; the skip decision deliberately lives in the
+  caller rather than inside the gate.
+- **Parallel node checks** — nodes are checked concurrently, with per-node
+  failures collected and reported rather than aborting the sweep. Worker count
+  is `cluster_health_check_parallel_workers` (default 5). Landed in
+  [#13584](https://github.com/scylladb/scylla-cluster-tests/pull/13584).
+
+Parallelism reduced wall-clock by roughly the worker count but did not remove
+the underlying waiting — the sleeps are now paid five at a time instead of one
+at a time. The original 120-minute figure is therefore no longer a valid
+baseline, and no measurement has been taken since.
+
+### Configuration that exists today
+
+Only `cluster_health_check` (on/off) and
+`cluster_health_check_parallel_workers`. Earlier revisions of this plan
+proposed five further parameters under two inconsistent naming schemes; none of
+them were implemented, and the names are superseded by this revision.
+
+### Constraint: the gate must stay synchronous
+
+A background health monitor was prototyped and rejected
+([#15209](https://github.com/scylladb/scylla-cluster-tests/pull/15209)): the
+check exists to decide whether to *stop the test* before the next disruption
+compounds an existing problem. Moving it off the critical path defeats its
+purpose and produces cascading failures that are hard to diagnose. Optimizations
+must make the gate cheaper, not asynchronous.
+
+### Related work
+
+`docs/plans/nemesis/nemesis-precheck.md` removes gate invocations for nemesis
+that can never run in a given configuration. It reduces *how often* the gate
+runs; this plan reduces *what each run costs*. The two are complementary and
+touch different code.
+
+Topology-aware node sampling — checking a representative subset rather than
+every node — is split into `docs/plans/infrastructure/health-check-sampling.md`,
+because it depends on information the framework does not record yet and its open
+questions were blocking review of the rest.
 
 ## Goals
 
-1. **Reduce health check time by 90%+** for large clusters (60+ nodes)
-2. **Skip redundant checks** when nemesis operations are skipped
-3. **Maintain split-brain detection** capability
-4. **Provide configurable modes** for different validation levels
-5. **Enable topology-aware sampling** for large clusters:
-   - Maintain DC and rack coverage
-   - **Prioritize nodes in same rack/region as nemesis target node** (higher risk of overload/issues)
-   - Include target node and recently added/modified nodes
-6. **Support parallel nemesis scenarios**:
-   - Enable health checks even when multiple nemesis operations run in parallel
-   - Exclude nodes that are currently target nodes of ongoing parallel nemesis operations
-   - This allows health validation of unaffected nodes while nemesis operations are in progress
+1. **Establish a real baseline.** Produce a measured breakdown of gate cost by
+   operation, by retry attempt, and by time-spent-waiting versus
+   time-spent-working. No further optimization is sized against estimates.
+2. **Make a transient disagreement cheap.** A condition that resolves on the
+   first retry must cost on the order of a second, not the full fixed delay.
+3. **Make a persistent disagreement cost once, not once per node.** Detecting
+   that one node is down must not cost the retry budget of every other node.
+4. **Restore the gate under parallel nemesis.** Health checks must run when
+   more than one nemesis is active, excluding only the nodes actually under
+   disruption, instead of being disabled wholesale.
+5. **Allow a cheaper check where full validation is not warranted.** Operators
+   of very large clusters must be able to trade validation depth for speed
+   through configuration, with `full` remaining the default.
+6. **Preserve split-brain detection.** Every reduction must keep the ability to
+   detect nodes disagreeing about cluster membership, or state plainly in its
+   documentation that it does not.
 
-## Proposed Solution
+## Implementation Phases
 
-### Phase 1: Skip Health Checks for Skipped Nemesis
-
-**Objective**: Eliminate redundant health checks when nemesis is skipped (100% time reduction in those cases)
-
-**Implementation**:
-- Track last nemesis event status in cluster object
-- If previous nemesis `is_skipped=True`, **automatically skip** the post-nemesis health check
-- Log skip reason for transparency
-- **Note**: This is now the **default behavior** (no configuration parameter needed)
-
-**Testing**:
-- Unit test: Verify skip logic with mocked nemesis events
-- Integration test: Run test with skipped nemesis, verify no health check in logs
-- Manual test: 10-node cluster with mixed skipped/executed nemesis
-
-**Expected Impact**: 100% reduction when nemesis is skipped
+Phases 1 and 2 are complete and retained for history. Phases 3 onward are the
+remaining work, ordered by dependency: measure, then fix what measurement
+confirms, then add configurability.
 
 ---
 
-### Phase 2: Parallel Health Check Execution
+### Phase 1: Skip the gate after a skipped nemesis — COMPLETE
 
-**Objective**: Check multiple nodes simultaneously to reduce total time
+**Importance**: Critical
 
-**Implementation**:
-- Use `ThreadPoolExecutor` with configurable worker count
-- Run health checks on multiple nodes in parallel
-- Ensure thread-safe event publishing and result aggregation
-- Handle failures gracefully (one node failure should not block others)
+Suppress the gate when the previous disruption was skipped, since no cluster
+state changed. Shipped in
+[#13522](https://github.com/scylladb/scylla-cluster-tests/pull/13522).
 
-**Configuration**:
-```yaml
-cluster_health_check_parallel_workers: 5  # default: 5, max recommended: 10
-```
-
-**Testing**:
-- Unit test: Mock parallel execution, verify all nodes checked
-- Integration test: 10-node cluster, verify parallelism with timing logs
-- Load test: Verify resource usage on large clusters
-
-**Expected Impact**:
-- 5 workers: ~80% time reduction (120 min → 24 min)
-- 10 workers: ~90% time reduction (120 min → 12 min)
-- **Note**: Diminishing returns beyond 10 workers due to API rate limits
-- **For smaller clusters**: Primary goal is correctness and expected behavior, time reduction is secondary benefit
+**Definition of Done**:
+- [x] Gate is skipped when the preceding disruption reported itself skipped
+- [x] Skip and its reason are logged
+- [x] Decision lives in the caller, not inside the gate
+- [x] Unit tests cover skipped, not-skipped, and no-previous-disruption cases
 
 ---
 
-### Phase 3: Configurable Health Check Operations
+### Phase 2: Parallel node checks — COMPLETE
 
-**Objective**: Allow selection of which health check operations to perform based on cluster size and requirements
+**Importance**: Critical
 
-**Check Operations** (can be combined):
+Check nodes concurrently instead of one at a time, collecting per-node failures
+rather than aborting on the first. Shipped in
+[#13584](https://github.com/scylladb/scylla-cluster-tests/pull/13584).
 
-#### Operation: `status`
-- `nodetool status` from selected nodes
-- Validate all nodes show expected status (UN for up nodes, DN acceptable during nemesis)
-- Cross-validate responses to detect split-brain
-- **Time**: ~2 seconds per node
-
-#### Operation: `peers`
-- Query `system.peers` table from selected nodes
-- Verify peer information consistency
-- **Time**: ~3-5 seconds per node
-
-#### Operation: `gossip`
-- `nodetool gossipinfo` from selected nodes
-- Parse and validate gossip state
-- **Time**: ~5-10 seconds per node (text parsing overhead)
-
-#### Operation: `raft`
-- Query Raft group0 membership
-- Verify all expected members present and in sync
-- **Limitation**: Requires Raft enabled (Scylla 5.0+)
-- **Time**: ~1-3 seconds (needs investigation - see Reference Performance Test Plan)
-
-#### Operation: `ring`
-- Token ring consistency check
-- Verify token distribution
-- **Time**: ~5-8 seconds per node
-
-**Predefined Modes**:
-
-#### Mode: `full` (default - maintains current behavior)
-- Operations: `['status', 'peers', 'gossip', 'raft', 'ring']`
-- All checks per sampled node
-- Maximum validation depth
-- **Use case**: Small clusters (<10 nodes), critical validation points
-- **Time**: ~2 min per node
-
-#### Mode: `basic`
-- Operations: `['status', 'raft']`
-- Quick validation of cluster state
-- Good split-brain detection when combined with proper sampling
-- **Use case**: Large clusters in stable state
-- **Time**: ~5 seconds per node
-
-#### Mode: `minimal`
-- Operations: `['status']`
-- Fastest validation
-- **Limitation**: Lower split-brain detection if run from single node
-- **Use case**: Very large clusters, quick smoke test
-- **Time**: ~2 seconds per node
-
-**Configuration**:
-```yaml
-# Option 1: Use predefined mode
-cluster_health_check_operations: 'full'  # full | basic | minimal
-
-# Option 2: Specify custom list of operations
-cluster_health_check_operations: ['status', 'raft']  # custom combination
-```
-
-**Important Notes on Status Checks**:
-- Initial analysis incorrectly stated `nodetool status` is a "single call"
-- **Reality**: For split-brain detection, we must cross-check each node's report against others
-- This requires calling `nodetool status` from **multiple nodes** (ideally majority)
-- Single-node `nodetool status` is fast (~2s) but may miss split-brain scenarios
-- **Trade-off**: Speed vs. split-brain detection reliability
-- **Node status during nemesis**: DN (Down) status is acceptable when nemesis operation is actively making node unavailable
-
-**Testing**:
-- Unit test: Mock each mode, verify only expected operations are called
-- Integration test: 10-node cluster with each mode, measure time
-- Manual test: Compare detection capabilities with simulated split-brain
-- Manual test: Verify DN nodes during nemesis don't fail health check
-
-**Expected Impact** (when combined with Phase 4 sampling):
-- `minimal` mode: 98% reduction (120 min → 2 min) - **lower split-brain detection**
-- `basic` mode: 95% reduction (120 min → 5 min) - **good split-brain detection with proper sampling**
-- `full` mode: maintains current time - **maximum validation**
+**Definition of Done**:
+- [x] Nodes are checked concurrently with a configurable worker count
+- [x] `cluster_health_check_parallel_workers` documented, default 5
+- [x] A failure on one node does not prevent other nodes being checked
+- [x] All per-node failures are reported, not just the first
+- [x] Unit tests cover the parallel path, the single-worker fallback, and failures
 
 ---
 
-### Phase 4: Configurable Node Sampling
+### Phase 3: Instrumentation and baseline
 
-**Objective**: Reduce checks proportionally while maintaining DC and rack coverage
+**Importance**: Critical
+**Dependencies**: none
 
-**Implementation**:
-- Select nodes based on topology-aware sampling strategy
-- **Guarantee**: Minimum coverage per datacenter and rack
-- **Priority**: Favor nodes in same rack/region as target node (higher risk of overload)
-- **Priority**: Include target node (if still in cluster) and recently added nodes
-- Apply full health check to sampled nodes only
+Make the gate's cost observable before changing it. Record, per gate
+invocation: elapsed time for each of the five state-gathering operations, the
+number of retry attempts each node consumed, which validator triggered each
+retry, and the split between time spent waiting and time spent working.
 
-**Configuration**:
-```yaml
-cluster_health_check_sampling_mode: 'all'  # all | cluster_quorum | dc_quorum | rack_quorum | dc_one | rack_one
-```
+Reuse the framework's existing timing helpers rather than introducing another
+one. No behaviour changes: this phase only observes.
 
-**Sampling Modes**:
+Then run the measurement against a multi-node longevity job and record the
+resulting breakdown in this document, replacing the stale 120-minute estimate
+with real numbers. Subsequent phases are sized against that table.
 
-- **`all`** (default): Check all nodes (current behavior)
-  - All nodes validated
-  - Maximum coverage, maximum time
+**Deliverables**: timing instrumentation in `sdcm/cluster.py` (the gate and the
+per-node retry loop) and `sdcm/utils/health_checker.py` (the validators, and the
+timing breakdown they are recorded into); a measured baseline table added to
+this plan.
 
-- **`cluster_quorum`**: Check majority (>50%) of all nodes
-  - Select >50% of total cluster nodes
-  - Ensures at least one node from each DC
-  - Good split-brain detection
-  - Time: ~50% of full check
-
-- **`dc_quorum`**: Check majority of nodes per datacenter
-  - Select >50% of nodes from each DC
-  - Balanced DC coverage
-  - Time: ~50% of full check
-
-- **`rack_quorum`**: Check majority of nodes per rack
-  - Select >50% of nodes from each rack
-  - Maximum rack coverage
-  - Time: ~50% of full check
-
-- **`dc_one`**: Check one node from each datacenter
-  - Select 1 node from each DC
-  - Minimal DC coverage
-  - Time: ~5-15 nodes for typical multi-DC clusters
-
-- **`rack_one`**: Check one node from each rack
-  - Select 1 node from each rack
-  - Minimal rack coverage
-  - Time: ~3-20 nodes depending on rack count
-
-**Selection Heuristics** (applied in all modes except `all`):
-
-These heuristics ensure health checks focus on nodes most likely to be affected by nemesis operations while ensuring complete cluster coverage over time:
-
-1. **HIGHEST PRIORITY: Always include all nodes participating in the nemesis**
-   - **For health checks done at the end of a nemesis**: Include ALL nodes that participated in the nemesis operation
-   - The target node (directly affected) is checked FIRST
-   - Additional participating nodes (e.g., replacement nodes, nodes involved in data migration) are checked next
-   - **Rationale**: These nodes underwent the most disruption and are most critical to validate
-   - **Note**: Participating node information is available from nemesis operation context
-
-2. **Prioritize nodes that participated in recent nemesis operations** (optional enhancement)
-   - Consider nodes from previous nemesis operations if not already selected
-   - **Note**: This requires tracking participation history across nemesis operations
-   - **Trade-off**: Added complexity vs. marginal benefit
-   - **Recommendation**: Start with current nemesis participants, extend if needed
-
-3. **Prioritize nodes in same rack/region as target node** ⭐ **KEY OPTIMIZATION**
-   - **Rationale**: Nodes in the same rack as the target have higher risk of:
-     - Network overload (redistributed traffic)
-     - Storage overload (data rebalancing)
-     - Resource contention (increased repair/streaming activity)
-   - **Example**: If nemesis targets node in rack1 of DC1, prefer other nodes in rack1-DC1 for sampling
-   - This maximizes detection of cascading failures or performance degradation
-
-4. **Rotate selection among remaining nodes to avoid never-checked nodes**
-   - **Track which nodes were checked in previous health checks** (maintain check history)
-   - **Prioritize nodes that haven't been checked recently** to ensure no node is perpetually skipped
-   - Cycle through unchecked nodes to ensure complete coverage over multiple nemesis operations
-   - **Goal**: Every node in the cluster should be checked at least once every N nemesis cycles
-   - This prevents blind spots where certain nodes could develop issues undetected
-
-5. **Ensure minimum of 2 nodes total** for cross-validation
-   - At least 2 nodes needed to detect basic disagreement
-   - Prevents false positives from single node reporting
-
-**Example** (60 nodes, 5 DCs × 3 racks/DC, `dc_quorum` mode):
-- DC1: 12 nodes → sample 7 (>50%)
-- DC2: 12 nodes → sample 7 (>50%)
-- DC3: 12 nodes → sample 7 (>50%)
-- DC4: 12 nodes → sample 7 (>50%)
-- DC5: 12 nodes → sample 7 (>50%)
-- **Total: 35 nodes checked** (~58% coverage, ~42% time reduction)
-
-**Example** (60 nodes, 5 DCs, `dc_one` mode):
-- DC1: 12 nodes → sample 1 (favor target node's rack if applicable)
-- DC2: 12 nodes → sample 1
-- DC3: 12 nodes → sample 1
-- DC4: 12 nodes → sample 1
-- DC5: 12 nodes → sample 1
-- **Total: 5 nodes checked** (~8% coverage, ~92% time reduction)
-
-**Testing**:
-- Unit test: Verify sampling algorithm for each mode
-- Unit test: Verify target node and recent nodes are prioritized
-- Unit test: Verify minimum guarantees (1 per DC/rack, 2 total)
-- Integration test: Multi-DC/rack cluster, verify sampling respects topology
-- Integration test: Verify rack/region proximity to target node
-
-**Expected Impact**:
-- `cluster_quorum`: ~50% time reduction
-- `dc_quorum`: ~50% time reduction
-- `rack_quorum`: ~50% time reduction
-- `dc_one`: ~90% time reduction (5-15 nodes typical)
-- `rack_one`: ~85-95% time reduction (3-20 nodes typical)
+**Definition of Done**:
+- [ ] Each state-gathering operation logs its own elapsed time
+- [ ] Each node logs its retry count and the validator that caused each retry
+- [ ] The gate logs total wall-clock and the waiting-versus-working split
+- [ ] No change to which checks run or when the gate passes or fails
+- [ ] Baseline measured on a multi-node cluster and recorded in this plan
 
 ---
 
-### Phase 5: Exclude Nodes Running Nemesis
+### Phase 4: Backoff and cluster-level short-circuit
 
-**Objective**: Skip health checks on nodes actively participating in nemesis operations
+**Importance**: Critical
+**Dependencies**: Phase 3
 
-**Implementation**:
-- Check `node.running_nemesis` flag before health check
-- Skip node if flag is set (node may be legitimately down during nemesis operation)
-- Log exclusion for transparency
-- **Important**: DN status during active nemesis operation should not fail health check
-- **Note**: Nodes successfully removed during nemesis (e.g., decommissioned, terminated) are automatically excluded from health checks as they're no longer in the cluster topology
+Address the two causes measurement is expected to confirm.
+
+**Backoff.** Replace the flat retry delay with a short first delay that grows,
+keeping a comparable worst-case ceiling. A disagreement that resolves
+immediately — the overwhelmingly common case — then costs about a second
+instead of the full delay. This applies to both retrying call paths, which
+share the same constants, and closes
+[SCT-808](https://scylladb.atlassian.net/browse/SCT-808).
+
+**Short-circuit.** Stop every node independently paying the retry budget for
+the same cluster-wide condition. When the disagreement is about a node's
+membership state rather than about the reporting node, the gate should reach
+that conclusion once for the cluster instead of once per node.
+
+**Definition of Done**:
+- [ ] Retry delay starts short and grows; worst-case ceiling is documented
+- [ ] Both retrying call paths use the shared backoff
+- [ ] A cluster-wide condition costs one retry budget, not one per node
+- [ ] Gate still fails for conditions that do not clear, with the same events
+- [ ] Unit tests cover backoff timing and the short-circuit
+- [ ] Measured improvement recorded against the Phase 3 baseline
+- [ ] SCT-808 closed
+
+---
+
+### Phase 5: Exclude nodes under nemesis; restore the gate under parallel nemesis
+
+**Importance**: Critical
+**Dependencies**: Phase 4 — not a technical dependency. Restoring the gate for
+parallel-nemesis tests adds gate invocations to exactly the tests that have none
+today, so the retries those gates perform should be cheap before that happens.
+Reordering is possible if Phase 4 stalls, at the cost of a slower rollout.
+
+A node under an active disruption is expected to be unavailable. Today the gate
+neither excludes it nor tolerates it, so it disables itself entirely whenever
+more than one nemesis runs — losing the safety gate exactly where chaos is
+highest.
+
+Change two behaviours:
+
+- Nodes currently marked as running a nemesis are excluded from the set of
+  nodes being checked.
+- Those nodes being reported as down *by other nodes* is treated as expected,
+  not as a critical health failure.
+
+Together these remove the wholesale bail-out: the gate runs under parallel
+nemesis over the nodes that are not under disruption, and the checks that were
+being silently skipped along with it — the running-nemesis count check and
+partition validation — run again.
 
 **Configuration**:
 ```yaml
 cluster_health_check_exclude_running_nemesis: true  # default: true
 ```
 
-**Use Case**:
-- Parallel nemesis scenarios where multiple nemesis threads run concurrently
-- Avoids checking nodes that are intentionally disrupted
-- Enables health validation of non-affected nodes during parallel nemesis
-- Prevents false failures when node is legitimately down during nemesis execution
-
-**Considerations**:
-- May reduce total checked nodes below desired sample
-- Should still enforce minimum guarantees from Phase 4
-
-**Testing**:
-- Unit test: Mock nodes with `running_nemesis=True`, verify exclusion
-- Integration test: Run parallel nemesis, verify active nodes excluded
-- Manual test: Verify health check completes successfully with nemesis in progress
-- Manual test: Verify health check doesn't fail when nemesis makes node unavailable
-
-**Expected Impact**: Variable (depends on nemesis duration and concurrency)
+**Definition of Done**:
+- [ ] Nodes marked as running a nemesis are not themselves checked
+- [ ] Those nodes reported as down by others does not fail the gate
+- [ ] The gate runs with more than one nemesis active
+- [ ] Running-nemesis count check and partition validation run under parallel nemesis
+- [ ] Setting the parameter to `false` restores checking every node
+- [ ] Parameter documented and default added
+- [ ] Unit tests cover exclusion, tolerance, and the parallel-nemesis path
 
 ---
 
-### Phase 6: Documentation Review and Update
+### Phase 6: Configurable check operations
 
-**Objective**: Ensure all health check documentation across the codebase is accurate, comprehensive, and consistent with the optimization implementation
+**Importance**: Important
+**Dependencies**: Phase 5
 
-**Scope**: Review and update health check documentation in the following areas:
+Let operators trade validation depth for speed. `full` keeps today's behaviour
+and remains the default; `basic` keeps membership and Raft consistency;
+`minimal` keeps only node status. An explicit list may be given instead of a
+named mode.
 
-1. **Configuration Documentation**:
-   - `docs/configuration_options.md` - Auto-generated configuration reference (ensure accurate descriptions)
-   - Source parameter descriptions in `sdcm/sct_config.py` (these feed into auto-generated docs)
-   - Test case YAML examples with health check configurations
-   - Default configuration files in `defaults/test_default.yaml` and backend-specific defaults
+Each mode must document what it stops detecting — `minimal` in particular has
+materially weaker split-brain detection and must say so.
 
-2. **Plan and Design Documentation**:
-   - This document (`docs/plans/infrastructure/health-check-optimization.md`) - Keep updated with implementation progress
-   - Add migration guide for users of older health check configurations
-   - Document breaking changes or behavioral differences from previous versions
+**Configuration**:
+```yaml
+# named mode
+cluster_health_check_operations: 'full'   # full | basic | minimal
 
-**Implementation Tasks**:
+# or an explicit list
+cluster_health_check_operations: ['status', 'raft']
+```
 
-1. **Audit Phase**:
-   - Create checklist of all files containing health check references
-   - Identify outdated, incomplete, or missing documentation
-   - Flag inconsistencies between code behavior and documentation
-
-2. **Update Phase**:
-   - Update docstrings to match current implementation
-   - Add examples for new configuration parameters introduced in Phases 1-5
-   - Document edge cases, limitations, and known issues
-   - Update configuration option descriptions with recommended values per cluster size
-   - Add troubleshooting section for common health check issues
-
-3. **Validation Phase**:
-   - Cross-reference code implementation with documentation
-   - Verify all configuration parameters are documented
-   - Ensure examples in documentation are tested and working
-   - Check for broken links and outdated references
+**Definition of Done**:
+- [ ] Named modes and explicit lists both accepted; invalid values rejected at config load
+- [ ] `full` is the default and behaves exactly as before this phase
+- [ ] Only the selected operations are gathered — unselected ones are not fetched
+- [ ] Each mode's detection tradeoff documented
+- [ ] Parameter documented and default added
+- [ ] Unit tests assert that unselected operations are not performed
 
 ---
 
-## Reference Performance Test Plan
+### Phase 7: Documentation and rollout
 
-**Purpose**: Establish baseline measurements to evaluate speed of each health check optimization
+**Importance**: Important
+**Dependencies**: Phase 6
 
-**Primary Goal**: Measure and compare the execution time of different health check modes and sampling strategies to validate the expected performance improvements (90%+ time reduction target).
+**Definition of Done**:
+- [ ] `docs/configuration_options.md` regenerated
+- [ ] Recommended settings per cluster size documented, with their tradeoffs
+- [ ] Migration note for tests that currently set `cluster_health_check: false`
+      purely for speed, which may no longer need to
+- [ ] Large-cluster test-case configurations updated to the recommended settings
+- [ ] This plan's status advanced and its baseline table filled in
 
-**Test Objectives**:
-1. **Measure actual execution time** for each health check mode and sampling strategy
-2. **Compare measured vs. expected performance** to validate optimization effectiveness
-3. **Identify performance bottlenecks** (specifically investigate why Raft checks appear slower than expected)
-4. **Validate correctness** of split-brain detection capabilities under different modes
-5. **Establish reference metrics** for future performance regression testing
+## Testing Requirements
 
-**Test Setup**:
-- **Cluster**: 30-node cluster (3 DCs × 10 nodes each)
-- **Scylla Version**: 5.2+ (Raft enabled)
-- **Infrastructure**: AWS i3en.large instances (matching production use case)
-- **Instrumentation**: Add timing metrics to health check code to measure each operation
-- **Baseline**: Run with current implementation (`cluster_health_check_mode: 'full'`, `cluster_health_check_sample_nodes: 'all'`) to establish baseline timing
+**Unit.** Extend the existing suites rather than adding parallel ones:
+`unit_tests/unit/test_health_check_parallel.py` for gate behaviour,
+`unit_tests/unit/test_utils_health_checker.py` for the validators and their
+retry behaviour, and `unit_tests/unit/nemesis/execute_nemesis/` for the
+interaction between the gate and the nemesis runner.
 
-**Performance Test Cases**:
+Timing-sensitive tests must assert on the delay sequence the code requests, not
+on real elapsed time.
 
-Each test case should:
-- Run against the same 30-node cluster setup
-- Measure total health check execution time
-- Report time per node and per operation
-- Execute after a controlled nemesis operation for consistency
-- Repeat 3 times and report average ± std deviation
+**Integration.** For Phase 5, a run with more than one nemesis active must show
+the gate executing and excluding only the disrupted nodes. For Phase 6, a run
+per mode must show that unselected operations are never issued.
 
-### TC1: Baseline Measurement (Current Implementation)
-```yaml
-cluster_health_check_mode: 'full'
-cluster_health_check_sample_nodes: 'all'
-```
-**What to measure**:
-- Total health check execution time for all 30 nodes
-- Average time per node
-- Breakdown by operation: nodetool status, system.peers query, gossipinfo, raft, tokenring
-- Network traffic volume
-- CPU impact on cluster nodes
+**Performance.** Phase 3 establishes the baseline; Phases 4 and 5 each report
+their measured improvement against it on the same cluster shape. Measure at
+least: total gate wall-clock, per-operation time, retry counts, and the
+waiting-versus-working split.
 
-**Expected baseline**: ~60 minutes total (2 min/node × 30 nodes)
-**Success criteria**: Establish baseline for comparison with optimizations
-
-### TC2: Status-Only Mode
-```yaml
-cluster_health_check_mode: 'status_only'
-cluster_health_check_sample_nodes: 'all'
-```
-**What to measure**: Time for single `nodetool status` call that checks all nodes
-**Expected**: ~1-2 minutes (98% faster than baseline)
-**Success criteria**: <3 minutes, all 30 nodes detected as UP
-
-### TC3: Majority Status Mode
-```yaml
-cluster_health_check_mode: 'majority_status'
-cluster_health_check_sample_nodes: 'all'
-```
-**What to measure**: Time to check >50% of nodes and cross-validate
-**Expected**: ~8-12 minutes (80-87% faster than baseline)
-**Success criteria**:
-- <15 minutes execution time
-- Successfully detect simulated split-brain scenario
-
-### TC4: Raft-Only Mode (Performance Investigation)
-```yaml
-cluster_health_check_mode: 'raft_only'
-cluster_health_check_sample_nodes: 'all'
-```
-**What to measure**:
-- Time for Raft group0 query from single node
-- CQL query execution time vs response parsing time
-- Compare with equivalent nodetool command time
-
-**Expected**: <5 minutes
-**Investigation**: If >5 minutes, add detailed logging to identify bottleneck:
-- Is it CQL connection setup?
-- Is it query execution time?
-- Is it response parsing?
-- Does it scale linearly with cluster size?
-
-**Success criteria**: Identify root cause if Raft check is slower than expected
-
-### TC5: DC-Based Sampling
-```yaml
-cluster_health_check_mode: 'full'
-cluster_health_check_sample_nodes: 'dc_one'
-```
-**What to measure**: Time to check 1 node per DC (3 nodes total for 3 DCs)
-**Expected**: ~6 minutes (90% faster than baseline, 3 nodes × 2 min/node)
-**Success criteria**:
-- <10 minutes execution time
-- Verify target node and recently added nodes are selected
-- Verify one node per DC guarantee
-
-### TC6: Parallel Execution
-```yaml
-cluster_health_check_mode: 'full'
-cluster_health_check_sample_nodes: 'all'
-cluster_health_check_parallel_workers: 10
-```
-**What to measure**:
-- Total execution time with 10 parallel workers
-- Cluster CPU and network impact during parallel checks
-- Verify no race conditions or dropped checks
-
-**Expected**: ~12 minutes (80% faster than baseline, limited by slowest checks)
-**Success criteria**:
-- <20 minutes execution time
-- All 30 nodes checked successfully
-- No cluster performance degradation
-
-### TC7: Combined Optimizations (Target Configuration)
-```yaml
-cluster_health_check_mode: 'majority_status'
-cluster_health_check_sample_nodes: 'dc_quorum'
-cluster_health_check_parallel_workers: 10
-cluster_health_check_skip_if_nemesis_skipped: true
-```
-**What to measure**:
-- Time with skipped nemesis (should skip health check entirely)
-- Time with executed nemesis using combined optimizations
-- Verify split-brain detection still works
-
-**Expected**:
-- Skipped nemesis: 0 minutes (100% reduction)
-- Executed nemesis: ~4-6 minutes (90-93% faster than baseline)
-
-**Success criteria**:
-- Skipped nemesis: health check skipped, logged clearly
-- Executed nemesis: <10 minutes
-- Split-brain detection: >95% detection rate in test scenarios
-
-**Instrumentation**:
-```python
-import time
-from contextlib import contextmanager
-
-@contextmanager
-def measure_operation(operation_name):
-    start = time.time()
-    try:
-        yield
-    finally:
-        elapsed = time.time() - start
-        LOGGER.info(f"Health check operation '{operation_name}' took {elapsed:.2f}s")
-```
-
-**Metrics to Collect**:
-- Total health check time
-- Per-node check time
-- Per-operation time (status, peers, gossip, raft, tokenring)
-- Network traffic volume
-- Cluster CPU impact
-- Split-brain detection success rate
-
----
-
-## Raft Check Investigation
-
-**Observation**: Raft checks seem slower than expected
-
-**Investigation Plan**:
-
-1. **Instrument `get_group0_members()`**:
-   - Add timing logs
-   - Measure CQL query time
-   - Measure response parsing time
-   - Identify bottleneck
-
-2. **Compare with nodetool**:
-   - Measure equivalent `nodetool` command time
-   - Determine if CQL or nodetool is faster for Raft info
-
-3. **Optimize query**:
-   - Check if we're querying unnecessary columns
-   - Verify connection pooling is used
-   - Consider caching group0 state (if safe)
-
-4. **Test at scale**:
-   - 10-node cluster
-   - 30-node cluster
-   - 60-node cluster
-   - Measure if Raft check scales linearly with cluster size
-
-**Hypothesis**:
-- Raft check **should** be fast (~1-3s) as it queries internal Raft state
-- If slower, likely due to:
-  - Network latency to query node
-  - Large Raft log replay
-  - Inefficient query or parsing
-  - Connection overhead
-
-**Expected Outcome**:
-- Identify root cause of slow Raft checks
-- Optimize implementation
-- Update plan with actual performance data
-
----
-
-## Recommended Configurations
-
-### Small Clusters (<10 nodes)
-```yaml
-cluster_health_check: true
-cluster_health_check_mode: 'full'
-cluster_health_check_skip_if_nemesis_skipped: true
-```
-**Rationale**: Full validation is fast enough, provides maximum confidence
-
-### Medium Clusters (10-30 nodes)
-```yaml
-cluster_health_check: true
-cluster_health_check_mode: 'majority_status'
-cluster_health_check_parallel_workers: 5
-cluster_health_check_skip_if_nemesis_skipped: true
-cluster_health_check_exclude_running_nemesis: true
-```
-**Rationale**: Balance between speed and split-brain detection
-
-### Large Clusters (30-60 nodes)
-```yaml
-cluster_health_check: true
-cluster_health_check_mode: 'majority_status'
-cluster_health_check_sample_nodes: 'dc_quorum'
-cluster_health_check_parallel_workers: 10
-cluster_health_check_skip_if_nemesis_skipped: true
-cluster_health_check_exclude_running_nemesis: true
-```
-**Rationale**: Significant time savings while maintaining split-brain detection via DC-based quorum
-
-### Very Large Clusters (60+ nodes)
-```yaml
-cluster_health_check: true
-cluster_health_check_mode: 'status_only'
-cluster_health_check_sample_nodes: 'dc_one'
-cluster_health_check_parallel_workers: 10
-cluster_health_check_skip_if_nemesis_skipped: true
-cluster_health_check_exclude_running_nemesis: true
-```
-**Rationale**: Prioritize speed for stable large clusters, check one node per DC
-**Note**: Reduced split-brain detection - consider periodic full checks
-
-### Critical Tests (Release validation, etc.)
-```yaml
-cluster_health_check: true
-cluster_health_check_mode: 'full'
-cluster_health_check_parallel_workers: 10
-cluster_health_check_skip_if_nemesis_skipped: false  # Always validate
-```
-**Rationale**: Maximum validation confidence, moderate speed improvement
-
----
-
-## Heuristics for Split-Brain Detection
-
-**Challenge**: Full cross-validation requires checking all nodes, which is slow
-
-**Proposed Heuristic**: Majority Validation
-
-Instead of validating every node against every other node, we can:
-
-1. **Select a majority** of nodes (>50%, e.g., 31 of 60)
-2. **Query `nodetool status`** from each selected node
-3. **Cross-validate responses**:
-   - If all majority nodes agree on cluster state → likely healthy
-   - If disagreement exists → potential split-brain, trigger full check
-4. **Fail fast**: If minority disagrees, escalate to full validation
-
-**Mathematical Basis**:
-- In a split-brain scenario, cluster partitions into groups
-- The largest partition must contain >50% of nodes to maintain quorum
-- Checking majority guarantees we include nodes from largest partition
-- If majority agrees, cluster is either healthy or we're in majority partition
-
-**Edge Cases**:
-- **50/50 split**: May not detect split-brain if we only sample one partition
-- **Mitigation**: Always include nodes from multiple DCs in sample
-- **3-way partition**: Rare, but possible; requires full validation
-
-**Implementation**:
-```python
-def check_cluster_health_with_majority(self, majority_percentage=60):
-    """
-    Check cluster health using majority of nodes for split-brain detection.
-
-    Args:
-        majority_percentage: Percentage of nodes to check (default 60%)
-
-    Returns:
-        True if healthy, False if split-brain detected
-    """
-    # Sample majority of nodes, ensuring DC diversity
-    sample_nodes = self._sample_nodes_by_majority(majority_percentage)
-
-    # Collect status from each sampled node
-    status_reports = {}
-    for node in sample_nodes:
-        status_reports[node] = node.get_nodes_status()
-
-    # Cross-validate: all sampled nodes should agree
-    if self._check_consensus(status_reports):
-        LOGGER.info("Cluster health check passed (majority consensus)")
-        return True
-    else:
-        LOGGER.warning("Disagreement detected, performing full validation")
-        # Fall back to full check
-        return self.check_cluster_health_full()
-```
-
-**Testing**:
-- Simulate 2-partition split-brain
-- Simulate 3-partition split-brain
-- Verify detection with various majority percentages (55%, 60%, 70%)
-
----
+**Correctness.** A node made genuinely unavailable outside of a nemesis must
+still fail the gate at every phase. A simulated disagreement about cluster
+membership must still be detected in `full` and `basic` modes.
 
 ## Success Criteria
 
-1. **Performance**:
-   - ✅ 60-node cluster with `majority_status` + sampling: <15 min (87% reduction)
-   - ✅ 60-node cluster with `status_only`: <3 min (97% reduction)
-   - ✅ Skipped nemesis: 0 min health check (100% reduction)
+1. A measured baseline exists in this document, and every subsequent phase
+   reports its improvement against it.
+2. A disagreement that clears immediately costs roughly a second rather than a
+   full retry delay.
+3. One node being down costs one retry budget for the cluster, not one per node.
+4. The gate runs under parallel nemesis, and running-nemesis count and
+   partition validation are no longer silently skipped.
+5. `full` mode detects everything it detects today; any mode that detects less
+   says so in its documentation.
+6. New parameters are documented with safe defaults. Tests running a single
+   nemesis see no behavioural change. Parallel-nemesis tests do change, by
+   design: the gate they silently lost is restored over their non-disrupted
+   nodes, and Phase 5's rollout covers that.
+7. `uv run sct.py pre-commit` passes; MASTER.md and progress.json reflect the
+   plan's status.
 
-2. **Correctness**:
-   - ✅ Split-brain detection with `majority_status` mode: >95% success rate
-   - ✅ All nodes validated in `full` mode
-   - ✅ No false positives in healthy clusters
-
-3. **Configurability**:
-   - ✅ All 5 configuration parameters implemented
-   - ✅ Default values are safe and reasonable
-   - ✅ Documentation complete
-
-4. **Testing**:
-   - ✅ Unit test coverage >90%
-   - ✅ All integration tests pass
-   - ✅ Performance validated on real clusters
-
-5. **Adoption**:
-   - ✅ Updated default configs for large cluster tests
-   - ✅ Migration guide for existing tests
-   - ✅ Monitoring/logging for health check performance
-
----
-
-## Risks & Mitigation
+## Risk Mitigation
 
 | Risk | Impact | Probability | Mitigation |
 |------|--------|-------------|------------|
-| Missed split-brain with `status_only` | High | Medium | Use `majority_status` for critical tests; document limitation |
-| Parallel execution overloads cluster | Medium | Low | Limit default workers to 5; test at scale; make configurable |
-| Raft check remains slow | Low | Medium | Investigate early (Phase 6); have fallback to status checks |
-| Sampling misses issues | Medium | Low | Ensure DC diversity; minimum node guarantees; periodic full checks |
-| Configuration complexity | Low | High | Provide presets for common scenarios; clear documentation |
-
----
-
-## Open Questions
-
-1. **What is acceptable false-negative rate for split-brain detection?**
-   - `status_only`: ~20% miss rate (acceptable for quick checks?)
-   - `majority_status`: ~5% miss rate (acceptable for normal checks?)
-
-2. **How should sampling balance favored vs randomized nodes?**
-   - Favored nodes: Target node, recently modified nodes, same rack/region nodes
-   - Randomize selection among remaining nodes for better coverage
-   - Goal: Combine deterministic priority with random coverage
-
-3. **Should we provide a configuration suggestion tool?**
-   - Script/tool that suggests optimal config based on:
-     * Cluster size (node count, DC count, rack count)
-     * Test type (longevity, performance, upgrade, etc.)
-     * Risk tolerance (speed vs accuracy trade-off)
-   - Example: `sct.py suggest-health-check-config --nodes 60 --dcs 5`
-
-4. **Should we add automatic mode selection based on cluster size?**
-   ```yaml
-   cluster_health_check_mode: 'auto'  # Selects mode based on node count
-   ```
-
-5. **Should we track health check performance metrics and issue detection?**
-   - Collect metrics per option into Adaptive Timeout system
-   - Track time per check, success rate, failures detected
-   - **Issue tracking approach**:
-     - Add label to SCT and Scylla issues if surfaced by health check (e.g., `detected-by:health-check`)
-     - Enables measuring detection effectiveness
-     - Note: Tracking false positives is more complex - requires manual validation
-   - → Use metrics for auto-tuning and configuration optimization
-   - → Use issue tracking to validate health check effectiveness
-
----
-
-## References
-
-- Issue: [#9547 - Health checks take 2+ hours on 60-node setup](https://github.com/scylladb/scylla-cluster-tests/issues/9547)
-- Related: Nemesis event tracking and skip logic
-- Code: `sdcm/cluster.py` - `check_cluster_health()`
-- Code: `sdcm/utils/health_checker.py` - Health check functions
-- Config: `sdcm/sct_config.py` - Configuration parameters
-
----
-
-## Appendix: Current Health Check Flow
-
-```python
-def check_cluster_health(self):
-    if not self.params.get("cluster_health_check"):
-        return
-
-    for node in self.nodes:  # Sequential!
-        node.check_node_health()  # Calls 5 expensive operations per node
-```
-
-```python
-def node_health_events(self):
-    nodes_status = self.get_nodes_status()           # nodetool status
-    peers_details = self.get_peers_info()            # CQL: system.peers
-    gossip_info = self.get_gossip_info()             # nodetool gossipinfo
-    group0_members = self.raft.get_group0_members()  # Raft query
-    tokenring_members = self.get_token_ring_members() # Token ring query
-
-    # Then 5 validation functions cross-reference all this data
-    return itertools.chain(
-        check_nodes_status(...),
-        check_node_status_in_gossip_and_nodetool_status(...),
-        check_schema_version(...),
-        check_nulls_in_peers(...),
-        check_group0_tokenring_consistency(...),
-    )
-```
-
-**Total**: 60 nodes × (5 operations + 5 validations) × ~2 min/node = 120 min
+| Shorter retries turn transient lag into false failures | High | Medium | Keep the worst-case ceiling comparable to today's; Phase 3 measurement shows how many attempts real conditions need |
+| Short-circuiting hides a genuine per-node problem | High | Low | Short-circuit only where the disagreement is about another node's membership, never where it is about the reporting node |
+| Excluding nemesis nodes masks damage the nemesis caused | Medium | Medium | Exclusion is scoped to the disruption's duration; the node is checked on the next gate, once released |
+| Restoring the gate under parallel nemesis destabilises those tests | Medium | Medium | Parameter defaults preserve exclusion; roll out on a limited set of parallel-nemesis jobs first |
+| `minimal` mode misses split-brain | High | Medium | Not the default; documented limitation; recommended only alongside sampling |
+| Configuration surface grows unmanageable | Low | High | Two new parameters only; sampling deliberately deferred to its own plan |

--- a/docs/plans/infrastructure/health-check-sampling.md
+++ b/docs/plans/infrastructure/health-check-sampling.md
@@ -1,0 +1,158 @@
+---
+status: draft
+domain: framework
+created: 2026-09-08
+last_updated: 2026-09-08
+owner: fruch
+---
+
+# Health Check Node Sampling Plan
+
+Split out of `docs/plans/infrastructure/health-check-optimization.md`, which
+reduces what each health-check gate costs. This plan reduces how many nodes
+each gate covers. It is deliberately separate: it depends on information the
+framework does not record today, and its open questions were blocking review of
+the cost work.
+
+**Do not start this plan before the parent plan's instrumentation phase has
+produced a measured baseline.** Sampling trades coverage for time, and there is
+currently no evidence about how much time is left to win once the retry costs
+are fixed. If the parent plan's phases bring the gate down to a few minutes,
+sampling may not be worth its complexity at all — that decision is the first
+deliverable here.
+
+## Problem Statement
+
+The health gate checks every node in the cluster, and each node reports on the
+whole cluster. Coverage is therefore quadratic in cluster size while the
+information gained is heavily redundant: on a healthy 60-node cluster, the
+sixtieth node's report says the same thing as the first.
+
+For very large clusters this is the last remaining source of scale-dependent
+cost after the parent plan's work. The tradeoff is real, though: checking fewer
+nodes weakens split-brain detection, which is the main thing the gate exists to
+catch.
+
+## Current State
+
+`sdcm/cluster.py:BaseScyllaCluster.check_cluster_health` checks every node,
+with no notion of topology or of which nodes are more likely to be affected.
+
+The framework does expose the topology needed to sample: nodes carry a
+datacenter and rack index, and `sdcm/cluster.py:BaseScyllaCluster` can already
+group nodes by rack. `sdcm/nemesis/utils/node_allocator.py:NemesisNodeAllocator`
+holds the canonical datacenter/rack filtering used to pick nemesis targets, and
+is the natural place to reuse rather than reimplement.
+
+**What is missing.** The earlier design assumed the gate could prioritise "the
+nodes that participated in the last disruption". It cannot, for two reasons:
+
+- The gate runs *before* a disruption, not after it. The disruption whose
+  damage would justify prioritising a node finished on the previous cycle.
+- The allocator's record of which nodes a disruption held is cleared when the
+  disruption ends, before the next cycle's gate runs.
+
+Recording participation so the gate can use it is therefore new work, and its
+shape is unresolved — see Needs Investigation.
+
+## Goals
+
+1. **Decide whether sampling is warranted at all**, from the parent plan's
+   measured baseline, before building it.
+2. **Reduce the checked set proportionally** while guaranteeing coverage of
+   every datacenter and every rack.
+3. **Avoid permanent blind spots** — no node may go unchecked indefinitely
+   across a long run.
+4. **Keep split-brain detection honest** — document, per sampling mode, what it
+   can no longer detect.
+5. **Default to no sampling**, so existing tests are unaffected.
+
+## Implementation Phases
+
+### Phase 1: Decision from measurement
+
+**Importance**: Critical
+**Dependencies**: parent plan's instrumentation and backoff phases
+
+Take the parent plan's post-fix measurements on the largest available cluster
+and decide whether sampling is still worth building. Record the decision and
+its numbers here.
+
+**Definition of Done**:
+- [ ] Post-fix gate cost measured on a large multi-DC cluster
+- [ ] Go/no-go decision recorded with the numbers behind it
+- [ ] If no-go, this plan is closed as `complete` with the rationale
+
+---
+
+### Phase 2: Topology-aware sampling
+
+**Importance**: Important
+**Dependencies**: Phase 1 (go decision)
+
+Select a subset of nodes to check, guaranteeing at least one node per
+datacenter and per rack, and never fewer than two nodes overall so that
+disagreement remains detectable. Rotate the selection across gates so that
+every node is checked within a bounded number of cycles.
+
+Reuse the existing datacenter/rack filtering rather than adding a second
+implementation of it.
+
+**Configuration**:
+```yaml
+cluster_health_check_sampling_mode: 'all'  # all | cluster_quorum | dc_quorum | rack_quorum | dc_one | rack_one
+```
+
+**Definition of Done**:
+- [ ] `all` is the default and checks every node, as today
+- [ ] Every other mode guarantees at least one node per datacenter and per rack
+- [ ] Never fewer than two nodes are checked
+- [ ] Selection rotates so no node is skipped indefinitely
+- [ ] Interaction with nemesis-node exclusion is defined: exclusion does not
+      drop the sample below its guarantees
+- [ ] Each mode's detection tradeoff documented
+- [ ] Parameter documented, default added, `docs/configuration_options.md` regenerated
+- [ ] Unit tests cover the guarantees for multi-DC and multi-rack topologies
+
+## Needs Investigation
+
+- **Prioritising nodes affected by the previous disruption.** Requires
+  recording which nodes a disruption held, and keeping that record past the
+  disruption's cleanup so the next gate can read it. Whether this is worth the
+  coupling between the nemesis runner and the gate is unresolved.
+- **Detection rate of each sampling mode.** The acceptable false-negative rate
+  for split-brain detection has never been agreed. Without it, the modes cannot
+  be recommended for anything.
+- **Escalation on disagreement.** Whether a sampled gate that finds
+  disagreement should escalate to a full check, and what that costs.
+
+## Testing Requirements
+
+**Unit.** Sampling selection is pure logic over topology and should be tested
+directly: per-mode guarantees, minimum node count, rotation across repeated
+gates, and behaviour when exclusion removes candidates. Extend
+`unit_tests/unit/test_health_check_parallel.py`.
+
+**Integration.** A multi-DC, multi-rack cluster must show the sample respecting
+topology, and repeated gates must show rotation covering every node.
+
+**Correctness.** A simulated membership disagreement must still be detected in
+every mode that claims to detect it.
+
+## Success Criteria
+
+1. The go/no-go decision is recorded with measurements behind it.
+2. If built: `all` remains the default and no existing test changes behaviour.
+3. Every non-default mode's coverage guarantees hold on multi-DC, multi-rack
+   topologies, and are unit-tested.
+4. No node goes unchecked for more than a documented number of gates.
+5. Each mode's detection limits are documented.
+
+## Risk Mitigation
+
+| Risk | Impact | Probability | Mitigation |
+|------|--------|-------------|------------|
+| Sampling misses a real problem | High | Medium | Guaranteed per-DC and per-rack coverage; rotation; `all` stays the default |
+| Built without being needed | Medium | High | Phase 1 is an explicit go/no-go gated on measurement |
+| Sampling and nemesis exclusion interact badly | Medium | Medium | Define exclusion as applied before selection, with guarantees enforced afterwards |
+| Rotation state adds cross-gate coupling | Low | Medium | Keep the state on the cluster object and treat loss of it as "check everything" |

--- a/docs/plans/progress.json
+++ b/docs/plans/progress.json
@@ -46,9 +46,19 @@
       "title": "Health Check Optimization",
       "file": "infrastructure/health-check-optimization.md",
       "domain": "framework",
-      "status": "draft",
+      "status": "in_progress",
       "created": "2026-01-11",
-      "phases_total": null,
+      "phases_total": 7,
+      "phases_done": 2
+    },
+    {
+      "id": "health-check-sampling",
+      "title": "Health Check Node Sampling",
+      "file": "infrastructure/health-check-sampling.md",
+      "domain": "framework",
+      "status": "draft",
+      "created": "2026-09-08",
+      "phases_total": 2,
       "phases_done": 0
     },
     {
@@ -269,15 +279,6 @@
       "domain": "config",
       "status": "pending_pr",
       "pr": 13845,
-      "phases_total": null,
-      "phases_done": 0
-    },
-    {
-      "id": "nemesis-extraction-phase3",
-      "title": "Nemesis Extraction Phase 3",
-      "domain": "nemesis",
-      "status": "pending_pr",
-      "pr": 13769,
       "phases_total": null,
       "phases_done": 0
     },


### PR DESCRIPTION
Refreshes `docs/plans/infrastructure/health-check-optimization.md`, which is cited by `docs/plans/INSTRUCTIONS.md` as the reference example of a well-structured plan and had drifted badly from the code.

Tracked as [SCT-523](https://scylladb.atlassian.net/browse/SCT-523).

## What was stale

- **Phase 1 shipped** — the gate is skipped after a skipped nemesis (#13522, after an initial revert).
- **Phase 2 shipped** — nodes are checked in parallel (#13584).
- Both of the plan's stated root causes were therefore already fixed, and its "Current Health Check Flow" appendix no longer matched the code.
- It proposed five config parameters under **two mutually inconsistent naming schemes** (`cluster_health_check_operations`/`_sampling_mode` in the phases vs `cluster_health_check_mode`/`_sample_nodes` in the test plan and recommended configs). None exist.
- It described the gate as a *post*-nemesis check. It is a *pre*-nemesis gate, which matters: Phase 4 was built on prioritising "nodes that participated in the nemesis", and that information is already cleared by the time the gate runs.

## What was wrong

The plan attributed ~2 min/node to "5 expensive operations". It is almost entirely fixed retry delays — and they amplify.

The checked state is cluster-wide: every node reports on every other node, and the first validator fails on *any* node not in `UN`. So one condition — one node held down by a nemesis, one node lagging in gossip — is detected independently by every node, and every node then burns its full retry budget waiting for it. That is what produces the two hours in #9547, and parallel workers divide it rather than remove it.

[SCT-808](https://scylladb.atlassian.net/browse/SCT-808) independently measured the same flat delay on the schema-agreement path: 42 hits in 21 minutes, **every one resolving on the first retry**, ~50% of a test phase. Same constants, so it is folded into this plan.

Also recorded: the background-health-monitor approach was already prototyped and rejected in #15209 — the gate exists to decide whether to stop the test, so it has to stay synchronous. The refreshed plan states that as a constraint so it isn't re-proposed.

## New phase order

Measure -> fix -> configure.

| Phase | |
|---|---|
| 1-2 | marked complete, retained for history |
| 3 | Instrumentation and baseline — no behaviour change; replaces the stale 120-min estimate with real numbers before anything is optimized |
| 4 | Backoff + cluster-level short-circuit; closes SCT-808 |
| 5 | Exclude nodes under nemesis and restore the gate under parallel nemesis (today it disables itself wholesale, silently taking the running-nemesis count check and partition validation with it) |
| 6 | Configurable check operations (`full` default \| `basic` \| `minimal`) |
| 7 | Documentation and rollout |

## Split out

Topology-aware node sampling moves to a new `health-check-sampling.md`. It depends on nemesis-participation data the framework does not record, and its open questions were the ones blocking review of the cost work. Its first phase is an explicit go/no-go gated on Phase 3's measurement — if the retry fixes bring the gate down to minutes, sampling may not be worth building.

## Conventions

Written to the behaviour-over-code rules from #16002: no line numbers, no snippets of internals, module/symbol references only. 377 and 158 lines.

`nemesis-precheck.md` (@pehala) is cross-referenced rather than edited — it reduces *how often* the gate runs, this plan reduces *what each run costs*.

### Testing
- [x] `uv run sct.py pre-commit` — all hooks pass
- Docs-only; no framework code.

### PR pre-checks (self review)
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SCT-523]: https://scylladb.atlassian.net/browse/SCT-523?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SCT-808]: https://scylladb.atlassian.net/browse/SCT-808?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ