### PR TITLE
improvement(perf trigger): drop 2024.x and 2025.x from perf regression

### DIFF
--- a/configurations/triggers/perf-regression.yaml
+++ b/configurations/triggers/perf-regression.yaml
@@ -63,6 +63,15 @@ defaults:
   billing_project: "weekly performance regression"
 
 jobs:
+  # Perf regression no longer runs for any 2024.x or 2025.x release, so only master and
+  # 2026.x and up are measured. Version filters match by prefix, which is why the entries
+  # below say "2025." / "2024." — that covers every minor of those years.
+  #
+  # 2024.x/2025.x were the only consumers of the x86 (i4i/i3en) release job variants, so
+  # those entries are kept for reference but turned off with `disabled: true`. Do NOT
+  # neutralize a job by emptying its `include_versions`: an empty list is *no* filter,
+  # which makes the job run for every version instead of none.
+
   # === i8g vnodes (aarch64) ===
 
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-i8g-vnodes"
@@ -78,7 +87,7 @@ jobs:
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-i8g-vnodes"
     backend: "aws"
     arch: "aarch64"
-    exclude_versions: ["2025.2", "2025.1", "2024.2", "2024.1", "master"]
+    exclude_versions: ["2025.", "2024.", "master"]
     labels: []
     job_throttle_category: "SCT-perf-eu-west-2-i8g"
     params:
@@ -98,18 +107,18 @@ jobs:
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-with-nemesis-i8g-vnodes"
     backend: "aws"
     arch: "aarch64"
-    exclude_versions: ["2025.2", "2025.1", "2024.2", "2024.1", "master"]
+    exclude_versions: ["2025.", "2024.", "master"]
     labels: []
     job_throttle_category: "SCT-perf-eu-west-1-i8g"
     params:
       region: "eu-west-1"
       sub_tests: '["test_latency_mixed_with_nemesis"]'
 
-  # === x86 vnodes (non-master only) ===
+  # === x86 vnodes — retired (kept for reference) ===
 
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-vnodes"
     backend: "aws"
-    include_versions: ["2025.2", "2025.1", "2024.2", "2024.1"]
+    disabled: true  # retired with the 2024.x / 2025.x releases
     labels: []
     params:
       region: "us-east-1"
@@ -117,16 +126,17 @@ jobs:
 
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-write-vnodes"
     backend: "aws"
-    include_versions: ["2025.2", "2025.1", "2024.2", "2024.1"]
+    disabled: true  # retired with the 2024.x / 2025.x releases
     labels: []
     params:
       region: "us-east-1"
       sub_tests: '["test_write_gradual_increase_load"]'
 
-  # === Latency with rolling upgrade (all versions) ===
+  # === Latency with rolling upgrade ===
 
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-during-rolling-upgrade"
     backend: "aws"
+    exclude_versions: ["2025.", "2024."]
     disabled: true
     labels: []
     params:
@@ -134,20 +144,21 @@ jobs:
       rolling_upgrade_test: "true"
       new_scylla_repo: "http://downloads.scylladb.com.s3.amazonaws.com/unstable/scylla/{branch_id}/deb/unified/latest/scylladb-{branch}/scylla.list"
 
-  # === Latency with nemesis x86 (non-master only) ===
+  # === Latency with nemesis x86 — retired (kept for reference) ===
 
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-with-nemesis"
     backend: "aws"
-    include_versions: ["2025.2", "2025.1", "2024.2", "2024.1"]
+    disabled: true  # retired with the 2024.x / 2025.x releases
     labels: []
     params:
       region: "eu-west-2"
       sub_tests: '["test_latency_mixed_with_nemesis"]'
 
-  # === Latency with nemesis rbno-disabled (all versions) ===
+  # === Latency with nemesis rbno-disabled ===
 
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-with-nemesis-rbno-disabled"
     backend: "aws"
+    exclude_versions: ["2025.", "2024."]
     params:
       region: "eu-west-3"
     disabled: true
@@ -158,6 +169,7 @@ jobs:
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-simple-query-weekly-microbenchmark_arm64"
     backend: "aws"
     arch: "aarch64"
+    exclude_versions: ["2025.", "2024."]
     labels: []
     params:
       region: "us-east-1"
