### PR TITLE
chore(qodo): make Qodo code review manual-only

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,0 +1,21 @@
+# Qodo Merge (qodo.ai) configuration.
+#
+# Reviews are manual-only: Qodo does not run automatically when a PR is
+# opened/updated, nor on new commits pushed to a PR. To get a review, comment
+# on the PR with a command, e.g.:
+#
+#   /agentic_review
+#   /agentic_describe
+#   /improve
+#
+# Repository-root config takes precedence over the organization-level
+# `pr-agent-settings` repo and over the Qodo portal settings.
+[github_app]
+# Commands run automatically when a PR is opened or updated. Empty = none.
+pr_commands = []
+
+# Commands run automatically on new commits pushed to an open PR. Empty = none.
+push_commands = []
+
+# Do not re-trigger anything on push.
+handle_push_trigger = false


### PR DESCRIPTION
Qodo Merge currently reviews every PR automatically when it's opened and again on each push. This adds a repository-root `.pr_agent.toml` that clears the automatic GitHub App triggers, so a review only happens when someone explicitly asks for one.

```toml
[github_app]
pr_commands = []
push_commands = []
handle_push_trigger = false
```

To get a review, comment on the PR:

```
/agentic_review
```

(`/agentic_describe`, `/improve`, etc. still work the same way.)

Notes:
- Repository-root config takes precedence over the org-level `pr-agent-settings` repo and over the Qodo portal settings, so this is authoritative regardless of what the portal has configured.
- Qodo reads the config from the **target** branch, so this only takes effect once merged to master — this PR itself will still get an automatic review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)