### PR TITLE
feature(skills): add capacity-failure-analysis skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -354,6 +354,7 @@ Modular, task-specific guidance for AI agents lives in the `skills/` directory. 
 | reviewing-pipeline-docs | Guides reviewing and generating test_metadata sections for SCT test-case YAML files. Use when adding or auditing test_metadata, checking description/tier/labels accuracy, or running lint-test-docs. | `skills/reviewing-pipeline-docs/SKILL.md` |
 | labeling-pipelines | Guides bulk-labeling and linting test-case YAML files with test_metadata. Use when finding coverage gaps, auto-fixing mismatches, or auditing label accuracy across a directory. | `skills/labeling-pipelines/SKILL.md` |
 | stack-sync | Manage stacked PRs via the gh-stack CLI extension (native GitHub stacked PR support). Use when splitting a large change into a chain of small reviewable PRs, checking stack status, or syncing/rebasing/merging stack layers. | `skills/stack-sync/SKILL.md` |
+| capacity-failure-analysis | Analyze AWS capacity and provisioning failures in SCT runs using Argus and Jenkins. Use when counting CapacityReservationError failures per week, grouping them by region, job or instance type, or deciding which region to move a perf job to. | `skills/capacity-failure-analysis/SKILL.md` |
 
 When creating a new skill, follow the process in `skills/designing-skills/workflows/create-a-skill.md`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,3 +31,4 @@ Available skills (invoke via Skill tool or `/skill-name`):
 - `labeling-pipelines` — Add test_metadata to test-case YAML files
 - `reviewing-pipeline-docs` — Review test_metadata sections for accuracy
 - `stack-sync` — Manage stacked PRs via the gh-stack CLI extension (native GitHub stacked PR support)
+- `capacity-failure-analysis` — Measure AWS capacity/provisioning failures per week, region and job

--- a/skills/capacity-failure-analysis/SKILL.md
+++ b/skills/capacity-failure-analysis/SKILL.md
@@ -137,6 +137,13 @@ tests are tabulated in `skills/perf-weekly-status-report/SKILL.md` under "Test R
 | Placement-group variant dominates | Configuration or leaked-resource bug, not capacity — inspect cleanup |
 | High run count but low rate | Healthy; do not "fix" it |
 
+## Output
+
+Every report is saved to `~/Downloads/capacity-failures-<period>-<date>.html`, always, without waiting to be
+asked — an Artifact link is tied to a session, while the file on disk is what gets attached to a ticket or
+reopened later. Publish an Artifact too when a shareable link helps, and give the user both. The local file
+needs its own `<!doctype html>` skeleton; see [report-format.md](references/report-format.md).
+
 ## Reference Index
 
 | File | Content |
@@ -159,3 +166,4 @@ tests are tabulated in `skills/perf-weekly-status-report/SKILL.md` under "Test R
 - [ ] Only runs whose final status is `test_error` with a CRITICAL event are counted
 - [ ] Regions with too few runs to be meaningful are flagged rather than ranked
 - [ ] Remediation advice names a specific region or instance type, with the rate that justifies it
+- [ ] The report is saved to `~/Downloads/capacity-failures-<period>-<date>.html` and the path given to the user

--- a/skills/capacity-failure-analysis/SKILL.md
+++ b/skills/capacity-failure-analysis/SKILL.md
@@ -64,6 +64,16 @@ and tries the next AZ, then the next region. Only a run whose *final* status is 
 event was actually killed. Match on severity and final status, not on the presence of the string anywhere in
 the log, or the numbers will be inflated by failures the framework handled correctly.
 
+### Ask for the Reporting Period First
+
+**The period is the user's choice, not a default — ask before collecting anything.**
+
+Offer three: **from first start** (`--period all`), **last month** (`--period month`), **last week**
+(`--period week`). It matters because the period silently changes how much of the region breakdown is
+measured versus guessed: Jenkins rotates builds out of history, so a long period finds more failures but
+resolves fewer of their regions from the authoritative source. Picking a window silently hands the user a
+report whose confidence they had no say in. Skip the question only when the request already names a period.
+
 ## When to Use
 
 - Counting how many runs or builds failed with a capacity or provisioning error over a time window
@@ -102,14 +112,15 @@ the repository root so `sdcm` imports resolve:
 
 ```bash
 PYTHONPATH=. .venv/bin/python skills/capacity-failure-analysis/capacity_failure_stats.py \
-    --registry tests.tsv --weeks 12 --json-out capacity.json
+    --registry tests.tsv --period month --json-out capacity.json
 ```
 
 | Flag | Purpose |
 |------|---------|
 | `--test-id UUID` | One Argus test UUID; repeatable |
 | `--registry FILE` | TSV of `name<TAB>test_id[<TAB>category]` — preferred for multi-job sweeps |
-| `--weeks N` | Look-back window, default 12 |
+| `--period all\|month\|week` | Reporting period: since the first recorded run, last 30 days, or last 7 days |
+| `--weeks N` | Explicit window in weeks when the user wants something other than the three periods (default 12) |
 | `--no-jenkins` | Skip Jenkins lookup; regions come from Argus and inference only (much less accurate) |
 | `--json-out FILE` | Full per-run dataset, the input for the HTML report |
 
@@ -140,6 +151,7 @@ tests are tabulated in `skills/perf-weekly-status-report/SKILL.md` under "Test R
 
 ## Success Criteria
 
+- [ ] The reporting period was chosen by the user, not assumed
 - [ ] Every failure count is paired with the run total and the rate
 - [ ] Builds hit is reported alongside failed runs
 - [ ] Region provenance is stated: how many measured from Jenkins, how many inferred, with inference accuracy