@@ -166,6 +178,7 @@ jobs:
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-simple-query-weekly-microbenchmark_arm64-write"
     backend: "aws"
     arch: "aarch64"
+    exclude_versions: ["2025.", "2024."]
     labels: []
     params:
       region: "us-east-1"
@@ -173,6 +186,7 @@ jobs:
 
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-simple-query-weekly-microbenchmark_x86_64"
     backend: "aws"
+    exclude_versions: ["2025.", "2024."]
     labels: []
     params:
       region: "us-east-1"
@@ -180,6 +194,7 @@ jobs:
 
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-simple-query-weekly-microbenchmark_x86_64-write"
     backend: "aws"
+    exclude_versions: ["2025.", "2024."]
     labels: []
     params:
       region: "us-east-1"
@@ -187,6 +202,7 @@ jobs:
 
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-cql-raw-weekly-microbenchmark_x86_64"
     backend: "aws"
+    exclude_versions: ["2025.", "2024."]
     labels: []
     params:
       region: "us-east-1"
@@ -194,6 +210,7 @@ jobs:
 
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-cql-raw-weekly-microbenchmark_x86_64-write"
     backend: "aws"
+    exclude_versions: ["2025.", "2024."]
     labels: []
     params:
       region: "us-east-1"
@@ -202,6 +219,7 @@ jobs:
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-cql-raw-weekly-microbenchmark_arm64"
     backend: "aws"
     arch: "aarch64"
+    exclude_versions: ["2025.", "2024."]
     labels: []
     params:
       region: "us-east-1"
@@ -210,6 +228,7 @@ jobs:
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-cql-raw-weekly-microbenchmark_arm64-write"
     backend: "aws"
     arch: "aarch64"
+    exclude_versions: ["2025.", "2024."]
     labels: []
     params:
       region: "us-east-1"
@@ -219,6 +238,7 @@ jobs:
 
   - job_name: "/scylla-master/perf-regression/perf-regression-predefined-throughput-steps-sanity-vnodes"
     backend: "aws"
+    exclude_versions: ["2025.", "2024."]
     disabled: true
     labels: ["master-daily"]
 
@@ -236,7 +256,7 @@ jobs:
 
   - job_name: "/scylla-master/perf-regression/latte-perf-regression-latency-steady-state-custom-d1-workload1-vnodes"
     backend: "gce"
-    exclude_versions: ["2024.1", "2024.2"]
+    exclude_versions: ["2025.", "2024."]
     pre_release: ["rc1", "rc3"]
     labels: ["gce-custom-monthly"]
     params:
@@ -245,7 +265,7 @@ jobs:
 
   - job_name: "/scylla-master/perf-regression/latte-perf-regression-latency-steady-state-custom-d1-workload1-tablets"
     backend: "gce"
-    exclude_versions: ["2024.1", "2024.2"]
+    exclude_versions: ["2025.", "2024."]
     pre_release: ["rc1", "rc3"]
     labels: ["gce-custom-monthly"]
     params:
@@ -267,18 +287,18 @@ jobs:
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-i8g-tablets"
     backend: "aws"
     arch: "aarch64"
-    exclude_versions: ["2025.2", "2025.1", "2024.1", "2024.2", "master"]
+    exclude_versions: ["2025.", "2024.", "master"]
     labels: []
     job_throttle_category: "SCT-perf-us-west-2-i8g"
     params:
       region: "us-west-2"
       sub_tests: '["test_read_gradual_increase_load", "test_mixed_gradual_increase_load", "test_write_gradual_increase_load", "test_read_disk_only_gradual_increase_load"]'
 
-  # === x86 tablets (non-master only) ===
+  # === x86 tablets — retired (kept for reference) ===
 
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-tablets"
     backend: "aws"
-    include_versions: ["2025.2", "2025.1"]
+    disabled: true  # retired with the 2024.x / 2025.x releases
     labels: []
     params:
       region: "us-east-1"
@@ -286,20 +306,17 @@ jobs:
 
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-write-tablets"
     backend: "aws"
-    include_versions: ["2025.2", "2025.1"]
+    disabled: true  # retired with the 2024.x / 2025.x releases
     labels: []
     params:
       region: "us-east-1"
       sub_tests: '["test_write_gradual_increase_load"]'
 
