### PR TITLE
fix(oci): resolve loader shapes through sizing so OCI loaders default to Arm

### DIFF
--- a/configurations/oci/longevity-100gb-4h-cql-stress.yaml
+++ b/configurations/oci/longevity-100gb-4h-cql-stress.yaml
@@ -9,4 +9,6 @@ availability_zone: "a,b,c" # use real AZs to balance limited DenseIO shapes usag
 oci_instance_type_db: "VM.DenseIO.E5.Flex:8" # <shape-name>:<ocpus>:<ram>:<nvmes>
 instance_provision: 'on_demand' # DenseIO shapes cannot be 'spot'
 
-oci_instance_type_loader:  "VM.Standard3.Flex:8:16" # <shape-name>:<ocpus>:<ram>:<nvmes>
+sizing_loader:
+  vcpu: 16
+  memory: '>=16'

--- a/configurations/oci/longevity-150GB-12h-autorization-LimitedMonkey.yaml
+++ b/configurations/oci/longevity-150GB-12h-autorization-LimitedMonkey.yaml
@@ -9,4 +9,6 @@ availability_zone: "a,b,c" # use real AZs to balance limited DenseIO shapes usag
 oci_instance_type_db: "VM.DenseIO.E5.Flex:8" # <shape-name>:<ocpus>:<ram>:<nvmes>
 instance_provision: 'on_demand' # DenseIO shapes cannot be 'spot'
 
-oci_instance_type_loader:  "VM.Standard3.Flex:8:32" # <shape-name>:<ocpus>:<ram>:<nvmes>
+sizing_loader:
+  vcpu: 16
+  memory: '>=32'

--- a/configurations/oci/longevity-mv-si-4days.yaml
+++ b/configurations/oci/longevity-mv-si-4days.yaml
@@ -9,4 +9,6 @@ availability_zone: "a,b,c" # use real AZs to balance limited DenseIO shapes usag
 oci_instance_type_db: "VM.DenseIO.E5.Flex:16" # <shape-name>:<ocpus>:<ram>:<nvmes>
 instance_provision: 'on_demand' # DenseIO shapes cannot be 'spot'
 
-oci_instance_type_loader:  "VM.Standard3.Flex:8:32" # <shape-name>:<ocpus>:<ram>:<nvmes>
+sizing_loader:
+  vcpu: 16
+  memory: '>=32'


### PR DESCRIPTION
Three OCI overlays pin `oci_instance_type_loader` to `VM.Standard3.Flex`, an Intel shape. An explicit shape bypasses the sizing resolver, so `longevity-100gb-4h-oci`, `longevity-mv-si-4days-streaming-oci` and `longevity-150gb-asymmetric-cluster-12h-oci` kept x86 loaders after #15860 made Arm the loader default.

The overlays now express the loader size as a `sizing_loader` constraint with the same vCPU count and memory. The resolver picks `VM.Standard.A1.Flex:8:32` and `VM.Standard.A1.Flex:8:16` for them.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
- [x] Matcher check against `data/instance_catalog`: `vcpu: 16, memory: '>=32'` → `VM.Standard.A1.Flex:8:32`, `vcpu: 16, memory: '>=16'` → `VM.Standard.A1.Flex:8:16`
- [ ] Post-merge run of each affected pipeline shows `VM.Standard.A1.Flex` loaders

### PR pre-checks (self review)
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config/config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)

Fixes: https://scylladb.atlassian.net/browse/SCT-990