--- a/skills/capacity-failure-analysis/SKILL.md
+++ b/skills/capacity-failure-analysis/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: capacity-failure-analysis
+description: >-
+  Analyze AWS capacity and provisioning failures in SCT test runs using Argus and
+  Jenkins. Use when asked how many runs failed with CapacityReservationError,
+  ProvisioningCapacityExhausted or InsufficientInstanceCapacity, when counting
+  provisioning failures per week, when grouping capacity failures by AWS region,
+  availability zone, instance type or job, when deciding which region to move a
+  perf job to, or when investigating why a job cannot get i8g or i4i capacity.
+  Triggers include "capacity reservation failures", "how many runs failed to
+  provision", "capacity failures per week", "group failures by region", "which
+  region has capacity", "why can't we provision". Covers Argus event signatures,
+  the region-provenance problem (Argus records no region for these runs), Jenkins
+  build-parameter lookup, and generating an HTML report.
+---
+
+# Capacity Failure Analysis
+
+Measure and explain AWS capacity failures that kill SCT runs before provisioning finishes.
+
+## Essential Principles
+
+### Rank Regions by Rate, Never by Count
+
+**A region's failure count is dominated by how many runs it hosts; only the rate says whether it is unhealthy.**
+
+In a real 12-week sweep `us-east-1` had the second-highest raw failure count (25) purely because it carried
+256 of 471 runs — its rate was 9.8%, the *lowest* of any affected region, while `eu-north-1` failed 40.7% of
+27 runs. Reporting counts alone points remediation at the wrong region. Always print runs, failures and rate
+together, and sort the remediation discussion by rate.
+
+### State Region Provenance Every Time
+
+**Argus records no region for these runs, so every region figure is second-hand — say where it came from.**
+
+The test aborts before a single instance is allocated, so `region_name` is empty on 100% of capacity-failed
+runs. Region has to be recovered from the Jenkins `region` build parameter, and Jenkins rotates builds out of
+history within weeks. A region breakdown that does not disclose how many values were measured versus inferred
+invites decisions built on guesses. See [region-resolution.md](references/region-resolution.md).
+
+### Count Builds Alongside Runs
+
+**SCT retries provisioning, so one blocked Jenkins build can appear as several failed Argus runs.**
+
+Build 79 of `latency-650gb-with-nemesis-i8g-tablets` produced two runs, both capacity failures. "77 failed
+runs" and "50 blocked builds" describe the same window; the first measures wasted attempts, the second
+measures how often a scheduled job actually did not deliver a result. Quoting only runs overstates impact.
+
+### Separate the Two CapacityReservationError Raise Sites
+
+**The same exception type means two different problems with two different fixes.**
+
+`capacity_reservation.py:201` means no AZ in the region had the requested instances — a real capacity
+shortage, fixed by changing region or instance type. `capacity_reservation.py:156` means the placement group
+was missing or unavailable — a configuration or cleanup bug, not a capacity shortage. Lumping them together
+sends people hunting for capacity that was never the problem.
+
+### A Retried Failure Is Not a Failed Run
+
+**Capacity errors that the AZ or region fallback recovered from must not be counted as failures.**
+
+`sdcm/sct_provision/aws/layout.py:137` catches `CapacityReservationError` and `ProvisioningCapacityExhausted`
+and tries the next AZ, then the next region. Only a run whose *final* status is `test_error` with a CRITICAL
+event was actually killed. Match on severity and final status, not on the presence of the string anywhere in
+the log, or the numbers will be inflated by failures the framework handled correctly.
+
+## When to Use
+
+- Counting how many runs or builds failed with a capacity or provisioning error over a time window
+- Breaking capacity failures down per week, per AWS region, per job or per instance family
+- Deciding which region or instance type a perf job should move to
+- Investigating why a specific job repeatedly cannot get capacity
+- Producing an HTML or email report of provisioning-failure statistics for stakeholders
+- Checking whether an AZ or region fallback change actually reduced failures
+
+## When NOT to Use
+
+- Comparing performance results between runs — use `test-run-comparison-reports`
+- Producing the regular weekly perf status email — use `perf-weekly-status-report`
+- Debugging a single run's non-capacity failure (nemesis error, latency regression, test assertion)
+- Changing the capacity reservation code itself — this skill measures behaviour, it does not modify `sdcm/provision/aws/`
+- Any non-AWS backend; capacity reservation is AWS-only
+
+## Error Signatures
+
+Detection is on Argus events, not raw logs. Full detail in [error-signatures.md](references/error-signatures.md).
+
+| Signature | Raised at | Fatal? | Means |
+|-----------|-----------|--------|-------|
+| `CapacityReservationError` "in any availability zone" | `sdcm/provision/aws/capacity_reservation.py:201` | Yes | No AZ in the region had the instances |
+| `CapacityReservationError` "placement group" | `sdcm/provision/aws/capacity_reservation.py:156` | Yes | Placement group missing or unavailable |
+| `ProvisioningCapacityExhausted` | `sdcm/sct_provision/aws/layout.py:137` | Usually no | Caught by AZ/region fallback |
+| `InsufficientInstanceCapacity` | AWS API, surfaced by boto | Usually no | Raw EC2 capacity error |
+
+A fatal capacity failure looks like this in Argus: run `status == "test_error"` plus a CRITICAL
+`TestFrameworkEvent` reading `Failed to provision aws resources: CapacityReservationError: ...`.
+
+## Helper Script
+
+`capacity_failure_stats.py` does collection, classification, region resolution and aggregation. Run it from
+the repository root so `sdcm` imports resolve:
+
+```bash
+PYTHONPATH=. .venv/bin/python skills/capacity-failure-analysis/capacity_failure_stats.py \
+    --registry tests.tsv --weeks 12 --json-out capacity.json
+```
+
+| Flag | Purpose |
+|------|---------|
+| `--test-id UUID` | One Argus test UUID; repeatable |
+| `--registry FILE` | TSV of `name<TAB>test_id[<TAB>category]` — preferred for multi-job sweeps |
+| `--weeks N` | Look-back window, default 12 |
+| `--no-jenkins` | Skip Jenkins lookup; regions come from Argus and inference only (much less accurate) |
+| `--json-out FILE` | Full per-run dataset, the input for the HTML report |
+
+The Argus CLI cannot enumerate the tests in a group, so test UUIDs must be supplied. The 20 enterprise perf
+tests are tabulated in `skills/perf-weekly-status-report/SKILL.md` under "Test Registry".
+
+## Choosing a Remediation
+
+| Finding | Action |
+|---------|--------|
+| One region's rate far above the others, same instance type | Move the job to a region with a low rate and enough run history to trust |
+| All regions bad for one instance family (e.g. every i8g job) | Instance-family shortage — raise with AWS or switch family |
+| Failures cluster in specific weeks across every region | External AWS capacity event — check dates before changing config |
+| Placement-group variant dominates | Configuration or leaked-resource bug, not capacity — inspect cleanup |
+| High run count but low rate | Healthy; do not "fix" it |
+
+## Reference Index
+
+| File | Content |
+|------|---------|
+| [error-signatures.md](references/error-signatures.md) | Every capacity signature, its raise site, fallback behaviour, and how it appears in Argus |
+| [region-resolution.md](references/region-resolution.md) | Why Argus has no region for these runs, the Jenkins lookup, and the inference rules |
+| [report-format.md](references/report-format.md) | Structure, palette and caveat conventions for the HTML report |
+
+| Workflow | Purpose |
+|----------|---------|
+| [analyze-capacity-failures.md](workflows/analyze-capacity-failures.md) | 5-phase process from question to published report |
+
+## Success Criteria
+
+- [ ] Every failure count is paired with the run total and the rate
+- [ ] Builds hit is reported alongside failed runs
+- [ ] Region provenance is stated: how many measured from Jenkins, how many inferred, with inference accuracy
+- [ ] Signature variants are distinguished, not merged into one "capacity" bucket
+- [ ] Only runs whose final status is `test_error` with a CRITICAL event are counted
+- [ ] Regions with too few runs to be meaningful are flagged rather than ranked
+- [ ] Remediation advice names a specific region or instance type, with the rate that justifies it