-  # === Tablets latency — rolling upgrade (non-master) ===
+  # === Tablets latency, rolling upgrade x86 — retired (kept for reference) ===
 
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-during-rolling-upgrade-tablets"
     backend: "aws"
-    # 2025.2 has no published unstable deb nightly artifacts on the S3 bucket yet
-    # (only build-packages/relocatable/testLogs); keep this restricted to 2025.1
-    # until nightly builds resume for 2025.2.
-    include_versions: ["2025.1"]
+    disabled: true  # retired with the 2024.x / 2025.x releases
     labels: []
     params:
       region: "eu-west-2"
@@ -307,11 +324,11 @@ jobs:
       rolling_upgrade_test: "true"
       new_scylla_repo: "http://downloads.scylladb.com.s3.amazonaws.com/unstable/scylla/{branch_id}/deb/unified/latest/scylladb-{branch}/scylla.list"
 
-  # === Tablets latency with nemesis (non-master) ===
+  # === Tablets latency with nemesis x86 — retired (kept for reference) ===
 
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-with-nemesis-tablets"
     backend: "aws"
-    include_versions: ["2025.2", "2025.1"]
+    disabled: true  # retired with the 2024.x / 2025.x releases
     labels: []
     params:
       region: "eu-west-3"
@@ -334,7 +351,7 @@ jobs:
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-during-rolling-upgrade-i8g-tablets"
     backend: "aws"
     arch: "aarch64"
-    exclude_versions: ["2025.2", "2025.1", "2024.2", "2024.1", "master"]
+    exclude_versions: ["2025.", "2024.", "master"]
     labels: []
     job_throttle_category: "SCT-perf-eu-west-2-i8g"
     params:
@@ -358,7 +375,7 @@ jobs:
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-with-nemesis-i8g-tablets"
     backend: "aws"
     arch: "aarch64"
-    exclude_versions: ["2025.2", "2025.1", "2024.2", "2024.1", "master"]
+    exclude_versions: ["2025.", "2024.", "master"]
     labels: []
     job_throttle_category: "SCT-perf-eu-west-2-i8g"
     params:
@@ -370,7 +387,7 @@ jobs:
   - job_name: "/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-2.5tb-i8g-elasticity"
     backend: "aws"
     arch: "aarch64"
-    exclude_versions: ["2024.1", "2024.2", "2025.1", "2025.4", "master"]
+    exclude_versions: ["2025.", "2024.", "master"]
     labels: []
     params:
       region: "eu-north-1"

--- a/docs/perf-tests-region-scheduling.md
+++ b/docs/perf-tests-region-scheduling.md
@@ -55,13 +55,27 @@ Master monthly (master-monthly):
 - predefined-throughput-steps-i8g-vnodes — versions: ['master'], labels: ['master-monthly'], all 4 sub tests
 - latency-650gb-with-nemesis-i8g-vnodes — versions: ['master'], labels: ['master-monthly'], all 3 sub tests (mixed, read, write)
 
