### PR TITLE
fix(backtrace-decoding): drop the local addr2line fallback

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -243,6 +243,8 @@ HOUR_IN_SEC: int = 60 * MINUTE_IN_SEC
 MAX_TIME_WAIT_FOR_NEW_NODE_UP: int = HOUR_IN_SEC * 8
 MAX_TIME_WAIT_FOR_ALL_NODES_UP: int = MAX_TIME_WAIT_FOR_NEW_NODE_UP + HOUR_IN_SEC
 MAX_TIME_WAIT_FOR_DECOMMISSION: int = HOUR_IN_SEC * 6
+# cooldown for this build after backtrace service failure
+BACKTRACE_SERVICE_COOLDOWN_SEC: int = 15 * MINUTE_IN_SEC
 
 LOGGER = logging.getLogger(__name__)
 
@@ -476,6 +478,7 @@ class BaseNode(AutoSshContainerMixin):
         self._db_log_reader_thread = None
         self._scylla_manager_journal_thread = None
         self._decoding_backtraces_thread = None
+        self._backtrace_service_cooldown: dict[str, float] = {}
 
         self._short_hostname = None
         self._alert_manager: Optional[PrometheusAlertManagerListener] = None
@@ -2188,16 +2191,23 @@ class BaseNode(AutoSshContainerMixin):
 
     def start_decode_on_monitor_node_thread(self):
         self._decoding_backtraces_thread = threading.Thread(
-            target=self.decode_backtrace, name="DecodeOnMonitorNodeThread", daemon=True
+            target=self.decode_backtrace, name="DecodeBacktraceThread", daemon=True
         )
         self._decoding_backtraces_thread.daemon = True
         self._decoding_backtraces_thread.start()
 
     @lru_cache(maxsize=None)
