### PR TITLE
SCYLLADB-4346: SC performance tests with topology operations (cql-stress leader-aware, i4i + i8g)

### DIFF
--- a/configurations/performance/cassandra_stress_gradual_load_steps_sc_50k_unthrottled_only_write.yaml
+++ b/configurations/performance/cassandra_stress_gradual_load_steps_sc_50k_unthrottled_only_write.yaml
@@ -1,0 +1,8 @@
+# Define load ops for steps
+# # For debugging, you can set a specific thread count for each step (per load).
+## The value of perf_gradual_threads[load] must be either:
+##   - a single-element list or integer (applied to all throttle steps)
+##   - a list with the same length as perf_gradual_throttle_steps[load] (one thread count per step).
+perf_gradual_threads: {"read": 620, "write": 500, "mixed": 1900, "read_disk_only": 620}  # number of threads to use for each load type
+perf_gradual_throttle_steps: {"read": ['150000', '300000', '450000', '600000', '700000', 'unthrottled'], "mixed": ['50000', '150000', '300000', '450000', 'unthrottled'], "write": ['50000', 'unthrottled'], "read_disk_only": ['80000', '165000', '250000', '300000', 'unthrottled']}  # where every value is in ops
+perf_gradual_step_duration: {"read": '30m', "write": '30m', "mixed": '30m', "read_disk_only": '30m'}  # duration per step; None means until completion of the stress command

--- a/configurations/performance/cassandra_stress_gradual_load_steps_strong_consistency.yaml
+++ b/configurations/performance/cassandra_stress_gradual_load_steps_strong_consistency.yaml
@@ -1,0 +1,13 @@
+# Increase disk sizes for strong consistency performance tests
+root_disk_size_runner: 200
+root_disk_size_loader: 100
+
+
+# Define load ops for steps
+# # For debugging, you can set a specific thread count for each step (per load).
+## The value of perf_gradual_threads[load] must be either:
+##   - a single-element list or integer (applied to all throttle steps)
+##   - a list with the same length as perf_gradual_throttle_steps[load] (one thread count per step).
+perf_gradual_threads: {"read": 620, "write": 400, "mixed": 1900, "read_disk_only": 620}  # number of threads to use for each load type
+perf_gradual_throttle_steps: {"read": ['150000', '300000', '450000', '600000', '700000', 'unthrottled'], "mixed": ['50000', '150000', '300000', '450000', 'unthrottled'], "write": ['50000', '75000', '100000', '200000', 'unthrottled'], "read_disk_only": ['80000', '165000', '250000', '300000', 'unthrottled']}  # where every value is in ops
+perf_gradual_step_duration: {"read": '30m', "write": '30m', "mixed": '30m', "read_disk_only": '30m'}  # duration per step; None means until completion of the stress command

--- a/configurations/performance/cassandra_stress_gradual_load_steps_strong_consistency_1round_write.yaml
+++ b/configurations/performance/cassandra_stress_gradual_load_steps_strong_consistency_1round_write.yaml
@@ -1,0 +1,13 @@
+# Increase disk sizes for strong consistency performance tests
+root_disk_size_runner: 500
+root_disk_size_loader: 500
+instance_type_runner: 'r6i.8xlarge'
+
+# Define load ops for steps
+# # For debugging, you can set a specific thread count for each step (per load).
+## The value of perf_gradual_threads[load] must be either:
+##   - a single-element list or integer (applied to all throttle steps)
+##   - a list with the same length as perf_gradual_throttle_steps[load] (one thread count per step).
+perf_gradual_threads: {"read": 620, "write": 400, "mixed": 1900, "read_disk_only": 620}  # number of threads to use for each load type
+perf_gradual_throttle_steps: {"read": ['150000', '300000', '450000', '600000', '700000', 'unthrottled'], "mixed": ['50000', '150000', '300000', '450000', 'unthrottled'], "write": ['50000'], "read_disk_only": ['80000', '165000', '250000', '300000', 'unthrottled']}  # where every value is in ops
+perf_gradual_step_duration: {"read": '30m', "write": '30m', "mixed": '30m', "read_disk_only": '30m'}  # duration per step; None means until completion of the stress command

--- a/configurations/performance/cassandra_stress_gradual_load_steps_strong_consistency_unthrottled_only_write.yaml
+++ b/configurations/performance/cassandra_stress_gradual_load_steps_strong_consistency_unthrottled_only_write.yaml
@@ -1,0 +1,8 @@
+# Define load ops for steps
+# # For debugging, you can set a specific thread count for each step (per load).
+## The value of perf_gradual_threads[load] must be either:
+##   - a single-element list or integer (applied to all throttle steps)
+##   - a list with the same length as perf_gradual_throttle_steps[load] (one thread count per step).
+perf_gradual_threads: {"read": 620, "write": 500, "mixed": 1900, "read_disk_only": 620}  # number of threads to use for each load type
+perf_gradual_throttle_steps: {"read": ['150000', '300000', '450000', '600000', '700000', 'unthrottled'], "mixed": ['50000', '150000', '300000', '450000', 'unthrottled'], "write": ['unthrottled'], "read_disk_only": ['80000', '165000', '250000', '300000', 'unthrottled']}  # where every value is in ops
+perf_gradual_step_duration: {"read": '30m', "write": '30m', "mixed": '30m', "read_disk_only": '30m'}  # duration per step; None means until completion of the stress command

--- a/configurations/performance/latency-decorator-error-thresholds-nemesis-sc-tablets.yaml
+++ b/configurations/performance/latency-decorator-error-thresholds-nemesis-sc-tablets.yaml
@@ -1,0 +1,70 @@
+# Latency-decorator error thresholds for the Strong Consistency "latency during topology operations"
+# jobs, modelled on latency-decorator-error-thresholds-nemesis-ent-tablets.yaml.
+#
+# SC writes go through Raft, and node add / remove additionally reconfigures the Raft groups of every
+# migrated tablet, so the EC duration limits for the topology disruptions are not transferable. Until
+# a first run measures them, every topology disruption is report-only (fixed_limit: null): the
+# duration is still collected and shown in Argus, it just cannot fail the run on a guessed number.
+#
+# The manager-repair and backup limits are kept at the EC values - they are not consistency-sensitive.
+#
+# PLACEHOLDER values are marked below and get replaced from the first SC run (SCYLLADB-4417).
+
+latency_decorator_error_thresholds:
+  write:
+    _mgmt_repair_cli:
+      duration:
+        fixed_limit: 7200
+    terminate_node:
+      duration:
+        fixed_limit: null
+    add_new_nodes:
+      duration:
+        fixed_limit: null  # PLACEHOLDER - EC value is 2500
+    decommission_nodes:
+      duration:
+        fixed_limit: null  # PLACEHOLDER - EC value is 1800
+    replace_node:
+      duration:
+        fixed_limit: null  # PLACEHOLDER - EC value is 3600
+    _run_manager_backup:
+      duration:
+        fixed_limit: 18000
+  read:
+    _mgmt_repair_cli:
+      duration:
+        fixed_limit: 3200
+    terminate_node:
+      duration:
+        fixed_limit: null
+    add_new_nodes:
+      duration:
+        fixed_limit: null  # PLACEHOLDER - EC value is 3200
+    decommission_nodes:
+      duration:
+        fixed_limit: null  # PLACEHOLDER - EC value is 1800
+    replace_node:
+      duration:
+        fixed_limit: null  # PLACEHOLDER - EC value is 3000
+    _run_manager_backup:
+      duration:
+        fixed_limit: 18000
+  mixed:
+    _mgmt_repair_cli:
+      duration:
+        fixed_limit: 4200
+    terminate_node:
+      duration:
+        fixed_limit: null
+    add_new_nodes:
+      duration:
+        fixed_limit: null  # PLACEHOLDER - EC value is 2500
+    decommission_nodes:
+      duration:
+        fixed_limit: null  # PLACEHOLDER - EC value is 1600
+    replace_node:
+      duration:
+        fixed_limit: null  # PLACEHOLDER - EC value is 3000
+    _run_manager_backup:
+      duration:
+        fixed_limit: 18000

--- a/configurations/stress_images/cql-stress-eventual-consistency-lwt.yaml
+++ b/configurations/stress_images/cql-stress-eventual-consistency-lwt.yaml
@@ -1,0 +1,2 @@
+stress_image:
+  cql-stress-cassandra-stress: 'aleksbykov/cql-stress:write-if-not-exists'

--- a/configurations/stress_images/cql-stress-strong-consistency-leader-awarness.yaml
+++ b/configurations/stress_images/cql-stress-strong-consistency-leader-awarness.yaml
@@ -1,0 +1,2 @@
+stress_image:
+  cql-stress-cassandra-stress: 'aleksbykov/cql-stress:leader-aware-strong-consistency'

--- a/configurations/stress_images/cql-stress-strong-consistency-lwt.yaml
+++ b/configurations/stress_images/cql-stress-strong-consistency-lwt.yaml
@@ -1,0 +1,2 @@
+stress_image:
+  cql-stress-cassandra-stress: 'aleksbykov/cql-stress:strong-consistency-lwt'

--- a/configurations/stress_images/cql-stress-strong-consistency.yaml
+++ b/configurations/stress_images/cql-stress-strong-consistency.yaml
@@ -1,0 +1,3 @@
+stress_image:
+  # cql-stress-cassandra-stress: 'aleksbykov/cql-stress:strong-consistency'
+  cql-stress-cassandra-stress: 'jadw1/cql-stress:strong-consistency-load-balancing-v1'

--- a/configurations/strong_consistency/ec_baseline_align_with_sc.yaml
+++ b/configurations/strong_consistency/ec_baseline_align_with_sc.yaml
@@ -1,0 +1,16 @@
+# EC baseline companion for the "latency during topology operations" jobs.
+#
+# The EC chain omits enable_experimental_sc.yaml, which would otherwise carry three unrelated changes:
+# the strongly-consistent-tables feature (correctly dropped for EC), a different append_scylla_args,
+# and api_address. Dropping all three at once is what makes the existing EC gradual baseline an
+# imperfect comparison (see commit 172372628). This fragment restores the two settings that
+# have nothing to do with consistency, so the only variable left between the SC and EC jobs is the
+# keyspace clause.
+#
+# Keep in sync with configurations/strong_consistency/enable_experimental_sc.yaml.
+
+append_scylla_args: '--blocked-reactor-notify-ms 50 --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc --abort-on-internal-error 0 --abort-on-ebadf 1'
+
+# the EC baseline runs the same leader-aware cql-stress image, which queries the Scylla REST API
+append_scylla_yaml:
+  api_address: "0.0.0.0"

--- a/configurations/strong_consistency/enable_commitlog_sync_batch.yaml
+++ b/configurations/strong_consistency/enable_commitlog_sync_batch.yaml
@@ -1,0 +1,3 @@
+append_scylla_yaml:
+  commitlog_sync: 'batch'
+  commitlog_sync_batch_window_in_ms: 100

--- a/configurations/strong_consistency/enable_experimental_sc.yaml
+++ b/configurations/strong_consistency/enable_experimental_sc.yaml
@@ -1,0 +1,9 @@
+experimental_features:
+  - strongly-consistent-tables
+
+append_scylla_args: '--blocked-reactor-notify-ms 50 --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc --abort-on-internal-error 0 --abort-on-ebadf 1'
+
+# Bind the REST API to all interfaces so that cql-stress leader-aware
+# load balancing can query Raft leader info from loader nodes.
+append_scylla_yaml:
+  api_address: "0.0.0.0"

--- a/configurations/strong_consistency/nemesis_650gb_cql_stress_base.yaml
+++ b/configurations/strong_consistency/nemesis_650gb_cql_stress_base.yaml
@@ -1,0 +1,22 @@
+# Shared, consistency-agnostic settings for the "latency during topology operations" jobs that drive
+# the 650GB dataset with cql-stress-cassandra-stress instead of cassandra-stress.
+#
+# Stacked on top of test-cases/performance/perf-regression-latency-650gb-with-nemesis.yaml, which it
+# overrides, and kept free of anything SC/EC- or architecture-specific so that all four jobs
+# (i4i/i8g x SC/EC) share exactly the same loader shape.
+#
+# Loader sizing: the workload fragments ask for 250 connections per shard per loader, so with
+# 4 loaders every db shard accepts 1000 connections in aggregate. Against a 4xlarge db node
+# (16 vCPU -> 15 shards) that is 3750 connections held open by each loader, far beyond what the
+# c5.2xlarge of the base test-case can drive - hence c7i.8xlarge, the same loader the SC gradual
+# throughput jobs use (test-cases/performance/perf-regression-predefined-throughput-steps.yaml).
+
+n_loaders: 4
+instance_type_loader: 'c7i.8xlarge'
+
+# cql-stress always runs in a docker container on the loader
+use_prepared_loaders: false
+round_robin: true
+
+user_prefix: 'perf-lat-nemesis-cqls'
+email_subject_postfix: 'latency during topology operations'

--- a/configurations/strong_consistency/prepare_cql_stress_ks_with_ec.yaml
+++ b/configurations/strong_consistency/prepare_cql_stress_ks_with_ec.yaml
@@ -1,0 +1,10 @@
+prepare_stress_cmd: []
+prepare_write_cmd: []
+pre_create_keyspace: ["CREATE KEYSPACE keyspace1 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3} and tablets = {'enabled': true};"]
+
+stress_cmd_w:  [
+  "cql-stress-cassandra-stress write cl=QUORUM duration=$duration -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerHost=8 cql3 native -rate 'threads=$threads $throttle' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..402653184",
+  "cql-stress-cassandra-stress write cl=QUORUM duration=$duration -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerHost=8 cql3 native -rate 'threads=$threads $throttle' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=402653185..805306368",
+  "cql-stress-cassandra-stress write cl=QUORUM duration=$duration -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerHost=8 cql3 native -rate 'threads=$threads $throttle' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=805306369..1207959552",
+  "cql-stress-cassandra-stress write cl=QUORUM duration=$duration -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerHost=8 cql3 native -rate 'threads=$threads $throttle' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1207959553..1610612736"
+]

--- a/configurations/strong_consistency/prepare_cql_stress_ks_with_ec_1kpershard.yaml
+++ b/configurations/strong_consistency/prepare_cql_stress_ks_with_ec_1kpershard.yaml
@@ -1,0 +1,10 @@
+prepare_stress_cmd: []
+prepare_write_cmd: []
+pre_create_keyspace: ["CREATE KEYSPACE keyspace1 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3} and tablets = {'enabled': true};"]
+
+stress_cmd_w:  [
+  "cql-stress-cassandra-stress write cl=QUORUM duration=$duration -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerShard=250 cql3 native -rate 'threads=$threads $throttle' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..402653184",
+  "cql-stress-cassandra-stress write cl=QUORUM duration=$duration -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerShard=250 cql3 native -rate 'threads=$threads $throttle' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=402653185..805306368",
+  "cql-stress-cassandra-stress write cl=QUORUM duration=$duration -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerShard=250 cql3 native -rate 'threads=$threads $throttle' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=805306369..1207959552",
+  "cql-stress-cassandra-stress write cl=QUORUM duration=$duration -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerShard=250 cql3 native -rate 'threads=$threads $throttle' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1207959553..1610612736"
+]

--- a/configurations/strong_consistency/prepare_cql_stress_ks_with_sc.yaml
+++ b/configurations/strong_consistency/prepare_cql_stress_ks_with_sc.yaml
@@ -1,0 +1,10 @@
+prepare_stress_cmd: []
+prepare_write_cmd: []
+pre_create_keyspace: ["CREATE KEYSPACE keyspace1 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3} and consistency = 'global' and tablets = {'enabled': true};"]
+
+stress_cmd_w:  [
+  "cql-stress-cassandra-stress write cl=QUORUM duration=$duration -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerShard=28 cql3 native -rate 'threads=$threads $throttle' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..402653184",
+  "cql-stress-cassandra-stress write cl=QUORUM duration=$duration -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerShard=28 cql3 native -rate 'threads=$threads $throttle' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=402653185..805306368",
+  "cql-stress-cassandra-stress write cl=QUORUM duration=$duration -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerShard=28 cql3 native -rate 'threads=$threads $throttle' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=805306369..1207959552",
+  "cql-stress-cassandra-stress write cl=QUORUM duration=$duration -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerShard=28 cql3 native -rate 'threads=$threads $throttle' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1207959553..1610612736"
+]

--- a/configurations/strong_consistency/prepare_cql_stress_ks_with_sc_1kpershard.yaml
+++ b/configurations/strong_consistency/prepare_cql_stress_ks_with_sc_1kpershard.yaml
@@ -1,0 +1,10 @@
+prepare_stress_cmd: []
+prepare_write_cmd: []
+pre_create_keyspace: ["CREATE KEYSPACE keyspace1 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3} and consistency = 'global' and tablets = {'enabled': true};"]
+
+stress_cmd_w:  [
+  "cql-stress-cassandra-stress write cl=QUORUM duration=$duration -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerShard=250 cql3 native -rate 'threads=$threads $throttle' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..402653184",
+  "cql-stress-cassandra-stress write cl=QUORUM duration=$duration -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerShard=250 cql3 native -rate 'threads=$threads $throttle' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=402653185..805306368",
+  "cql-stress-cassandra-stress write cl=QUORUM duration=$duration -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerShard=250 cql3 native -rate 'threads=$threads $throttle' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=805306369..1207959552",
+  "cql-stress-cassandra-stress write cl=QUORUM duration=$duration -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerShard=250 cql3 native -rate 'threads=$threads $throttle' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1207959553..1610612736"
+]

--- a/configurations/strong_consistency/prepare_cql_stress_nemesis_ks_with_ec_1kpershard.yaml
+++ b/configurations/strong_consistency/prepare_cql_stress_nemesis_ks_with_ec_1kpershard.yaml
@@ -1,0 +1,44 @@
+# Eventual Consistency baseline workload for the "latency during topology operations" jobs.
+#
+# Byte-identical to prepare_cql_stress_nemesis_ks_with_sc_1kpershard.yaml except that the keyspace is
+# created without the "consistency = 'global'" clause: same tool, same image, same connection count,
+# same rates, so the SC-vs-EC delta per disruption is attributable to consistency alone. The EC chain
+# pairs this with ec_baseline_align_with_sc.yaml, which restores the scylla args and api_address that
+# enable_experimental_sc.yaml would otherwise have set.
+#
+# Original header of the SC fragment follows.
+#
+# Strong Consistency workload for the "latency during topology operations" jobs
+# (performance_regression_test.PerformanceRegressionTest, test_latency_{write,read,mixed}_with_nemesis).
+#
+# Replaces the cassandra-stress commands of
+# test-cases/performance/perf-regression-latency-650gb-with-nemesis.yaml with
+# cql-stress-cassandra-stress, which is the only stress tool with a Raft-leader-aware load balancing
+# policy - without it every SC write pays an extra hop to the leader and the measurement says more
+# about the driver than about the database.
+#
+# Connections: -mode connectionsPerShard=250 with n_loaders=4 gives 1000 connections per shard in
+# aggregate, the same convention as prepare_cql_stress_ks_with_sc_1kpershard.yaml.
+#
+# cl=QUORUM everywhere, including the population phase: the leader-aware driver requires it
+# (cl=ALL does not work with it, see commit 1505752b6).
+#
+# Rates: the stress commands are single strings, so each one runs on *all* loaders and the aggregate
+# rate is 4x the "fixed=" value. Write starts from the 50k ops/s step of the SC gradual job
+# (50000 / 4 = 12500), read and mixed from the rates of the cassandra-stress baseline job.
+# These are starting points, to be calibrated from the first run (SCYLLADB-4417).
+
+prepare_stress_cmd: []
+pre_create_keyspace: ["CREATE KEYSPACE keyspace1 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3} and tablets = {'enabled': true};"]
+
+# 4 x 162500001 rows of ~1KB = ~650GB, one command per loader (round_robin)
+prepare_write_cmd: [
+    "cql-stress-cassandra-stress write cl=QUORUM n=162500001 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerHost=8 cql3 native -rate threads=50 throttle=37500/s -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..162500001",
+    "cql-stress-cassandra-stress write cl=QUORUM n=162500001 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerHost=8 cql3 native -rate threads=50 throttle=37500/s -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=162500002..325000002",
+    "cql-stress-cassandra-stress write cl=QUORUM n=162500001 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerHost=8 cql3 native -rate threads=50 throttle=37500/s -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=325000003..487500003",
+    "cql-stress-cassandra-stress write cl=QUORUM n=162500001 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerHost=8 cql3 native -rate threads=50 throttle=37500/s -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=487500004..650000004"
+]
+
+stress_cmd_w: "cql-stress-cassandra-stress write no-warmup cl=QUORUM duration=2850m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerShard=250 cql3 native -rate 'threads=500 fixed=12500/s' -col 'size=FIXED(1024) n=FIXED(1)' -pop 'dist=gauss(1..650000000,325000000,9750000)' "
+stress_cmd_r: "cql-stress-cassandra-stress read no-warmup cl=QUORUM duration=800m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerShard=250 cql3 native -rate 'threads=620 fixed=10310/s' -col 'size=FIXED(1024) n=FIXED(1)' -pop 'dist=gauss(1..650000000,325000000,9750000)' "
+stress_cmd_m: "cql-stress-cassandra-stress mixed no-warmup cl=QUORUM duration=800m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerShard=250 cql3 native -rate 'threads=620 fixed=8750/s' -col 'size=FIXED(1024) n=FIXED(1)' -pop 'dist=gauss(1..650000000,325000000,6500000)' "

--- a/configurations/strong_consistency/prepare_cql_stress_nemesis_ks_with_sc_1kpershard.yaml
+++ b/configurations/strong_consistency/prepare_cql_stress_nemesis_ks_with_sc_1kpershard.yaml
@@ -1,0 +1,34 @@
+# Strong Consistency workload for the "latency during topology operations" jobs
+# (performance_regression_test.PerformanceRegressionTest, test_latency_{write,read,mixed}_with_nemesis).
+#
+# Replaces the cassandra-stress commands of
+# test-cases/performance/perf-regression-latency-650gb-with-nemesis.yaml with
+# cql-stress-cassandra-stress, which is the only stress tool with a Raft-leader-aware load balancing
+# policy - without it every SC write pays an extra hop to the leader and the measurement says more
+# about the driver than about the database.
+#
+# Connections: -mode connectionsPerShard=250 with n_loaders=4 gives 1000 connections per shard in
+# aggregate, the same convention as prepare_cql_stress_ks_with_sc_1kpershard.yaml.
+#
+# cl=QUORUM everywhere, including the population phase: the leader-aware driver requires it
+# (cl=ALL does not work with it, see commit 1505752b6).
+#
+# Rates: the stress commands are single strings, so each one runs on *all* loaders and the aggregate
+# rate is 4x the "fixed=" value. Write starts from the 50k ops/s step of the SC gradual job
+# (50000 / 4 = 12500), read and mixed from the rates of the cassandra-stress baseline job.
+# These are starting points, to be calibrated from the first run (SCYLLADB-4417).
+
+prepare_stress_cmd: []
+pre_create_keyspace: ["CREATE KEYSPACE keyspace1 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3} and consistency = 'global' and tablets = {'enabled': true};"]
+
+# 4 x 162500001 rows of ~1KB = ~650GB, one command per loader (round_robin)
+prepare_write_cmd: [
+    "cql-stress-cassandra-stress write cl=QUORUM n=162500001 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerHost=8 cql3 native -rate threads=50 throttle=37500/s -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..162500001",
+    "cql-stress-cassandra-stress write cl=QUORUM n=162500001 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerHost=8 cql3 native -rate threads=50 throttle=37500/s -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=162500002..325000002",
+    "cql-stress-cassandra-stress write cl=QUORUM n=162500001 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerHost=8 cql3 native -rate threads=50 throttle=37500/s -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=325000003..487500003",
+    "cql-stress-cassandra-stress write cl=QUORUM n=162500001 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerHost=8 cql3 native -rate threads=50 throttle=37500/s -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=487500004..650000004"
+]
+
+stress_cmd_w: "cql-stress-cassandra-stress write no-warmup cl=QUORUM duration=2850m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerShard=250 cql3 native -rate 'threads=500 fixed=12500/s' -col 'size=FIXED(1024) n=FIXED(1)' -pop 'dist=gauss(1..650000000,325000000,9750000)' "
+stress_cmd_r: "cql-stress-cassandra-stress read no-warmup cl=QUORUM duration=800m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerShard=250 cql3 native -rate 'threads=620 fixed=10310/s' -col 'size=FIXED(1024) n=FIXED(1)' -pop 'dist=gauss(1..650000000,325000000,9750000)' "
+stress_cmd_m: "cql-stress-cassandra-stress mixed no-warmup cl=QUORUM duration=800m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerShard=250 cql3 native -rate 'threads=620 fixed=8750/s' -col 'size=FIXED(1024) n=FIXED(1)' -pop 'dist=gauss(1..650000000,325000000,6500000)' "