->= Scylla version 2025.3 (non-master):
-- predefined-throughput-steps-i8g-tablets — ignore_versions: ['2025.2', '2025.1', '2024.1', '2024.2', 'master'], all sub tests
-- latency-650gb-during-rolling-upgrade-i8g-tablets — ignore_versions: ['2025.2', '2025.1', '2024.2', '2024.1', 'master'], mixed load
-- latency-650gb-with-nemesis-i8g-tablets — ignore_versions: ['2025.2', '2025.1', '2024.2', '2024.1', 'master'], read + mixed
-- predefined-throughput-steps-i8g-vnodes — ignore_versions: ['2025.2', '2025.1', '2024.2', '2024.1', 'master'], mixed only
-- latency-650gb-with-nemesis-i8g-vnodes — ignore_versions: ['2025.2', '2025.1', '2024.2', '2024.1', 'master'], mixed only
+Non-master releases on i8g (2026.x and up — every 2024.x and 2025.x branch was dropped
+from the perf regression trigger):
+- predefined-throughput-steps-i8g-tablets — exclude_versions: ['2025.', '2024.', 'master'], all sub tests
+- latency-650gb-during-rolling-upgrade-i8g-tablets — exclude_versions: ['2025.', '2024.', 'master'], mixed load
+- latency-650gb-with-nemesis-i8g-tablets — exclude_versions: ['2025.', '2024.', 'master'], read + mixed
+- predefined-throughput-steps-i8g-vnodes — exclude_versions: ['2025.', '2024.', 'master'], mixed only
+- latency-650gb-with-nemesis-i8g-vnodes — exclude_versions: ['2025.', '2024.', 'master'], mixed only
 ```
+
+`exclude_versions` matches by prefix, so '2025.' / '2024.' cover every minor of those years.
+Every other live entry carries the same exclusions — the weekly simple-query and cql-raw
+microbenchmarks, the elasticity job, the GCE latte jobs, the alternator job and the two
+already-disabled x86 jobs — so no perf regression job is triggered for a 2024.x or 2025.x
+release.
+
+2024.x/2025.x were the only consumers of the x86 (i4i/i3en) release job variants, so those
+seven entries — predefined-throughput-steps[-write]-vnodes, predefined-throughput-steps[-write]-tablets,
+latency-650gb-with-nemesis, latency-650gb-with-nemesis-tablets and
+latency-650gb-during-rolling-upgrade-tablets — stay in the matrix for reference but are
+turned off with `disabled: true`. Do not switch a job off by emptying its `include_versions`:
+an empty list is *no* filter, so the job runs for every version instead of none.
 
 ## Final Region Assignment
 

--- a/docs/plans/i8g-performance-jobs-migration.md
+++ b/docs/plans/i8g-performance-jobs-migration.md
@@ -13,6 +13,12 @@ The current performance regression testing infrastructure uses i4i.4xlarge (x86_
 
 The migration impacts critical weekly performance testing jobs for both vnodes and tablets configurations across Scylla releases that support ARM64 architecture: 2025.3, 2025.4, and master. **Releases 2024.1, 2024.2, 2025.1, and 2025.2 do not support i8g and will remain on i4i instances.**
 
+**Update (2026-09-10):** moving 2025.1 onto the i8g jobs was considered and dropped.
+Instead, every 2024.x and 2025.x branch was removed from `configurations/triggers/perf-regression.yaml`
+altogether, and the x86 release-only job variants they were the last consumers of are now
+`disabled: true` there. Perf regression runs for master and 2026.x and up only, so the
+"keep older releases on i4i" parts of this plan no longer have any releases to apply to.
+
 ## 2. Current State
 
 ### Existing Infrastructure

--- a/unit_tests/trigger_matrix/test_perf_regression.py
+++ b/unit_tests/trigger_matrix/test_perf_regression.py
@@ -53,8 +53,8 @@ def test_gce_custom_monthly_with_master_selects_latte(perf_config):
 def test_gce_custom_monthly_non_rc_excluded(perf_config):
     result = filter_jobs(
         perf_config.jobs,
-        scylla_version="2025.1:latest",
-        resolved_version="2025.1.3-0.20250525.abc",
+        scylla_version="2026.1:latest",
+        resolved_version="2026.1.3-0.20260525.abc",
         labels_selector="gce-custom-monthly",
     )
     assert len(result) == 0
@@ -63,18 +63,70 @@ def test_gce_custom_monthly_non_rc_excluded(perf_config):
 def test_gce_custom_monthly_rc1_included(perf_config):
     result = filter_jobs(
         perf_config.jobs,
-        scylla_version="2025.1:latest",
-        resolved_version="2025.1.3-rc1-0.20250525.abc",
+        scylla_version="2026.1:latest",
+        resolved_version="2026.1.3-rc1-0.20260525.abc",
         labels_selector="gce-custom-monthly",
     )
     assert len(result) == 2
 
 
+@pytest.mark.parametrize(
+    "scylla_version,resolved_version",
+    [
+        ("2024.1:latest", "2024.1.15-0.20250115.abc"),
+        ("2024.2:latest", "2024.2.11-0.20250320.abc"),
+        ("2025.1:latest", "2025.1.3-0.20250525.abc"),
+        ("2025.1:latest", "2025.1.3-rc1-0.20250525.abc"),
+        ("2025.2:latest", "2025.2.2-0.20250825.abc"),
+        ("2025.3:latest", "2025.3.5-0.20251025.abc"),
+        ("2025.4:latest", "2025.4.1-0.20260125.abc"),
+    ],
+)
+def test_no_perf_jobs_for_2024_and_2025_releases(perf_config, scylla_version, resolved_version):
+    """Perf regression was dropped for every 2024.x and 2025.x branch — a release trigger
+    for one of them must select nothing, on any labels selector.
+    """
+    for labels_selector in ("", "gce-custom-monthly", "master-monthly"):
+        result = filter_jobs(
+            perf_config.jobs,
+            scylla_version=scylla_version,
+            resolved_version=resolved_version,
+            labels_selector=labels_selector,
+        )
+        assert result == [], (
+            f"{scylla_version} (labels_selector={labels_selector!r}) still selects {[job.job_name for job in result]}"
+        )
+
+
+RETIRED_X86_JOBS = [
+    "scylla-enterprise-perf-regression-predefined-throughput-steps-vnodes",
+    "scylla-enterprise-perf-regression-predefined-throughput-steps-write-vnodes",
+    "scylla-enterprise-perf-regression-latency-650gb-with-nemesis",
+    "scylla-enterprise-perf-regression-predefined-throughput-steps-tablets",
+    "scylla-enterprise-perf-regression-predefined-throughput-steps-write-tablets",
+    "scylla-enterprise-perf-regression-latency-650gb-during-rolling-upgrade-tablets",
+    "scylla-enterprise-perf-regression-latency-650gb-with-nemesis-tablets",
+]
+
+
+@pytest.mark.parametrize("job_name", RETIRED_X86_JOBS)
+def test_retired_x86_jobs_stay_disabled(perf_config, job_name):
+    """The x86 (i4i/i3en) release variants were retired together with 2024.x/2025.x and are
+    kept in the matrix for reference only. They must stay `disabled: true` — emptying their
+    `include_versions` instead does the opposite of switching them off, since an empty list
+    is no filter at all and would run them for every version, master included.
+    """
+    entries = [job for job in perf_config.jobs if job.job_name.rsplit("/", 1)[-1] == job_name]
+    assert entries, f"{job_name} not found in perf-regression.yaml"
+    for job in entries:
+        assert job.disabled, f"{job_name} is retired but not disabled"
+
+
 def test_rolling_upgrade_jobs_resolve_new_scylla_repo(perf_config):
     """SCT-782: rolling_upgrade_test jobs must get scylla_version cleared and a fully
     resolved new_scylla_repo from build_job_parameters(), with the directory segment
-    branch-prefixed (e.g. 'branch-2025.1' / 'master') and the filename segment bare
-    (e.g. 'scylladb-2025.1' / 'scylladb-master').
+    branch-prefixed (e.g. 'branch-2026.1' / 'master') and the filename segment bare
+    (e.g. 'scylladb-2026.1' / 'scylladb-master').
     """
     rolling_upgrade_jobs = [
         job for job in perf_config.jobs if str(job.params.get("rolling_upgrade_test", "")).lower() == "true"
@@ -84,7 +136,7 @@ def test_rolling_upgrade_jobs_resolve_new_scylla_repo(perf_config):
     )
 
     for job in rolling_upgrade_jobs:
-        params = build_job_parameters(job, perf_config.defaults, "2025.1:latest", {})
+        params = build_job_parameters(job, perf_config.defaults, "2026.1:latest", {})
         assert params["scylla_version"] == "", f"Job {job.job_name} should have blank scylla_version"
         new_scylla_repo = params.get("new_scylla_repo", "")
         assert new_scylla_repo, f"Job {job.job_name} missing new_scylla_repo"
@@ -94,12 +146,12 @@ def test_rolling_upgrade_jobs_resolve_new_scylla_repo(perf_config):
         assert "{branch_id}" not in new_scylla_repo, (
             f"Job {job.job_name} has unresolved {{branch_id}} placeholder in new_scylla_repo: {new_scylla_repo}"
         )
-        assert "/branch-2025.1/deb/" in new_scylla_repo, (
+        assert "/branch-2026.1/deb/" in new_scylla_repo, (
             f"Job {job.job_name} new_scylla_repo directory segment must be branch-prefixed "
-            f"('branch-2025.1'): {new_scylla_repo}"
+            f"('branch-2026.1'): {new_scylla_repo}"
         )
-        assert "/scylladb-2025.1/" in new_scylla_repo, (
-            f"Job {job.job_name} new_scylla_repo filename segment must stay bare ('scylladb-2025.1'): {new_scylla_repo}"
+        assert "/scylladb-2026.1/" in new_scylla_repo, (
+            f"Job {job.job_name} new_scylla_repo filename segment must stay bare ('scylladb-2026.1'): {new_scylla_repo}"
         )
 
     for job in rolling_upgrade_jobs:


### PR DESCRIPTION
Perf regression jobs were still triggered for every enterprise branch back to 2024.1, on two parallel sets of entries in `configurations/triggers/perf-regression.yaml`: the i8g (aarch64) variants for 2025.3 and up, and x86 (i4i/i3en) variants kept alive only for 2024.1, 2024.2, 2025.1 and 2025.2. Those branches are no longer worth the perf capacity, so they are dropped from the trigger entirely rather than routed to different instances.

### What changed

- **Every selectable entry now excludes the `2025.` / `2024.` prefixes.** `exclude_versions` matches by prefix, so that covers every minor of those years — 2025.3 and 2025.4 included, not just the four branches that used to be named.
- **The entries that carried no version filter at all get the same exclusions**, since they would otherwise still fire for a 2024.x/2025.x release trigger: the weekly simple-query and cql-raw microbenchmarks (arm64 + x86_64, read + write), `latency-2.5tb-i8g-elasticity`, the two GCE latte jobs, `scylla-release-perf-regression-alternator`, and the already-disabled x86 rolling-upgrade, rbno-disabled and daily sanity jobs.
- **The seven x86 release-only variants are turned off with `disabled: true`** and kept in the matrix for reference: `predefined-throughput-steps[-write]-vnodes`, `predefined-throughput-steps[-write]-tablets`, `latency-650gb-with-nemesis`, `latency-650gb-with-nemesis-tablets`, `latency-650gb-during-rolling-upgrade-tablets`. 2024.x/2025.x were their only consumers.

Not with an empty `include_versions`: `filter_jobs()` checks `if job.include_versions and not _is_version_included(...)`, so an empty list is *no* filter and would run those jobs for **every** version, master included. `test_retired_x86_jobs_stay_disabled` pins that they stay disabled, and the comment at the top of the `jobs:` list spells out the trap.

### Resulting selection

| `scylla_version` | jobs selected |
|---|---|
| 2024.1, 2024.2, 2025.1, 2025.2, 2025.3, 2025.4 | **0** — on every labels selector |
| 2026.1 | 14 (unchanged) |
| master | 17 (unchanged) |

No `cron_triggers` entry is left without jobs, so `utils/build_system/generate_trigger_jenkinsfiles.py` produces no diff.

### Notes for reviewers

- **Perf coverage for 2025.x ends here**, microbenchmarks included. Nothing in this matrix runs for those branches any more; the Argus history stays, but no new points land.
- The docs that described the old per-version routing are updated: the trigger section of `docs/perf-tests-region-scheduling.md` and the version-support note in `docs/plans/i8g-performance-jobs-migration.md`.
- `vars/perfRegressionParallelPipelinebyRegion.groovy` still carries the legacy `testRegionMatrix` with the old version lists. It is left alone: `jenkins-pipelines/master-triggers/sct_triggers/perf-regression-trigger.jenkinsfile` drives the YAML matrix, so that Groovy list is not what triggers these jobs.

### Testing

`unit_tests/trigger_matrix` — 284 passed. New tests: `test_no_perf_jobs_for_2024_and_2025_releases` (2024.1 → 2025.4 across three labels selectors) and `test_retired_x86_jobs_stay_disabled`. The rolling-upgrade entry-count assertion stays at 4.

Refs: https://scylladb.atlassian.net/browse/SCT-984 — that ticket asked for 2025.1 to run on i8g; this PR supersedes it, since 2025.1 is no longer perf-tested at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