--- a/skills/capacity-failure-analysis/capacity_failure_stats.py
+++ b/skills/capacity-failure-analysis/capacity_failure_stats.py
@@ -1,0 +1,371 @@
+#!/usr/bin/env python3
+"""Collect AWS capacity-provisioning failures for SCT test runs from Argus.
+
+Counts runs that died before provisioning with a capacity error signature
+(CapacityReservationError and friends), resolves the AWS region each failure
+happened in, and aggregates by week, region and job.
+
+Region needs two sources: Argus leaves ``region_name`` empty on these runs
+because the test aborts before any instance is allocated, so the region comes
+from the Jenkins ``region`` build parameter, with a nearest-neighbour fallback
+for builds that have rotated out of Jenkins history. See
+``references/region-resolution.md``.
+
+Run from the repository root so ``sdcm`` is importable::
+
+    PYTHONPATH=. .venv/bin/python skills/capacity-failure-analysis/capacity_failure_stats.py \
+        --registry tests.tsv --weeks 12 --json-out capacity.json
+"""
+
+import argparse
+import json
+import logging
+import re
+import subprocess
+import sys
+from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timedelta, timezone
+
+LOGGER = logging.getLogger("capacity-failure-stats")
+
+# Signatures of "we could not get the machines" failures. Keep CapacityReservationError
+# first: it is the only one that aborts the test outright, the others are usually
+# retried by the AZ/region fallback in sdcm/sct_provision/aws/layout.py.
+SIGNATURES = {
+    "CapacityReservationError": re.compile(r"CapacityReservationError", re.IGNORECASE),
+    "ProvisioningCapacityExhausted": re.compile(r"ProvisioningCapacityExhausted", re.IGNORECASE),
+    "InsufficientInstanceCapacity": re.compile(r"InsufficientInstanceCapacity", re.IGNORECASE),
+}
+
+JENKINS_TREE = "?tree=number,timestamp,result,actions[parameters[name,value]]"
+
+
+class ArgusError(RuntimeError):
+    """Raised when the argus CLI returns a non-zero exit status."""
+
+
+def argus(*args: str) -> object:
+    """Run the argus CLI and return its parsed JSON output.
+
+    Args:
+        *args: Arguments passed straight to the ``argus`` executable.
+
+    Returns:
+        The decoded JSON document, or None when the command printed nothing.
+
+    Raises:
+        ArgusError: If the CLI exits non-zero.
+    """
+    proc = subprocess.run(["argus", *args], capture_output=True, text=True, check=False)
+    if proc.returncode != 0:
+        raise ArgusError(f"argus {' '.join(args)}: {proc.stderr.strip()[:300]}")
+    return json.loads(proc.stdout or "null")
+
+
+def parse_timestamp(value: str) -> datetime:
+    """Parse an Argus ISO-8601 timestamp into an aware datetime."""
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def iso_week(when: datetime) -> str:
+    """Return the ISO week label (e.g. ``2026-W36``) for a datetime."""
+    year, week, _ = when.isocalendar()
+    return f"{year}-W{week:02d}"
+
+
+def week_monday(week: str) -> str:
+    """Return the Monday of an ISO week label as an ISO date string."""
+    return str(datetime.fromisocalendar(int(week[:4]), int(week[6:]), 1).date())
+
+
+def load_registry(path: str) -> list[dict]:
+    """Load a ``name<TAB>test_id[<TAB>category]`` registry file."""
+    tests = []
+    with open(path, encoding="utf-8") as registry:
+        for line in registry:
+            if not line.strip() or line.startswith("#"):
+                continue
+            fields = line.rstrip("\n").split("\t")
+            tests.append({"name": fields[0], "test_id": fields[1], "category": fields[2] if len(fields) > 2 else ""})
+    return tests
+
+
+def collect_runs(tests: list[dict], after: float, limit: int) -> list[dict]:
+    """List every Argus run of the given tests started after a Unix timestamp."""
+    runs = []
+    for test in tests:
+        try:
+            found = argus("run", "list", "--test-id", test["test_id"], "--after", str(after), "--limit", str(limit))
+        except ArgusError as exc:
+            LOGGER.warning("skipping %s: %s", test["name"], exc)
+            continue
+        for run in found or []:
+            run["_test"] = test
+        runs.extend(found or [])
+        LOGGER.info("%s: %s runs", test["name"], len(found or []))
+    return runs
+
+
+def match_signature(run_id: str) -> tuple[str | None, str]:
+    """Classify one run by the capacity signature in its CRITICAL/ERROR events.
+
+    Args:
+        run_id: Argus run UUID.
+
+    Returns:
+        A ``(signature, message)`` pair, or ``(None, "")`` when the run shows no
+        capacity failure. Only SCT runs have per-event records.
+    """
+    try:
+        events = argus("run", "events", "--run-id", run_id, "--limit", "200") or []
+    except ArgusError as exc:
+        LOGGER.warning("events unavailable for %s: %s", run_id, exc)
+        return None, ""
+    for name, pattern in SIGNATURES.items():
+        for event in events:
+            message = event.get("message", "")
+            if pattern.search(message):
+                return name, re.sub(r"\s+", " ", message).strip()
+    return None, ""
+
+
+def argus_region(run_id: str) -> list[str]:
+    """Return the regions Argus recorded for a run (empty for pre-provisioning failures)."""
+    try:
+        details = argus("run", "details", "--run-id", run_id) or {}
+    except ArgusError as exc:
+        LOGGER.warning("details unavailable for %s: %s", run_id, exc)
+        return []
+    regions = list(details.get("region_name") or [])
+    for resource in details.get("allocated_resources") or []:
+        region = (resource.get("instance_info") or {}).get("region")
+        if region and region not in regions:
+            regions.append(region)
+    return regions
+
+
+def jenkins_regions(build_urls: list[str], workers: int) -> dict[str, str | None]:
+    """Fetch the ``region`` build parameter for each Jenkins build URL.
+
+    Builds that have rotated out of Jenkins history answer 404; those map to None
+    so the caller can fall back to inference.
+    """
+    import requests  # noqa: PLC0415  # optional dependency: only needed with --jenkins
+    from sdcm.keystore import KeyStore  # noqa: PLC0415
+
+    credentials = KeyStore().get_json("jenkins.json")
+    auth = (credentials["username"], credentials["password"])
+
+    def fetch(url: str) -> tuple[str, str | None]:
+        try:
+            response = requests.get(url.rstrip("/") + "/api/json" + JENKINS_TREE, auth=auth, timeout=90)
+            if response.status_code != 200:
+                return url, None
+            params = {}
+            for action in response.json().get("actions", []):
+                for param in action.get("parameters", []) or []:
+                    params[param["name"]] = param.get("value")
+            return url, params.get("region")
+        except Exception as exc:  # noqa: BLE001  # a single unreachable build must not abort the sweep
+            LOGGER.warning("jenkins fetch failed for %s: %s", url, exc)
+            return url, None
+
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        return dict(pool.map(fetch, build_urls))
+
+
+def resolve_regions(runs: list[dict]) -> dict[str, float]:
+    """Attach a region to every run, in order of trustworthiness.
+
+    Jenkins build parameter beats the Argus record (they agree wherever both
+    exist, and Jenkins covers the failed runs that Argus does not); anything
+    still missing is inferred from the temporally nearest run of the same job.
+
+    Args:
+        runs: Run dicts, mutated in place with ``region`` and ``region_src``.
+
+    Returns:
+        Accuracy stats for the inference, so the caller can print a caveat.
+    """
+    for run in runs:
+        if run.get("jenkins_region"):
+            run["region"], run["region_src"] = run["jenkins_region"], "jenkins"
+        elif run.get("argus_regions"):
+            run["region"], run["region_src"] = run["argus_regions"][0], "argus"
+        else:
+            run["region"], run["region_src"] = None, None
+
+    by_test: dict[str, list[dict]] = defaultdict(list)
+    for run in runs:
+        by_test[run["_test"]["name"]].append(run)
+
+    def nearest(target: dict) -> str | None:
+        best, best_gap = None, None
+        for other in by_test[target["_test"]["name"]]:
+            if other["run_id"] == target["run_id"] or not other["region"]:
+                continue
+            gap = abs((other["_started"] - target["_started"]).total_seconds())
+            if best_gap is None or gap < best_gap:
+                best, best_gap = other, gap
+        return best["region"] if best else None
+
+    hits = misses = 0
+    for run in runs:
+        if not run["region"]:
+            continue
+        predicted = nearest(run)
+        if predicted:
+            hits += predicted == run["region"]
+            misses += predicted != run["region"]
+
+    filled = 0
+    for run in runs:
+        if run["region"]:
+            continue
+        predicted = nearest(run)
+        if predicted:
+            run["region"], run["region_src"] = predicted, "inferred"
+            filled += 1
+        else:
+            run["region"], run["region_src"] = "unknown", "unknown"
+
+    checked = hits + misses
+    return {
+        "inferred": filled,
+        "cross_validated": checked,
+        "accuracy_pct": round(100.0 * hits / checked, 1) if checked else 0.0,
+        "unknown": sum(1 for run in runs if run["region"] == "unknown"),
+    }
+
+
+def aggregate(records: list[dict], key) -> list[dict]:
+    """Group records by a key function into run/failure/build counts."""
+    buckets: dict[str, dict] = defaultdict(lambda: {"runs": 0, "failures": 0, "builds": set(), "hit_builds": set()})
+    for record in records:
+        bucket = buckets[key(record)]
+        bucket["runs"] += 1
+        bucket["builds"].add(record["build"])
+        if record["signature"]:
+            bucket["failures"] += 1
+            bucket["hit_builds"].add(record["build"])
+    rows = []
+    for name, bucket in buckets.items():
+        rows.append(
+            {
+                "key": name,
+                "runs": bucket["runs"],
+                "failures": bucket["failures"],
+                "pct": round(100.0 * bucket["failures"] / bucket["runs"], 1) if bucket["runs"] else 0.0,
+                "builds": len(bucket["builds"]),
+                "hit_builds": len(bucket["hit_builds"]),
+            }
+        )
+    return sorted(rows, key=lambda row: (-row["failures"], row["key"]))
+
+
+def print_table(title: str, rows: list[dict]) -> None:
+    """Print one aggregation as a fixed-width table."""
+    print(f"\n{title}")
+    print(f"{'':<46} {'Runs':>6} {'Fails':>6} {'%':>7} {'Builds':>7} {'Hit':>5}")
+    print("-" * 82)
+    for row in rows:
+        print(
+            f"{row['key']:<46} {row['runs']:>6} {row['failures']:>6} {row['pct']:>6.1f}% {row['builds']:>7} {row['hit_builds']:>5}"
+        )
+    runs = sum(row["runs"] for row in rows)
+    failures = sum(row["failures"] for row in rows)
+    print("-" * 82)
+    print(f"{'TOTAL':<46} {runs:>6} {failures:>6} {100.0 * failures / runs if runs else 0:>6.1f}%")
+
+
+def main() -> int:
+    """Entry point: collect, classify, resolve regions and report."""
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument("--test-id", action="append", help="Argus test UUID (repeatable)")
+    source.add_argument("--registry", help="TSV file: name<TAB>test_id[<TAB>category]")
+    parser.add_argument("--weeks", type=int, default=12, help="Look-back window in weeks (default: 12)")
+    parser.add_argument("--limit", type=int, default=500, help="Max runs fetched per test (default: 500)")
+    parser.add_argument("--workers", type=int, default=10, help="Parallel API calls (default: 10)")
+    parser.add_argument(
+        "--no-jenkins", action="store_true", help="Skip Jenkins; regions come from Argus and inference only"
+    )
+    parser.add_argument("--json-out", help="Write the full per-run dataset here")
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(message)s", stream=sys.stderr)
+
+    tests = (
+        load_registry(args.registry)
+        if args.registry
+        else [{"name": test_id, "test_id": test_id, "category": ""} for test_id in args.test_id]
+    )
+    after = (datetime.now(timezone.utc) - timedelta(weeks=args.weeks)).timestamp()
+
+    raw_runs = collect_runs(tests, after, args.limit)
+    if not raw_runs:
+        LOGGER.error("no runs found in the window")
+        return 1
+
+    runs = []
+    for raw in raw_runs:
+        runs.append(
+            {
+                "run_id": raw["id"],
+                "_test": raw["_test"],
+                "_started": parse_timestamp(raw["start_time"]),
+                "start": raw["start_time"],
+                "week": iso_week(parse_timestamp(raw["start_time"])),
+                "status": raw["status"],
+                "build": raw.get("build_job_url", ""),
+            }
+        )
+
+    LOGGER.info("classifying %s runs...", len(runs))
+    with ThreadPoolExecutor(max_workers=args.workers) as pool:
+        for run, (signature, message) in zip(runs, pool.map(lambda r: match_signature(r["run_id"]), runs)):
+            run["signature"], run["message"] = signature, message
+
+    LOGGER.info("resolving regions...")
+    with ThreadPoolExecutor(max_workers=args.workers) as pool:
+        for run, regions in zip(runs, pool.map(lambda r: argus_region(r["run_id"]), runs)):
+            run["argus_regions"] = regions
+    if not args.no_jenkins:
+        found = jenkins_regions(sorted({run["build"] for run in runs if run["build"]}), args.workers)
+        for run in runs:
+            run["jenkins_region"] = found.get(run["build"])
+    provenance = resolve_regions(runs)
+
+    for run in runs:
+        run["test"] = run["_test"]["name"]
+        run["test_id"] = run["_test"]["test_id"]
+        run["category"] = run["_test"]["category"]
+        del run["_test"], run["_started"]
+
+    failures = [run for run in runs if run["signature"]]
+    print(
+        f"\nWindow: {datetime.fromtimestamp(after, timezone.utc):%Y-%m-%d} to today "
+        f"({args.weeks} weeks) · {len(tests)} tests · {len(runs)} runs · {len(failures)} capacity failures"
+    )
+    print(f"Signatures: {dict((name, sum(1 for r in failures if r['signature'] == name)) for name in SIGNATURES)}")
+    print(
+        f"Region provenance: {sum(1 for r in runs if r['region_src'] == 'jenkins')} jenkins, "
+        f"{sum(1 for r in runs if r['region_src'] == 'argus')} argus, "
+        f"{provenance['inferred']} inferred "
+        f"(inference cross-validates at {provenance['accuracy_pct']}% on {provenance['cross_validated']} runs)"
+    )
+
+    print_table("Per region", aggregate(runs, lambda r: r["region"]))
+    print_table("Per week", aggregate(runs, lambda r: f"{r['week']} (w/c {week_monday(r['week'])})"))
+    print_table("Per job", aggregate(runs, lambda r: r["test"]))
+
+    if args.json_out:
+        with open(args.json_out, "w", encoding="utf-8") as out:
+            json.dump({"provenance": provenance, "runs": runs}, out, indent=2)
+        LOGGER.info("wrote %s", args.json_out)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/capacity-failure-analysis/capacity_failure_stats.py
+++ b/skills/capacity-failure-analysis/capacity_failure_stats.py
@@ -14,7 +14,10 @@ for builds that have rotated out of Jenkins history. See
 Run from the repository root so ``sdcm`` is importable::
 
     PYTHONPATH=. .venv/bin/python skills/capacity-failure-analysis/capacity_failure_stats.py \