+    @retrying(
+        n=3,
+        sleep_time=5,
+        allowed_exceptions=(requests.RequestException,),
+        message="Decoding backtrace via backtrace.scylladb.com",
+    )
     def _decode_via_external_service(self, build_id: str, raw_backtrace: str) -> str:
         """Decode backtrace using the external backtraces.scylladb.com service.
 
-        Avoids loading 1+ GB DWARF debug info on the monitor node (prevents OOM).
+        Transient HTTP/network errors (404, 5xx, timeouts, connection errors) are retried;
+        a reply with success=false is a processing error on the service side and is final.
 
         Args:
             build_id: hex build ID of the scylla binary
@@ -2207,7 +2217,7 @@ class BaseNode(AutoSshContainerMixin):
             decoded backtrace string (stdout from the service)
 
         Raises:
-            requests.RequestException: on network/HTTP error
+            requests.RequestException: on network/HTTP error after all retries
             ValueError: if the service returns success=false
         """
         response = requests.post(
@@ -2230,42 +2240,10 @@ class BaseNode(AutoSshContainerMixin):
                     break
                 event = obj["event"]
                 self.log.debug("Event origin severity: %s", event.severity)
-                build_id = obj["build_id"]
-                raw_backtrace_oneline = " ".join(event.raw_backtrace.split("\n"))
-
-                decoded = None
-                if build_id:
-                    try:
-                        decoded = self._decode_via_external_service(build_id, event.raw_backtrace)
-                        self.log.debug("Decoded backtrace via external service for build_id=%s", build_id)
-                    except Exception as exc:  # noqa: BLE001
-                        self.log.warning("External backtrace service failed (%s), falling back to local addr2line", exc)
-
-                if decoded is None:
-                    scylla_debug_file = self.copy_scylla_debug_info(obj["node"], build_id)
-                    decoded = self.decode_backtrace_local(scylla_debug_file, raw_backtrace_oneline).stdout
-
-                event.backtrace = decoded
-                the_map = FindIssuePerBacktrace()
-                if issue_url := the_map.find_issue(backtrace_type=event.type, decoded_backtrace=event.backtrace):
-                    event.known_issue = issue_url
-                    skip_per_issue = SkipPerIssues(issue_url, self.parent_cluster.params)
-                    # If found issue is closed
-                    if not skip_per_issue.issues_opened():
-                        if skip_per_issue.issues_labeled():
-                            # If found issue has skip label, this issue was fixed but won't be backported to the tested branch.
-                            # So this reactor stall is expected and shouldn't fail the test
-                            # if this event severity is Error or Critical - decrease to warning.
-                            event.severity = (
-                                Severity.WARNING if event.severity.value > Severity.WARNING.value else event.severity
-                            )
-                        else:
-                            # If found issue has no skip label - increase severity to Error (if not).
-                            # A reason: the issue was fixed, and it is not expected to get this reactor stall
-                            event.severity = (
-                                Severity.ERROR if event.severity.value < Severity.ERROR.value else event.severity
-                            )
-                    self.log.debug("Found issue for %s event: %s", event.event_id, event.known_issue)
+                event.build_id = obj["build_id"]
+                if decoded := self._decode_backtrace_via_service(event.build_id, event.raw_backtrace):
+                    event.backtrace = decoded
+                    self._match_known_issue(event)
             except queue.Empty:
                 pass
             except Exception as details:  # noqa: BLE001
@@ -2280,73 +2258,52 @@ class BaseNode(AutoSshContainerMixin):
             if self.termination_event.is_set() and self.test_config.DECODING_QUEUE.empty():
                 break
 
-    def copy_scylla_debug_info(self, node_name: str, build_id: str):
-        """Copy scylla debug file from db-node to monitor-node.
+    def _decode_backtrace_via_service(self, build_id: Optional[str], raw_backtrace: str) -> Optional[str]:
+        """Decode a backtrace with backtrace.scylladb.com, or return None to publish it undecoded.
 
-        Skip if debug file already exists on monitor node.
-
-        Copy via builder
-        :param node_name: db node name
-        :type node_name: str
-        :param build_id: build id of scylla binary
-        :type build_id: str
-        :returns: path on monitor node
-        :rtype: {str}
+        Backtraces are never decoded locally. An undecoded backtrace can still be decoded later from
+        the build id and the raw addresses.
         """
-        final_scylla_debug_file = os.path.join("/tmp", f"debug_{build_id}")
-        res = self.remoter.run(f"test -f {final_scylla_debug_file}", ignore_status=True, verbose=False)
-        if res.exited == 0:
-            return final_scylla_debug_file
-        db_nodes = self.parent_cluster.targets["db_cluster"].nodes
-        db_node = next(iter([n for n in db_nodes if n.name == node_name]), None)
-        assert db_node, f"Node named: {node_name} wasn't found"
+        if not build_id:
+            self.log.warning("No build-id known for this backtrace, publishing it undecoded")
+            return None
 
-        debug_file = db_node.get_scylla_debuginfo_file(build_id)
-        LOGGER.debug("Debug info file %s", debug_file)
-        base_scylla_debug_file = os.path.basename(debug_file)
-        transit_scylla_debug_file = os.path.join(db_node.parent_cluster.logdir, base_scylla_debug_file)
-        db_node.remoter.receive_files(debug_file, transit_scylla_debug_file)
-        self.remoter.send_files(transit_scylla_debug_file, final_scylla_debug_file)
-        self.log.info("File on monitor node %s: %s", self, final_scylla_debug_file)
-        self.log.info("Remove transit file: %s", transit_scylla_debug_file)
-        os.remove(transit_scylla_debug_file)
-        return final_scylla_debug_file
+        if time.monotonic() < self._backtrace_service_cooldown.get(build_id, 0):
+            self.log.debug("Backtrace service is in cooldown for build_id=%s, publishing raw backtrace", build_id)
+            return None
 
-    def get_scylla_debuginfo_file(self, build_id: str):
-        """Lookup the scylla debug information for a given build_id."""
-        # first try default location
-        scylla_debug_info = "/usr/lib/debug/bin/scylla.debug"
-        results = self.remoter.run(f"[[ -f {scylla_debug_info} ]]", ignore_status=True)
-        if results.ok:
-            return scylla_debug_info
+        try:
+            decoded = self._decode_via_external_service(build_id, raw_backtrace)
+        except Exception as exc:  # noqa: BLE001
+            self._backtrace_service_cooldown[build_id] = time.monotonic() + BACKTRACE_SERVICE_COOLDOWN_SEC
+            self.log.warning(
+                "External backtrace service failed for build_id=%s (%s); publishing the raw backtrace, "
+                "it can be decoded later. Not asking the service about this build for the next %d min",
+                build_id,
+                exc,
+                BACKTRACE_SERVICE_COOLDOWN_SEC // MINUTE_IN_SEC,
+            )
+            return None
+        self.log.debug("Decoded backtrace via external service for build_id=%s", build_id)
+        return decoded
 
-        # then try the relocatable location
-        results = self.remoter.run("ls /usr/lib/debug/opt/scylladb/libexec/scylla*.debug", ignore_status=True)
-        if results.stdout.strip():
-            return results.stdout.strip()
+    def _match_known_issue(self, event) -> None:
+        """Look the decoded backtrace up in the known-issues map and adjust the event severity."""
+        issue_url = FindIssuePerBacktrace().find_issue(backtrace_type=event.type, decoded_backtrace=event.backtrace)
+        if not issue_url:
+            return
 
-        # then look it up based on the build id
-        if build_id:
-            scylla_debug_info = f"/usr/lib/debug/.build-id/{build_id[:2]}/{build_id[2:]}.debug"
-            results = self.remoter.run(f"[[ -f {scylla_debug_info} ]]", ignore_status=True)
-            if results.ok:
-                return scylla_debug_info
+        event.known_issue = issue_url
+        skip_per_issue = SkipPerIssues(issue_url, self.parent_cluster.params)
 
-        raise Exception("Couldn't find scylla debug information")
+        if not skip_per_issue.issues_opened():
+            if skip_per_issue.issues_labeled():
+                if event.severity.value > Severity.WARNING.value:
+                    event.severity = Severity.WARNING
+            elif event.severity.value < Severity.ERROR.value:
+                event.severity = Severity.ERROR
 
-    @lru_cache(maxsize=None)
-    def decode_backtrace_local(self, scylla_debug_file, raw_backtrace):
-        """run decode backtrace on monitor node
-
-        Decode backtrace on monitor node
-        :param scylla_debug_file: file path on db-node
-        :type scylla_debug_file: str
-        :param raw_backtrace: string with backtrace data
-        :type raw_backtrace: str
-        :returns: result of bactrace
-        :rtype: {str}
-        """
-        return self.remoter.run(f"addr2line -Cpife {scylla_debug_file} {raw_backtrace}", verbose=True)
+        self.log.debug("Found issue for %s event: %s", event.event_id, event.known_issue)
 
     def get_scylla_build_id(self) -> Optional[str]:
         for scylla_executable in (
@@ -3028,23 +2985,6 @@ class BaseNode(AutoSshContainerMixin):
             f"| sudo bash -s -- --scylla-version {version}",
             retry=3,
         )
-
-    def install_scylla_debuginfo(self) -> None:
-        if ComparableScyllaVersion(self.scylla_version) > "2025.1.0~dev":
-            # since source available versions, theres only on option for package names
-            package_prefix = "scylla"
-        else:
-            package_prefix = self.scylla_pkg()
-
-        if self.distro.is_rhel_like or self.distro.is_sles:
-            package_name = rf"{package_prefix}-debuginfo-{self.scylla_version}\*"
-        else:
-            package_name = rf"{package_prefix}-server-dbg={self.scylla_version}\*"
-
-        self.log.debug("Installing Scylla debug info...")
-        # using ignore_status=True cause of docker image doesn't have the repo/list available
-        # TODO: find a why to identify the package, otherwise we don't have debug symbols
-        self.install_package(package_name=package_name, ignore_status=True)
 
     def is_scylla_installed(self, raise_if_not_installed=False):
         if self.get_scylla_binary_version():
@@ -6301,9 +6241,6 @@ class BaseScyllaCluster:
                 node.remoter.sudo("systemctl restart syslog-ng")
             elif self.params.get("logs_transport") == "vector":
                 node.remoter.sudo("systemctl restart vector")
-        if self.test_config.BACKTRACE_DECODING:
-            node.install_scylla_debuginfo()
-
         simulated_regions_num = self.params.get("simulated_regions")
         if self.test_config.MULTI_REGION or simulated_regions_num > 1 or self.params.get("simulated_racks") > 1:
             if simulated_regions_num > 1:

--- a/sdcm/cluster_docker.py
+++ b/sdcm/cluster_docker.py
@@ -490,8 +490,6 @@ class ScyllaDockerCluster(cluster.BaseScyllaCluster, DockerCluster):
 
         node.is_scylla_installed(raise_if_not_installed=True)
         self.check_aio_max_nr(node)
-        if self.test_config.BACKTRACE_DECODING:
-            node.install_scylla_debuginfo()
 
         if any([self.params.get("server_encrypt"), self.params.get("client_encrypt")]):
             self._generate_db_node_certs(node)

--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -2982,8 +2982,6 @@ class ScyllaPodCluster(cluster.BaseScyllaCluster, PodCluster):
         return []
 
     def node_setup(self, node: BaseScyllaPodContainer, verbose: bool = False, timeout: int = 3600):
-        if self.test_config.BACKTRACE_DECODING:
-            node.install_scylla_debuginfo()
         self.node_config_setup()
 
     def node_startup(self, node: BaseScyllaPodContainer, verbose: bool = False, timeout: int = 3600):

--- a/sdcm/sct_events/base.py
+++ b/sdcm/sct_events/base.py
@@ -450,6 +450,7 @@ class LogEventProtocol(SctEventProtocol, Protocol[T_log_event]):
     line_number: int
     backtrace: Optional[str]
     raw_backtrace: Optional[str]
+    build_id: Optional[str]
 
     def add_info(self: T_log_event, node, line: str, line_number: int) -> T_log_event: ...
 
@@ -470,6 +471,7 @@ class LogEvent(Generic[T_log_event], InformationalEvent, abstract=True):
         self.line_number = 0
         self.backtrace = None
         self.raw_backtrace = None
+        self.build_id: Optional[str] = None
         self.subcontext = []
         self.known_issue = None
 
@@ -525,6 +527,8 @@ class LogEvent(Generic[T_log_event], InformationalEvent, abstract=True):
             fmt += " node={0.node}"
         if self.known_issue:
             fmt += " known_issue={0.known_issue}"
+        if self.build_id:
+            fmt += " build_id={0.build_id}"
         if self.line is not None:
             fmt += "\n{0.line}"
         if self.backtrace:

--- a/unit_tests/unit/test_decode_backtrace.py
+++ b/unit_tests/unit/test_decode_backtrace.py
@@ -26,10 +26,16 @@ from sdcm.sct_events.database import SYSTEM_ERROR_EVENTS_PATTERNS
 from unit_tests.lib.dummy_remote import DummyRemote
 from unit_tests.lib.fake_cluster import DummyNode
 
+DECODED_BY_SERVICE = "decoded-by-external"
+BUILD_ID = "abc123"
 
-class DecodeDummyNode(DummyNode):
-    def copy_scylla_debug_info(self, node_name, debug_file):
-        return "scylla_debug_info_file"
+
+def _service_response(success=True, stdout=DECODED_BY_SERVICE, stderr=""):
+    """Build a fake requests.Response for the backtrace service."""
+    response = MagicMock()
+    response.json.return_value = {"success": success, "stdout": stdout, "stderr": stderr}
+    response.raise_for_status.return_value = None
+    return response
 
 
 @pytest.fixture(name="test_config")
@@ -47,7 +53,7 @@ def test_config_fixture():
 @pytest.fixture(name="dummy_node")
 def dummy_node_fixture(tmp_path):
     """Fixture to create a dummy node for testing."""
-    dummy_node = DecodeDummyNode(
+    dummy_node = DummyNode(
         name="test_node",
         parent_cluster=None,
         base_logdir=tmp_path,
@@ -59,7 +65,7 @@ def dummy_node_fixture(tmp_path):
 @pytest.fixture(name="monitor_node")
 def monitor_node_fixture(tmp_path):
     """Fixture to create a monitor node for testing."""
-    monitor_node = DecodeDummyNode(
+    monitor_node = DummyNode(
         name="test_monitor_node",
         parent_cluster=None,
         base_logdir=tmp_path,
@@ -68,6 +74,29 @@ def monitor_node_fixture(tmp_path):
     yield monitor_node
 
     # Cleanup
+    monitor_node.termination_event.set()
+    monitor_node.stop_task_threads()
+    monitor_node.wait_till_tasks_threads_are_stopped()
+
+
+def _make_db_log_reader(dummy_node, decoding_queue, stall_decoding=True, disable_regex=None):
+    db_log_reader = DbLogReader(
+        system_log=dummy_node.system_log,
+        node_name=str(dummy_node),
+        remoter=dummy_node.remoter,
+        decoding_queue=decoding_queue,
+        system_event_patterns=SYSTEM_ERROR_EVENTS_PATTERNS,
+        log_lines=True,
+        backtrace_stall_decoding=stall_decoding,
+        backtrace_decoding_disable_regex=disable_regex,
+    )
+    db_log_reader._build_id = BUILD_ID
+    return db_log_reader
+
+
+def _run_decode_thread_over_log(monitor_node, db_log_reader):
+    monitor_node.start_decode_on_monitor_node_thread()
+    db_log_reader._read_and_publish_events()
     monitor_node.termination_event.set()
     monitor_node.stop_task_threads()
     monitor_node.wait_till_tasks_threads_are_stopped()
@@ -115,34 +144,19 @@ def test_reactor_stall_not_decoded_when_no_decoding_queue(
 def test_backtraces_decoded_when_enabled(
     test_config, dummy_node, monitor_node, events_function_scope, log_file, test_data_dir
 ):
-    """Backtraces are decoded to addr2line commands when decoding is enabled."""
+    """Backtraces flow from the db log reader through the decode thread to the published event."""
     dummy_node.system_log = str(test_data_dir / log_file)
+    db_log_reader = _make_db_log_reader(dummy_node, test_config.DECODING_QUEUE)
 
-    db_log_reader = DbLogReader(
-        system_log=dummy_node.system_log,
-        node_name=str(dummy_node),
-        remoter=dummy_node.remoter,
-        decoding_queue=test_config.DECODING_QUEUE,
-        system_event_patterns=SYSTEM_ERROR_EVENTS_PATTERNS,
-        log_lines=True,
-        backtrace_stall_decoding=True,
-        backtrace_decoding_disable_regex=None,
-    )
-
-    monitor_node.start_decode_on_monitor_node_thread()
-    db_log_reader._read_and_publish_events()
-    monitor_node.termination_event.set()
-    monitor_node.stop_task_threads()
-    monitor_node.wait_till_tasks_threads_are_stopped()
+    with patch("sdcm.cluster.requests.post", return_value=_service_response()):
+        _run_decode_thread_over_log(monitor_node, db_log_reader)
 
     events = events_function_scope.published_events
 
     assert any(event.get("raw_backtrace") for event in events), "should have at least one backtrace"
     for event in events:
-        if event.get("backtrace") and event.get("raw_backtrace"):
-            assert event["backtrace"].strip() == "addr2line -Cpife scylla_debug_info_file {}".format(
-                " ".join(event["raw_backtrace"].split("\n"))
-            )
+        if event.get("raw_backtrace"):
+            assert event["backtrace"] == DECODED_BY_SERVICE
 
 
 @pytest.mark.parametrize(
@@ -190,26 +204,11 @@ def test_backtrace_decoding_configuration(
         event_filter: Lambda function to filter events for validation
         should_decode: Whether the filtered events should have decoded backtraces
     """
-    # Setup
     dummy_node.system_log = str(test_data_dir / "system.log")
+    db_log_reader = _make_db_log_reader(dummy_node, test_config.DECODING_QUEUE, stall_decoding, disable_regex)
 
-    # Create db_log_reader with specific configuration
-    db_log_reader = DbLogReader(
-        system_log=dummy_node.system_log,
-        node_name=str(dummy_node),
-        remoter=dummy_node.remoter,
-        decoding_queue=test_config.DECODING_QUEUE,
-        system_event_patterns=SYSTEM_ERROR_EVENTS_PATTERNS,
-        log_lines=True,
-        backtrace_stall_decoding=stall_decoding,
-        backtrace_decoding_disable_regex=disable_regex,
-    )
-
-    monitor_node.start_decode_on_monitor_node_thread()
-    db_log_reader._read_and_publish_events()
-    monitor_node.termination_event.set()
-    monitor_node.stop_task_threads()
-    monitor_node.wait_till_tasks_threads_are_stopped()
+    with patch("sdcm.cluster.requests.post", return_value=_service_response()):
+        _run_decode_thread_over_log(monitor_node, db_log_reader)
 
     events = events_function_scope.published_events
 
@@ -218,7 +217,7 @@ def test_backtrace_decoding_configuration(
 
     for event in filtered_events:
         if should_decode:
-            assert event.get("backtrace") is not None, (
+            assert event.get("backtrace") == DECODED_BY_SERVICE, (
                 f"Event of type {event.get('type')} should have decoded backtrace"
             )
         else:
@@ -245,34 +244,28 @@ def _run_decode_with_queue_item(monitor_node, build_id, raw_backtrace):
 
     monitor_node.test_config = config
 
-    monitor_node.decode_backtrace()
+    # retries must not slow the unit tests down
+    with patch("time.sleep"):
+        monitor_node.decode_backtrace()
     return event
 
 
-def test_external_service_success_skips_local_addr2line(monitor_node):
-    """When external service succeeds, copy_scylla_debug_info and local addr2line are NOT called."""
-    mock_response = MagicMock()
-    mock_response.json.return_value = {"success": True, "stdout": "decoded-by-external", "stderr": ""}
-    mock_response.raise_for_status.return_value = None
+def test_external_service_success_sets_decoded_backtrace(monitor_node):
+    """A successful service reply becomes the decoded backtrace; nothing is run on the monitor node."""
+    monitor_node.remoter = MagicMock()
 
-    with (
-        patch("sdcm.cluster.requests.post", return_value=mock_response) as mock_post,
-        patch.object(monitor_node, "copy_scylla_debug_info") as mock_copy,
-    ):
-        event = _run_decode_with_queue_item(monitor_node, "abc123", "0x1234\n0x5678")
+    with patch("sdcm.cluster.requests.post", return_value=_service_response()) as mock_post:
+        event = _run_decode_with_queue_item(monitor_node, BUILD_ID, "0x1234\n0x5678")
 
-    assert event.backtrace == "decoded-by-external"
-    mock_copy.assert_not_called()
+    assert event.backtrace == DECODED_BY_SERVICE
+    assert event.build_id == BUILD_ID
     mock_post.assert_called_once()
+    monitor_node.remoter.run.assert_not_called()
 
 
 def test_external_service_post_request_payload(monitor_node):
     """Verify the POST request sends correct URL, build_id and input format."""
-    mock_response = MagicMock()
-    mock_response.json.return_value = {"success": True, "stdout": "decoded", "stderr": ""}
-    mock_response.raise_for_status.return_value = None
-
-    with patch("sdcm.cluster.requests.post", return_value=mock_response) as mock_post:
+    with patch("sdcm.cluster.requests.post", return_value=_service_response()) as mock_post:
         _run_decode_with_queue_item(monitor_node, "abc123def", "0x1234\n0x5678")
 
     mock_post.assert_called_once_with(
@@ -283,27 +276,67 @@ def test_external_service_post_request_payload(monitor_node):
 
 
 @pytest.mark.parametrize(
-    "side_effect,description",
+    "side_effect,expected_calls",
     [
-        (requests.HTTPError(response=MagicMock(status_code=404)), "HTTP 404"),
-        (requests.Timeout("timed out"), "timeout"),
-        (requests.ConnectionError("connection refused"), "connection error"),
+        pytest.param(requests.HTTPError(response=MagicMock(status_code=404)), 3, id="http_404"),
+        pytest.param(
+            _service_response(success=False, stdout="", stderr="OSError: [Errno 28] No space left on device"),
+            1,
+            id="service_side_error_is_final",
+        ),
     ],
 )
-def test_external_service_failure_falls_back_to_local(monitor_node, side_effect, description):
-    """When external service fails (%s), fall back to local addr2line."""
-    with patch("sdcm.cluster.requests.post", side_effect=side_effect):
-        event = _run_decode_with_queue_item(monitor_node, "abc123", "0x1234\n0x5678")
+def test_external_service_failure_publishes_raw_backtrace(monitor_node, side_effect, expected_calls):
+    """When the service fails, the event keeps only its raw backtrace and nothing is decoded on the monitor."""
+    monitor_node.remoter = MagicMock()
 
-    assert event.backtrace is not None, f"Should fall back to local for {description}"
-    assert "addr2line" in event.backtrace
+    with (
+        patch("sdcm.cluster.requests.post", side_effect=[side_effect] * expected_calls) as mock_post,
+        patch("sdcm.cluster.FindIssuePerBacktrace") as mock_find_issue,
+    ):
+        event = _run_decode_with_queue_item(monitor_node, BUILD_ID, "0x1234\n0x5678")
+
+    assert event.backtrace is None
+    assert event.raw_backtrace == "0x1234\n0x5678"
+    assert event.build_id == BUILD_ID, "the build id must stay with the raw backtrace so it can be decoded later"
+    assert mock_post.call_count == expected_calls
+    monitor_node.remoter.run.assert_not_called()
+    mock_find_issue.assert_not_called()
 
 
-def test_no_build_id_skips_external_service(monitor_node):
-    """When build_id is None, external service is never called."""
+def test_external_service_retries_transient_errors(monitor_node):
+    """Transient HTTP errors are retried and a later success is used."""
+    with patch(
+        "sdcm.cluster.requests.post",
+        side_effect=[requests.Timeout("timed out"), requests.ConnectionError("refused"), _service_response()],
+    ) as mock_post:
+        event = _run_decode_with_queue_item(monitor_node, BUILD_ID, "0x1234\n0x5678")
+
+    assert event.backtrace == DECODED_BY_SERVICE
+    assert mock_post.call_count == 3
+
+
+def test_external_service_cooldown_skips_build_after_failure(monitor_node):
+    """After a final failure the service is not asked about the same build again while the cooldown lasts."""
+    with patch("sdcm.cluster.requests.post", return_value=_service_response(success=False)) as mock_post:
+        first = _run_decode_with_queue_item(monitor_node, BUILD_ID, "0x1111")
+        second = _run_decode_with_queue_item(monitor_node, BUILD_ID, "0x2222")
+        other_build = _run_decode_with_queue_item(monitor_node, "def456", "0x3333")
+
+    assert first.backtrace is None
+    assert second.backtrace is None
+    assert other_build.backtrace is None
+    assert mock_post.call_count == 2, "one call per build id: the second event of abc123 must be skipped"
+
+
+def test_no_build_id_publishes_raw_backtrace(monitor_node):
+    """Without a build id there is nothing to decode against: no service call, nothing run on the monitor."""
+    monitor_node.remoter = MagicMock()
+
     with patch("sdcm.cluster.requests.post") as mock_post:
         event = _run_decode_with_queue_item(monitor_node, None, "0x1234\n0x5678")
 
     mock_post.assert_not_called()
-    assert event.backtrace is not None
-    assert "addr2line" in event.backtrace
+    monitor_node.remoter.run.assert_not_called()
+    assert event.backtrace is None
+    assert event.build_id is None

--- a/unit_tests/unit/test_sct_events_database.py
+++ b/unit_tests/unit/test_sct_events_database.py
@@ -211,3 +211,15 @@ def test_index_special_column_error_event_msgfmt():
         "(IndexSpecialColumnErrorEvent Severity.ERROR) period_type=one-time "
         "event_id=ac449879-485a-4b06-8596-3fbe58881093: message=m1"
     )
+
+
+def test_log_event_message_carries_build_id_with_raw_backtrace():
+    """An undecoded backtrace is only useful later together with the build id it belongs to."""
+    event = DatabaseLogEvent.REACTOR_STALLED().add_info("node1", "Reactor stalled for 45 ms", 1)
+    event.raw_backtrace = "0x1234\n0x5678"
+    event.build_id = "abc123"
+
+    message = str(event)
+
+    assert "build_id=abc123" in message
+    assert "0x1234\n0x5678" in message


### PR DESCRIPTION
When backtrace.scylladb.com fails, SCT copies the scylla debug file to the monitor node and runs addr2line there. addr2line needs 6-7 GB on the 8 GB monitor VM, which hangs it for up to an hour and fails every nemesis that has to reach the monitor (sctool, genconfig.py).

The fix is to drop that and have service the only decoder. Transient HTTP errors are retried 3 times, a build that fails is not asked about again for 15 minutes. When decoding fails the event is published with its raw backtrace, so it can be decoded later. The debuginfo package install on db nodes is removed, as nothing uses it any more.

Fixes: SCT-509

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :green_circle: [longevity-10gb-3h-azure-test (original failing test)](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/longevity-10gb-3h-azure-test/46/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code