--- a/configurations/strong_consistency/prepare_cql_stress_read_disk_ks_with_ec.yaml
+++ b/configurations/strong_consistency/prepare_cql_stress_read_disk_ks_with_ec.yaml
@@ -1,0 +1,16 @@
+prepare_stress_cmd: []
+pre_create_keyspace: ["CREATE KEYSPACE keyspace1 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3} and tablets = {'enabled': true};"]
+
+prepare_write_cmd: [
+    "cql-stress-cassandra-stress write  cl=ALL n=162500001 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerHost=8 cql3 native -rate threads=50 throttle=37500/s -col 'size=FIXED(1024) n=FIXED(1)'  -pop seq=1..162500001",
+    "cql-stress-cassandra-stress write  cl=ALL n=162500001 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerHost=8 cql3 native -rate threads=50 throttle=37500/s -col 'size=FIXED(1024) n=FIXED(1)'  -pop seq=162500002..325000002",
+    "cql-stress-cassandra-stress write  cl=ALL n=162500001 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerHost=8 cql3 native -rate threads=50 throttle=37500/s -col 'size=FIXED(1024) n=FIXED(1)'  -pop seq=325000003..487500003",
+    "cql-stress-cassandra-stress write  cl=ALL n=162500001 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerHost=8 cql3 native -rate threads=50 throttle=37500/s -col 'size=FIXED(1024) n=FIXED(1)'  -pop seq=487500004..650000004"
+]
+
+stress_cmd_read_disk: [
+  "cql-stress-cassandra-stress read  cl=QUORUM duration=$duration -mode connectionsPerHost=8 cql3 native -rate 'threads=$threads $throttle' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..162500001",
+  "cql-stress-cassandra-stress read  cl=QUORUM duration=$duration -mode connectionsPerHost=8 cql3 native -rate 'threads=$threads $throttle' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=162500002..325000002",
+  "cql-stress-cassandra-stress read  cl=QUORUM duration=$duration -mode connectionsPerHost=8 cql3 native -rate 'threads=$threads $throttle' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=325000003..487500003",
+  "cql-stress-cassandra-stress read  cl=QUORUM duration=$duration -mode connectionsPerHost=8 cql3 native -rate 'threads=$threads $throttle' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=487500004..650000004"
+]

--- a/configurations/strong_consistency/prepare_cql_stress_read_disk_ks_with_sc.yaml
+++ b/configurations/strong_consistency/prepare_cql_stress_read_disk_ks_with_sc.yaml
@@ -1,0 +1,16 @@
+prepare_stress_cmd: []
+pre_create_keyspace: ["CREATE KEYSPACE keyspace1 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3} and consistency = 'global' and tablets = {'enabled': true};"]
+
+prepare_write_cmd: [
+    "cql-stress-cassandra-stress write  cl=ALL n=162500001 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerHost=8 cql3 native -rate threads=50 throttle=37500/s -col 'size=FIXED(1024) n=FIXED(1)'  -pop seq=1..162500001",
+    "cql-stress-cassandra-stress write  cl=ALL n=162500001 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerHost=8 cql3 native -rate threads=50 throttle=37500/s -col 'size=FIXED(1024) n=FIXED(1)'  -pop seq=162500002..325000002",
+    "cql-stress-cassandra-stress write  cl=ALL n=162500001 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerHost=8 cql3 native -rate threads=50 throttle=37500/s -col 'size=FIXED(1024) n=FIXED(1)'  -pop seq=325000003..487500003",
+    "cql-stress-cassandra-stress write  cl=ALL n=162500001 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerHost=8 cql3 native -rate threads=50 throttle=37500/s -col 'size=FIXED(1024) n=FIXED(1)'  -pop seq=487500004..650000004"
+]
+
+stress_cmd_read_disk: [
+  "cql-stress-cassandra-stress read  cl=QUORUM duration=$duration -mode connectionsPerHost=8 cql3 native -rate 'threads=$threads $throttle' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..162500001",
+  "cql-stress-cassandra-stress read  cl=QUORUM duration=$duration -mode connectionsPerHost=8 cql3 native -rate 'threads=$threads $throttle' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=162500002..325000002",
+  "cql-stress-cassandra-stress read  cl=QUORUM duration=$duration -mode connectionsPerHost=8 cql3 native -rate 'threads=$threads $throttle' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=325000003..487500003",
+  "cql-stress-cassandra-stress read  cl=QUORUM duration=$duration -mode connectionsPerHost=8 cql3 native -rate 'threads=$threads $throttle' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=487500004..650000004"
+]