-        --registry tests.tsv --weeks 12 --json-out capacity.json
+        --registry tests.tsv --period month --json-out capacity.json
+
+Periods: ``--period all`` (since the first recorded run), ``month`` (30 days),
+``week`` (7 days), or ``--weeks N`` for anything else.
 """
 
 import argparse
@@ -91,8 +94,37 @@ def load_registry(path: str) -> list[dict]:
     return tests
 
 
+def resolve_window(period: str | None, weeks: int | None) -> tuple[float, str]:
+    """Turn the requested reporting period into an ``--after`` timestamp and a label.
+
+    The three named periods are the ones the skill offers up front. ``all`` means
+    "since the first recorded run", expressed as epoch 0 so Argus applies no lower
+    bound at all.
+
+    Args:
+        period: One of ``all``, ``month``, ``week``, or None when ``weeks`` is used.
+        weeks: Explicit look-back in weeks, used when ``period`` is None.
+
+    Returns:
+        A ``(after_timestamp, human_label)`` pair.
+    """
+    now = datetime.now(timezone.utc)
+    if period == "all":
+        return 0.0, "all recorded history"
+    if period == "month":
+        return (now - timedelta(days=30)).timestamp(), "last month (30 days)"
+    if period == "week":
+        return (now - timedelta(days=7)).timestamp(), "last week (7 days)"
+    return (now - timedelta(weeks=weeks)).timestamp(), f"last {weeks} weeks"
+
+
 def collect_runs(tests: list[dict], after: float, limit: int) -> list[dict]:
-    """List every Argus run of the given tests started after a Unix timestamp."""
+    """List every Argus run of the given tests started after a Unix timestamp.
+
+    Warns when a test returns exactly ``limit`` runs, because the window is then
+    probably truncated — most likely on ``--period all``, where the whole history
+    can exceed the default page size.
+    """
     runs = []
     for test in tests:
         try:
@@ -103,6 +135,10 @@ def collect_runs(tests: list[dict], after: float, limit: int) -> list[dict]:
         for run in found or []:
             run["_test"] = test
         runs.extend(found or [])
+        if len(found or []) >= limit:
+            LOGGER.warning(
+                "%s returned the full limit of %s runs - raise --limit, results may be truncated", test["name"], limit
+            )
         LOGGER.info("%s: %s runs", test["name"], len(found or []))
     return runs
 
@@ -285,7 +321,13 @@ def main() -> int:
     source = parser.add_mutually_exclusive_group(required=True)
     source.add_argument("--test-id", action="append", help="Argus test UUID (repeatable)")
     source.add_argument("--registry", help="TSV file: name<TAB>test_id[<TAB>category]")
-    parser.add_argument("--weeks", type=int, default=12, help="Look-back window in weeks (default: 12)")
+    window = parser.add_mutually_exclusive_group()
+    window.add_argument(
+        "--period",
+        choices=["all", "month", "week"],
+        help="Reporting period: all = since the first recorded run, month = last 30 days, week = last 7 days",
+    )
+    window.add_argument("--weeks", type=int, help="Explicit look-back window in weeks (default: 12)")
     parser.add_argument("--limit", type=int, default=500, help="Max runs fetched per test (default: 500)")
     parser.add_argument("--workers", type=int, default=10, help="Parallel API calls (default: 10)")
     parser.add_argument(
@@ -301,7 +343,7 @@ def main() -> int:
         if args.registry
         else [{"name": test_id, "test_id": test_id, "category": ""} for test_id in args.test_id]
     )
-    after = (datetime.now(timezone.utc) - timedelta(weeks=args.weeks)).timestamp()
+    after, window_label = resolve_window(args.period, args.weeks or 12)
 
     raw_runs = collect_runs(tests, after, args.limit)
     if not raw_runs:
@@ -344,9 +386,12 @@ def main() -> int:
         del run["_test"], run["_started"]
 
     failures = [run for run in runs if run["signature"]]
+    # On --period all the requested lower bound is epoch 0, so report the first run
+    # actually found rather than 1970.
+    first_seen = min(run["start"] for run in runs)[:10]
     print(
-        f"\nWindow: {datetime.fromtimestamp(after, timezone.utc):%Y-%m-%d} to today "
-        f"({args.weeks} weeks) · {len(tests)} tests · {len(runs)} runs · {len(failures)} capacity failures"
+        f"\nWindow: {window_label} · {first_seen} to today "
+        f"· {len(tests)} tests · {len(runs)} runs · {len(failures)} capacity failures"
     )
     print(f"Signatures: {dict((name, sum(1 for r in failures if r['signature'] == name)) for name in SIGNATURES)}")
     print(

--- a/skills/capacity-failure-analysis/references/error-signatures.md
+++ b/skills/capacity-failure-analysis/references/error-signatures.md
@@ -1,0 +1,101 @@
+# Capacity Error Signatures
+
+How each AWS capacity failure is raised in SCT, whether the framework recovers from it, and what it looks
+like in Argus. Detection must be based on Argus events rather than raw logs, because a string that appears
+in a log may belong to an attempt the framework then recovered from.
+
+## Raise Sites
+
+### CapacityReservationError — no availability zone
+
+`sdcm/provision/aws/capacity_reservation.py:201`
+
+```python
+raise CapacityReservationError("Failed to create capacity reservation in any availability zone.")
+```
+
+`SCTCapacityReservation.create()` walks every supported AZ in the region and requests a reservation for each
+instance type. If any instance type fails in an AZ it cancels that AZ's partial reservations and falls back
+to the next one. This exception is only raised after **every** AZ has been tried, so it is genuine regional
+capacity exhaustion for the requested instance types. This is the dominant signature in practice: in a
+12-week sweep of the enterprise perf suite, all 77 fatal capacity failures came from this line.
+
+**Remediation:** different region, different instance type, or a smaller cluster.
+
+### CapacityReservationError — placement group
+
+`sdcm/provision/aws/capacity_reservation.py:156`
+
+```python
+raise CapacityReservationError("Failed to find available placement group.")
+```
+
+Raised when `use_placement_group` is set but `describe_placement_groups` returns nothing in the `available`
+state for the test's `TestId` tag. Nothing to do with capacity — the placement group was never created, was
+left in a bad state, or was cleaned up early.
+
+**Remediation:** inspect provisioning order and resource cleanup, not AWS capacity.
+
+Distinguish the two by matching on the message text, not the exception type. Reporting them together sends
+people looking for capacity that was never the problem.
+
+### ProvisioningCapacityExhausted
+
+Caught alongside `CapacityReservationError` at `sdcm/sct_provision/aws/layout.py:137`. Both feed the AZ and
+region fallback, so an occurrence usually does **not** end the run.
+
+### InsufficientInstanceCapacity
+
+The raw EC2 API error, surfaced through botocore. Normally wrapped by one of the above before it reaches the
+test, so it rarely appears as a standalone fatal signature.
+
+## Fallback Behaviour
+
+`sdcm/tester.py:2059` catches `CapacityReservationError` from a region attempt and marks the region
+exhausted rather than failing:
+
+```python
+try:
+    region_exhausted, attempt_error, _ = self._attempt_region_legacy(loader_info, db_info, monitor_info)
+except CapacityReservationError as exc:
+    region_exhausted, attempt_error = True, exc
+```
+
+The run only dies once every candidate region is exhausted. Two consequences for measurement:
+
+1. A capacity error in the log is not a failed run. Only the final status counts.
+2. When a run *does* die, the region recorded in Jenkins is the region it *started* in, which may not be the
+   last one it tried. Treat the region attribution as "the region this job was aimed at", which is the right
+   granularity for deciding where to schedule it anyway.
+
+## Argus Representation
+
+A fatal capacity failure has both of these:
+
+- Run `status == "test_error"`
+- A CRITICAL `TestFrameworkEvent` whose message matches the signature
+
+```console
+$ argus run events --run-id 15ecbb63-1842-4ed3-8760-d411a37d57f4
+[
+  {
+    "severity": "CRITICAL",
+    "event_type": "TestFrameworkEvent",
+    "message": "(TestFrameworkEvent Severity.CRITICAL) Failed to provision aws resources: CapacityReservationError: Failed to create capacity reservation in any availability zone."
+  }
+]
+```
+
+`argus run events` returns only CRITICAL and ERROR events, and only for SCT-plugin runs; other plugin types
+need `argus run activity`. `argus run activity` is empty for these runs, so events are the only usable
+source.
+
+## Counting Rules
+
+| Rule | Why |
+|------|-----|
+| Require final status `test_error` | Excludes runs the AZ/region fallback rescued |
+| Require severity CRITICAL | ERROR-level capacity messages are retried attempts |
+| Match the message, not just the exception name | Separates the two `CapacityReservationError` variants |
+| Count distinct `build_job_url` as well as runs | Provisioning retries create several runs per Jenkins build |
+| Verify the signature mix before reporting | If one signature is 100% of hits, say so; it changes the remediation |

--- a/skills/capacity-failure-analysis/references/region-resolution.md
+++ b/skills/capacity-failure-analysis/references/region-resolution.md
@@ -1,0 +1,80 @@
+# Resolving the Region of a Capacity Failure
+
+The hardest part of this analysis. Argus knows the region for runs that provisioned successfully and knows
+nothing for exactly the runs being measured.
+
+## Why Argus Has No Region
+
+A capacity failure aborts the test before any instance is allocated, so the fields that would carry the
+region are never populated:
+
+| Field | Passed run | Capacity-failed run |
+|-------|-----------|---------------------|
+| `region_name` | `["eu-west-2"]` | `[]` |
+| `allocated_resources` | Full node list with per-node `region` | `[]` |
+| `sct_runner_host` | Object with IPs | `null` |
+| `cloud_setup` | Instance types and AMIs | `null` |
+
+Measured on a 12-week sweep: **0 of 77** capacity-failed runs had any region in Argus, against 381 of 471
+runs overall. Never assume the field will be there — check, and fall back.
+
+## Source 1: Jenkins Build Parameter (Authoritative)
+
+The `region` build parameter of the Jenkins build that launched the run:
+
+```python
+url = build_job_url.rstrip("/") + "/api/json?tree=number,timestamp,result,actions[parameters[name,value]]"
+response = requests.get(url, auth=(creds["username"], creds["password"]), timeout=90)
+```
+
+Credentials come from `KeyStore().get_json("jenkins.json")` — the same shared account SCT tooling uses
+elsewhere. Requires `PYTHONPATH=.` when running a script outside `sct.py`.
+
+**Validation:** across a full dataset, wherever both the Jenkins parameter and an Argus region existed they
+agreed on **207 of 207** runs. The parameter can be trusted where it is available.
+
+**Coverage is the problem.** Jenkins rotates old builds out of history and they answer HTTP 404. Coverage
+falls off sharply with window length — roughly 80% at 6 weeks, but only about half at 12 weeks. Always
+report actual coverage rather than assuming it.
+
+Note the pipeline definitions under `jenkins-pipelines/performance/` do **not** set a region; it comes from
+the job's parameter defaults or the trigger, so it can only be read per build, never from the repository.
+
+## Source 2: Nearest-Neighbour Inference (Fallback)
+
+For runs whose build has rotated away, take the region of the temporally closest run of the **same job**
+that has a known region. Jobs stay in one region for long stretches, so this is usually right.
+
+**Always cross-validate before trusting it.** Predict the region of runs whose region *is* known and measure
+the hit rate:
+
+```
+nearest-neighbour cross-validation: 391 correct / 427 (91.6%)
+```
+
+The helper script prints this automatically. Rules:
+
+- Above ~90%: usable, provided every inferred value is labelled
+- 70-90%: usable for the overall shape, not for ranking small regions
+- Below 70%: do not infer; report the measured subset only and say what is missing
+
+Never infer across different jobs. Two jobs running the same week can sit in different regions, so a
+cross-job neighbour carries no signal.
+
+## Reporting Rules
+
+State the split every time, for example:
+
+> Region comes from the Jenkins `region` build parameter (39 of 77). The remaining 38 failures sit on builds
+> that have rotated out of Jenkins history, so their region is inferred from the nearest run of the same job,
+> an inference that cross-validates at 91.6%.
+
+Mark inferred values visibly in any table or report, and warn that small regions are the ones most sensitive
+to inference error — a region with 3 failures can move materially on a single wrong guess.
+
+## Fallback Order
+
+1. Jenkins `region` build parameter — measured, authoritative
+2. Argus `region_name` or `allocated_resources[].instance_info.region` — measured, but absent on failures
+3. Nearest run of the same job — inferred, must be cross-validated and labelled
+4. Otherwise `unknown` — report as its own bucket, never silently drop

--- a/skills/capacity-failure-analysis/references/region-resolution.md
+++ b/skills/capacity-failure-analysis/references/region-resolution.md
@@ -34,8 +34,17 @@ elsewhere. Requires `PYTHONPATH=.` when running a script outside `sct.py`.
 agreed on **207 of 207** runs. The parameter can be trusted where it is available.
 
 **Coverage is the problem.** Jenkins rotates old builds out of history and they answer HTTP 404. Coverage
-falls off sharply with window length — roughly 80% at 6 weeks, but only about half at 12 weeks. Always
-report actual coverage rather than assuming it.
+falls off sharply with window length, which is exactly why the skill asks the user to pick a period before
+collecting anything:
+
+| Period | Flag | Typical Jenkins coverage | Consequence |
+|--------|------|--------------------------|-------------|
+| Last week | `--period week` | Near total | Region breakdown is essentially all measured |
+| Last month | `--period month` | High | A small inferred tail, safe to rank regions |
+| From first start | `--period all` | Low and falling with age | Most regions inferred; report shape, not rankings |
+
+These are expectations, not guarantees — the rotation depth changes per job. Always report the actual
+coverage the run produced rather than quoting this table.
 
 Note the pipeline definitions under `jenkins-pipelines/performance/` do **not** set a region; it comes from
 the job's parameter defaults or the trigger, so it can only be read per build, never from the repository.

--- a/skills/capacity-failure-analysis/references/report-format.md
+++ b/skills/capacity-failure-analysis/references/report-format.md
@@ -59,6 +59,36 @@ invites someone to move a job on the strength of an inferred value.
 
 ## Publishing
 
-Publish as an Artifact for sharing. For a local copy the file needs a real
-`<!doctype html><html><head>...</head><body>` wrapper — the Artifact host supplies that at publish time, so
-the artifact source alone opens in quirks mode.
+**Always write the report to `~/Downloads`, every run, without being asked.** Publishing as an Artifact as
+well is good for sharing a link, but the local copy is not optional: an Artifact lives behind a URL and a
+session, while the file on disk is what survives, gets attached to a ticket, and can be reopened offline.
+
+Name it `capacity-failures-<period>-<YYYY-MM-DD>.html`, for example
+`capacity-failures-month-2026-09-10.html`. The period is in the name because reports for different windows
+are not interchangeable — a `week` report and an `all` report of the same date carry very different region
+confidence, and a name without the period invites someone to quote the wrong one. Regenerating the same
+period on the same day overwrites deliberately; a different period never collides.
+
+The local file needs a real skeleton, because the Artifact host supplies one only at publish time and the
+artifact source alone opens in quirks mode:
+
+```html
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+  html{color-scheme:light dark}
+  body{margin:0;font:14px system-ui,sans-serif}
+  img{max-width:100%}
+  [hidden]{display:none!important}
+</style>
+</head>
+<body>
+<!-- report content -->
+</body>
+</html>
+```
+
+Report the saved path to the user alongside any Artifact link.

--- a/skills/capacity-failure-analysis/references/report-format.md
+++ b/skills/capacity-failure-analysis/references/report-format.md
@@ -1,0 +1,64 @@
+# Capacity Failure Report Format
+
+Conventions for the HTML report. Applies whether the output is published as an Artifact or written to a
+standalone file.
+
+## Section Order
+
+Lead with the grouping the reader asked for; the rest supports it.
+
+1. **Header** — the headline number in a sentence: how many runs of how many, the single dominant signature,
+   and where it concentrates
+2. **Stat row** — failed runs, share of all runs, builds hit, regions affected, worst region by rate
+3. **Primary grouping** — one row per region: failure count, rate meter, a 12-week strip, and the jobs hit
+4. **Week x grouping** — stacked bar of failures per ISO week, coloured by region
+5. **Table view** — the same week x region numbers as a table
+6. **Region x job matrix** — which jobs are hit where
+7. **Failure log** — every failure with Argus and Jenkins links, grouped by region
+8. **Method and caveats** — detection rule, runs-vs-builds, region provenance, inference accuracy, scope
+
+Sections 4 and 5 are a pair. The validated categorical palette has three light-mode hues below 3:1 contrast,
+which obliges either visible direct labels or a table view; ship both.
+
+## Numbers
+
+- Always three together: runs, failures, rate. A bare count invites the wrong conclusion.
+- Order regions by failure count in the spine, but discuss remediation by rate.
+- Flag any region with fewer than ~10 runs as too small to rank.
+- Use `font-variant-numeric: tabular-nums` everywhere digits line up.
+- Give both runs and builds hit; they answer different questions.
+
+## Colour
+
+Use the validated categorical palette, slots in fixed order, one hue per region:
+
+| Slot | Light | Dark |
+|------|-------|------|
+| 1 | `#2a78d6` | `#3987e5` |
+| 2 | `#eb6834` | `#d95926` |
+| 3 | `#1baf7a` | `#199e70` |
+| 4 | `#eda100` | `#c98500` |
+| 5 | `#e87ba4` | `#d55181` |
+
+Regions with zero failures take a muted neutral, never a hue — spending a categorical slot on an unaffected
+region implies it is part of the story. Keep page chrome near-monochrome so the region hues are the only
+saturated element. Validate any substitution with the `dataviz` skill's `validate_palette.js`, and define
+every colour as a token on bare `:root` so all three theme states resolve.
+
+## Caveats Are Not Optional
+
+The method section must carry:
+
+- The exact detection rule, with the source file and line the error is raised at
+- Runs versus builds, and which one each figure counts
+- Region provenance: measured versus inferred, with the inference accuracy
+- Scope: which tests were swept, and that the Argus CLI cannot enumerate a group so others may be missing
+
+A capacity report drives scheduling decisions. Publishing region rankings without the provenance note
+invites someone to move a job on the strength of an inferred value.
+
+## Publishing
+
+Publish as an Artifact for sharing. For a local copy the file needs a real
+`<!doctype html><html><head>...</head><body>` wrapper — the Artifact host supplies that at publish time, so
+the artifact source alone opens in quirks mode.

--- a/skills/capacity-failure-analysis/workflows/analyze-capacity-failures.md
+++ b/skills/capacity-failure-analysis/workflows/analyze-capacity-failures.md
@@ -1,0 +1,100 @@
+# Workflow: Analyze Capacity Failures
+
+Five phases from "how many runs failed with X" to a published report. Phases are numbered because the
+region resolution in Phase 3 depends on the run set from Phase 2, and reporting before provenance is known
+produces figures that cannot be defended.
+
+## Phase 1: Establish Scope
+
+**Entry:** A question about capacity or provisioning failures.
+
+1. Fix the **time window**. Default to 12 weeks. Warn the user that Jenkins region coverage degrades with
+   window length (roughly 80% at 6 weeks, about half at 12) — a longer window buys more failures but a
+   larger inferred fraction.
+2. Fix the **test set**. The Argus CLI requires explicit test UUIDs and has no command to enumerate a group,
+   so a job name alone is not enough. Resolve UUIDs from, in order:
+   - the "Test Registry" table in `skills/perf-weekly-status-report/SKILL.md` (the 20 enterprise perf tests)
+   - `argus run get --run-id UUID`, which returns the `test_id` for an example run the user supplied
+   - the user, asked directly
+3. Write the set to a TSV of `name<TAB>test_id<TAB>category`.
+4. If the user named one job as an example, confirm whether they want just that job or the whole suite —
+   the two answers differ by an order of magnitude in effort and in conclusion.
+
+**Exit:** A TSV of test UUIDs and an agreed window.
+
+## Phase 2: Collect and Classify
+
+**Entry:** Phase 1 complete.
+
+1. Run the helper script from the repository root:
+
+   ```bash
+   PYTHONPATH=. .venv/bin/python skills/capacity-failure-analysis/capacity_failure_stats.py \
+       --registry tests.tsv --weeks 12 --json-out capacity.json
+   ```
+
+2. Read the signature breakdown it prints. If one signature is the whole population, say so in the report —
+   it narrows the remediation. If the placement-group variant appears, split it out; it is a configuration
+   bug, not a capacity shortage.
+3. Sanity-check the failure count against total `test_error` runs. Capacity failures being the large
+   majority of `test_error` is expected; capacity failures *exceeding* `test_error` means the matcher is
+   catching recovered attempts and the rule is wrong.
+
+**Exit:** `capacity.json` exists, and the signature mix is understood.
+
+## Phase 3: Establish Region Provenance
+
+**Entry:** `capacity.json` exists.
+
+1. Read the provenance line the script prints: how many regions came from Jenkins, from Argus, and from
+   inference, plus the cross-validation accuracy.
+2. Apply the accuracy thresholds from [region-resolution.md](../references/region-resolution.md):
+   above ~90% infer and label; 70-90% use for shape only; below 70% do not infer at all.
+3. If Jenkins coverage is poor and the window is negotiable, offer the user a shorter window with better
+   coverage as an alternative.
+4. Confirm no region bucket is `unknown`. If any remain, report them as their own row — never drop them, as
+   dropping silently changes the denominator.
+
+**Exit:** The measured-versus-inferred split is known and a sentence describing it has been drafted.
+
+## Phase 4: Aggregate and Interpret
+
+**Entry:** Phase 3 complete.
+
+1. Build three groupings: per region, per ISO week, per job. Every row carries runs, failures and rate.
+2. Rank remediation by **rate**, not count. Flag regions with fewer than ~10 runs as too small to rank.
+3. Cross-check region against instance family. If every affected job shares one family (i8g, i4i), the story
+   is an instance shortage rather than a regional one, and the remediation changes accordingly.
+4. Look for weeks where every region fails at once — that indicates an external AWS capacity event, and no
+   configuration change will help.
+5. Pick the remediation from the table in `SKILL.md` and name a concrete target region or instance type,
+   quoting the rate that justifies it.
+
+**Exit:** A ranked region table and a specific, justified recommendation.
+
+## Phase 5: Report
+
+**Entry:** Phase 4 complete.
+
+1. Build the HTML following [report-format.md](../references/report-format.md) — section order, the
+   validated palette, both the chart and its table view.
+2. Include the method section in full: detection rule with source line, runs versus builds, region
+   provenance with inference accuracy, and scope limits.
+3. Publish as an Artifact. If the user also wants a local file, wrap it in a real
+   `<!doctype html><html><head></head><body>` skeleton first.
+
+**Exit:** Report published and the link given to the user.
+
+## Verification
+
+Before delivering, confirm every item:
+
+- [ ] Failure counts reproduce from `capacity.json` — spot-check one region's total against the run list
+- [ ] Every count is paired with a run total and a rate
+- [ ] Builds hit is reported as well as failed runs
+- [ ] Provenance sentence states measured versus inferred, with the accuracy figure
+- [ ] Inferred values are visibly marked in the failure log
+- [ ] Signature variants are separated, not merged
+- [ ] Regions too small to rank are flagged
+- [ ] The recommendation names a region or instance type and the rate behind it
+- [ ] Scope limits are stated, including that non-registry tests were not swept

--- a/skills/capacity-failure-analysis/workflows/analyze-capacity-failures.md
+++ b/skills/capacity-failure-analysis/workflows/analyze-capacity-failures.md
@@ -92,10 +92,15 @@ produces figures that cannot be defended.
    validated palette, both the chart and its table view.
 2. Include the method section in full: detection rule with source line, runs versus builds, region
    provenance with inference accuracy, and scope limits.
-3. Publish as an Artifact. If the user also wants a local file, wrap it in a real
-   `<!doctype html><html><head></head><body>` skeleton first.
+3. **Save the report to `~/Downloads` — always, without being asked.** Name it
+   `capacity-failures-<period>-<YYYY-MM-DD>.html` (e.g. `capacity-failures-month-2026-09-10.html`) and wrap
+   it in a real `<!doctype html><html><head></head><body>` skeleton, which the Artifact host supplies only
+   at publish time. The local file is the copy that outlives the session and can be attached to a ticket.
+4. Publish as an Artifact as well, for a shareable link.
+5. Give the user both the saved path and the Artifact link.
 
-**Exit:** Report published and the link given to the user.
+**Exit:** The report exists at `~/Downloads/capacity-failures-<period>-<date>.html`, and the user has been
+given that path.
 
 ## Verification
 

--- a/skills/capacity-failure-analysis/workflows/analyze-capacity-failures.md
+++ b/skills/capacity-failure-analysis/workflows/analyze-capacity-failures.md
@@ -8,9 +8,21 @@ produces figures that cannot be defended.
 
 **Entry:** A question about capacity or provisioning failures.
 
-1. Fix the **time window**. Default to 12 weeks. Warn the user that Jenkins region coverage degrades with
-   window length (roughly 80% at 6 weeks, about half at 12) — a longer window buys more failures but a
-   larger inferred fraction.
+1. **Ask the user which period to report on, before doing anything else.** Do not assume a default — the
+   period changes both the effort and how trustworthy the region breakdown is, so it is not a choice to make
+   on the user's behalf. Offer exactly these three:
+
+   | Answer | Flag | Covers | Region provenance |
+   |--------|------|--------|-------------------|
+   | From first start | `--period all` | Every run Argus has recorded | Mostly inferred — Jenkins has rotated away nearly all old builds |
+   | Last month | `--period month` | Last 30 days | Good — most builds still in Jenkins history |
+   | Last week | `--period week` | Last 7 days | Best — nearly every build still present |
+
+   State the trade-off when asking, because it is the whole reason the question exists: a longer period
+   finds more failures but resolves fewer regions from Jenkins, so more of the region breakdown is inferred
+   rather than measured. If the user wants something else ("last quarter", "since June"), use `--weeks N`.
+
+   Skip the question only when the user already named a period in their request.
 2. Fix the **test set**. The Argus CLI requires explicit test UUIDs and has no command to enumerate a group,
    so a job name alone is not enough. Resolve UUIDs from, in order:
    - the "Test Registry" table in `skills/perf-weekly-status-report/SKILL.md` (the 20 enterprise perf tests)


### PR DESCRIPTION
Adds a skill for measuring AWS capacity and provisioning failures in SCT runs — counting
`CapacityReservationError` and friends over a window and grouping them by region, job and week.

### Why

Capacity failures kill perf-regression runs before provisioning finishes, and answering "how often, and
where?" turned out to need non-obvious knowledge that was worth writing down rather than re-deriving:

- **Argus records no region for exactly these runs.** The test aborts before any instance is allocated, so
  `region_name`, `allocated_resources` and `cloud_setup` are all empty. Measured on a 12-week sweep: 0 of 77
  capacity-failed runs had a region in Argus, against 381 of 471 runs overall.
- **Region has to come from the Jenkins `region` build parameter**, which agrees with Argus wherever both
  exist (207/207) but only covers builds Jenkins has not yet rotated out of history. Anything older is
  inferred from the nearest run of the same job, cross-validated and labelled.
- **One Jenkins build can produce several failed Argus runs**, because SCT retries provisioning — so runs
  and builds answer different questions and both belong in a report.
- **A region's failure count is dominated by how many runs it hosts.** In that sweep `us-east-1` had the
  second-highest count purely from volume while having the *lowest* rate of any affected region.
- **`CapacityReservationError` has two raise sites** — no-AZ (real shortage) and placement-group
  (configuration bug) — that need different fixes.

### What's in it

- `SKILL.md` — six principles, error-signature table, remediation routing
- `capacity_failure_stats.py` — collects runs from Argus, classifies by error signature, resolves regions
  through the Jenkins → Argus → inference chain, aggregates by week/region/job
- `references/error-signatures.md`, `references/region-resolution.md`, `references/report-format.md`
- `workflows/analyze-capacity-failures.md` — 5 numbered phases with entry/exit criteria and a verification
  checklist

The skill asks which period to report on (from first start / last month / last week) before collecting
anything, because the period silently sets how much of the region breakdown is measured versus inferred.
Measured on one job: last week gives 7/7 regions from Jenkins, last month 35/35, all history only 37/110
with 50 inferred.

Registered in `AGENTS.md` (Copilot) and `CLAUDE.md` (Claude Code).

### Testing

- `capacity_failure_stats.py` run end-to-end against live Argus and Jenkins for all three periods
- Full skill invocation produced a report over 5 i8g jobs / 30 days: 35 of 152 runs, 34 of 35 failure
  regions measured from Jenkins
- `uv run sct.py pre-commit` passes; all internal doc links resolve; frontmatter is 832/1024 chars

🤖 Generated with [Claude Code](https://claude.com/claude-code)
