### PR TITLE
fix(minicloud): count oracle nodes only when db_type sets them

### DIFF
--- a/sdcm/utils/minicloud/preflight.py
+++ b/sdcm/utils/minicloud/preflight.py
@@ -15,10 +15,12 @@ GUEST_NODE_COUNT_PARAMS = (
     "n_db_nodes",
     "n_loaders",
     "n_monitor_nodes",
-    "n_test_oracle_db_nodes",
     "n_db_zero_token_nodes",
     "n_vector_store_nodes",
 )
+
+# Count `n_test_oracle_db_nodes` only for db types that actually provision an oracle cluster
+ORACLE_GUEST_DB_TYPES = ("mixed_scylla", "mixed_cassandra")
 
 
 def sum_node_counts(value) -> int:
@@ -71,7 +73,10 @@ def check_host_memory(config: MinicloudConfig, params) -> None:
         return  # non-lightweight sizing follows the requested instance types; out of scope here
     # every pool that becomes a guest has to be counted, or a test with an oracle cluster,
     # zero-token nodes or a vector store passes the gate and still OOM-kills the container.
-    guests = sum(sum_node_counts(params.get(name)) for name in GUEST_NODE_COUNT_PARAMS)
+    counted_params = list(GUEST_NODE_COUNT_PARAMS)
+    if params.get("db_type") in ORACLE_GUEST_DB_TYPES:
+        counted_params.append("n_test_oracle_db_nodes")
+    guests = sum(sum_node_counts(params.get(name)) for name in counted_params)
     # n_db_nodes is only where the cluster *starts*. A test that grows it - the scale tests set
     # cluster_target_size, and longevity_test grows to it - peaks higher, and the peak is what has
     # to fit: a gate that sizes the initial cluster only would pass and then let the run die at the
@@ -107,7 +112,7 @@ def check_host_memory(config: MinicloudConfig, params) -> None:
             f"not enough memory for this test: {guests} guest(s) x "
             f"{per_guest_gib:.1f}GiB ({config.lightweight_memory}){headroom_note} = "
             f"{needed_gib:.1f}GiB needed, but only {budget_gib:.1f}GiB is available from "
-            f"{budget_source}. Reduce {'/'.join(GUEST_NODE_COUNT_PARAMS)}, lower "
+            f"{budget_source}. Reduce {'/'.join(counted_params)}, lower "
             f"minicloud_lightweight_memory, raise the budget, or set "
             f"SCT_MINICLOUD_SKIP_MEMORY_CHECK=true if you know the real footprint - otherwise the "
             f"container is OOM-killed mid-test (exit 137) taking every VM with it."

--- a/unit_tests/unit/minicloud/test_preflight.py
+++ b/unit_tests/unit/minicloud/test_preflight.py
@@ -124,11 +124,13 @@ def test_check_host_memory_counts_every_guest_pool(tmp_path):
     """Oracle, zero-token and vector-store nodes are guests too.
 
     Leaving them out of the arithmetic let a test pass the gate and then OOM-kill the
-    container mid-run (exit 137), taking every VM with it.
+    container mid-run (exit 137), taking every VM with it. db_type is the mixed one that
+    actually provisions the oracle cluster, so all six pools are real guests here.
     """
     manager = MinicloudManager(config=MinicloudConfig(state_dir=str(tmp_path), lightweight=True))
     # 1 + 1 + 1 + 1 + 1 + 1 = 6 guests x 4GiB + 2GiB headroom = 26GiB needed, 16GiB available
     params = {
+        "db_type": "mixed_scylla",
         "n_db_nodes": 1,
         "n_loaders": 1,
         "n_monitor_nodes": 1,
@@ -139,6 +141,23 @@ def test_check_host_memory_counts_every_guest_pool(tmp_path):
     with _meminfo_path_patch(16 * 1024 * 1024):
         with pytest.raises(MinicloudError, match="6 guest.*26.0GiB needed"):
             manager._check_host_memory(params)
+
+
+def test_check_host_memory_ignores_the_oracle_pool_without_a_mixed_db_type(tmp_path):
+    """n_test_oracle_db_nodes defaults to 1, but the oracle cluster only exists for mixed db_type.
+
+    tester.py creates it solely when db_type is mixed_scylla/mixed_cassandra, so counting it
+    for an ordinary longevity run invents a guest that is never provisioned and rejects a test
+    that fits - which is what blocked longevity-100gb-4h on a 123GiB lab machine.
+    """
+    manager = MinicloudManager(
+        config=MinicloudConfig(state_dir=str(tmp_path), lightweight=True, lightweight_memory="10GiB")
+    )
+    # 6 db + 2 loaders + 1 monitor = 9 guests x 10GiB + 2GiB headroom = 92GiB, under the 100GiB budget.
+    # Counting the phantom oracle node makes it 102GiB and the run never starts.
+    params = {"n_db_nodes": 6, "n_loaders": 2, "n_monitor_nodes": 1, "n_test_oracle_db_nodes": 1}
+    with _meminfo_path_patch(100 * 1024 * 1024):
+        manager._check_host_memory(params)  # must not raise
 
 
 def test_check_host_memory_counts_the_grown_cluster_not_the_initial_one(tmp_path):


### PR DESCRIPTION
n_test_oracle_db_nodes defaults to 1, but tester.py builds the oracle cluster only for db_type mixed_scylla/mixed_cassandra. The memory gate counted it for every test, including a guest that never exists into calculation (e.g. a 9-guest longevity run was counted as a 10-nodes setup during preflight).

The fix is to include oracle nodes only when db_type explicitly sets them.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :yellow_circle: [aws sanity on minicloud](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/mc/job/mc-longevity-10gb-1h/41/)
The test itself failed, but later into the test (2h40m into the test). The original problem is resolved - that one when preflight counted oracle node and failed as requested memory for the test env exceeded what lab node provides (example test run failing because of this - [aws sanity, failed due to requesting one extra node ](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/mc/job/mc-longevity-10gb-1h/26/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code