--- a/configurations/strong_consistency/prepare_cql_stress_read_disk_ks_with_sc.yaml
+++ b/configurations/strong_consistency/prepare_cql_stress_read_disk_ks_with_sc.yaml
@@ -2,10 +2,10 @@ prepare_stress_cmd: []
 pre_create_keyspace: ["CREATE KEYSPACE keyspace1 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3} and consistency = 'global' and tablets = {'enabled': true};"]
 
 prepare_write_cmd: [
-    "cql-stress-cassandra-stress write  cl=ALL n=162500001 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerHost=8 cql3 native -rate threads=50 throttle=37500/s -col 'size=FIXED(1024) n=FIXED(1)'  -pop seq=1..162500001",
-    "cql-stress-cassandra-stress write  cl=ALL n=162500001 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerHost=8 cql3 native -rate threads=50 throttle=37500/s -col 'size=FIXED(1024) n=FIXED(1)'  -pop seq=162500002..325000002",
-    "cql-stress-cassandra-stress write  cl=ALL n=162500001 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerHost=8 cql3 native -rate threads=50 throttle=37500/s -col 'size=FIXED(1024) n=FIXED(1)'  -pop seq=325000003..487500003",
-    "cql-stress-cassandra-stress write  cl=ALL n=162500001 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerHost=8 cql3 native -rate threads=50 throttle=37500/s -col 'size=FIXED(1024) n=FIXED(1)'  -pop seq=487500004..650000004"
+    "cql-stress-cassandra-stress write  cl=QUORUM n=162500001 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerHost=8 cql3 native -rate threads=50 throttle=37500/s -col 'size=FIXED(1024) n=FIXED(1)'  -pop seq=1..162500001",
+    "cql-stress-cassandra-stress write  cl=QUORUM n=162500001 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerHost=8 cql3 native -rate threads=50 throttle=37500/s -col 'size=FIXED(1024) n=FIXED(1)'  -pop seq=162500002..325000002",
+    "cql-stress-cassandra-stress write  cl=QUORUM n=162500001 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerHost=8 cql3 native -rate threads=50 throttle=37500/s -col 'size=FIXED(1024) n=FIXED(1)'  -pop seq=325000003..487500003",
+    "cql-stress-cassandra-stress write  cl=QUORUM n=162500001 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerHost=8 cql3 native -rate threads=50 throttle=37500/s -col 'size=FIXED(1024) n=FIXED(1)'  -pop seq=487500004..650000004"
 ]
 
 stress_cmd_read_disk: [

--- a/configurations/strong_consistency/prepare_cql_stress_read_ks_with_ec.yaml
+++ b/configurations/strong_consistency/prepare_cql_stress_read_ks_with_ec.yaml
@@ -1,0 +1,23 @@
+prepare_stress_cmd: []
+pre_create_keyspace: ["CREATE KEYSPACE keyspace1 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3} and tablets = {'enabled': true};"]
+
+prepare_write_cmd: [
+    "cql-stress-cassandra-stress write  cl=ALL n=162500001 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerHost=8 cql3 native -rate threads=50 throttle=37500/s -col 'size=FIXED(1024) n=FIXED(1)'  -pop seq=1..162500001",
+    "cql-stress-cassandra-stress write  cl=ALL n=162500001 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerHost=8 cql3 native -rate threads=50 throttle=37500/s -col 'size=FIXED(1024) n=FIXED(1)'  -pop seq=162500002..325000002",
+    "cql-stress-cassandra-stress write  cl=ALL n=162500001 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerHost=8 cql3 native -rate threads=50 throttle=37500/s -col 'size=FIXED(1024) n=FIXED(1)'  -pop seq=325000003..487500003",
+    "cql-stress-cassandra-stress write  cl=ALL n=162500001 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerHost=8 cql3 native -rate threads=50 throttle=37500/s -col 'size=FIXED(1024) n=FIXED(1)'  -pop seq=487500004..650000004"
+]
+
+stress_cmd_r: [
+  "cql-stress-cassandra-stress read  cl=QUORUM duration=$duration -mode connectionsPerHost=8 cql3 native -rate 'threads=$threads $throttle' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..5000000",
+  "cql-stress-cassandra-stress read  cl=QUORUM duration=$duration -mode connectionsPerHost=8 cql3 native -rate 'threads=$threads $throttle' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=5000001..10000000",
+  "cql-stress-cassandra-stress read  cl=QUORUM duration=$duration -mode connectionsPerHost=8 cql3 native -rate 'threads=$threads $throttle' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=10000001..15000000",
+  "cql-stress-cassandra-stress read  cl=QUORUM duration=$duration -mode connectionsPerHost=8 cql3 native -rate 'threads=$threads $throttle' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=15000001..20000000"
+]
+
+stress_cmd_cache_warmup: [
+  "cql-stress-cassandra-stress read  cl=ALL n=5000000 -mode connectionsPerHost=8 cql3 native -rate 'threads=$threads' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..5000000",
+  "cql-stress-cassandra-stress read  cl=ALL n=5000000 -mode connectionsPerHost=8 cql3 native -rate 'threads=$threads' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=5000001..10000000",
+  "cql-stress-cassandra-stress read  cl=ALL n=5000000 -mode connectionsPerHost=8 cql3 native -rate 'threads=$threads' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=10000001..15000000",
+  "cql-stress-cassandra-stress read  cl=ALL n=5000000 -mode connectionsPerHost=8 cql3 native -rate 'threads=$threads' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=15000001..20000000"
+]

--- a/configurations/strong_consistency/prepare_cql_stress_read_ks_with_sc.yaml
+++ b/configurations/strong_consistency/prepare_cql_stress_read_ks_with_sc.yaml
@@ -1,0 +1,23 @@
+prepare_stress_cmd: []
+pre_create_keyspace: ["CREATE KEYSPACE keyspace1 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3} and consistency = 'global' and tablets = {'enabled': true};"]
+
+prepare_write_cmd: [
+    "cql-stress-cassandra-stress write  cl=ALL n=162500001 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerHost=8 cql3 native -rate threads=50 throttle=37500/s -col 'size=FIXED(1024) n=FIXED(1)'  -pop seq=1..162500001",
+    "cql-stress-cassandra-stress write  cl=ALL n=162500001 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerHost=8 cql3 native -rate threads=50 throttle=37500/s -col 'size=FIXED(1024) n=FIXED(1)'  -pop seq=162500002..325000002",
+    "cql-stress-cassandra-stress write  cl=ALL n=162500001 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerHost=8 cql3 native -rate threads=50 throttle=37500/s -col 'size=FIXED(1024) n=FIXED(1)'  -pop seq=325000003..487500003",
+    "cql-stress-cassandra-stress write  cl=ALL n=162500001 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerHost=8 cql3 native -rate threads=50 throttle=37500/s -col 'size=FIXED(1024) n=FIXED(1)'  -pop seq=487500004..650000004"
+]
+
+stress_cmd_r: [
+  "cql-stress-cassandra-stress read  cl=QUORUM duration=$duration -mode connectionsPerHost=8 cql3 native -rate 'threads=$threads $throttle' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..5000000",
+  "cql-stress-cassandra-stress read  cl=QUORUM duration=$duration -mode connectionsPerHost=8 cql3 native -rate 'threads=$threads $throttle' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=5000001..10000000",
+  "cql-stress-cassandra-stress read  cl=QUORUM duration=$duration -mode connectionsPerHost=8 cql3 native -rate 'threads=$threads $throttle' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=10000001..15000000",
+  "cql-stress-cassandra-stress read  cl=QUORUM duration=$duration -mode connectionsPerHost=8 cql3 native -rate 'threads=$threads $throttle' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=15000001..20000000"
+]
+
+stress_cmd_cache_warmup: [
+  "cql-stress-cassandra-stress read  cl=ALL n=5000000 -mode connectionsPerHost=8 cql3 native -rate 'threads=$threads' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..5000000",
+  "cql-stress-cassandra-stress read  cl=ALL n=5000000 -mode connectionsPerHost=8 cql3 native -rate 'threads=$threads' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=5000001..10000000",
+  "cql-stress-cassandra-stress read  cl=ALL n=5000000 -mode connectionsPerHost=8 cql3 native -rate 'threads=$threads' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=10000001..15000000",
+  "cql-stress-cassandra-stress read  cl=ALL n=5000000 -mode connectionsPerHost=8 cql3 native -rate 'threads=$threads' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=15000001..20000000"
+]

--- a/configurations/strong_consistency/prepare_cql_stress_read_ks_with_sc.yaml
+++ b/configurations/strong_consistency/prepare_cql_stress_read_ks_with_sc.yaml
@@ -2,10 +2,10 @@ prepare_stress_cmd: []
 pre_create_keyspace: ["CREATE KEYSPACE keyspace1 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3} and consistency = 'global' and tablets = {'enabled': true};"]
 
 prepare_write_cmd: [
-    "cql-stress-cassandra-stress write  cl=ALL n=162500001 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerHost=8 cql3 native -rate threads=50 throttle=37500/s -col 'size=FIXED(1024) n=FIXED(1)'  -pop seq=1..162500001",
-    "cql-stress-cassandra-stress write  cl=ALL n=162500001 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerHost=8 cql3 native -rate threads=50 throttle=37500/s -col 'size=FIXED(1024) n=FIXED(1)'  -pop seq=162500002..325000002",
-    "cql-stress-cassandra-stress write  cl=ALL n=162500001 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerHost=8 cql3 native -rate threads=50 throttle=37500/s -col 'size=FIXED(1024) n=FIXED(1)'  -pop seq=325000003..487500003",
-    "cql-stress-cassandra-stress write  cl=ALL n=162500001 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerHost=8 cql3 native -rate threads=50 throttle=37500/s -col 'size=FIXED(1024) n=FIXED(1)'  -pop seq=487500004..650000004"
+    "cql-stress-cassandra-stress write  cl=QUORUM n=162500001 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerHost=8 cql3 native -rate threads=50 throttle=37500/s -col 'size=FIXED(1024) n=FIXED(1)'  -pop seq=1..162500001",
+    "cql-stress-cassandra-stress write  cl=QUORUM n=162500001 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerHost=8 cql3 native -rate threads=50 throttle=37500/s -col 'size=FIXED(1024) n=FIXED(1)'  -pop seq=162500002..325000002",
+    "cql-stress-cassandra-stress write  cl=QUORUM n=162500001 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerHost=8 cql3 native -rate threads=50 throttle=37500/s -col 'size=FIXED(1024) n=FIXED(1)'  -pop seq=325000003..487500003",
+    "cql-stress-cassandra-stress write  cl=QUORUM n=162500001 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerHost=8 cql3 native -rate threads=50 throttle=37500/s -col 'size=FIXED(1024) n=FIXED(1)'  -pop seq=487500004..650000004"
 ]
 
 stress_cmd_r: [

--- a/configurations/strong_consistency/prepare_cs_ks_with_ec.yaml
+++ b/configurations/strong_consistency/prepare_cs_ks_with_ec.yaml
@@ -1,0 +1,10 @@
+prepare_stress_cmd: []
+prepare_write_cmd: []
+pre_create_keyspace: ["CREATE KEYSPACE keyspace1 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3} and tablets = {'enabled': true};"]
+
+stress_cmd_w:  [
+  "cassandra-stress write cl=QUORUM duration=$duration -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerHost=8 cql3 native -rate 'threads=$threads $throttle' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..402653184",
+  "cassandra-stress write cl=QUORUM duration=$duration -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerHost=8 cql3 native -rate 'threads=$threads $throttle' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=402653185..805306368",
+  "cassandra-stress write cl=QUORUM duration=$duration -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerHost=8 cql3 native -rate 'threads=$threads $throttle' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=805306369..1207959552",
+  "cassandra-stress write cl=QUORUM duration=$duration -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerHost=8 cql3 native -rate 'threads=$threads $throttle' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1207959553..1610612736"
+]

--- a/configurations/strong_consistency/prepare_cs_ks_with_sc.yaml
+++ b/configurations/strong_consistency/prepare_cs_ks_with_sc.yaml
@@ -1,0 +1,10 @@
+prepare_stress_cmd: []
+prepare_write_cmd: []
+pre_create_keyspace: ["CREATE KEYSPACE keyspace1 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3} and consistency = 'global' and tablets = {'enabled': true};"]
+
+stress_cmd_w:  [
+  "cassandra-stress write cl=QUORUM duration=$duration -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerHost=8 cql3 native -rate 'threads=$threads $throttle' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..402653184",
+  "cassandra-stress write cl=QUORUM duration=$duration -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerHost=8 cql3 native -rate 'threads=$threads $throttle' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=402653185..805306368",
+  "cassandra-stress write cl=QUORUM duration=$duration -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerHost=8 cql3 native -rate 'threads=$threads $throttle' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=805306369..1207959552",
+  "cassandra-stress write cl=QUORUM duration=$duration -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerHost=8 cql3 native -rate 'threads=$threads $throttle' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1207959553..1610612736"
+]

--- a/configurations/strong_consistency/prepare_cs_read_disk_ks_with_ec.yaml
+++ b/configurations/strong_consistency/prepare_cs_read_disk_ks_with_ec.yaml
@@ -1,0 +1,2 @@
+prepare_stress_cmd: []
+pre_create_keyspace: ["CREATE KEYSPACE keyspace1 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3} and tablets = {'enabled': true};"]

--- a/configurations/strong_consistency/prepare_cs_read_disk_ks_with_sc.yaml
+++ b/configurations/strong_consistency/prepare_cs_read_disk_ks_with_sc.yaml
@@ -1,0 +1,2 @@
+prepare_stress_cmd: []
+pre_create_keyspace: ["CREATE KEYSPACE keyspace1 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3} and consistency = 'global' and tablets = {'enabled': true};"]

--- a/configurations/strong_consistency/prepare_cs_read_ks_with_ec.yaml
+++ b/configurations/strong_consistency/prepare_cs_read_ks_with_ec.yaml
@@ -1,0 +1,2 @@
+prepare_stress_cmd: []
+pre_create_keyspace: ["CREATE KEYSPACE keyspace1 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3} and tablets = {'enabled': true};"]

--- a/configurations/strong_consistency/prepare_cs_read_ks_with_sc.yaml
+++ b/configurations/strong_consistency/prepare_cs_read_ks_with_sc.yaml
@@ -1,0 +1,2 @@
+prepare_stress_cmd: []
+pre_create_keyspace: ["CREATE KEYSPACE keyspace1 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3} and consistency = 'global' and tablets = {'enabled': true};"]

--- a/docs/building-custom-cql-stress-image.md
+++ b/docs/building-custom-cql-stress-image.md
@@ -1,0 +1,204 @@
+# Building a Custom cql-stress Docker Image
+
+This document describes how to build a custom Docker image for
+[cql-stress](https://github.com/scylladb/cql-stress) from a feature branch or
+pull request, push it to Docker Hub, and configure SCT to use it.
+
+## Background
+
+SCT uses the `cql-stress` Docker image to run `cql-stress-cassandra-stress` and
+`cql-stress-scylla-bench` stress tools on loader nodes. The default image is
+defined in `defaults/docker_images/cql-stress-cassandra-stress/values_cql-stress-cassandra-stress.yaml`.
+
+When testing experimental features that require cql-stress changes not yet
+released, you need to build a custom image from source.
+
+### Reference: Strong Consistency Build (2026-03-31)
+
+This guide was created while building a custom image from
+[PR #181](https://github.com/scylladb/cql-stress/pull/181) — a Raft-leader-aware
+load balancing policy for strong consistency performance testing. The resulting
+image is published at `<repo>/cql-stress:strong-consistency` on docker hub.
+
+## Prerequisites
+
+- Docker installed and running
+- Docker Hub account with a Personal Access Token (PAT) for pushing
+- Git
+
+## Step-by-Step Instructions
+
+### Step 1: Clone the cql-stress repository
+
+```bash
+git clone https://github.com/scylladb/cql-stress.git
+cd cql-stress
+```
+
+### Step 2: Checkout the target branch or PR
+
+If the code is in an unmerged PR from a fork, add the fork as a remote:
+
+```bash
+# Replace <fork-user> and <branch-name> with actual values
+git remote add <fork-user> https://github.com/<fork-user>/cql-stress.git
+git fetch <fork-user> <branch-name>
+git checkout <fork-user>/<branch-name>
+```
+
+**Example** (PR #181 — strong consistency):
+
+```bash
+git remote add jadw1 https://github.com/Jadw1/cql-stress.git
+git fetch jadw1 strong_consistent_load_balancing_policy
+git checkout jadw1/strong_consistent_load_balancing_policy
+```
+
+If the code is on a branch in the main repo, simply:
+
+```bash
+git checkout <branch-name>
+```
+
+### Step 3: (Optional) Speed up the build
+
+The default Dockerfile uses `cargo build --profile dist` which enables LTO
+(Link Time Optimization) and takes 20+ minutes. For development/testing builds,
+edit the Dockerfile to use `--release` instead (~5 minutes):
+
+```bash
+sed -i 's/--profile dist/--release/' Dockerfile
+sed -i 's|target/dist/|target/release/|g' Dockerfile
+```
+
+Or apply the changes manually:
+
+```diff
+# In the builder stage RUN command:
+-    && cargo build --profile dist --all
++    && cargo build --release --all
+
+# In the production stage COPY commands:
+-COPY --from=builder /app/target/dist/cql-stress-cassandra-stress /usr/local/bin/cql-stress-cassandra-stress
+-COPY --from=builder /app/target/dist/cql-stress-scylla-bench /usr/local/bin/cql-stress-scylla-bench
++COPY --from=builder /app/target/release/cql-stress-cassandra-stress /usr/local/bin/cql-stress-cassandra-stress
++COPY --from=builder /app/target/release/cql-stress-scylla-bench /usr/local/bin/cql-stress-scylla-bench
+```
+
+Use `--profile dist` only when building a production-quality image for official
+benchmarks.
+
+### Step 4: Build the Docker image
+
+```bash
+docker build -t <your-dockerhub-user>/cql-stress:<tag> .
+```
+
+**Example:**
+
+```bash
+docker build -t aleksbykov/cql-stress:strong-consistency .
+```
+
+### Step 5: Verify the image
+
+```bash
+# Check the binary runs and prints version info
+docker run --rm <your-dockerhub-user>/cql-stress:<tag> -c "cql-stress-cassandra-stress version"
+```
+
+Expected output includes the git SHA matching the branch head commit:
+
+```
+cql-stress:
+- Version: 0.2.4
+- Build Date: 2026-03-30T09:13:14Z
+- Git SHA: f0222094ec3f58b66d20cc74e55725bd31c561a9
+scylla-driver:
+- Version: 1.5.0
+```
+
+> **Note:** The version subcommand is `version` (not `--version`).
+
+### Step 6: Push the image to Docker Hub
+
+```bash
+# Log in (use a PAT, not your password)
+docker login -u <your-dockerhub-user>
+
+# Push
+docker push <your-dockerhub-user>/cql-stress:<tag>
+```
+
+**Example:**
+
+```bash
+docker login -u aleksbykov
+docker push aleksbykov/cql-stress:strong-consistency
+```
+
+## Configure SCT to Use the Custom Image
+
+### Option A: Config fragment file (recommended)
+
+Create a YAML file in `configurations/stress_images/`:
+
+```yaml
+# configurations/stress_images/cql-stress-<feature-name>.yaml
+stress_image:
+  cql-stress-cassandra-stress: '<your-dockerhub-user>/cql-stress:<tag>'
+```
+
+Include it in any test's config chain:
+
+```bash
+uv run sct.py run-test longevity_test.LongevityTest.test_custom_time \
+  --backend aws \
+  --config test-cases/my-test.yaml,configurations/stress_images/cql-stress-<feature-name>.yaml
+```
+
+SCT uses deep dict merging — only the `cql-stress-cassandra-stress` key is
+overridden; all other stress tool images are preserved.
+
+### Option B: Environment variable
+
+```bash
+export SCT_STRESS_IMAGE='{"cql-stress-cassandra-stress": "<your-dockerhub-user>/cql-stress:<tag>"}'
+```
+
+### Option C: Inline in test-case YAML
+
+Add directly to any test-case YAML file:
+
+```yaml
+stress_image:
+  cql-stress-cassandra-stress: '<your-dockerhub-user>/cql-stress:<tag>'
+```
+
+## How SCT Loads Stress Images
+
+1. `sct_config.py` → `load_docker_images_defaults()` scans all YAML files under
+   `defaults/docker_images/` and populates the `stress_image` dict
+2. User config files are merged on top (deep merge — partial overrides work)
+3. Environment variables override last
+4. `CqlStressCassandraStressThread` reads the image from
+   `stress_image.cql-stress-cassandra-stress` and pulls it on loader nodes
+   before running
+
+## Files Reference
+
+| File | Purpose |
+|------|---------|
+| `defaults/docker_images/cql-stress-cassandra-stress/values_cql-stress-cassandra-stress.yaml` | Default cql-stress image (upstream release) |
+| `configurations/stress_images/cql-stress-strong-consistency.yaml` | Override for strong-consistency custom build |
+| `configurations/stress_images/cs-java8.yaml` | Existing example of stress image override |
+| `sdcm/cql_stress_cassandra_stress_thread.py` | Thread class that runs cql-stress via Docker |
+| `sdcm/sct_config.py` (`load_docker_images_defaults`) | Config loading logic for stress images |
+
+## Cleanup
+
+After testing is complete:
+
+1. Remove the config fragment if no longer needed
+2. Optionally delete the image from Docker Hub
+3. Remove the local clone: `rm -rf /path/to/cql-stress`

--- a/docs/plans/MASTER.md
+++ b/docs/plans/MASTER.md
@@ -57,7 +57,7 @@ For plan writing guidelines, see [INSTRUCTIONS.md](INSTRUCTIONS.md).
 | Jenkins Uno-Choice Billing Project | `draft` | [jenkins-uno-choice-billing-project.md](jenkins/jenkins-uno-choice-billing-project.md) |
 | Centralized Trigger Matrix | `draft` | [centralized-trigger-matrix.md](jenkins/centralized-trigger-matrix.md) |
 | i8g Performance Jobs Migration | `draft` | [i8g-performance-jobs-migration.md](i8g-performance-jobs-migration.md) |
-| SC Perf Tests with Topology Operations | `draft` | [sc-topology-operations-perf-tests.md](jenkins/sc-topology-operations-perf-tests.md) |
+| SC Perf Tests with Topology Operations | `in_progress` | [sc-topology-operations-perf-tests.md](jenkins/sc-topology-operations-perf-tests.md) |
 | Perf-Simple-Query Offline Installer Trigger | `complete` | [perf-simple-query-offline-installer-trigger.md](jenkins/perf-simple-query-offline-installer-trigger.md), [#14340](https://github.com/scylladb/scylla-cluster-tests/pull/14340) |
 
 ### Config — Configuration system

--- a/docs/plans/MASTER.md
+++ b/docs/plans/MASTER.md
@@ -57,6 +57,7 @@ For plan writing guidelines, see [INSTRUCTIONS.md](INSTRUCTIONS.md).
 | Jenkins Uno-Choice Billing Project | `draft` | [jenkins-uno-choice-billing-project.md](jenkins/jenkins-uno-choice-billing-project.md) |
 | Centralized Trigger Matrix | `draft` | [centralized-trigger-matrix.md](jenkins/centralized-trigger-matrix.md) |
 | i8g Performance Jobs Migration | `draft` | [i8g-performance-jobs-migration.md](i8g-performance-jobs-migration.md) |
+| SC Perf Tests with Topology Operations | `draft` | [sc-topology-operations-perf-tests.md](jenkins/sc-topology-operations-perf-tests.md) |
 | Perf-Simple-Query Offline Installer Trigger | `complete` | [perf-simple-query-offline-installer-trigger.md](jenkins/perf-simple-query-offline-installer-trigger.md), [#14340](https://github.com/scylladb/scylla-cluster-tests/pull/14340) |
 
 ### Config — Configuration system

--- a/docs/plans/assets/progress-roadmap.svg
+++ b/docs/plans/assets/progress-roadmap.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="840" height="988" viewBox="0 0 840 988">
 <rect width="840" height="988" fill="#0D1B2A" rx="8"/>
 <text x="420" y="60" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="22" font-weight="bold" fill="#00BCD4">SCT Implementation Plans</text>
-<text x="420" y="84" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="13" fill="#8899AA">32 plans across 9 domains</text>
+<text x="420" y="84" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="13" fill="#8899AA">33 plans across 9 domains</text>
 <rect x="30" y="120" width="780" height="50" rx="6" fill="#1B2A4A" stroke="#2A3F5F" stroke-width="1"/>
 <circle cx="50" cy="148" r="5" fill="#607D8B"/>
-<text x="60" y="152" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#E0E6ED">Draft: 11</text>
+<text x="60" y="152" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#E0E6ED">Draft: 12</text>
 <circle cx="180" cy="148" r="5" fill="#FFC107"/>
 <text x="190" y="152" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#E0E6ED">In Progress: 3</text>
 <circle cx="310" cy="148" r="5" fill="#2196F3"/>
@@ -16,14 +16,14 @@
 <circle cx="700" cy="148" r="5" fill="#9E9E9E"/>
 <text x="710" y="152" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#E0E6ED">Pending PR: 13</text>
 <rect x="40" y="175" width="760" height="20" rx="10" fill="#1B2A4A" stroke="#2A3F5F" stroke-width="1"/>
-<rect x="40" y="175" width="118.75" height="20" rx="10" fill="#4CAF50"/>
-<text x="99.375" y="189" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="bold" fill="#0D1B2A">5</text>
-<rect x="158.75" y="175" width="71.25" height="20" rx="0" fill="#FFC107"/>
-<text x="194.375" y="189" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="bold" fill="#0D1B2A">3</text>
-<rect x="230.0" y="175" width="261.25" height="20" rx="0" fill="#607D8B"/>
-<text x="360.625" y="189" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="bold" fill="#0D1B2A">11</text>
-<rect x="491.25" y="175" width="308.75" height="20" rx="0" fill="#9E9E9E"/>
-<text x="645.625" y="189" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="bold" fill="#0D1B2A">13</text>
+<rect x="40" y="175" width="115.15151515151516" height="20" rx="10" fill="#4CAF50"/>
+<text x="97.57575757575758" y="189" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="bold" fill="#0D1B2A">5</text>
+<rect x="155.15151515151516" y="175" width="69.0909090909091" height="20" rx="0" fill="#FFC107"/>
+<text x="189.6969696969697" y="189" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="bold" fill="#0D1B2A">3</text>
+<rect x="224.24242424242425" y="175" width="276.3636363636364" height="20" rx="0" fill="#607D8B"/>
+<text x="362.42424242424244" y="189" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="bold" fill="#0D1B2A">12</text>
+<rect x="500.6060606060606" y="175" width="299.3939393939394" height="20" rx="0" fill="#9E9E9E"/>
+<text x="650.3030303030303" y="189" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="bold" fill="#0D1B2A">13</text>
 <rect x="30" y="220" width="380" height="32" rx="4" fill="#1B2A4A" stroke="#00BCD4" stroke-width="1"/>
 <text x="42" y="241" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="bold" fill="#00BCD4">cluster</text>
 <text x="398" y="241" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#8899AA">5 plans</text>
@@ -44,7 +44,7 @@
 <text x="398" y="382" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#607D8B">Draft</text>
 <rect x="30" y="408" width="380" height="32" rx="4" fill="#1B2A4A" stroke="#00BCD4" stroke-width="1"/>
 <text x="42" y="429" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="bold" fill="#00BCD4">ci-cd</text>
-<text x="398" y="429" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#8899AA">8 plans</text>
+<text x="398" y="429" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#8899AA">9 plans</text>
 <circle cx="44" cy="454" r="4" fill="#607D8B"/>
 <text x="56" y="458" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">Jenkins Pipeline Cluster Reuse</text>
 <text x="398" y="458" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#607D8B">Draft</text>
@@ -69,21 +69,24 @@
 <circle cx="44" cy="650" r="4" fill="#9E9E9E"/>
 <text x="56" y="654" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">curl Retry/Timeout Linting</text>
 <text x="398" y="654" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#9E9E9E">Pending PR</text>
-<rect x="30" y="680" width="380" height="32" rx="4" fill="#1B2A4A" stroke="#00BCD4" stroke-width="1"/>
-<text x="42" y="701" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="bold" fill="#00BCD4">framework</text>
-<text x="398" y="701" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#8899AA">4 plans</text>
-<circle cx="44" cy="726" r="4" fill="#607D8B"/>
-<text x="56" y="730" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">Full Version Tag Lookup</text>
-<text x="398" y="730" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#607D8B">Draft</text>
+<circle cx="44" cy="678" r="4" fill="#607D8B"/>
+<text x="56" y="682" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">SC Perf Tests with Topology Operations</text>
+<text x="398" y="682" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#607D8B">Draft</text>
+<rect x="30" y="708" width="380" height="32" rx="4" fill="#1B2A4A" stroke="#00BCD4" stroke-width="1"/>
+<text x="42" y="729" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="bold" fill="#00BCD4">framework</text>
+<text x="398" y="729" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#8899AA">4 plans</text>
 <circle cx="44" cy="754" r="4" fill="#607D8B"/>
-<text x="56" y="758" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">Health Check Optimization</text>
+<text x="56" y="758" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">Full Version Tag Lookup</text>
 <text x="398" y="758" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#607D8B">Draft</text>
 <circle cx="44" cy="782" r="4" fill="#607D8B"/>
-<text x="56" y="786" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">Feature-Aware Adaptive Timeouts for T...</text>
+<text x="56" y="786" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">Health Check Optimization</text>
 <text x="398" y="786" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#607D8B">Draft</text>
-<circle cx="44" cy="810" r="4" fill="#9E9E9E"/>
-<text x="56" y="814" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">Keystore Improvements</text>
-<text x="398" y="814" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#9E9E9E">Pending PR</text>
+<circle cx="44" cy="810" r="4" fill="#607D8B"/>
+<text x="56" y="814" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">Feature-Aware Adaptive Timeouts for T...</text>
+<text x="398" y="814" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#607D8B">Draft</text>
+<circle cx="44" cy="838" r="4" fill="#9E9E9E"/>
+<text x="56" y="842" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">Keystore Improvements</text>
+<text x="398" y="842" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#9E9E9E">Pending PR</text>
 <rect x="430" y="220" width="380" height="32" rx="4" fill="#1B2A4A" stroke="#00BCD4" stroke-width="1"/>
 <text x="442" y="241" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="bold" fill="#00BCD4">nemesis</text>
 <text x="798" y="241" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#8899AA">4 plans</text>

--- a/docs/plans/assets/progress-roadmap.svg
+++ b/docs/plans/assets/progress-roadmap.svg
@@ -4,9 +4,9 @@
 <text x="420" y="84" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="13" fill="#8899AA">33 plans across 9 domains</text>
 <rect x="30" y="120" width="780" height="50" rx="6" fill="#1B2A4A" stroke="#2A3F5F" stroke-width="1"/>
 <circle cx="50" cy="148" r="5" fill="#607D8B"/>
-<text x="60" y="152" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#E0E6ED">Draft: 12</text>
+<text x="60" y="152" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#E0E6ED">Draft: 11</text>
 <circle cx="180" cy="148" r="5" fill="#FFC107"/>
-<text x="190" y="152" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#E0E6ED">In Progress: 3</text>
+<text x="190" y="152" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#E0E6ED">In Progress: 4</text>
 <circle cx="310" cy="148" r="5" fill="#2196F3"/>
 <text x="320" y="152" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#E0E6ED">Approved: 0</text>
 <circle cx="440" cy="148" r="5" fill="#F44336"/>
@@ -18,10 +18,10 @@
 <rect x="40" y="175" width="760" height="20" rx="10" fill="#1B2A4A" stroke="#2A3F5F" stroke-width="1"/>
 <rect x="40" y="175" width="115.15151515151516" height="20" rx="10" fill="#4CAF50"/>
 <text x="97.57575757575758" y="189" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="bold" fill="#0D1B2A">5</text>
-<rect x="155.15151515151516" y="175" width="69.0909090909091" height="20" rx="0" fill="#FFC107"/>
-<text x="189.6969696969697" y="189" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="bold" fill="#0D1B2A">3</text>
-<rect x="224.24242424242425" y="175" width="276.3636363636364" height="20" rx="0" fill="#607D8B"/>
-<text x="362.42424242424244" y="189" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="bold" fill="#0D1B2A">12</text>
+<rect x="155.15151515151516" y="175" width="92.12121212121212" height="20" rx="0" fill="#FFC107"/>
+<text x="201.21212121212122" y="189" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="bold" fill="#0D1B2A">4</text>
+<rect x="247.27272727272728" y="175" width="253.33333333333331" height="20" rx="0" fill="#607D8B"/>
+<text x="373.93939393939394" y="189" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="bold" fill="#0D1B2A">11</text>
 <rect x="500.6060606060606" y="175" width="299.3939393939394" height="20" rx="0" fill="#9E9E9E"/>
 <text x="650.3030303030303" y="189" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="bold" fill="#0D1B2A">13</text>
 <rect x="30" y="220" width="380" height="32" rx="4" fill="#1B2A4A" stroke="#00BCD4" stroke-width="1"/>
@@ -69,9 +69,9 @@
 <circle cx="44" cy="650" r="4" fill="#9E9E9E"/>
 <text x="56" y="654" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">curl Retry/Timeout Linting</text>
 <text x="398" y="654" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#9E9E9E">Pending PR</text>
-<circle cx="44" cy="678" r="4" fill="#607D8B"/>
+<circle cx="44" cy="678" r="4" fill="#FFC107"/>
 <text x="56" y="682" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">SC Perf Tests with Topology Operations</text>
-<text x="398" y="682" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#607D8B">Draft</text>
+<text x="398" y="682" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#FFC107">In Progress</text>
 <rect x="30" y="708" width="380" height="32" rx="4" fill="#1B2A4A" stroke="#00BCD4" stroke-width="1"/>
 <text x="42" y="729" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="bold" fill="#00BCD4">framework</text>
 <text x="398" y="729" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#8899AA">4 plans</text>

--- a/docs/plans/jenkins/sc-topology-operations-perf-tests.md
+++ b/docs/plans/jenkins/sc-topology-operations-perf-tests.md
@@ -175,10 +175,14 @@ SC keyspace pre-creation plus `prepare_write_cmd` and the three steady-state wor
   `perf-regression-latency-650gb-with-nemesis.yaml` (41 240/s and 35 000/s aggregate →
   `fixed=10310/s` / `fixed=8750/s`) — see Phase 14 for calibration.
 
+**Verified against upstream cql-stress** (scylladb/cql-stress, master):
+- `-pop 'dist=...'` is supported (`settings/option/population.rs`), and `GAUSSIAN(min..max,mean,stdev)` accepts
+  the aliases `GAUSS` / `NORMAL` / `NORM` (`java_generate/distribution/normal.rs`), so
+  `dist=gauss(1..650000000,325000000,9750000)` is valid.
+- `-mode connectionsPerShard=` exists and takes precedence over `connectionsPerHost=` (`settings/option/mode.rs`).
+- `-rate ... fixed=` is supported (`settings/option/rate.rs`), so coordinated-omission-corrected latency works.
+
 **Needs Investigation**:
-- cql-stress support for `-pop 'dist=gauss(...)'`. It is used by
-  `configurations/performance/cql-stress-650gb-8-col-i4i-80-percent-throughput-oss.yaml` (elasticity pipeline)
-  but not by any SC job. Fallback if unsupported: `dist=UNIFORM(1..650000000)`.
 - Thread counts per workload for cql-stress at 250 conns/shard (the gradual SC job uses 500 write / 620 read
   threads per loader as a starting point).
 

--- a/docs/plans/jenkins/sc-topology-operations-perf-tests.md
+++ b/docs/plans/jenkins/sc-topology-operations-perf-tests.md
@@ -1,5 +1,5 @@
 ---
-status: draft
+status: in_progress
 domain: ci-cd
 created: 2026-09-11
 last_updated: 2026-09-11
@@ -453,17 +453,40 @@ One row per phase = one SCYLLADB-4346 sub-task = at least one commit. Updated as
 
 | # | Phase | Sub-task | Commit(s) | Status |
 |---|-------|----------|-----------|--------|
-| 1 | Stop cql-stress load cleanly when nemesis ends | [SCYLLADB-4404](https://scylladb.atlassian.net/browse/SCYLLADB-4404) | — | not started |
-| 2 | Shared base fragment for 650 GB cql-stress nemesis runs | [SCYLLADB-4405](https://scylladb.atlassian.net/browse/SCYLLADB-4405) | — | not started |
-| 3 | SC keyspace + cql-stress workload fragment | [SCYLLADB-4406](https://scylladb.atlassian.net/browse/SCYLLADB-4406) | — | not started |
-| 4 | EC baseline workload fragment | [SCYLLADB-4407](https://scylladb.atlassian.net/browse/SCYLLADB-4407) | — | not started |
-| 5 | SC latency-thresholds fragment | [SCYLLADB-4408](https://scylladb.atlassian.net/browse/SCYLLADB-4408) | — | not started |
-| 6 | i4i SC pipeline | [SCYLLADB-4409](https://scylladb.atlassian.net/browse/SCYLLADB-4409) | — | not started |
-| 7 | i8g SC pipeline | [SCYLLADB-4410](https://scylladb.atlassian.net/browse/SCYLLADB-4410) | — | not started |
-| 8 | i4i EC baseline pipeline | [SCYLLADB-4411](https://scylladb.atlassian.net/browse/SCYLLADB-4411) | — | not started |
-| 9 | i8g EC baseline pipeline | [SCYLLADB-4412](https://scylladb.atlassian.net/browse/SCYLLADB-4412) | — | not started |
-| 10 | `test_metadata` for the new pipelines | [SCYLLADB-4413](https://scylladb.atlassian.net/browse/SCYLLADB-4413) | — | not started |
-| 11 | Config-chain regression test | [SCYLLADB-4414](https://scylladb.atlassian.net/browse/SCYLLADB-4414) | — | not started |
-| 12 | Documentation | [SCYLLADB-4415](https://scylladb.atlassian.net/browse/SCYLLADB-4415) | — | not started |
-| 13 | Dry-run validation of the four chains | [SCYLLADB-4416](https://scylladb.atlassian.net/browse/SCYLLADB-4416) | — | not started |
-| 14 | Rate and threshold calibration after first run | [SCYLLADB-4417](https://scylladb.atlassian.net/browse/SCYLLADB-4417) | — | not started |
+| 1 | Stop cql-stress load cleanly when nemesis ends | [SCYLLADB-4404](https://scylladb.atlassian.net/browse/SCYLLADB-4404) | `8efd6ab2f` | done |
+| 2 | Shared base fragment for 650 GB cql-stress nemesis runs | [SCYLLADB-4405](https://scylladb.atlassian.net/browse/SCYLLADB-4405) | `4aa785562` | done |
+| 3 | SC keyspace + cql-stress workload fragment | [SCYLLADB-4406](https://scylladb.atlassian.net/browse/SCYLLADB-4406) | `6fb78b2a1` | done |
+| 4 | EC baseline workload fragment | [SCYLLADB-4407](https://scylladb.atlassian.net/browse/SCYLLADB-4407) | `1c12c1558` | done |
+| 5 | SC latency-thresholds fragment | [SCYLLADB-4408](https://scylladb.atlassian.net/browse/SCYLLADB-4408) | `486797d3f` | done |
+| 6 | i4i SC pipeline | [SCYLLADB-4409](https://scylladb.atlassian.net/browse/SCYLLADB-4409) | `cd45ec3d1` | done |
+| 7 | i8g SC pipeline | [SCYLLADB-4410](https://scylladb.atlassian.net/browse/SCYLLADB-4410) | `6578dcaed` | done |
+| 8 | i4i EC baseline pipeline | [SCYLLADB-4411](https://scylladb.atlassian.net/browse/SCYLLADB-4411) | `1c5f55a4b` | done |
+| 9 | i8g EC baseline pipeline | [SCYLLADB-4412](https://scylladb.atlassian.net/browse/SCYLLADB-4412) | `269193c97` | done |
+| 10 | `test_metadata` for the new pipelines | [SCYLLADB-4413](https://scylladb.atlassian.net/browse/SCYLLADB-4413) | `e09dbba6d` | done |
+| 11 | Config-chain regression test | [SCYLLADB-4414](https://scylladb.atlassian.net/browse/SCYLLADB-4414) | `bf64833ad` | done |
+| 12 | Documentation | [SCYLLADB-4415](https://scylladb.atlassian.net/browse/SCYLLADB-4415) | `7b434362e` | done |
+| 13 | Dry-run validation of the four chains | [SCYLLADB-4416](https://scylladb.atlassian.net/browse/SCYLLADB-4416) | see sub-task | done |
+| 14 | Rate and threshold calibration after first run | [SCYLLADB-4417](https://scylladb.atlassian.net/browse/SCYLLADB-4417) | — | blocked - needs the first run |
+
+### Validation performed for phase 13
+
+All four chains were resolved offline through `SCTConfiguration`, including `verify_configuration()`
+and `check_required_files()`, and every invariant held:
+
+| Check | Result |
+|-------|--------|
+| chains resolve | 4/4, no errors |
+| `experimental_features` | `['strongly-consistent-tables']` on SC, `[]` on EC |
+| `append_scylla_yaml` merge | `api_address: 0.0.0.0` **and** `commitlog_sync: batch` / window 100 present in all four |
+| `append_scylla_args` | identical string in all four (`--blocked-reactor-notify-ms 50 ... --abort-on-internal-error 0`) |
+| `instance_type_db` | `i4i.4xlarge` / `i8g.4xlarge` as intended |
+| `instance_type_loader` | `c7i.8xlarge`, `n_loaders: 4` |
+| stress image | `aleksbykov/cql-stress:leader-aware-strong-consistency` |
+| stress commands | all cql-stress, `cl=QUORUM`, `connectionsPerShard=250`, rates 12500 / 10310 / 8750 per loader |
+| nemesis | `SisyphusMonkey` + `NemesisSequence`, interval 30 min |
+
+`unit_tests/unit/test_sc_topology_operations_pipelines.py` (36 cases) and
+`unit_tests/unit/test_perf_stress_event_classes.py` (10 cases) pass offline, and `ruff check` /
+`ruff format --check` are clean on the changed Python files. `sct.py lint-test-docs` passes on
+`test-cases/performance/perf-regression-latency-650gb-with-nemesis.yaml` (the remaining failures in
+that directory are pre-existing test-cases with no `test_metadata` at all).

--- a/docs/plans/jenkins/sc-topology-operations-perf-tests.md
+++ b/docs/plans/jenkins/sc-topology-operations-perf-tests.md
@@ -449,23 +449,25 @@ All phase DoD items are checked, plus:
 
 ## Tracking
 
-One row per phase = one SCYLLADB-4346 sub-task = at least one commit. Updated as implementation proceeds.
+One row per phase = one SCYLLADB-4346 sub-task = at least one commit. Updated as implementation
+proceeds. Every commit carries its sub-task key in the subject line, so a rebase does not
+invalidate this table: find a phase's commit with `git log --grep=SCYLLADB-44<nn>`.
 
 | # | Phase | Sub-task | Commit(s) | Status |
 |---|-------|----------|-----------|--------|
-| 1 | Stop cql-stress load cleanly when nemesis ends | [SCYLLADB-4404](https://scylladb.atlassian.net/browse/SCYLLADB-4404) | `8efd6ab2f` | done |
-| 2 | Shared base fragment for 650 GB cql-stress nemesis runs | [SCYLLADB-4405](https://scylladb.atlassian.net/browse/SCYLLADB-4405) | `4aa785562` | done |
-| 3 | SC keyspace + cql-stress workload fragment | [SCYLLADB-4406](https://scylladb.atlassian.net/browse/SCYLLADB-4406) | `6fb78b2a1` | done |
-| 4 | EC baseline workload fragment | [SCYLLADB-4407](https://scylladb.atlassian.net/browse/SCYLLADB-4407) | `1c12c1558` | done |
-| 5 | SC latency-thresholds fragment | [SCYLLADB-4408](https://scylladb.atlassian.net/browse/SCYLLADB-4408) | `486797d3f` | done |
-| 6 | i4i SC pipeline | [SCYLLADB-4409](https://scylladb.atlassian.net/browse/SCYLLADB-4409) | `cd45ec3d1` | done |
-| 7 | i8g SC pipeline | [SCYLLADB-4410](https://scylladb.atlassian.net/browse/SCYLLADB-4410) | `6578dcaed` | done |
-| 8 | i4i EC baseline pipeline | [SCYLLADB-4411](https://scylladb.atlassian.net/browse/SCYLLADB-4411) | `1c5f55a4b` | done |
-| 9 | i8g EC baseline pipeline | [SCYLLADB-4412](https://scylladb.atlassian.net/browse/SCYLLADB-4412) | `269193c97` | done |
-| 10 | `test_metadata` for the new pipelines | [SCYLLADB-4413](https://scylladb.atlassian.net/browse/SCYLLADB-4413) | `e09dbba6d` | done |
-| 11 | Config-chain regression test | [SCYLLADB-4414](https://scylladb.atlassian.net/browse/SCYLLADB-4414) | `bf64833ad` | done |
-| 12 | Documentation | [SCYLLADB-4415](https://scylladb.atlassian.net/browse/SCYLLADB-4415) | `7b434362e` | done |
-| 13 | Dry-run validation of the four chains | [SCYLLADB-4416](https://scylladb.atlassian.net/browse/SCYLLADB-4416) | see sub-task | done |
+| 1 | Stop cql-stress load cleanly when nemesis ends | [SCYLLADB-4404](https://scylladb.atlassian.net/browse/SCYLLADB-4404) | 1 commit | done |
+| 2 | Shared base fragment for 650 GB cql-stress nemesis runs | [SCYLLADB-4405](https://scylladb.atlassian.net/browse/SCYLLADB-4405) | 1 commit | done |
+| 3 | SC keyspace + cql-stress workload fragment | [SCYLLADB-4406](https://scylladb.atlassian.net/browse/SCYLLADB-4406) | 1 commit | done |
+| 4 | EC baseline workload fragment | [SCYLLADB-4407](https://scylladb.atlassian.net/browse/SCYLLADB-4407) | 1 commit | done |
+| 5 | SC latency-thresholds fragment | [SCYLLADB-4408](https://scylladb.atlassian.net/browse/SCYLLADB-4408) | 1 commit | done |
+| 6 | i4i SC pipeline | [SCYLLADB-4409](https://scylladb.atlassian.net/browse/SCYLLADB-4409) | 1 commit | done |
+| 7 | i8g SC pipeline | [SCYLLADB-4410](https://scylladb.atlassian.net/browse/SCYLLADB-4410) | 1 commit | done |
+| 8 | i4i EC baseline pipeline | [SCYLLADB-4411](https://scylladb.atlassian.net/browse/SCYLLADB-4411) | 1 commit | done |
+| 9 | i8g EC baseline pipeline | [SCYLLADB-4412](https://scylladb.atlassian.net/browse/SCYLLADB-4412) | 1 commit | done |
+| 10 | `test_metadata` for the new pipelines | [SCYLLADB-4413](https://scylladb.atlassian.net/browse/SCYLLADB-4413) | 1 commit | done |
+| 11 | Config-chain regression test | [SCYLLADB-4414](https://scylladb.atlassian.net/browse/SCYLLADB-4414) | 1 commit | done |
+| 12 | Documentation | [SCYLLADB-4415](https://scylladb.atlassian.net/browse/SCYLLADB-4415) | 1 commit | done |
+| 13 | Dry-run validation of the four chains | [SCYLLADB-4416](https://scylladb.atlassian.net/browse/SCYLLADB-4416) | 1 commit | done |
 | 14 | Rate and threshold calibration after first run | [SCYLLADB-4417](https://scylladb.atlassian.net/browse/SCYLLADB-4417) | — | blocked - needs the first run |
 
 ### Validation performed for phase 13

--- a/docs/plans/jenkins/sc-topology-operations-perf-tests.md
+++ b/docs/plans/jenkins/sc-topology-operations-perf-tests.md
@@ -1,0 +1,465 @@
+---
+status: draft
+domain: ci-cd
+created: 2026-09-11
+last_updated: 2026-09-11
+owner: aleksbykov
+---
+
+# Strong Consistency Performance Tests with Topology Operations
+
+Jira: [SCYLLADB-4346](https://scylladb.atlassian.net/browse/SCYLLADB-4346) — *Performance tests with topology operations*
+
+## Problem Statement
+
+Strong Consistency (SC) performance in SCT is measured today only under a **steady, undisturbed cluster**: the
+`PerformanceRegressionPredefinedStepsTest` gradual-throughput jobs grow the load in throttle steps against a
+3-node cluster that never changes shape. The parent Jira asks for the missing half of the picture — SC latency
+**while topology changes** (grow / terminate+replace / shrink) are in flight, using the Rust driver's
+leader-aware tablet routing.
+
+Concrete gaps today:
+
+1. **No SC job exercises topology operations.** All 8 SC/EC pipelines under
+   `jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/` use
+   `performance_regression_gradual_grow_throughput.PerformanceRegressionPredefinedStepsTest`, which never starts
+   a nemesis (`nemesis_add_node_cnt: 0` in the base test-case).
+2. **The existing latency-during-operations job cannot run cql-stress.** `perf-regression-latency-650gb-with-nemesis.yaml`
+   is hard-wired to `cassandra-stress`, which has no leader-aware load balancing policy, so SC writes are routed
+   to a non-leader replica and the measurement is dominated by the extra hop.
+3. **The framework kills cql-stress load as a test failure.** `PerformanceRegressionTest._stop_load_when_nemesis_threads_end()`
+   (`performance_regression_test.py:203`) downgrades only `CassandraStressEvent` before calling
+   `self.loaders.kill_stress_thread()`. A cql-stress run killed the same way raises a **CRITICAL**
+   `CqlStressCassandraStressEvent.failure` and fails the job at the very end of an ~14 h run.
+4. **No arm64 (i8g) coverage for SC at all.** SC jobs exist only for the x86 `i4i.4xlarge` shape.
+
+Measurable pain: an SC latency-during-topology-operations number does not exist for either i4i or i8g, and the
+first attempt to produce one with cql-stress would fail in step 3 after burning a full test run.
+
+## Current State
+
+### Test classes
+
+| File | Class / method | Role |
+|------|----------------|------|
+| `performance_regression_test.py:674-693` | `test_latency_read_with_nemesis`, `test_latency_write_with_nemesis`, `test_latency_mixed_with_nemesis` | Sub-tests used by the `-with-nemesis` pipelines |
+| `performance_regression_test.py:285-303` | `PerformanceRegressionTest.run_workload()` | Starts load on **all** loaders, sleeps `nemesis_interval`, then runs the nemesis for exactly 1 cycle |
+| `performance_regression_test.py:203-212` | `_stop_load_when_nemesis_threads_end()` | Joins nemesis threads, filters `CassandraStressEvent` to NORMAL, kills stress |
+| `performance_regression_test.py:214-263` | `preload_data()` | Calls `_pre_create_keyspace()` when `pre_create_keyspace` is set, then runs `prepare_write_cmd` round-robin |
+| `sdcm/nemesis/__init__.py:4144-4168` | `disrupt_run_unique_sequence()` | The `NemesisSequence` body: manager repair → `_grow_cluster` → `_terminate_and_replace_node` → `_shrink_cluster` |
+
+### Stress-tool plumbing
+
+| File | Fact |
+|------|------|
+| `sdcm/tester.py:3001` | `run_stress_thread()` dispatches on the literal `cql-stress-cassandra-stress` **before** the `cassandra-stress` branch, so a cql-stress command in `stress_cmd_w/r/m` is routed correctly with no code change |
+| `sdcm/cql_stress_cassandra_stress_thread.py:62` | Image comes from `stress_image.cql-stress-cassandra-stress` |
+| `sdcm/cql_stress_cassandra_stress_thread.py:111-117` | `-pop seq=x..y` is rewritten to `dist=SEQ(x..y)`; `n=FIXED(k)` is rewritten to `n=k` |
+| `sdcm/cql_stress_cassandra_stress_thread.py:148` | HDR file is `hdrh-cscs-*.hdr`; the collector pattern in `sdcm/utils/hdrhistogram.py:141` is `*/hdrh-*.hdr`, so HDR latency collection already works |
+| `sdcm/stress_thread.py:135-150` | `set_hdr_tags()` is inherited by `CqlStressCassandraStressThread`; `fixed=` rate produces the `-rt` tags the nemesis latency decorator expects |
+| `sdcm/sct_events/loaders.py:78,87` | `CassandraStressEvent` and `CqlStressCassandraStressEvent` are **siblings**, both derived from `StressEvent` — this is why gap 3 above exists |
+| `sdcm/utils/loader_utils.py:203-241` | `_run_all_stress_cmds()` runs each command without `round_robin`, i.e. **each command runs on every loader** |
+| `performance_regression_gradual_grow_throughput.py:555` | Confirms the project convention: a throttle step is an **aggregate** rate, divided by `num_loaders` before it reaches the command |
+
+### Existing configuration building blocks (all verified to exist)
+
+| File | Content |
+|------|---------|
+| `test-cases/performance/perf-regression-latency-650gb-with-nemesis.yaml` | Base: 650 M rows, `SisyphusMonkey` + `nemesis_selector: 'NemesisSequence'`, `nemesis_interval: 30`, 3 db nodes / 4 loaders, `i3en.2xlarge` db + `c5.2xlarge` loaders, `use_hdrhistogram: true` |
+| `configurations/strong_consistency/enable_experimental_sc.yaml` | `strongly-consistent-tables` feature, `--blocked-reactor-notify-ms 50`, `api_address: "0.0.0.0"` (needed by the leader-aware driver) |
+| `configurations/strong_consistency/enable_commitlog_sync_batch.yaml` | `commitlog_sync: batch`, `commitlog_sync_batch_window_in_ms: 100` |
+| `configurations/stress_images/cql-stress-strong-consistency-leader-awarness.yaml` | `aleksbykov/cql-stress:leader-aware-strong-consistency` |
+| `configurations/strong_consistency/prepare_cql_stress_ks_with_sc_1kpershard.yaml` | SC keyspace (`consistency = 'global'`, tablets) + 4 cql-stress commands with `-mode connectionsPerShard=250` |
+| `configurations/strong_consistency/prepare_cql_stress_ks_with_ec_1kpershard.yaml` | EC twin of the above (no `consistency` clause) |
+| `configurations/aws/i4i_4xlarge.yaml` | `instance_type_db: 'i4i.4xlarge'` |
+| `configurations/arm_instance_types/i8g_4xlarge.yaml` | `instance_type_db: 'i8g.4xlarge'` |
+| `configurations/performance/latency-decorator-error-thresholds-nemesis-ent-tablets.yaml` | Per-disruption duration limits for write/read/mixed |
+| `configurations/disable_kms.yaml`, `configurations/disable_speculative_retry.yaml` | Attached by every SC job |
+
+### Config-merge semantics (verified in `sdcm/sct_config.py:2924-2934` + `:475`)
+
+Config files are merged with `anyconfig.MS_DICTS`, so **dict** options (`append_scylla_yaml`) from several
+fragments are merged key-by-key, while **scalar/string** options (`append_scylla_args`, `instance_type_*`) are
+replaced by the last file in the list. Fragment order in the jenkinsfile therefore matters and is part of the
+deliverable of each pipeline phase.
+
+### Reference job being adapted
+
+`scylla-enterprise-perf-regression-predefined-throughput-steps-cql-stress-write-unthrottle-tablets-sc.jenkinsfile`
+(the "write-50k-unthrottled-commitlog-batch-tablets-sc" job) chains:
+base steps test-case → `cassandra_stress_gradual_load_steps_sc_50k_unthrottled_only_write.yaml` → `disable_kms`
+→ `disable_speculative_retry` → `latency-decorator-error-thresholds-steps-ent-tablets` → `enable_experimental_sc`
+→ `enable_commitlog_sync_batch` → cql-stress image → `prepare_cql_stress_ks_with_sc_1kpershard`.
+Its throttled step is **50 000 ops/s aggregate**, which is the anchor for the steady rate used here.
+
+## Goals
+
+1. **SC latency-during-topology-operations is measurable on i4i.** A single Jenkins job runs
+   `test_latency_write_with_nemesis`, `test_latency_read_with_nemesis` and `test_latency_mixed_with_nemesis`
+   against an SC keyspace with cql-stress leader-aware routing and reports per-disruption P90/P99 to Argus.
+2. **Same coverage on i8g (arm64).**
+3. **EC baselines exist for both shapes**, differing from the SC job only by the keyspace `consistency` clause
+   and the SC feature flag, so an SC-vs-EC delta can be computed per disruption.
+4. **1000 connections per shard in aggregate** — `-mode connectionsPerShard=250` × 4 loaders, matching the
+   existing `*_1kpershard.yaml` convention.
+5. **A cql-stress load killed at the end of the nemesis sequence does not fail the test** — no CRITICAL
+   `CqlStressCassandraStressEvent` in a passing run.
+6. **Each phase below lands as at least one commit** mapped 1:1 to a SCYLLADB-4346 sub-task.
+
+## Implementation Phases
+
+Phases 1-4 are prerequisites; 5-10 are the deliverable jobs; 11-14 are hardening and documentation.
+
+---
+
+### Phase 1: Stop cql-stress load cleanly when the nemesis sequence ends
+
+**Importance**: Critical
+**Description**: Teach `_stop_load_when_nemesis_threads_end()` to downgrade the stress event class that matches
+the load actually running. Today it hard-codes `CassandraStressEvent`; a cql-stress workload killed by
+`kill_stress_thread()` raises a CRITICAL `CqlStressCassandraStressEvent.failure` and fails the run.
+
+**Deliverables**:
+- `performance_regression_test.py`: select the severity-filter event class(es) from `self.stress_cmd`
+  (or filter both `CassandraStressEvent` and `CqlStressCassandraStressEvent` via nested
+  `EventsSeverityChangerFilter` contexts).
+- `unit_tests/unit/` test asserting the filter set chosen for a cassandra-stress command and for a
+  cql-stress command.
+
+**Definition of Done**:
+- [ ] A cql-stress `stress_cmd_w` produces a filter that covers `CqlStressCassandraStressEvent`
+- [ ] Existing cassandra-stress behaviour is unchanged (same filter as today)
+- [ ] New unit test passes; `uv run sct.py pre-commit` clean
+
+---
+
+### Phase 2: Shared base fragment for the 650 GB cql-stress nemesis runs
+
+**Importance**: Critical
+**Description**: Add `configurations/strong_consistency/nemesis_650gb_cql_stress_base.yaml` holding everything
+that is common to all four new jobs and independent of consistency mode: loader shape sized for 250
+connections/shard (`instance_type_loader: 'c7i.8xlarge'`, `n_loaders: 4`), `use_prepared_loaders: false`,
+`round_robin: true`, and the `email_subject_postfix` / `user_prefix` identifying the new job family.
+
+**Dependencies**: none (can land in parallel with Phase 1)
+
+**Deliverables**:
+- New config fragment, applied **after** the base test-case so it overrides `c5.2xlarge`.
+
+**Definition of Done**:
+- [ ] Fragment contains no consistency-specific or arch-specific option
+- [ ] `instance_type_loader` resolves to `c7i.8xlarge` in the resolved config for the i4i chain
+- [ ] Rationale for the loader shape (15 shards × 250 conns × 4 loaders) recorded as a YAML comment
+
+---
+
+### Phase 3: SC keyspace + cql-stress workload fragment (1000 conns/shard aggregate)
+
+**Importance**: Critical
+**Description**: Add `configurations/strong_consistency/prepare_cql_stress_nemesis_ks_with_sc_1kpershard.yaml`:
+SC keyspace pre-creation plus `prepare_write_cmd` and the three steady-state workloads rewritten for
+`cql-stress-cassandra-stress` against the 650 GB dataset.
+
+**Dependencies**: Phase 2
+
+**Deliverables**:
+- `pre_create_keyspace`: `CREATE KEYSPACE keyspace1 ... consistency = 'global' and tablets = {'enabled': true}`
+  (matching the wording already used by `prepare_cql_stress_ks_with_sc_1kpershard.yaml`).
+- `prepare_write_cmd`: 4 × `cql-stress-cassandra-stress write cl=QUORUM n=162500001 ... -pop seq=<quarter>`
+  (650 M rows × 1 KB ≈ 650 GB), one per loader via `round_robin`.
+- `stress_cmd_w` / `stress_cmd_r` / `stress_cmd_m`: single commands (each runs on all 4 loaders) with
+  `cl=QUORUM`, `-mode connectionsPerShard=250 cql3 native`, `-rate 'threads=<N> fixed=<per-loader>/s'`,
+  `-col 'size=FIXED(1024) n=FIXED(1)'`, `-pop 'dist=gauss(1..650000000,325000000,9750000)'`.
+- Starting rates, expressed as aggregate-÷-4: **write 50 000/s → `fixed=12500/s`** (anchored on the SC
+  50k throttled step of the reference job); **read and mixed** start from the EC baseline rates of
+  `perf-regression-latency-650gb-with-nemesis.yaml` (41 240/s and 35 000/s aggregate →
+  `fixed=10310/s` / `fixed=8750/s`) — see Phase 14 for calibration.
+
+**Needs Investigation**:
+- cql-stress support for `-pop 'dist=gauss(...)'`. It is used by
+  `configurations/performance/cql-stress-650gb-8-col-i4i-80-percent-throughput-oss.yaml` (elasticity pipeline)
+  but not by any SC job. Fallback if unsupported: `dist=UNIFORM(1..650000000)`.
+- Thread counts per workload for cql-stress at 250 conns/shard (the gradual SC job uses 500 write / 620 read
+  threads per loader as a starting point).
+
+**Definition of Done**:
+- [ ] Aggregate connections per shard = 1000 (250 × 4 loaders) documented in a YAML comment
+- [ ] All commands use `cl=QUORUM` (the leader-aware driver requires it — cf. commit `1505752b6`)
+- [ ] Resolved config for the SC chain contains no `cassandra-stress` command in `prepare_write_cmd`,
+      `stress_cmd_w`, `stress_cmd_r`, `stress_cmd_m`
+
+---
+
+### Phase 4: EC baseline workload fragment
+
+**Importance**: Critical
+**Description**: Add `configurations/strong_consistency/prepare_cql_stress_nemesis_ks_with_ec_1kpershard.yaml`
+— byte-identical to Phase 3 except the keyspace is created without the `consistency = 'global'` clause.
+
+**Dependencies**: Phase 3
+
+**Deliverables**:
+- EC fragment; a `diff` against the SC fragment shows only the `pre_create_keyspace` line.
+
+**Decision needed from reviewer**: the existing EC steps job also drops `enable_commitlog_sync_batch.yaml` and
+`enable_experimental_sc.yaml`, which silently changes `append_scylla_args`
+(`--blocked-reactor-notify-ms 50` → `5`) and durability settings, so the EC/SC delta is not isolated to
+consistency alone (noted in commit `172372628`). **Recommendation: keep `enable_commitlog_sync_batch.yaml` in
+the EC chain** and add a tiny fragment pinning the same `append_scylla_args`, so the only variable is the
+keyspace clause. Confirm before Phase 8.
+
+**Definition of Done**:
+- [ ] `diff` between SC and EC fragments is limited to `pre_create_keyspace`
+- [ ] The isolation decision above is recorded in the fragment header comment
+
+---
+
+### Phase 5: SC latency-thresholds fragment for topology operations
+
+**Importance**: Important
+**Description**: Add `configurations/performance/latency-decorator-error-thresholds-nemesis-sc-tablets.yaml`.
+SC writes go through Raft, so `add_new_nodes` / `decommission_nodes` / `replace_node` durations and the
+latency error thresholds from the EC file are not transferable.
+
+**Dependencies**: Phase 3
+
+**Deliverables**:
+- Fragment modelled on `latency-decorator-error-thresholds-nemesis-ent-tablets.yaml` with SC-appropriate
+  `fixed_limit` values for write/read/mixed.
+
+**Needs Investigation**: the SC limits themselves. First runs use the EC values with `fixed_limit: null`
+(report-only) for the topology disruptions; real numbers land in Phase 14.
+
+**Definition of Done**:
+- [ ] Fragment covers `add_new_nodes`, `decommission_nodes`, `replace_node`, `terminate_node`, `_mgmt_repair_cli`
+      for all three workloads
+- [ ] Values that are placeholders are marked as such in comments
+
+---
+
+### Phase 6: i4i SC pipeline
+
+**Importance**: Critical
+**Description**: Add
+`jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-with-nemesis-cql-stress-tablets-sc.jenkinsfile`.
+
+**Dependencies**: Phases 1-5
+
+**Deliverables**: `perfRegressionParallelPipeline` with
+`test_name: "performance_regression_test.PerformanceRegressionTest"`,
+`sub_tests: ["test_latency_write_with_nemesis", "test_latency_read_with_nemesis", "test_latency_mixed_with_nemesis"]`,
+`test_email_title: "SC latency during topology operations / tablets"`, and this config chain **in order**:
+
+1. `test-cases/performance/perf-regression-latency-650gb-with-nemesis.yaml`
+2. `configurations/disable_kms.yaml`
+3. `configurations/disable_speculative_retry.yaml`
+4. `configurations/performance/latency-decorator-error-thresholds-nemesis-sc-tablets.yaml`
+5. `configurations/aws/i4i_4xlarge.yaml`
+6. `configurations/strong_consistency/nemesis_650gb_cql_stress_base.yaml`
+7. `configurations/strong_consistency/enable_experimental_sc.yaml`
+8. `configurations/strong_consistency/enable_commitlog_sync_batch.yaml`
+9. `configurations/stress_images/cql-stress-strong-consistency-leader-awarness.yaml`
+10. `configurations/strong_consistency/prepare_cql_stress_nemesis_ks_with_sc_1kpershard.yaml`
+
+**Definition of Done**:
+- [ ] Resolved config shows `experimental_features: [strongly-consistent-tables]`, `api_address: "0.0.0.0"`,
+      `commitlog_sync: batch` **all present together** (MS_DICTS merge of `append_scylla_yaml`)
+- [ ] `instance_type_db: i4i.4xlarge`, `instance_type_loader: c7i.8xlarge`, `n_loaders: 4`
+- [ ] `stress_image.cql-stress-cassandra-stress` = the leader-aware image
+- [ ] `nemesis_class_name: SisyphusMonkey`, `nemesis_selector: NemesisSequence` inherited from the base test-case
+
+---
+
+### Phase 7: i8g (arm64) SC pipeline
+
+**Importance**: Critical
+**Description**: Same as Phase 6 with `configurations/arm_instance_types/i8g_4xlarge.yaml` replacing the i4i
+fragment at position 5.
+
+**Dependencies**: Phase 6
+
+**Needs Investigation**: **does `aleksbykov/cql-stress:leader-aware-strong-consistency` have an arm64 manifest?**
+The loaders stay x86 (`c7i.8xlarge`) so the stress container itself runs on x86 and this is likely a non-issue —
+but `configurations/c-s-driver-version-4.yaml`, attached by the existing i8g nemesis job for cassandra-stress,
+must **not** be carried over, since it is meaningless for cql-stress. Confirm before merging.
+
+**Definition of Done**:
+- [ ] `instance_type_db: i8g.4xlarge` in the resolved config
+- [ ] No cassandra-stress-only fragment in the chain
+- [ ] Arm image question answered and recorded in the plan
+
+---
+
+### Phase 8: i4i EC baseline pipeline
+
+**Importance**: Important
+**Description**: `...-latency-650gb-with-nemesis-cql-stress-tablets-ec.jenkinsfile` — Phase 6's chain with the
+EC fragment from Phase 4 and the SC feature flag handled per the Phase 4 decision.
+
+**Dependencies**: Phases 4, 6
+
+**Definition of Done**:
+- [ ] Resolved config has **no** `strongly-consistent-tables` feature
+- [ ] Everything else (instance types, image, rates, thresholds) identical to the i4i SC job
+- [ ] A documented diff of the two resolved configs is attached to the PR
+
+---
+
+### Phase 9: i8g EC baseline pipeline
+
+**Importance**: Important
+**Description**: EC twin of Phase 7.
+
+**Dependencies**: Phases 7, 8
+
+**Definition of Done**:
+- [ ] Resolved config differs from the i8g SC job only in the SC-specific options
+- [ ] `instance_type_db: i8g.4xlarge`
+
+---
+
+### Phase 10: `test_metadata` for the new pipelines
+
+**Importance**: Important
+**Description**: The base `perf-regression-latency-650gb-with-nemesis.yaml` carries no `test_metadata`. Add one
+covering the new job family (description, tier, `test_type: performance`, `stress_tools: [cql-stress-cassandra-stress]`,
+`nemesis_labels` for the topology disruptions, `features` incl. strongly-consistent tables and tablets), following
+the `reviewing-pipeline-docs` skill.
+
+**Dependencies**: Phases 6-9
+
+**Definition of Done**:
+- [ ] `uv run sct.py lint-test-docs` (or the documented equivalent) reports no gap for the new/edited files
+- [ ] Metadata cross-checked against the actual nemesis sequence (`grow` / `terminate+replace` / `shrink` / manager repair)
+
+---
+
+### Phase 11: Config-chain regression test
+
+**Importance**: Important
+**Description**: Add a unit test that resolves each of the four new jenkinsfile config chains through
+`SCTConfiguration` and asserts the invariants that silent merge-order bugs would break: SC flag present/absent,
+`api_address` **and** `commitlog_sync` both surviving the `append_scylla_yaml` merge, `connectionsPerShard=250`
+in every stress command, leader-aware image, correct instance types.
+
+**Dependencies**: Phases 6-9
+
+**Deliverables**:
+- Parametrized test in `unit_tests/` over the four pipelines.
+
+**Definition of Done**:
+- [ ] Test fails if a fragment is reordered so that `append_scylla_args` or `api_address` is lost
+- [ ] Test runs offline (no cloud credentials)
+
+---
+
+### Phase 12: Documentation
+
+**Importance**: Important
+**Description**: Extend `docs/strong-consistency-performance-tests-guide.md` with a
+"Topology operations" section: the new job family, the config chain, what `NemesisSequence` actually does,
+the 1000-connections-per-shard convention, and how to read the per-disruption latency in Argus. Fix the stale
+statement in the guide that SC keyspaces use `consistency = 'local'` (the configs use `'global'`).
+
+**Dependencies**: Phases 6-9
+
+**Definition of Done**:
+- [ ] Guide lists all four new pipelines with their config chains
+- [ ] `consistency = 'local'` / `'global'` discrepancy resolved against the actual YAML
+- [ ] Plan registered in `docs/plans/MASTER.md` and `docs/plans/progress.json`
+
+---
+
+### Phase 13: Dry-run validation of the four chains
+
+**Importance**: Critical
+**Description**: Resolve every new chain locally (config-only, no provisioning) and fix whatever the resolver
+rejects — unknown options, type errors, `append_*` conflicts.
+
+**Dependencies**: Phases 6-9
+
+**Definition of Done**:
+- [ ] All four chains resolve with no error
+- [ ] `uv run sct.py pre-commit` clean on the whole branch
+- [ ] Resolved-config excerpts pasted into the PR description
+
+---
+
+### Phase 14: Rate and threshold calibration after the first run
+
+**Importance**: Important
+**Description**: After the first i4i SC run (executed by the owner, not by CI), replace the placeholder
+`fixed=` rates and the report-only latency thresholds with values derived from the measured steady-state
+throughput, and re-check that the steady phase is not saturating the cluster before the nemesis starts.
+
+**Dependencies**: first successful run of Phase 6's job
+
+**Definition of Done**:
+- [ ] Steady-state (pre-nemesis) load is between 50 % and 70 % of the measured SC unthrottled throughput
+- [ ] `latency-decorator-error-thresholds-nemesis-sc-tablets.yaml` has real `fixed_limit` values
+- [ ] Argus run linked from SCYLLADB-4346
+
+## Testing Requirements
+
+### Unit tests
+- Phase 1: event-filter selection for cassandra-stress vs cql-stress commands.
+- Phase 11: config-chain resolution invariants for all four pipelines.
+
+### Integration tests
+- None new. The existing `unit_tests/integration/test_cql_stress_cassandra_stress_thread.py` already covers the
+  cql-stress thread against a docker Scylla; no thread-level change is introduced by this plan.
+
+### Manual testing (owner-run, not CI)
+1. i4i SC job, `test_latency_write_with_nemesis` only, to validate the end-to-end chain cheaply.
+2. Full i4i SC job (all three sub-tests) — confirms Phase 1 (no CRITICAL cql-stress event at teardown).
+3. i8g SC job.
+4. EC baselines for both shapes.
+5. Verify in Argus that per-disruption P90/P99 rows appear for `add_new_nodes`, `replace_node`,
+   `decommission_nodes`.
+
+### Performance-measurement acceptance
+- HDR histogram files `hdrh-cscs-*.hdr` are collected from every loader.
+- The steady-state segment before the first disruption is long enough (`nemesis_interval: 30` min) to give a
+  clean baseline.
+
+## Success Criteria
+
+All phase DoD items are checked, plus:
+
+1. Four jenkinsfiles exist and each resolves cleanly (Phase 13).
+2. One full SC run per shape completes without a CRITICAL stress event (Phases 1, 6, 7).
+3. An SC-vs-EC per-disruption latency delta can be computed for i4i and i8g (Phases 8, 9).
+4. Every phase corresponds to a SCYLLADB-4346 sub-task with at least one commit.
+
+## Risk Mitigation
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| Topology operations are unsupported/broken on strongly-consistent keyspaces | Medium | High — job fails mid-sequence | Run the write-only sub-test first; a failure here is a genuine SCYLLADB finding, so capture the node logs and file it rather than working around it |
+| `dist=gauss(...)` unsupported by cql-stress | Medium | Medium — no load at all | Verified fallback to `dist=UNIFORM(...)` / `seq=`; decided in Phase 3 before any run |
+| `append_scylla_args` clobbered by fragment order (string option, last wins) | High if unchecked | Medium — wrong reactor-stall threshold | Phase 11 asserts the resolved value; fragment order fixed in the jenkinsfile |
+| Leader-aware driver cannot reach the REST API | Low | High — routing silently degrades to non-leader | `enable_experimental_sc.yaml` sets `api_address: "0.0.0.0"`; Phase 11 asserts it survives the `append_scylla_yaml` merge |
+| Loader saturation at 250 conns/shard on `c7i.8xlarge` | Medium | Medium — latency measures the loader, not Scylla | Check loader CPU in the first run (Phase 14); scale `n_loaders` or threads rather than connections, which are fixed by the requirement |
+| ~14 h per job × 4 jobs of AWS cost | High | Medium | Land i4i SC first, calibrate, then roll out the remaining three |
+| Custom cql-stress image is a personal Docker Hub tag | Medium | Medium — image may disappear or drift | Record the exact digest in the PR; follow-up ticket to move it to the ScyllaDB registry |
+
+## Tracking
+
+One row per phase = one SCYLLADB-4346 sub-task = at least one commit. Updated as implementation proceeds.
+
+| # | Phase | Sub-task | Commit(s) | Status |
+|---|-------|----------|-----------|--------|
+| 1 | Stop cql-stress load cleanly when nemesis ends | [SCYLLADB-4404](https://scylladb.atlassian.net/browse/SCYLLADB-4404) | — | not started |
+| 2 | Shared base fragment for 650 GB cql-stress nemesis runs | [SCYLLADB-4405](https://scylladb.atlassian.net/browse/SCYLLADB-4405) | — | not started |
+| 3 | SC keyspace + cql-stress workload fragment | [SCYLLADB-4406](https://scylladb.atlassian.net/browse/SCYLLADB-4406) | — | not started |
+| 4 | EC baseline workload fragment | [SCYLLADB-4407](https://scylladb.atlassian.net/browse/SCYLLADB-4407) | — | not started |
+| 5 | SC latency-thresholds fragment | [SCYLLADB-4408](https://scylladb.atlassian.net/browse/SCYLLADB-4408) | — | not started |
+| 6 | i4i SC pipeline | [SCYLLADB-4409](https://scylladb.atlassian.net/browse/SCYLLADB-4409) | — | not started |
+| 7 | i8g SC pipeline | [SCYLLADB-4410](https://scylladb.atlassian.net/browse/SCYLLADB-4410) | — | not started |
+| 8 | i4i EC baseline pipeline | [SCYLLADB-4411](https://scylladb.atlassian.net/browse/SCYLLADB-4411) | — | not started |
+| 9 | i8g EC baseline pipeline | [SCYLLADB-4412](https://scylladb.atlassian.net/browse/SCYLLADB-4412) | — | not started |
+| 10 | `test_metadata` for the new pipelines | [SCYLLADB-4413](https://scylladb.atlassian.net/browse/SCYLLADB-4413) | — | not started |
+| 11 | Config-chain regression test | [SCYLLADB-4414](https://scylladb.atlassian.net/browse/SCYLLADB-4414) | — | not started |
+| 12 | Documentation | [SCYLLADB-4415](https://scylladb.atlassian.net/browse/SCYLLADB-4415) | — | not started |
+| 13 | Dry-run validation of the four chains | [SCYLLADB-4416](https://scylladb.atlassian.net/browse/SCYLLADB-4416) | — | not started |
+| 14 | Rate and threshold calibration after first run | [SCYLLADB-4417](https://scylladb.atlassian.net/browse/SCYLLADB-4417) | — | not started |

--- a/docs/plans/progress.json
+++ b/docs/plans/progress.json
@@ -308,6 +308,16 @@
       "created": "2026-06-28",
       "phases_total": 8,
       "phases_done": 0
+    },
+    {
+      "id": "sc-topology-operations-perf-tests",
+      "title": "SC Perf Tests with Topology Operations",
+      "file": "jenkins/sc-topology-operations-perf-tests.md",
+      "domain": "ci-cd",
+      "status": "draft",
+      "created": "2026-09-11",
+      "phases_total": 14,
+      "phases_done": 0
     }
   ]
 }

--- a/docs/plans/progress.json
+++ b/docs/plans/progress.json
@@ -314,10 +314,10 @@
       "title": "SC Perf Tests with Topology Operations",
       "file": "jenkins/sc-topology-operations-perf-tests.md",
       "domain": "ci-cd",
-      "status": "draft",
+      "status": "in_progress",
       "created": "2026-09-11",
       "phases_total": 14,
-      "phases_done": 0
+      "phases_done": 13
     }
   ]
 }

--- a/docs/strong-consistency-performance-tests-guide.md
+++ b/docs/strong-consistency-performance-tests-guide.md
@@ -1,0 +1,209 @@
+# How to Run Strong Consistency Performance Tests in SCT
+
+## Overview
+
+This guide explains how to use Scylla Cluster Tests (SCT) to run performance tests for the Strong Consistency (SC) feature. The test suite includes write, cached-read, and read-from-disk workloads, each run as a pair of SC and Eventual Consistency (EC) baseline tests for direct comparison. All tests use the gradual throughput increase methodology (`PerformanceRegressionPredefinedStepsTest`), where load is applied at predefined throttle steps and latency is measured at each step.
+
+The key difference between SC and EC configurations is the keyspace creation: SC keyspaces include a `consistency` clause (`consistency = 'global'` in every current config under `configurations/strong_consistency/`), while EC keyspaces omit it. Both use `tablets = {'enabled': true}` with `NetworkTopologyStrategy` and `replication_factor = 3`.
+
+## Jenkins Pipelines
+
+All related automation jobs can be found at:
+[Scylla Master Strong Consistency Jobs](https://jenkins.scylladb.com/view/master/job/scylla-master/job/StrongConsistency/)
+
+The following Jenkins pipelines are available:
+
+| Pipeline | Test | Consistency |
+|----------|------|-------------|
+| `...-predefined-throughput-steps-write-tablets-sc.jenkinsfile` | `test_write_gradual_increase_load` | SC |
+| `...-predefined-throughput-steps-read-tablets-sc.jenkinsfile` | `test_read_gradual_increase_load` | SC |
+| `...-predefined-throughput-steps-read-tablets-ec.jenkinsfile` | `test_read_gradual_increase_load` | EC baseline |
+| `...-predefined-throughput-steps-read-disk-tablets-sc.jenkinsfile` | `test_read_disk_only_gradual_increase_load` | SC |
+| `...-predefined-throughput-steps-read-disk-tablets-ec.jenkinsfile` | `test_read_disk_only_gradual_increase_load` | EC baseline |
+
+All pipelines are located under `jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/` and use the test class `performance_regression_gradual_grow_throughput.PerformanceRegressionPredefinedStepsTest`.
+
+### Throttle Steps
+
+The SC-specific load steps are defined in `configurations/performance/cassandra_stress_gradual_load_steps_strong_consistency.yaml`:
+
+| Workload | Threads | Throttle Steps (ops/s) |
+|----------|---------|------------------------|
+| write | 400 | 50000, 75000, 100000, 200000, unthrottled |
+| read | 620 | 150000, 300000, 450000, 600000, 700000, unthrottled |
+| read_disk_only | 620 | 80000, 165000, 250000, 300000, unthrottled |
+
+Each step runs for 30 minutes.
+
+## Execution Guide
+
+Each test is configured by stacking multiple YAML config fragments. The order matters -- later files override earlier ones.
+
+### 1. Enable Strong Consistency
+
+For any SC test, include the experimental feature flag configuration:
+`configurations/strong_consistency/enable_experimental_sc.yaml`
+
+This file does three things:
+- Enables the `strongly-consistent-tables` experimental feature
+- Sets `--blocked-reactor-notify-ms 50` (the non-SC default is `5`)
+- Sets `api_address: "0.0.0.0"` so that the Scylla REST API is accessible from loader nodes (required for cql-stress leader-aware load balancing)
+
+When running EC baselines, omit this file.
+
+### 2. Choose the Keyspace Preparation Configuration
+
+Select the config fragment matching your test type and stress tool:
+
+**Write tests:**
+
+| Tool | SC Config | EC Config |
+|------|-----------|-----------|
+| cassandra-stress | `prepare_cs_ks_with_sc.yaml` | `prepare_cs_ks_with_ec.yaml` |
+| cql-stress | `prepare_cql_stress_ks_with_sc.yaml` | `prepare_cql_stress_ks_with_ec.yaml` |
+
+**Read tests (cache-warmed):**
+
+| Tool | SC Config | EC Config |
+|------|-----------|-----------|
+| cassandra-stress | `prepare_cs_read_ks_with_sc.yaml` | `prepare_cs_read_ks_with_ec.yaml` |
+| cql-stress | `prepare_cql_stress_read_ks_with_sc.yaml` | `prepare_cql_stress_read_ks_with_ec.yaml` |
+
+**Read-from-disk tests (no cache warmup, 650M rows):**
+
+| Tool | SC Config | EC Config |
+|------|-----------|-----------|
+| cassandra-stress | `prepare_cs_read_disk_ks_with_sc.yaml` | `prepare_cs_read_disk_ks_with_ec.yaml` |
+| cql-stress | `prepare_cql_stress_read_disk_ks_with_sc.yaml` | `prepare_cql_stress_read_disk_ks_with_ec.yaml` |
+
+All files are under `configurations/strong_consistency/`.
+
+The `cassandra-stress` configs (`prepare_cs_*`) set only `pre_create_keyspace` and rely on the base test YAML for `stress_cmd_*` and `prepare_write_cmd`. The `cql-stress` configs (`prepare_cql_stress_*`) additionally override `stress_cmd_*` and `prepare_write_cmd` to use the `cql-stress-cassandra-stress` binary instead.
+
+### 3. Base Config Chain
+
+Every SC/EC performance pipeline uses a common chain of base configs:
+
+1. `test-cases/performance/perf-regression-predefined-throughput-steps.yaml` -- base test case
+2. `configurations/performance/cassandra_stress_gradual_load_steps_strong_consistency.yaml` -- SC-specific throttle steps and thread counts
+3. `configurations/disable_kms.yaml` -- disables KMS encryption
+4. `configurations/disable_speculative_retry.yaml` -- disables speculative retry
+5. `configurations/performance/latency-decorator-error-thresholds-steps-ent-tablets.yaml` -- latency error thresholds for enterprise tablets
+6. *(SC only)* `configurations/strong_consistency/enable_experimental_sc.yaml` -- enables SC feature
+7. `configurations/strong_consistency/prepare_*` -- keyspace and stress command configuration
+
+
+Note: The EC baseline omits `enable_experimental_sc.yaml`.
+
+## Leader-Awareness with cql-stress
+
+> **IMPORTANT: To run a test with leader-awareness using the `cql-stress` command, you must attach the following file to your test configuration:**
+> **`configurations/stress_images/cql-stress-strong-consistency.yaml`**
+
+This config fragment overrides the default `cql-stress-cassandra-stress` Docker image with a custom build that includes a Raft-leader-aware load balancing policy. The leader-aware driver routes requests to the tablet leader node, which is critical for accurate SC performance measurements.
+
+Additionally, the SC config (`enable_experimental_sc.yaml`) sets `api_address: "0.0.0.0"` to expose the Scylla REST API on all interfaces, allowing the cql-stress driver on loader nodes to query Raft leader information.
+
+For instructions on building custom cql-stress images from source, see [Building a Custom cql-stress Docker Image](building-custom-cql-stress-image.md).
+
+## Topology Operations (latency during grow / replace / shrink)
+
+The gradual-throughput jobs above measure SC on a cluster that never changes shape. A second job
+family measures SC latency **while topology operations run**, using
+`performance_regression_test.PerformanceRegressionTest` and the test-case
+`test-cases/performance/perf-regression-latency-650gb-with-nemesis.yaml`.
+
+### What the test does
+
+Each sub-test (`test_latency_write_with_nemesis`, `test_latency_read_with_nemesis`,
+`test_latency_mixed_with_nemesis`) preloads 650GB, starts a steady fixed-rate load on all loaders,
+waits one `nemesis_interval` (30 min) to establish a baseline, then runs `NemesisSequence` once.
+That disruption (`Nemesis.disrupt_run_unique_sequence`) is a fixed sequence of topology work:
+
+1. Scylla Manager repair (skipped when `use_mgmt` is false)
+2. grow the cluster (`_grow_cluster`)
+3. terminate and replace a node (`_terminate_and_replace_node`)
+4. shrink the cluster back (`_shrink_cluster`)
+
+with `nemesis_sequence_sleep_between_ops` (10 min) between steps. The latency decorator records
+P90/P99 per disruption and reports them to Argus; the duration limits live in
+`configurations/performance/latency-decorator-error-thresholds-nemesis-sc-tablets.yaml`, where the
+topology disruptions are report-only until calibrated.
+
+When the sequence ends, the load is killed on purpose. `_stop_load_when_nemesis_threads_end()`
+silences the stress-tool failure event that the kill produces, matching the event class to the tool
+in use - cql-stress and cassandra-stress publish unrelated sibling event classes.
+
+### Pipelines
+
+All four live under `jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/`
+and run all three sub-tests:
+
+| Pipeline | db instance | Consistency |
+|----------|-------------|-------------|
+| `...-latency-650gb-with-nemesis-cql-stress-tablets-sc.jenkinsfile` | `i4i.4xlarge` | SC |
+| `...-latency-650gb-with-nemesis-cql-stress-i8g-tablets-sc.jenkinsfile` | `i8g.4xlarge` | SC |
+| `...-latency-650gb-with-nemesis-cql-stress-tablets-ec.jenkinsfile` | `i4i.4xlarge` | EC baseline |
+| `...-latency-650gb-with-nemesis-cql-stress-i8g-tablets-ec.jenkinsfile` | `i8g.4xlarge` | EC baseline |
+
+### Config chain
+
+Fragment order matters. Dict options (`append_scylla_yaml`) are merged key by key, but string
+options (`append_scylla_args`, `instance_type_*`) are replaced by the last fragment that sets them.
+
+1. `test-cases/performance/perf-regression-latency-650gb-with-nemesis.yaml`
+2. `configurations/disable_kms.yaml`
+3. `configurations/disable_speculative_retry.yaml`
+4. `configurations/performance/latency-decorator-error-thresholds-nemesis-sc-tablets.yaml`
+5. `configurations/aws/i4i_4xlarge.yaml` **or** `configurations/arm_instance_types/i8g_4xlarge.yaml`
+6. `configurations/strong_consistency/nemesis_650gb_cql_stress_base.yaml` - loader shape
+7. *(SC)* `configurations/strong_consistency/enable_experimental_sc.yaml`
+   **or** *(EC)* `configurations/strong_consistency/ec_baseline_align_with_sc.yaml`
+8. `configurations/strong_consistency/enable_commitlog_sync_batch.yaml`
+9. `configurations/stress_images/cql-stress-strong-consistency-leader-awarness.yaml`
+10. `configurations/strong_consistency/prepare_cql_stress_nemesis_ks_with_{sc,ec}_1kpershard.yaml`
+
+Unlike the gradual EC baseline, the EC job here keeps the commitlog and scylla-args settings of the
+SC job (step 7, `ec_baseline_align_with_sc.yaml`), so the per-disruption SC-vs-EC delta is
+attributable to the keyspace `consistency` clause alone.
+
+`unit_tests/unit/test_sc_topology_operations_pipelines.py` resolves all four chains and asserts these
+invariants, so a fragment reorder fails in CI rather than 14 hours into a run.
+
+### 1000 connections per shard
+
+The workload fragments set `-mode connectionsPerShard=250`, and each `stress_cmd_*` is a single
+command, so it runs on **all** loaders: 250 x 4 loaders = 1000 connections per shard in aggregate.
+The same convention is used by `prepare_cql_stress_ks_with_sc_1kpershard.yaml`. Holding that many
+connections needs `c7i.8xlarge` loaders, which `nemesis_650gb_cql_stress_base.yaml` sets.
+
+Rates follow the project convention that a configured rate is per loader, so the aggregate is 4x
+the `fixed=` value: write `fixed=12500/s` (50k aggregate, the throttled step of the SC gradual job),
+read `fixed=10310/s` and mixed `fixed=8750/s` (the cassandra-stress baseline rates). All three are
+starting points to be calibrated from the first run.
+
+## Configuration Files Reference
+
+| File | Purpose |
+|------|---------|
+| `configurations/strong_consistency/enable_experimental_sc.yaml` | Enables SC feature, sets reactor notify ms, exposes REST API |
+| `configurations/strong_consistency/prepare_cs_ks_with_sc.yaml` | SC keyspace + cassandra-stress write commands |
+| `configurations/strong_consistency/prepare_cs_ks_with_ec.yaml` | EC keyspace + cassandra-stress write commands |
+| `configurations/strong_consistency/prepare_cs_read_ks_with_sc.yaml` | SC keyspace for read tests (cassandra-stress) |
+| `configurations/strong_consistency/prepare_cs_read_ks_with_ec.yaml` | EC keyspace for read tests (cassandra-stress) |
+| `configurations/strong_consistency/prepare_cs_read_disk_ks_with_sc.yaml` | SC keyspace for disk-only read tests (cassandra-stress) |
+| `configurations/strong_consistency/prepare_cs_read_disk_ks_with_ec.yaml` | EC keyspace for disk-only read tests (cassandra-stress) |
+| `configurations/strong_consistency/prepare_cql_stress_ks_with_sc.yaml` | SC keyspace + cql-stress write commands |
+| `configurations/strong_consistency/prepare_cql_stress_ks_with_ec.yaml` | EC keyspace + cql-stress write commands |
+| `configurations/strong_consistency/prepare_cql_stress_read_ks_with_sc.yaml` | SC keyspace + cql-stress read/warmup commands |
+| `configurations/strong_consistency/prepare_cql_stress_read_ks_with_ec.yaml` | EC keyspace + cql-stress read/warmup commands |
+| `configurations/strong_consistency/prepare_cql_stress_read_disk_ks_with_sc.yaml` | SC keyspace + cql-stress disk-only read commands |
+| `configurations/strong_consistency/prepare_cql_stress_read_disk_ks_with_ec.yaml` | EC keyspace + cql-stress disk-only read commands |
+| `configurations/stress_images/cql-stress-strong-consistency.yaml` | Custom cql-stress image with leader-aware load balancing |
+| `configurations/performance/cassandra_stress_gradual_load_steps_strong_consistency.yaml` | SC-specific throttle steps, thread counts, step durations |
+| `configurations/stress_images/cql-stress-strong-consistency-leader-awarness.yaml` | cql-stress image with Raft-leader-aware load balancing (topology-operations jobs) |
+| `configurations/strong_consistency/nemesis_650gb_cql_stress_base.yaml` | Loader shape for the topology-operations jobs |
+| `configurations/strong_consistency/prepare_cql_stress_nemesis_ks_with_sc_1kpershard.yaml` | SC keyspace + cql-stress write/read/mixed load for topology-operations jobs |
+| `configurations/strong_consistency/prepare_cql_stress_nemesis_ks_with_ec_1kpershard.yaml` | EC twin of the above |
+| `configurations/strong_consistency/ec_baseline_align_with_sc.yaml` | Restores the non-SC settings of `enable_experimental_sc.yaml` for EC baselines |
+| `configurations/performance/latency-decorator-error-thresholds-nemesis-sc-tablets.yaml` | Per-disruption latency limits for the SC topology-operations jobs |

--- a/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-with-nemesis-cql-stress-i8g-tablets-ec.jenkinsfile
+++ b/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-with-nemesis-cql-stress-i8g-tablets-ec.jenkinsfile
@@ -1,0 +1,15 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+// Eventual Consistency baseline for the i8g SC job.
+perfRegressionParallelPipeline(
+    backend: "aws",
+    region: "us-east-1",
+    provision_type: 'on_demand',
+    test_name: "performance_regression_test.PerformanceRegressionTest",
+    test_config: '''["test-cases/performance/perf-regression-latency-650gb-with-nemesis.yaml", "configurations/disable_kms.yaml", "configurations/disable_speculative_retry.yaml", "configurations/performance/latency-decorator-error-thresholds-nemesis-sc-tablets.yaml", "configurations/arm_instance_types/i8g_4xlarge.yaml", "configurations/strong_consistency/nemesis_650gb_cql_stress_base.yaml", "configurations/strong_consistency/ec_baseline_align_with_sc.yaml", "configurations/strong_consistency/enable_commitlog_sync_batch.yaml", "configurations/stress_images/cql-stress-strong-consistency-leader-awarness.yaml", "configurations/strong_consistency/prepare_cql_stress_nemesis_ks_with_ec_1kpershard.yaml"]''',
+    sub_tests: ["test_latency_write_with_nemesis", "test_latency_read_with_nemesis", "test_latency_mixed_with_nemesis"],
+    test_email_title: "EC latency during topology operations / tablets / i8g",
+)

--- a/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-with-nemesis-cql-stress-i8g-tablets-sc.jenkinsfile
+++ b/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-with-nemesis-cql-stress-i8g-tablets-sc.jenkinsfile
@@ -1,0 +1,17 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+// i8g (arm64 db nodes) twin of the i4i SC job. The loaders stay x86, so the cql-stress container
+// is unchanged; c-s-driver-version-4.yaml, attached by the cassandra-stress i8g nemesis job, is
+// deliberately not carried over - it configures the java driver cql-stress does not use.
+perfRegressionParallelPipeline(
+    backend: "aws",
+    region: "us-east-1",
+    provision_type: 'on_demand',
+    test_name: "performance_regression_test.PerformanceRegressionTest",
+    test_config: '''["test-cases/performance/perf-regression-latency-650gb-with-nemesis.yaml", "configurations/disable_kms.yaml", "configurations/disable_speculative_retry.yaml", "configurations/performance/latency-decorator-error-thresholds-nemesis-sc-tablets.yaml", "configurations/arm_instance_types/i8g_4xlarge.yaml", "configurations/strong_consistency/nemesis_650gb_cql_stress_base.yaml", "configurations/strong_consistency/enable_experimental_sc.yaml", "configurations/strong_consistency/enable_commitlog_sync_batch.yaml", "configurations/stress_images/cql-stress-strong-consistency-leader-awarness.yaml", "configurations/strong_consistency/prepare_cql_stress_nemesis_ks_with_sc_1kpershard.yaml"]''',
+    sub_tests: ["test_latency_write_with_nemesis", "test_latency_read_with_nemesis", "test_latency_mixed_with_nemesis"],
+    test_email_title: "SC latency during topology operations / tablets / i8g",
+)

--- a/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-with-nemesis-cql-stress-tablets-ec.jenkinsfile
+++ b/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-with-nemesis-cql-stress-tablets-ec.jenkinsfile
@@ -1,0 +1,18 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+// Eventual Consistency baseline for the i4i SC job. It drops enable_experimental_sc.yaml and uses
+// the EC keyspace, but keeps the same stress tool, image, connection count, rates, commitlog
+// settings and scylla args (ec_baseline_align_with_sc.yaml) so the per-disruption delta against
+// the SC job is attributable to the keyspace consistency clause alone.
+perfRegressionParallelPipeline(
+    backend: "aws",
+    region: "us-east-1",
+    provision_type: 'on_demand',
+    test_name: "performance_regression_test.PerformanceRegressionTest",
+    test_config: '''["test-cases/performance/perf-regression-latency-650gb-with-nemesis.yaml", "configurations/disable_kms.yaml", "configurations/disable_speculative_retry.yaml", "configurations/performance/latency-decorator-error-thresholds-nemesis-sc-tablets.yaml", "configurations/aws/i4i_4xlarge.yaml", "configurations/strong_consistency/nemesis_650gb_cql_stress_base.yaml", "configurations/strong_consistency/ec_baseline_align_with_sc.yaml", "configurations/strong_consistency/enable_commitlog_sync_batch.yaml", "configurations/stress_images/cql-stress-strong-consistency-leader-awarness.yaml", "configurations/strong_consistency/prepare_cql_stress_nemesis_ks_with_ec_1kpershard.yaml"]''',
+    sub_tests: ["test_latency_write_with_nemesis", "test_latency_read_with_nemesis", "test_latency_mixed_with_nemesis"],
+    test_email_title: "EC latency during topology operations / tablets / i4i",
+)

--- a/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-with-nemesis-cql-stress-tablets-sc.jenkinsfile
+++ b/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-with-nemesis-cql-stress-tablets-sc.jenkinsfile
@@ -1,0 +1,18 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+// Strong Consistency latency during topology operations (grow / terminate+replace / shrink),
+// driven by cql-stress with the Raft-leader-aware load balancing policy.
+// The fragment order matters: string options such as append_scylla_args are replaced by the
+// last file that sets them, so enable_experimental_sc.yaml has to come after the test-case.
+perfRegressionParallelPipeline(
+    backend: "aws",
+    region: "us-east-1",
+    provision_type: 'on_demand',
+    test_name: "performance_regression_test.PerformanceRegressionTest",
+    test_config: '''["test-cases/performance/perf-regression-latency-650gb-with-nemesis.yaml", "configurations/disable_kms.yaml", "configurations/disable_speculative_retry.yaml", "configurations/performance/latency-decorator-error-thresholds-nemesis-sc-tablets.yaml", "configurations/aws/i4i_4xlarge.yaml", "configurations/strong_consistency/nemesis_650gb_cql_stress_base.yaml", "configurations/strong_consistency/enable_experimental_sc.yaml", "configurations/strong_consistency/enable_commitlog_sync_batch.yaml", "configurations/stress_images/cql-stress-strong-consistency-leader-awarness.yaml", "configurations/strong_consistency/prepare_cql_stress_nemesis_ks_with_sc_1kpershard.yaml"]''',
+    sub_tests: ["test_latency_write_with_nemesis", "test_latency_read_with_nemesis", "test_latency_mixed_with_nemesis"],
+    test_email_title: "SC latency during topology operations / tablets / i4i",
+)

--- a/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-cql-stress-read-disk-tablets-ec.jenkinsfile
+++ b/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-cql-stress-read-disk-tablets-ec.jenkinsfile
@@ -1,0 +1,13 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+perfRegressionParallelPipeline(
+    backend: "aws",
+    region: "us-east-1",
+    provision_type: 'on_demand',
+    test_name: "performance_regression_gradual_grow_throughput.PerformanceRegressionPredefinedStepsTest",
+    test_config: '''["test-cases/performance/perf-regression-predefined-throughput-steps.yaml", "configurations/performance/cassandra_stress_gradual_load_steps_strong_consistency.yaml", "configurations/disable_kms.yaml", "configurations/disable_speculative_retry.yaml", "configurations/performance/latency-decorator-error-thresholds-steps-ent-tablets.yaml", "configurations/strong_consistency/prepare_cql_stress_read_disk_ks_with_ec.yaml"]''',
+    sub_tests: ["test_read_disk_only_gradual_increase_load"],
+)

--- a/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-cql-stress-read-disk-tablets-sc.jenkinsfile
+++ b/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-cql-stress-read-disk-tablets-sc.jenkinsfile
@@ -1,0 +1,13 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+perfRegressionParallelPipeline(
+    backend: "aws",
+    region: "us-east-1",
+    provision_type: 'on_demand',
+    test_name: "performance_regression_gradual_grow_throughput.PerformanceRegressionPredefinedStepsTest",
+    test_config: '''["test-cases/performance/perf-regression-predefined-throughput-steps.yaml", "configurations/performance/cassandra_stress_gradual_load_steps_strong_consistency.yaml", "configurations/disable_kms.yaml", "configurations/disable_speculative_retry.yaml", "configurations/performance/latency-decorator-error-thresholds-steps-ent-tablets.yaml", "configurations/stress_images/cql-stress-strong-consistency.yaml", "configurations/strong_consistency/enable_experimental_sc.yaml", "configurations/strong_consistency/prepare_cql_stress_read_disk_ks_with_sc.yaml"]''',
+    sub_tests: ["test_read_disk_only_gradual_increase_load"],
+)

--- a/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-cql-stress-read-tablets-ec.jenkinsfile
+++ b/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-cql-stress-read-tablets-ec.jenkinsfile
@@ -1,0 +1,13 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+perfRegressionParallelPipeline(
+    backend: "aws",
+    region: "us-east-1",
+    provision_type: 'on_demand',
+    test_name: "performance_regression_gradual_grow_throughput.PerformanceRegressionPredefinedStepsTest",
+    test_config: '''["test-cases/performance/perf-regression-predefined-throughput-steps.yaml", "configurations/performance/cassandra_stress_gradual_load_steps_strong_consistency.yaml", "configurations/disable_kms.yaml", "configurations/disable_speculative_retry.yaml", "configurations/performance/latency-decorator-error-thresholds-steps-ent-tablets.yaml", "configurations/strong_consistency/prepare_cql_stress_read_ks_with_ec.yaml"]''',
+    sub_tests: ["test_read_gradual_increase_load"],
+)

--- a/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-cql-stress-read-tablets-sc.jenkinsfile
+++ b/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-cql-stress-read-tablets-sc.jenkinsfile
@@ -1,0 +1,13 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+perfRegressionParallelPipeline(
+    backend: "aws",
+    region: "us-east-1",
+    provision_type: 'on_demand',
+    test_name: "performance_regression_gradual_grow_throughput.PerformanceRegressionPredefinedStepsTest",
+    test_config: '''["test-cases/performance/perf-regression-predefined-throughput-steps.yaml", "configurations/performance/cassandra_stress_gradual_load_steps_strong_consistency.yaml", "configurations/disable_kms.yaml", "configurations/disable_speculative_retry.yaml", "configurations/performance/latency-decorator-error-thresholds-steps-ent-tablets.yaml", "configurations/stress_images/cql-stress-strong-consistency.yaml", "configurations/strong_consistency/enable_experimental_sc.yaml", "configurations/strong_consistency/prepare_cql_stress_read_ks_with_sc.yaml"]''',
+    sub_tests: ["test_read_gradual_increase_load"],
+)

--- a/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-cql-stress-write-tablets-ec.jenkinsfile
+++ b/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-cql-stress-write-tablets-ec.jenkinsfile
@@ -1,0 +1,13 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+perfRegressionParallelPipeline(
+    backend: "aws",
+    region: "us-east-1",
+    provision_type: 'on_demand',
+    test_name: "performance_regression_gradual_grow_throughput.PerformanceRegressionPredefinedStepsTest",
+    test_config: '''["test-cases/performance/perf-regression-predefined-throughput-steps.yaml", "configurations/performance/cassandra_stress_gradual_load_steps_strong_consistency.yaml", "configurations/disable_kms.yaml", "configurations/disable_speculative_retry.yaml", "configurations/performance/latency-decorator-error-thresholds-steps-ent-tablets.yaml", "configurations/strong_consistency/prepare_cql_stress_ks_with_ec.yaml"]''',
+    sub_tests: ["test_write_gradual_increase_load"],
+)

--- a/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-cql-stress-write-tablets-sc.jenkinsfile
+++ b/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-cql-stress-write-tablets-sc.jenkinsfile
@@ -1,0 +1,13 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+perfRegressionParallelPipeline(
+    backend: "aws",
+    region: "us-east-1",
+    provision_type: 'on_demand',
+    test_name: "performance_regression_gradual_grow_throughput.PerformanceRegressionPredefinedStepsTest",
+    test_config: '''["test-cases/performance/perf-regression-predefined-throughput-steps.yaml", "configurations/performance/cassandra_stress_gradual_load_steps_strong_consistency.yaml", "configurations/disable_kms.yaml", "configurations/disable_speculative_retry.yaml", "configurations/performance/latency-decorator-error-thresholds-steps-ent-tablets.yaml", "configurations/stress_images/cql-stress-strong-consistency.yaml", "configurations/strong_consistency/enable_experimental_sc.yaml", "configurations/strong_consistency/prepare_cql_stress_ks_with_sc.yaml"]''',
+    sub_tests: ["test_write_gradual_increase_load"],
+)

--- a/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-cql-stress-write-unthrottle-tablets-ec.jenkinsfile
+++ b/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-cql-stress-write-unthrottle-tablets-ec.jenkinsfile
@@ -1,0 +1,13 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+perfRegressionParallelPipeline(
+    backend: "aws",
+    region: "us-east-1",
+    provision_type: 'on_demand',
+    test_name: "performance_regression_gradual_grow_throughput.PerformanceRegressionPredefinedStepsTest",
+    test_config: '''["test-cases/performance/perf-regression-predefined-throughput-steps.yaml", "configurations/performance/cassandra_stress_gradual_load_steps_sc_50k_unthrottled_only_write.yaml", "configurations/disable_kms.yaml", "configurations/disable_speculative_retry.yaml", "configurations/performance/latency-decorator-error-thresholds-steps-ent-tablets.yaml", "configurations/strong_consistency/prepare_cql_stress_ks_with_ec_1kpershard.yaml"]''',
+    sub_tests: ["test_write_gradual_increase_load"],
+)

--- a/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-cql-stress-write-unthrottle-tablets-sc.jenkinsfile
+++ b/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-cql-stress-write-unthrottle-tablets-sc.jenkinsfile
@@ -1,0 +1,13 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+perfRegressionParallelPipeline(
+    backend: "aws",
+    region: "us-east-1",
+    provision_type: 'on_demand',
+    test_name: "performance_regression_gradual_grow_throughput.PerformanceRegressionPredefinedStepsTest",
+    test_config: '''["test-cases/performance/perf-regression-predefined-throughput-steps.yaml", "configurations/performance/cassandra_stress_gradual_load_steps_sc_50k_unthrottled_only_write.yaml", "configurations/disable_kms.yaml", "configurations/disable_speculative_retry.yaml", "configurations/performance/latency-decorator-error-thresholds-steps-ent-tablets.yaml", "configurations/strong_consistency/enable_experimental_sc.yaml",  "configurations/strong_consistency/enable_commitlog_sync_batch.yaml", "configurations/stress_images/cql-stress-strong-consistency.yaml",  "configurations/strong_consistency/prepare_cql_stress_ks_with_sc_1kpershard.yaml"]''',
+    sub_tests: ["test_write_gradual_increase_load"],
+)

--- a/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-read-disk-tablets-ec.jenkinsfile
+++ b/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-read-disk-tablets-ec.jenkinsfile
@@ -1,0 +1,13 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+perfRegressionParallelPipeline(
+    backend: "aws",
+    region: "us-east-1",
+    provision_type: 'on_demand',
+    test_name: "performance_regression_gradual_grow_throughput.PerformanceRegressionPredefinedStepsTest",
+    test_config: '''["test-cases/performance/perf-regression-predefined-throughput-steps.yaml", "configurations/performance/cassandra_stress_gradual_load_steps_strong_consistency.yaml", "configurations/disable_kms.yaml", "configurations/disable_speculative_retry.yaml", "configurations/performance/latency-decorator-error-thresholds-steps-ent-tablets.yaml", "configurations/strong_consistency/prepare_cs_read_disk_ks_with_ec.yaml"]''',
+    sub_tests: ["test_read_disk_only_gradual_increase_load"],
+)

--- a/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-read-disk-tablets-sc.jenkinsfile
+++ b/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-read-disk-tablets-sc.jenkinsfile
@@ -1,0 +1,13 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+perfRegressionParallelPipeline(
+    backend: "aws",
+    region: "us-east-1",
+    provision_type: 'on_demand',
+    test_name: "performance_regression_gradual_grow_throughput.PerformanceRegressionPredefinedStepsTest",
+    test_config: '''["test-cases/performance/perf-regression-predefined-throughput-steps.yaml", "configurations/performance/cassandra_stress_gradual_load_steps_strong_consistency.yaml", "configurations/disable_kms.yaml", "configurations/disable_speculative_retry.yaml", "configurations/performance/latency-decorator-error-thresholds-steps-ent-tablets.yaml", "configurations/strong_consistency/enable_experimental_sc.yaml", "configurations/strong_consistency/prepare_cs_read_disk_ks_with_sc.yaml"]''',
+    sub_tests: ["test_read_disk_only_gradual_increase_load"],
+)

--- a/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-read-tablets-ec.jenkinsfile
+++ b/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-read-tablets-ec.jenkinsfile
@@ -1,0 +1,13 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+perfRegressionParallelPipeline(
+    backend: "aws",
+    region: "us-east-1",
+    provision_type: 'on_demand',
+    test_name: "performance_regression_gradual_grow_throughput.PerformanceRegressionPredefinedStepsTest",
+    test_config: '''["test-cases/performance/perf-regression-predefined-throughput-steps.yaml", "configurations/performance/cassandra_stress_gradual_load_steps_strong_consistency.yaml", "configurations/disable_kms.yaml", "configurations/disable_speculative_retry.yaml", "configurations/performance/latency-decorator-error-thresholds-steps-ent-tablets.yaml", "configurations/strong_consistency/prepare_cs_read_ks_with_ec.yaml"]''',
+    sub_tests: ["test_read_gradual_increase_load"],
+)

--- a/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-read-tablets-sc.jenkinsfile
+++ b/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-read-tablets-sc.jenkinsfile
@@ -1,0 +1,13 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+perfRegressionParallelPipeline(
+    backend: "aws",
+    region: "us-east-1",
+    provision_type: 'on_demand',
+    test_name: "performance_regression_gradual_grow_throughput.PerformanceRegressionPredefinedStepsTest",
+    test_config: '''["test-cases/performance/perf-regression-predefined-throughput-steps.yaml", "configurations/performance/cassandra_stress_gradual_load_steps_strong_consistency.yaml", "configurations/disable_kms.yaml", "configurations/disable_speculative_retry.yaml", "configurations/performance/latency-decorator-error-thresholds-steps-ent-tablets.yaml", "configurations/strong_consistency/enable_experimental_sc.yaml", "configurations/strong_consistency/prepare_cs_read_ks_with_sc.yaml"]''',
+    sub_tests: ["test_read_gradual_increase_load"],
+)

--- a/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-write-tablets-ec.jenkinsfile
+++ b/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-write-tablets-ec.jenkinsfile
@@ -1,0 +1,13 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+perfRegressionParallelPipeline(
+    backend: "aws",
+    region: "us-east-1",
+    provision_type: 'on_demand',
+    test_name: "performance_regression_gradual_grow_throughput.PerformanceRegressionPredefinedStepsTest",
+    test_config: '''["test-cases/performance/perf-regression-predefined-throughput-steps.yaml", "configurations/performance/cassandra_stress_gradual_load_steps_strong_consistency.yaml", "configurations/disable_kms.yaml", "configurations/disable_speculative_retry.yaml", "configurations/performance/latency-decorator-error-thresholds-steps-ent-tablets.yaml", "configurations/strong_consistency/prepare_cs_ks_with_ec.yaml"]''',
+    sub_tests: ["test_write_gradual_increase_load"],
+)

--- a/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-write-tablets-sc.jenkinsfile
+++ b/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-write-tablets-sc.jenkinsfile
@@ -1,0 +1,13 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+perfRegressionParallelPipeline(
+    backend: "aws",
+    region: "us-east-1",
+    provision_type: 'on_demand',
+    test_name: "performance_regression_gradual_grow_throughput.PerformanceRegressionPredefinedStepsTest",
+    test_config: '''["test-cases/performance/perf-regression-predefined-throughput-steps.yaml", "configurations/performance/cassandra_stress_gradual_load_steps_strong_consistency.yaml", "configurations/disable_kms.yaml", "configurations/disable_speculative_retry.yaml", "configurations/performance/latency-decorator-error-thresholds-steps-ent-tablets.yaml", "configurations/strong_consistency/enable_experimental_sc.yaml", "configurations/strong_consistency/prepare_cs_ks_with_sc.yaml"]''',
+    sub_tests: ["test_write_gradual_increase_load"],
+)

--- a/performance_regression_gradual_grow_throughput.py
+++ b/performance_regression_gradual_grow_throughput.py
@@ -1,5 +1,6 @@
 import pathlib
 import time
+from contextlib import contextmanager, nullcontext
 from enum import Enum
 from collections import defaultdict, Counter
 
@@ -8,7 +9,9 @@ from dataclasses import dataclass, replace
 from typing import List, Union
 
 from performance_regression_test import PerformanceRegressionTest
+from sdcm.rest.task_profiler_client import TaskProfilerClient
 from sdcm.stress.latte_thread import find_latte_fn_names
+from sdcm.utils.parallel_object import ParallelObject
 from sdcm.sct_events import Severity
 from sdcm.sct_events.system import TestFrameworkEvent
 from sdcm.utils.common import skip_optional_stage
@@ -35,6 +38,7 @@ class Workload:
     prepare_schema: bool
     test_keyspace: str = ""
     test_table: str = ""
+    task_profiler: bool = False
 
     def __post_init__(self):
         if isinstance(self.num_threads, int):
@@ -235,6 +239,37 @@ class PerformanceRegressionPredefinedStepsTest(PerformanceRegressionTest):
         )
         self._base_test_workflow(workload=workload, test_name="test_write_gradual_increase_load (100% writes)")
 
+    def test_write_gradual_increase_load_with_task_profiler(self):
+        """Run write workload with task profiler enabled.
+
+        Identical to test_write_gradual_increase_load but brackets each
+        throttle step with task profiler start/stop calls on all DB
+        nodes. The stop call also dumps per-shard profiling data.
+        Requires a Scylla build from
+        https://github.com/Jadw1/scylla/tree/sc_perf_with_profile
+        """
+        workload_type = "write"
+        keyspace, table = self.get_test_table_name(self.params.get("stress_cmd_w"))
+        workload = Workload(
+            workload_type=workload_type,
+            cs_cmd_tmpl=self.params.get("stress_cmd_w"),
+            cs_cmd_warm_up=None,
+            num_threads=self.get_num_threads_for_workload(workload_type),
+            throttle_steps=self.throttle_steps(workload_type),
+            preload_data=False,
+            drop_keyspace=True,
+            wait_no_compactions=False,
+            step_duration=self.step_duration(workload_type),
+            test_keyspace=keyspace,
+            test_table=table,
+            prepare_schema=True,
+            task_profiler=True,
+        )
+        self._base_test_workflow(
+            workload=workload,
+            test_name="test_write_gradual_increase_load_with_task_profiler (100% writes)",
+        )
+
     def test_read_gradual_increase_load(self):
         """
         Test steps:
@@ -327,6 +362,9 @@ class PerformanceRegressionPredefinedStepsTest(PerformanceRegressionTest):
                 self._run_cql_commands(matching_cmds)
 
     def preload_data(self, compaction_strategy=None):
+        if self.params.get("pre_create_keyspace"):
+            self._pre_create_keyspace()
+
         population_commands: list = self.params.get("prepare_write_cmd")
 
         self.log.info("Population c-s commands: %s", population_commands)
@@ -358,7 +396,9 @@ class PerformanceRegressionPredefinedStepsTest(PerformanceRegressionTest):
         self.log.info("Dataset has been populated")
 
     def prepare_schema(self, workload: Workload):
-        if workload.prepare_schema and (prepare_stress_cmds := self.params.get("prepare_stress_cmd")):
+        if workload.prepare_schema and self.params.get("pre_create_keyspace"):
+            self._pre_create_keyspace()
+        elif workload.prepare_schema and (prepare_stress_cmds := self.params.get("prepare_stress_cmd")):
             stress_queue = []
             for stress_cmd in prepare_stress_cmds:
                 self.log.info("Preparing schema using command: %s", stress_cmd)
@@ -589,17 +629,19 @@ class PerformanceRegressionPredefinedStepsTest(PerformanceRegressionTest):
             # _find_hdr_tags from stopping at the first queue and omitting the read tag.
             step_hdr_tags = [f"fn--{fn}" for cmd in workload.cs_cmd_tmpl for fn in find_latte_fn_names(cmd)]
 
-            run_step = (
-                latency_calculator_decorator(
-                    legend=f"Gradual test step {current_throttle_step} op/s", cycle_name=current_throttle_step
+            with self._task_profiler_step(current_throttle_step) if workload.task_profiler else nullcontext():
+                run_step = (
+                    latency_calculator_decorator(
+                        legend=f"Gradual test step {current_throttle_step} op/s", cycle_name=current_throttle_step
+                    )
+                )(self.run_step)
+                results, _ = run_step(
+                    stress_cmds=workload.cs_cmd_tmpl,
+                    step_params=step_params,
+                    step_duration=step_duration,
+                    hdr_tags=step_hdr_tags or None,
                 )
-            )(self.run_step)
-            results, _ = run_step(
-                stress_cmds=workload.cs_cmd_tmpl,
-                step_params=step_params,
-                step_duration=step_duration,
-                hdr_tags=step_hdr_tags or None,
-            )
+
             self.log.debug("All c-s commands results collected and saved in Argus")
 
             summary_result = self.check_latency_during_steps(step=current_throttle_step)
@@ -626,6 +668,132 @@ class PerformanceRegressionPredefinedStepsTest(PerformanceRegressionTest):
                 self.wait_for_no_tablets_splits()
 
         self.save_total_summary_in_file(total_summary)
+
+    @contextmanager
+    def _task_profiler_step(self, step_name: str):
+        """Bracket a single throttle step with task profiler start/stop+collect.
+
+        Starts the profiler on all DB nodes and always runs stop+collect in the
+        ``finally`` block, so any profiler that was started (even when a later
+        node's startup fails) is stopped and cannot skew subsequent steps.
+        Startup is inside the protected boundary and startup failures are
+        tolerated per node: nodes that started successfully are stopped, and a
+        failure to start on some nodes does not abort the whole step.
+        """
+        try:
+            self._task_profiler_start_all_nodes()
+            yield
+        finally:
+            try:
+                self._task_profiler_stop_and_collect(step_name=step_name)
+            except Exception:  # noqa: BLE001
+                self.log.error("Task profiler stop/collect failed for step %s", step_name, exc_info=True)
+
+    def _task_profiler_start_all_nodes(self, sampling_interval_ms: int = 10):
+        """Start task profiler on all DB nodes in parallel.
+
+        Startup failures are tolerated so a single node that fails to start does
+        not leave already-started profilers running on the other nodes; the
+        ``finally`` in :meth:`_task_profiler_step` still stops every node.
+        """
+
+        def start_on_node(node):
+            self.log.info("Starting task profiler on %s", node.name)
+            TaskProfilerClient(node).start(sampling_interval_ms=sampling_interval_ms)
+
+        results = ParallelObject(objects=self.db_cluster.nodes, timeout=120).run(start_on_node, ignore_exceptions=True)
+        for result in results:
+            if result.exc is not None:
+                self.log.warning("Failed to start task profiler on %s: %s", result.obj.name, result.exc)
+
+    def _task_profiler_stop_and_collect(self, step_name: str):
+        """Stop profiler, write dump files, verify, archive, download, and clean up for one step.
+
+        For each node in parallel:
+        1. Create the dump directory on the remote node.
+        2. Call the REST stop endpoint which stops profiling AND writes per-shard
+           folded-stack files to the given path.
+        3. Verify at least one dump file exists and is non-empty.
+        4. Create a tar.gz archive on the remote node.
+        5. Download the archive into node.logdir/ via receive_files.
+        6. Clean up remote files.
+        """
+
+        def stop_and_collect_on_node(node):
+            run_id = self.test_id  # unique per test run, prevents collisions on reused nodes
+            base_dir = f"/tmp/async_profile_{run_id}"  # noqa: S108 - remote scratch dir on ephemeral test node
+            dir_name = f"{step_name}_{node.name}"
+            dump_dir = f"{base_dir}/{dir_name}"
+            dump_filename = f"{dump_dir}/async_profile_{step_name}"
+            archive_name = f"async_profiles_{run_id}_{step_name}_{node.name}.tar.gz"
+            remote_archive = f"/tmp/{archive_name}"  # noqa: S108 - remote scratch dir on ephemeral test node
+
+            # mkdir must happen first (stop writes files into this dir).
+            # If mkdir fails, stop profiler with a fallback path so it
+            # doesn't keep running and skew subsequent steps.
+            try:
+                node.remoter.run(f"mkdir -p {dump_dir} && chmod 777 {dump_dir}")
+            except Exception:
+                self.log.warning("mkdir failed on %s, stopping profiler with fallback path", node.name)
+                try:
+                    TaskProfilerClient(node).stop(filename=f"{base_dir}/fallback_{step_name}")
+                except Exception:  # noqa: BLE001
+                    self.log.error("Fallback stop also failed on %s, profiler may still be running", node.name)
+                raise
+
+            # Stop profiler + write dump files into the prepared directory
+            self.log.info("Stopping task profiler on %s, dumping to %s", node.name, dump_filename)
+            TaskProfilerClient(node).stop(filename=dump_filename)
+
+            # Verify dumps exist
+            result = node.remoter.run(
+                f"ls {dump_dir}/async_profile_* 2>/dev/null | head -1",
+                ignore_status=True,
+            )
+            if result.failed or not result.stdout.strip():
+                raise FileNotFoundError(f"No task profiler dump files found on {node.name} under {dump_dir}/")
+
+            # Verify at least the first file is non-empty
+            first_file = result.stdout.strip()
+            size_result = node.remoter.run(f"stat -c %s {first_file}")
+            file_size = int(size_result.stdout.strip())
+            if file_size == 0:
+                raise ValueError(f"Task profiler dump file {first_file} on {node.name} is empty")
+
+            # Count total dump files
+            count_result = node.remoter.run(f"ls -1 {dump_dir}/async_profile_* | wc -l")
+            file_count = int(count_result.stdout.strip())
+            self.log.info(
+                "Found %d task profiler dump files on %s for step %s",
+                file_count,
+                node.name,
+                step_name,
+            )
+
+            # Archive
+            node.remoter.run(f"tar -czf {remote_archive} -C {base_dir} {dir_name}/")
+
+            # Download into node.logdir (where FileLog search_locally finds it)
+            node.remoter.receive_files(
+                src=remote_archive,
+                dst=node.logdir,
+            )
+            self.log.info(
+                "Downloaded %s to %s/%s",
+                archive_name,
+                node.logdir,
+                archive_name,
+            )
+
+            # Cleanup remote files
+            node.remoter.run(f"rm -rf {dump_dir} {remote_archive}")
+
+        results = ParallelObject(objects=self.db_cluster.nodes, timeout=600).run(
+            stop_and_collect_on_node, ignore_exceptions=True
+        )
+        for result in results:
+            if result.exc is not None:
+                self.log.warning("Failed to stop/collect task profiler on %s: %s", result.obj.name, result.exc)
 
     def save_total_summary_in_file(self, total_summary):
         total_summary_json = json.dumps(total_summary, indent=4, separators=(", ", ": "))

--- a/performance_regression_test.py
+++ b/performance_regression_test.py
@@ -16,6 +16,7 @@
 
 import os
 import time
+from contextlib import ExitStack
 from typing import Optional
 
 import yaml
@@ -26,7 +27,7 @@ from upgrade_test import UpgradeTest
 from sdcm.tester import ClusterTester, teardown_on_exception
 from sdcm.sct_events import Severity
 from sdcm.sct_events.filters import EventsSeverityChangerFilter
-from sdcm.sct_events.loaders import CassandraStressEvent
+from sdcm.sct_events.loaders import CassandraStressEvent, CqlStressCassandraStressEvent
 from sdcm.sct_events.system import HWPerforanceEvent, InfoEvent
 from sdcm.utils.parallel_object import ParallelObject
 from sdcm.utils.decorators import log_run_info, latency_calculator_decorator, optional_stage
@@ -200,14 +201,36 @@ class PerformanceRegressionTest(ClusterTester, loader_utils.LoaderUtilsMixin):
             )
             self.get_stress_results(queue=stress_queue, store_results=True)
 
+    @staticmethod
+    def _stress_event_classes(stress_cmd) -> list:
+        """Event classes published by the stress tool(s) that run `stress_cmd`.
+
+        cassandra-stress and cql-stress-cassandra-stress publish unrelated sibling event classes,
+        so a severity filter installed for one of them does not cover the other.
+        """
+        stress_cmds = [stress_cmd] if isinstance(stress_cmd, str) else list(stress_cmd or [])
+        event_classes = []
+        for cmd in stress_cmds:
+            # the cql-stress binary name contains "cassandra-stress", so it has to be matched first
+            if "cql-stress-cassandra-stress" in cmd:
+                event_classes.append(CqlStressCassandraStressEvent)
+            elif "cassandra-stress" in cmd:
+                event_classes.append(CassandraStressEvent)
+        # dict.fromkeys() de-duplicates while keeping the order
+        return list(dict.fromkeys(event_classes)) or [CassandraStressEvent]
+
     def _stop_load_when_nemesis_threads_end(self):
         for nemesis_thread in self.db_cluster.nemesis_threads:
             nemesis_thread.join()
-        with EventsSeverityChangerFilter(
-            new_severity=Severity.NORMAL,  # killing stress creates Critical error
-            event_class=CassandraStressEvent,
-            extra_time_to_expiration=60,
-        ):
+        with ExitStack() as stack:
+            for event_class in self._stress_event_classes(self.stress_cmd):
+                stack.enter_context(
+                    EventsSeverityChangerFilter(
+                        new_severity=Severity.NORMAL,  # killing stress creates Critical error
+                        event_class=event_class,
+                        extra_time_to_expiration=60,
+                    )
+                )
             self.loaders.kill_stress_thread()
 
     @optional_stage("perf_preload_data")

--- a/sdcm/argus_results.py
+++ b/sdcm/argus_results.py
@@ -40,8 +40,8 @@ if TYPE_CHECKING:
 LOGGER = logging.getLogger(__name__)
 
 LATENCY_ERROR_THRESHOLDS = {
-    "replace_node": {"percentile_90": 5, "percentile_99": 10},
-    "default": {"percentile_90": 5, "percentile_99": 10},
+    "replace_node": {"percentile_90": 5, "percentile_95": 7, "percentile_99": 10},
+    "default": {"percentile_90": 5, "percentile_95": 7, "percentile_99": 10},
 }
 
 
@@ -52,6 +52,8 @@ class LatencyCalculatorMixedResult(StaticGenericResultTable):
         Columns = [
             ColumnMetadata(name="P90 write", unit="ms", type=ResultType.FLOAT, higher_is_better=False),
             ColumnMetadata(name="P90 read", unit="ms", type=ResultType.FLOAT, higher_is_better=False),
+            ColumnMetadata(name="P95 write", unit="ms", type=ResultType.FLOAT, higher_is_better=False),
+            ColumnMetadata(name="P95 read", unit="ms", type=ResultType.FLOAT, higher_is_better=False),
             ColumnMetadata(name="P99 write", unit="ms", type=ResultType.FLOAT, higher_is_better=False),
             ColumnMetadata(name="P99 read", unit="ms", type=ResultType.FLOAT, higher_is_better=False),
             ColumnMetadata(name="Throughput write", unit="op/s", type=ResultType.INTEGER, higher_is_better=True),
@@ -70,6 +72,7 @@ class LatencyCalculatorWriteResult(StaticGenericResultTable):
         description = ""
         Columns = [
             ColumnMetadata(name="P90 write", unit="ms", type=ResultType.FLOAT, higher_is_better=False),
+            ColumnMetadata(name="P95 write", unit="ms", type=ResultType.FLOAT, higher_is_better=False),
             ColumnMetadata(name="P99 write", unit="ms", type=ResultType.FLOAT, higher_is_better=False),
             ColumnMetadata(name="Throughput write", unit="op/s", type=ResultType.INTEGER, higher_is_better=True),
             ColumnMetadata(name="duration", unit="HH:MM:SS", type=ResultType.DURATION, higher_is_better=False),
@@ -86,6 +89,7 @@ class LatencyCalculatorReadResult(StaticGenericResultTable):
         description = ""
         Columns = [
             ColumnMetadata(name="P90 read", unit="ms", type=ResultType.FLOAT, higher_is_better=False),
+            ColumnMetadata(name="P95 read", unit="ms", type=ResultType.FLOAT, higher_is_better=False),
             ColumnMetadata(name="P99 read", unit="ms", type=ResultType.FLOAT, higher_is_better=False),
             ColumnMetadata(name="Throughput read", unit="op/s", type=ResultType.INTEGER, higher_is_better=True),
             ColumnMetadata(name="duration", unit="HH:MM:SS", type=ResultType.DURATION, higher_is_better=False),
@@ -102,6 +106,7 @@ class LatencyCalculatorReadDiskOnlyResult(StaticGenericResultTable):
         description = ""
         Columns = [
             ColumnMetadata(name="P90 read", unit="ms", type=ResultType.FLOAT, higher_is_better=False),
+            ColumnMetadata(name="P95 read", unit="ms", type=ResultType.FLOAT, higher_is_better=False),
             ColumnMetadata(name="P99 read", unit="ms", type=ResultType.FLOAT, higher_is_better=False),
             ColumnMetadata(name="Throughput read", unit="op/s", type=ResultType.INTEGER, higher_is_better=True),
             ColumnMetadata(name="duration", unit="HH:MM:SS", type=ResultType.DURATION, higher_is_better=False),
@@ -327,7 +332,7 @@ def send_result_to_argus(  # noqa: PLR0914
       when "result['hdr_summary']" has more than 2 rows with unique HDR tags.
       It is useful for cases when we run multiple stress commands of different types in parallel
       like customer-scenarios covered by latte stress commands.
-      It stores the worst P90 and P99 latencies among all of the rows/results
+      It stores the worst P90, P95, and P99 latencies among all of the rows/results
       and summary throughput for all of them even if workload types are different.
     - Reactor stalls table is registered
       when relevant SCT events occured (result['reactor_stalls_stats'])
@@ -359,7 +364,7 @@ def send_result_to_argus(  # noqa: PLR0914
     for i, (workload_type_and_hdr_tag, hdr_data) in enumerate(hdr_summary.items()):
         (workload_type, hdr_tag) = workload_type_and_hdr_tag.split("--", maxsplit=1)
         row_name = f"{cycle}" + "" if skip_hdr_tag else f" (HDR tag: {hdr_tag})"
-        for percentile in ("90", "99"):
+        for percentile in ("90", "95", "99"):
             if (workload_type, percentile) not in summary_worst_lat:
                 summary_worst_lat[(workload_type, percentile)] = 0.0
             column_name = f"P{percentile} {workload_type.lower()}"

--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -1011,6 +1011,7 @@ class ScyllaLogCollector(LogCollector):
                 "|| true )"
             ),
         ),
+        FileLog(name="async_profiles_*.tar.gz", search_locally=True),
     ]
 
     cmd = "test -f /etc/scylla/ssl_conf/{0} && cat /etc/scylla/ssl_conf/{0}"

--- a/sdcm/rest/task_profiler_client.py
+++ b/sdcm/rest/task_profiler_client.py
@@ -1,0 +1,39 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2026 ScyllaDB
+
+from fabric.runners import Result
+
+from sdcm.rest.remote_curl_client import RemoteCurlClient
+
+
+class TaskProfilerClient(RemoteCurlClient):
+    def __init__(self, node: "BaseNode"):  # noqa F821
+        super().__init__(host="localhost:10000", endpoint="system", node=node)
+
+    def start(self, sampling_interval_ms: int = 100, timeout: int = 60) -> Result:
+        return self.run_remoter_curl(
+            method="POST",
+            path="task_profiler/start",
+            params={"sampling_interval_ms": str(sampling_interval_ms)},
+            timeout=timeout,
+            retry=0,  # no-retry: POST is non-idempotent; a retried start could double-start the profiler
+        )
+
+    def stop(self, filename: str, timeout: int = 300) -> Result:
+        return self.run_remoter_curl(
+            method="POST",
+            path="task_profiler/stop",
+            params={"filename": filename},
+            timeout=timeout,
+            retry=0,  # no-retry: POST is non-idempotent; retrying stop could overwrite/duplicate dump files
+        )

--- a/sdcm/utils/latency.py
+++ b/sdcm/utils/latency.py
@@ -149,6 +149,10 @@ def analyze_hdr_percentiles(result_stats: dict[str, Any]) -> dict[str, Any]:
                     cycle["hdr_summary"][workload]["color"].update({"percentile_90": "red"})
                 else:
                     cycle["hdr_summary"][workload]["color"].update({"percentile_90": ""})
+                if results["percentile_95"] > LATENCY_ERROR_THRESHOLDS[top_limit_operation]["percentile_95"]:
+                    cycle["hdr_summary"][workload]["color"].update({"percentile_95": "red"})
+                else:
+                    cycle["hdr_summary"][workload]["color"].update({"percentile_95": ""})
                 if results["percentile_99"] > LATENCY_ERROR_THRESHOLDS[top_limit_operation]["percentile_99"]:
                     cycle["hdr_summary"][workload]["color"].update({"percentile_99": "red"})
                 else:
@@ -161,6 +165,10 @@ def analyze_hdr_percentiles(result_stats: dict[str, Any]) -> dict[str, Any]:
                         results["color"].update({"percentile_90": "red"})
                     else:
                         results["color"].update({"percentile_90": ""})
+                    if results["percentile_95"] > LATENCY_ERROR_THRESHOLDS[top_limit_operation]["percentile_95"]:
+                        results["color"].update({"percentile_95": "red"})
+                    else:
+                        results["color"].update({"percentile_95": ""})
                     if results["percentile_99"] > LATENCY_ERROR_THRESHOLDS[top_limit_operation]["percentile_99"]:
                         results["color"].update({"percentile_99": "red"})
                     else:

--- a/test-cases/performance/perf-regression-latency-650gb-with-nemesis.yaml
+++ b/test-cases/performance/perf-regression-latency-650gb-with-nemesis.yaml
@@ -1,4 +1,25 @@
 test_duration: 840
+
+test_metadata:
+  description: >-
+    Latency during topology operations on a 3-node cluster holding a 650GB dataset: a steady
+    write, read or mixed load runs while the NemesisSequence disruption grows the cluster,
+    terminates and replaces a node and shrinks it back (preceded by a Scylla Manager repair),
+    and the latency decorator reports P90/P99 per disruption. Driven by cassandra-stress by
+    default; the Strong Consistency and Eventual Consistency variants of this test-case swap in
+    cql-stress-cassandra-stress with Raft-leader-aware routing through the
+    configurations/strong_consistency/ fragments.
+  test_type: performance
+  tier: ondemand
+  duration_class: medium
+  supported_backends:
+    - aws
+  stress_tools:
+    - cassandra-stress
+    - cql-stress-cassandra-stress
+  features:
+    - tablets
+    - vnodes
 prepare_write_cmd: ["cassandra-stress write no-warmup cl=ALL n=162500000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=200 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=1..162500000",
                     "cassandra-stress write no-warmup cl=ALL n=162500000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=200 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=162500000..325000000",
                     "cassandra-stress write no-warmup cl=ALL n=162500000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=200 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=325000000..487500000",

--- a/unit_tests/unit/test_argus_results.py
+++ b/unit_tests/unit/test_argus_results.py
@@ -18,11 +18,13 @@ import pytest
 from argus.client.generic_result import Cell, Status
 
 from sdcm.argus_results import (
-    ReactorStallStatsResult,
-    send_iotune_results_to_argus,
-    send_result_to_argus,
+    LATENCY_ERROR_THRESHOLDS,
     LatencyCalculatorMixedResult,
+    ReactorStallStatsResult,
+    send_result_to_argus,
+    send_iotune_results_to_argus,
 )
+from sdcm.utils.latency import analyze_hdr_percentiles
 
 
 def test_send_latency_decorator_result_to_argus(test_data_dir):
@@ -48,6 +50,7 @@ def test_send_latency_decorator_result_to_argus(test_data_dir):
                 sut_timestamp=0,
                 results=[
                     Cell(column="P90 write", row=row_name, value=2.15, status=Status.UNSET),
+                    Cell(column="P95 write", row=row_name, value=2.36, status=Status.UNSET),
                     Cell(column="P99 write", row=row_name, value=3.62, status=Status.UNSET),
                     Cell(column="duration", row=row_name, value=2654, status=Status.UNSET),
                     Cell(column="start time", row=row_name, value="12:14:23", status=Status.UNSET),
@@ -67,6 +70,7 @@ def test_send_latency_decorator_result_to_argus(test_data_dir):
                         status=Status.UNSET,
                     ),
                     Cell(column="P90 read", row=row_name, value=2.86, status=Status.UNSET),
+                    Cell(column="P95 read", row=row_name, value=3.53, status=Status.UNSET),
                     Cell(column="P99 read", row=row_name, value=5.36, status=Status.UNSET),
                 ],
             )
@@ -95,3 +99,50 @@ def test_send_iotune_results_to_argus_skips_when_no_run(run):
     send_iotune_results_to_argus(argus_client=argus_mock, results={}, node=MagicMock(), params={})
 
     argus_mock.submit_results.assert_not_called()
+
+
+def test_analyze_hdr_percentiles_p95_threshold_colors():
+    """P95 latencies must be colored 'red' above the threshold and '' at/below it.
+
+    Covers both the ``hdr_summary`` (per-cycle) and interval ``hdr`` values on each
+    side of the P95 threshold so incorrect or missing color assignments are detected.
+    """
+    p95_threshold = LATENCY_ERROR_THRESHOLDS["default"]["percentile_95"]
+    below_p95 = p95_threshold - 1
+    above_p95 = p95_threshold + 1
+
+    def _percentiles(percentile_95):
+        # Keep P90/P99 below their thresholds so only P95 color varies.
+        return {"percentile_90": 1, "percentile_95": percentile_95, "percentile_99": 1}
+
+    result_stats = {
+        "unknown_operation": {  # falls back to the "default" thresholds
+            "cycles": [
+                {
+                    "hdr_summary": {
+                        "WRITE": _percentiles(below_p95),
+                        "READ": _percentiles(above_p95),
+                    },
+                    "hdr": [
+                        {
+                            "WRITE": _percentiles(below_p95),
+                            "READ": _percentiles(above_p95),
+                        },
+                    ],
+                },
+            ],
+        },
+    }
+
+    analyzed = analyze_hdr_percentiles(result_stats)
+
+    cycle = analyzed["unknown_operation"]["cycles"][0]
+
+    # hdr_summary colors
+    assert cycle["hdr_summary"]["WRITE"]["color"]["percentile_95"] == ""
+    assert cycle["hdr_summary"]["READ"]["color"]["percentile_95"] == "red"
+
+    # interval hdr colors
+    interval = cycle["hdr"][0]
+    assert interval["WRITE"]["color"]["percentile_95"] == ""
+    assert interval["READ"]["color"]["percentile_95"] == "red"

--- a/unit_tests/unit/test_perf_stress_event_classes.py
+++ b/unit_tests/unit/test_perf_stress_event_classes.py
@@ -1,0 +1,71 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2026 ScyllaDB
+
+"""
+Unit tests for the stress-event classes silenced while the load is killed at the end of a
+nemesis run (PerformanceRegressionTest._stop_load_when_nemesis_threads_end).
+
+Killing the load raises a CRITICAL failure event from whichever stress tool is running, so the
+severity filter must match that tool: cassandra-stress and cql-stress-cassandra-stress publish
+unrelated sibling event classes.
+"""
+
+import pytest
+
+# import the module, not the class: pytest would collect an imported unittest.TestCase subclass
+import performance_regression_test as perf_regression_module
+from sdcm.sct_events.loaders import CassandraStressEvent, CqlStressCassandraStressEvent
+
+_stress_event_classes = perf_regression_module.PerformanceRegressionTest._stress_event_classes
+
+CS_CMD = (
+    "cassandra-stress write no-warmup cl=QUORUM duration=2850m -mode cql3 native "
+    "-rate 'threads=250 fixed=20332/s' -col 'size=FIXED(128) n=FIXED(8)'"
+)
+CQL_STRESS_CMD = (
+    "cql-stress-cassandra-stress write no-warmup cl=QUORUM duration=2850m "
+    "-mode connectionsPerShard=250 cql3 native -rate 'threads=500 fixed=12500/s' "
+    "-col 'size=FIXED(1024) n=FIXED(1)'"
+)
+
+
+@pytest.mark.parametrize(
+    "stress_cmd, expected",
+    [
+        pytest.param(CS_CMD, [CassandraStressEvent], id="cassandra-stress-str"),
+        pytest.param([CS_CMD], [CassandraStressEvent], id="cassandra-stress-list"),
+        pytest.param(CQL_STRESS_CMD, [CqlStressCassandraStressEvent], id="cql-stress-str"),
+        pytest.param([CQL_STRESS_CMD], [CqlStressCassandraStressEvent], id="cql-stress-list"),
+    ],
+)
+def test_single_tool_returns_its_own_event_class(stress_cmd, expected):
+    """A cql-stress command must not be silenced through CassandraStressEvent, and vice versa."""
+    assert _stress_event_classes(stress_cmd) == expected
+
+
+def test_commands_are_deduplicated():
+    """The per-loader commands of one workload are the same tool - filter it once."""
+    assert _stress_event_classes([CQL_STRESS_CMD] * 4) == [CqlStressCassandraStressEvent]
+
+
+def test_mixed_commands_return_both_classes_in_order():
+    assert _stress_event_classes([CS_CMD, CQL_STRESS_CMD]) == [
+        CassandraStressEvent,
+        CqlStressCassandraStressEvent,
+    ]
+
+
+@pytest.mark.parametrize("stress_cmd", [None, [], "", "scylla-bench -workload=sequential -mode=write"])
+def test_unknown_or_empty_command_falls_back_to_cassandra_stress(stress_cmd):
+    """Keep the pre-existing behaviour for anything this helper does not recognise."""
+    assert _stress_event_classes(stress_cmd) == [CassandraStressEvent]

--- a/unit_tests/unit/test_sc_topology_operations_pipelines.py
+++ b/unit_tests/unit/test_sc_topology_operations_pipelines.py
@@ -1,0 +1,163 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2026 ScyllaDB
+
+"""
+Config-chain regression tests for the SC/EC "latency during topology operations" pipelines.
+
+These jobs are assembled from ten YAML fragments each, and their correctness depends on merge
+order: dict options such as append_scylla_yaml are merged key by key, while string options such
+as append_scylla_args are replaced by the last fragment that sets them. Reordering or dropping a
+fragment therefore fails silently - the run starts, produces numbers, and measures the wrong
+thing. Every assertion here covers one of those silent failures.
+
+The chains are read from the jenkinsfiles themselves, so a pipeline edit that breaks an
+invariant fails here rather than 14 hours into a run.
+"""
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from sdcm import sct_config
+
+PIPELINE_DIR = Path("jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression")
+PIPELINE_PREFIX = "scylla-enterprise-perf-regression-latency-650gb-with-nemesis-cql-stress-"
+
+SC_PIPELINES = {
+    "i4i-sc": (PIPELINE_PREFIX + "tablets-sc.jenkinsfile", "i4i.4xlarge"),
+    "i8g-sc": (PIPELINE_PREFIX + "i8g-tablets-sc.jenkinsfile", "i8g.4xlarge"),
+}
+EC_PIPELINES = {
+    "i4i-ec": (PIPELINE_PREFIX + "tablets-ec.jenkinsfile", "i4i.4xlarge"),
+    "i8g-ec": (PIPELINE_PREFIX + "i8g-tablets-ec.jenkinsfile", "i8g.4xlarge"),
+}
+ALL_PIPELINES = {**SC_PIPELINES, **EC_PIPELINES}
+
+# set by enable_experimental_sc.yaml for SC, restored by ec_baseline_align_with_sc.yaml for EC
+EXPECTED_SCYLLA_ARGS = (
+    "--blocked-reactor-notify-ms 50 --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc "
+    "--abort-on-internal-error 0 --abort-on-ebadf 1"
+)
+STRESS_CMD_KEYS = ("prepare_write_cmd", "stress_cmd_w", "stress_cmd_r", "stress_cmd_m")
+
+
+def _config_chain(jenkinsfile_name: str) -> list:
+    content = (PIPELINE_DIR / jenkinsfile_name).read_text(encoding="utf-8")
+    match = re.search(r"test_config:\s*'''(\[.*?\])'''", content, re.DOTALL)
+    assert match, f"no test_config found in {jenkinsfile_name}"
+    return json.loads(match.group(1))
+
+
+def _as_list(value) -> list:
+    return [value] if isinstance(value, str) else list(value or [])
+
+
+@pytest.fixture(name="resolved_configs", scope="module")
+def fixture_resolved_configs():
+    """Resolve every pipeline's config chain once, without touching any cloud API.
+
+    ami_id_db_scylla is pinned so that SCTConfiguration skips the AMI lookup; nothing in these
+    assertions depends on the image.
+    """
+    configs = {}
+    with pytest.MonkeyPatch.context() as monkey:
+        monkey.setenv("SCT_CLUSTER_BACKEND", "aws")
+        monkey.setenv("SCT_AMI_ID_DB_SCYLLA", "ami-dummy")
+        for name, (jenkinsfile_name, _) in ALL_PIPELINES.items():
+            monkey.setenv("SCT_CONFIG_FILES", json.dumps(_config_chain(jenkinsfile_name)))
+            configs[name] = sct_config.SCTConfiguration()
+    return configs
+
+
+@pytest.fixture(name="conf")
+def fixture_conf(request, resolved_configs):
+    return resolved_configs[request.param]
+
+
+@pytest.mark.parametrize("conf", list(ALL_PIPELINES), indirect=True)
+def test_append_scylla_yaml_options_are_merged_not_replaced(conf):
+    """api_address and commitlog_sync come from different fragments and must both survive."""
+    append_scylla_yaml = conf.get("append_scylla_yaml") or {}
+    # the leader-aware cql-stress driver reads Raft leader info from the Scylla REST API
+    assert append_scylla_yaml.get("api_address") == "0.0.0.0"
+    assert append_scylla_yaml.get("commitlog_sync") == "batch"
+    assert append_scylla_yaml.get("commitlog_sync_batch_window_in_ms") == 100
+
+
+@pytest.mark.parametrize("conf", list(ALL_PIPELINES), indirect=True)
+def test_append_scylla_args_is_identical_for_sc_and_ec(conf):
+    """A string option: the last fragment wins, so a reorder silently changes the db settings."""
+    assert conf.get("append_scylla_args") == EXPECTED_SCYLLA_ARGS
+
+
+@pytest.mark.parametrize("conf", list(SC_PIPELINES), indirect=True)
+def test_sc_pipelines_enable_strongly_consistent_tables(conf):
+    assert conf.get("experimental_features") == ["strongly-consistent-tables"]
+    assert "consistency = 'global'" in conf.get("pre_create_keyspace")[0]
+
+
+@pytest.mark.parametrize("conf", list(EC_PIPELINES), indirect=True)
+def test_ec_pipelines_are_the_baseline(conf):
+    assert not conf.get("experimental_features")
+    assert "consistency" not in conf.get("pre_create_keyspace")[0]
+
+
+@pytest.mark.parametrize("conf", list(ALL_PIPELINES), indirect=True)
+def test_keyspace_uses_tablets(conf):
+    assert "tablets = {'enabled': true}" in conf.get("pre_create_keyspace")[0]
+
+
+@pytest.mark.parametrize("conf", list(ALL_PIPELINES), indirect=True)
+def test_every_stress_command_is_leader_aware_cql_stress(conf):
+    """A leftover cassandra-stress command would route SC writes away from the Raft leader."""
+    assert conf.get("stress_image")["cql-stress-cassandra-stress"].endswith(":leader-aware-strong-consistency")
+    for key in STRESS_CMD_KEYS:
+        commands = _as_list(conf.get(key))
+        assert commands, f"{key} is empty"
+        for cmd in commands:
+            assert "cql-stress-cassandra-stress" in cmd, f"{key} is not driven by cql-stress: {cmd}"
+            # the leader-aware driver does not support cl=ALL
+            assert "cl=QUORUM" in cmd, f"{key} does not use cl=QUORUM: {cmd}"
+
+
+@pytest.mark.parametrize("conf", list(ALL_PIPELINES), indirect=True)
+def test_steady_state_load_holds_1000_connections_per_shard(conf):
+    """250 connections per shard per loader x 4 loaders = 1000 per shard in aggregate."""
+    assert conf.get("n_loaders") == [4]
+    for key in ("stress_cmd_w", "stress_cmd_r", "stress_cmd_m"):
+        for cmd in _as_list(conf.get(key)):
+            assert "connectionsPerShard=250" in cmd, f"{key} does not set connectionsPerShard=250: {cmd}"
+
+
+@pytest.mark.parametrize("conf", list(ALL_PIPELINES), indirect=True)
+def test_loader_shape_can_drive_that_connection_count(conf):
+    """The c5.2xlarge of the base test-case cannot; nemesis_650gb_cql_stress_base.yaml overrides it."""
+    assert conf.get("instance_type_loader") == "c7i.8xlarge"
+
+
+@pytest.mark.parametrize(
+    "conf, expected_db_instance",
+    [pytest.param(name, instance, id=name) for name, (_, instance) in ALL_PIPELINES.items()],
+    indirect=["conf"],
+)
+def test_db_instance_type(conf, expected_db_instance):
+    assert conf.get("instance_type_db") == expected_db_instance
+
+
+@pytest.mark.parametrize("conf", list(ALL_PIPELINES), indirect=True)
+def test_topology_nemesis_is_inherited_from_the_base_test_case(conf):
+    """NemesisSequence is the disruption that grows, replaces and shrinks the cluster."""
+    assert conf.get("nemesis_class_name") == ["SisyphusMonkey"]
+    assert conf.get("nemesis_selector") == ["NemesisSequence"]


### PR DESCRIPTION
## Strong Consistency performance tests with topology operations

Parent: [SCYLLADB-4346](https://scylladb.atlassian.net/browse/SCYLLADB-4346)

SC performance is measured today only on a cluster that never changes shape. This adds the missing
half: SC latency **while topology operations run**, driven by cql-stress with the Raft-leader-aware
load balancing policy, on both i4i and i8g, each with an EC baseline.

Plan: `docs/plans/jenkins/sc-topology-operations-perf-tests.md` (14 phases, one sub-task and at
least one commit each, SCYLLADB-4404..4417).

### New jobs

All four run `performance_regression_test.PerformanceRegressionTest` with all three
`test_latency_{write,read,mixed}_with_nemesis` sub-tests against the 650GB dataset, while
`NemesisSequence` performs a Scylla Manager repair, grows the cluster, terminates and replaces a
node, and shrinks it back.

| Pipeline | db instance | Consistency | Sub-task |
|---|---|---|---|
| `...-latency-650gb-with-nemesis-cql-stress-tablets-sc` | `i4i.4xlarge` | SC | SCYLLADB-4409 |
| `...-latency-650gb-with-nemesis-cql-stress-i8g-tablets-sc` | `i8g.4xlarge` | SC | SCYLLADB-4410 |
| `...-latency-650gb-with-nemesis-cql-stress-tablets-ec` | `i4i.4xlarge` | EC baseline | SCYLLADB-4411 |
| `...-latency-650gb-with-nemesis-cql-stress-i8g-tablets-ec` | `i8g.4xlarge` | EC baseline | SCYLLADB-4412 |

### One framework fix (SCYLLADB-4404)

`PerformanceRegressionTest._stop_load_when_nemesis_threads_end()` downgraded only
`CassandraStressEvent` before killing the load at the end of the nemesis run.
`CqlStressCassandraStressEvent` is a sibling class, not a subclass, so a cql-stress workload killed
the same way publishes a CRITICAL failure event and fails the job at the very end of a ~14h run.
The filter now matches the tool that is actually running; cassandra-stress behaviour is unchanged.

### Configuration

New fragments under `configurations/strong_consistency/` and `configurations/performance/`:

- `nemesis_650gb_cql_stress_base.yaml` — loader shape. 250 connections/shard/loader against a
  4xlarge db node is 3750 connections per loader, far beyond the `c5.2xlarge` of the base
  test-case, so the loaders become `c7i.8xlarge` (the shape the SC gradual jobs already use).
- `prepare_cql_stress_nemesis_ks_with_sc_1kpershard.yaml` / `..._ec_1kpershard.yaml` — the workload.
  `-mode connectionsPerShard=250` over 4 loaders gives **1000 connections per shard in aggregate**,
  the same convention as the existing `*_1kpershard.yaml` files. `cl=QUORUM` everywhere, including
  the population phase, as the leader-aware driver requires (cf. 1505752b6).
- `ec_baseline_align_with_sc.yaml` — the existing EC gradual baseline drops
  `enable_experimental_sc.yaml` wholesale, which also changes `append_scylla_args` and
  `api_address`, so its SC-vs-EC delta is not attributable to consistency alone. This restores the
  two consistency-agnostic settings for the EC chain, leaving the keyspace clause as the only
  variable.
- `latency-decorator-error-thresholds-nemesis-sc-tablets.yaml` — SC writes go through Raft and node
  add/remove reconfigures the Raft group of every migrated tablet, so the EC duration limits do not
  transfer. The topology disruptions start report-only (`fixed_limit: null`) with the EC value in a
  comment, and get real limits after the first run (SCYLLADB-4417).

### Verification

No test was run against a cluster — configuration and unit level only.

- `-pop dist=gauss(...)`, `-mode connectionsPerShard=` and `-rate fixed=` were each checked against
  the cql-stress sources upstream rather than assumed.
- All four chains resolve through `SCTConfiguration` including `verify_configuration()` and
  `check_required_files()`. `api_address` **and** `commitlog_sync: batch` both survive the
  `append_scylla_yaml` merge; `append_scylla_args` is one identical string across all four jobs.
- `unit_tests/unit/test_sc_topology_operations_pipelines.py` (36 cases) resolves the four chains
  read from the jenkinsfiles themselves and asserts those invariants, so a fragment reorder fails in
  CI instead of 14 hours into a run. Confirmed it fails when `ec_baseline_align_with_sc.yaml` is
  dropped from the EC chain.
- `unit_tests/unit/test_perf_stress_event_classes.py` (10 cases) covers the event-filter fix.
- `sct.py lint-test-docs` passes on the edited test-case.

### Not done yet

- **SCYLLADB-4417** — the `fixed=` rates (write 12500/s per loader = 50k aggregate, the throttled
  step of the SC gradual job; read 10310/s and mixed 8750/s from the cassandra-stress baseline) and
  the report-only latency limits are starting points, to be calibrated from the first run.

### Note on the commit range

This branch also carries four earlier, not-yet-merged commits (`e4694c32a`, `172372628`,
`9a6b903ad`, `1505752b6`) from the same SC work stream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes: SCYLLADB-4346


[SCYLLADB-4346]: https://scylladb.atlassian.net/browse/SCYLLADB-4346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