### PR TITLE
fix(adaptive_timeouts): set hard timeout to 2x soft for tablet operations

### DIFF
--- a/sdcm/utils/adaptive_timeouts/__init__.py
+++ b/sdcm/utils/adaptive_timeouts/__init__.py
@@ -46,8 +46,7 @@ def _get_decommission_timeout(
             node_info["tablets_enabled"] = True
             estimated = int(node_info_service.node_data_size_mb / node_info_service.expected_throughput)
             soft_timeout = estimated * 2 + _STREAMING_OVERHEAD
-            hard_timeout = estimated * 4 + _STREAMING_OVERHEAD
-            return (soft_timeout, hard_timeout), node_info
+            return (soft_timeout, soft_timeout * 2), node_info
         else:
             # For non-tablet cases, calculate based on data size
             # rough estimation from previous runs almost 9h for 1TB
@@ -96,8 +95,7 @@ def _get_tablet_migration_timeout(
             node_info["tablets_enabled"] = True
             estimated = int(node_info_service.node_disk_size_mb * 0.9 / node_info_service.expected_throughput)
             soft_timeout = estimated * 2 + _STREAMING_OVERHEAD
-            hard_timeout = estimated * 4 + _STREAMING_OVERHEAD
-            return (soft_timeout, hard_timeout), node_info
+            return (soft_timeout, soft_timeout * 2), node_info
         else:
             soft_timeout = max(int(node_info_service.node_disk_size_mb * 0.9 * 0.03), 7200)  # 2 hours minimum
             return (soft_timeout, None), node_info

--- a/unit_tests/unit/test_adaptive_timeouts.py
+++ b/unit_tests/unit/test_adaptive_timeouts.py
@@ -209,10 +209,11 @@ def test_tablets_decommission_timeout_is_calculated_from_data_size(
         operation=Operations.DECOMMISSION, node=fake_node, stats_storage=adaptive_timeout_store
     ) as timeout:
         # node_data_size_mb=102400, expected_throughput=69/2*3=103.5 → estimated≈989.4s
-        # hard = int(estimated) * 4 + 600 (10-minute overhead) = 4556
+        # soft = int(estimated) * 2 + 600 (10-minute overhead); hard = soft * 2
         throughput = _I4I_LARGE_BASELINE_THROUGHPUT_MB_PER_SEC / _I4I_LARGE_SHARD_COUNT * 3
         estimated = int(102400 / throughput)
-        expected_hard = estimated * 4 + _STREAMING_OVERHEAD
+        soft_timeout = estimated * 2 + _STREAMING_OVERHEAD
+        expected_hard = soft_timeout * 2
         assert timeout == expected_hard
 
     soft_timeout_mock.assert_not_called()
@@ -249,10 +250,11 @@ def test_tablets_tablet_migration_timeout_is_calculated_from_disk_size(
     ) as timeout:
         # node_disk_size_mb=102400, expected_throughput=69/2*3=103.5
         # estimated = 102400 * 0.9 / 103.5 ≈ 889.9s
-        # hard = int(estimated) * 4 + 600 (10-minute overhead) = 4160
+        # soft = int(estimated) * 2 + 600 (10-minute overhead); hard = soft * 2
         throughput = _I4I_LARGE_BASELINE_THROUGHPUT_MB_PER_SEC / _I4I_LARGE_SHARD_COUNT * 3
         estimated = int(102400 * 0.9 / throughput)
-        expected_hard = estimated * 4 + _STREAMING_OVERHEAD
+        soft_timeout = estimated * 2 + _STREAMING_OVERHEAD
+        expected_hard = soft_timeout * 2
         assert timeout == expected_hard
 
     soft_timeout_mock.assert_not_called()


### PR DESCRIPTION
If an operation other than streaming is slow, for small data scenarios when the streaming is fast, the difference between soft and hard timeout is small, so hard timeout is often hit, which ends the test.

Closes: SCT-978

Example: 
https://argus.scylladb.com/tests/scylla-cluster-tests/f1530925-f137-4d42-96d0-4da978031f9b/results
soft timeout = 746.0s
hard timeout = 892.0s
actual duration = 1066s (would not have hit hard timeout with new formula, tests does not end).
```
Sep 07 10:42:48.356306 alternator-3h-2026-3-db-node-f1530925-1 scylla[7374]:  [shard  0:strm] api - decommission
Sep 07 11:00:34.666677 alternator-3h-2026-3-db-node-f1530925-1 scylla[7374]:  [shard  0:strm] storage_service - DECOMMISSIONING: done
```

> [!NOTE]
> Since the soft timeout remains the same, it will still fail, but not end the tests.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
